### PR TITLE
Add Matchmaker and WelcomeCrew functionality summaries

### DIFF
--- a/AUDIT/SUMMARY_MM_WC/MATCHMAKER_FUNCTIONALITY_2025-10-14.md
+++ b/AUDIT/SUMMARY_MM_WC/MATCHMAKER_FUNCTIONALITY_2025-10-14.md
@@ -1,0 +1,116 @@
+# C1C Matchmaker Functionality — 2025-10-14
+
+## Overview
+C1C Matchmaker is a Discord prefix-command bot that helps recruiters triage player applications, surface clan options, and publish welcome messaging while providing member-facing search panels and maintenance tooling.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1629-L1657】【F:AUDIT/20251010_src/MM/welcome.py†L303-L405】Its scope covers recruiter-facing filtering, public search cards, clan profile lookups, and the templated welcome workflow; unrelated moderation or application intake occurs outside this codebase.
+
+## Entry points, bot startup, and cog wiring
+* `main()` boots both the Discord client and the auxiliary aiohttp web server after validating the `DISCORD_TOKEN`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2530-L2544】
+* `start_webserver()` exposes readiness and health probes plus the emoji padding proxy used in embeds.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2465-L2495】
+* `on_ready()` seeds recurring tasks (`daily_recruiters_update`, `scheduled_cleanup`, `_watchdog`, and `sheets_refresh_scheduler`), syncs slash commands, and attaches the `Welcome` cog if it has not yet been added and primed.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2197-L2236】
+* The welcome cog is instantiated with sheet accessors, logging destinations, role gates, and default enablement derived from environment variables, then added asynchronously during the first `on_ready()` run.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2497-L2527】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2220-L2236】
+
+## Function map
+| File | Symbol | Responsibility |
+| --- | --- | --- |
+| `bot_clanmatch_prefix.py` | `get_ws`, `get_rows`, `clear_cache` | Lazy Google Sheets connection and caching of recruitment data.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L123-L149】 |
+|  | `row_matches` et al. | Apply raid difficulty, CvC, Siege, playstyle, and roster filters to sheet rows.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L232-L315】 |
+|  | `ClanMatchView` | Recruiter/member filter UI with select controls, roster toggles, pagination refresh, and search execution.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1161-L1563】 |
+|  | `PagedResultsView` / `MemberSearchPagedView` / `SearchResultFlipView` | Owner-locked Discord UI views that page result embeds or flip between profile/entry details.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L760-L1559】 |
+|  | Prefix commands (`help`, `clanmatch`, `clansearch`, `clan`, `ping`, `health`, `reload`, etc.) | Recruiter/member/admin command surface for panels, clan lookup, liveness, and cache management.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1566-L2091】 |
+|  | Event handlers (`on_raw_reaction_add`, `on_message_delete`, gateway/watchdog events) | Reaction-based embed flipping and lifecycle telemetry for restarts.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1989-L2297】 |
+|  | `daily_recruiters_update`, `scheduled_cleanup`, `_watchdog`, `sheets_refresh_scheduler` | Background jobs for daily recruiter summaries, channel hygiene, zombie detection, and sheet cache refreshes.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L620-L722】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2093-L2297】 |
+| `welcome.py` | `Welcome` cog | Template caching, per-tag welcome embed assembly, permission checks, general notice posting, and runtime toggles.【F:AUDIT/20251010_src/MM/welcome.py†L17-L405】 |
+
+## Event handlers
+* `on_raw_reaction_add` swaps between clan profile and entry criteria embeds when users react with 💡, maintaining a flip registry and re-arming the reaction for reuse.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1989-L2034】
+* `on_message_delete` removes stale reaction flip registrations when messages disappear.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2039-L2041】
+* Gateway telemetry (`on_socket_response`, `on_connect`, `on_resumed`, `on_ready`, `on_disconnect`) updates connection timestamps used by the watchdog restart logic.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2162-L2254】
+
+## Commands and permissions
+* Recruiter tools:
+  * `!clanmatch` (cooldown 2s) opens or refreshes the recruiter panel in a configured thread and rejects callers lacking recruiter/admin roles.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1678-L1797】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1122-L1175】
+  * `!clansearch` (cooldown 2s) launches a member-facing panel in-channel with the same filter set, tracked per user.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1806-L1847】
+  * `!clan <tag|name>` fetches sheet data, builds a profile embed (with padded emoji thumbnail), and registers the reaction flip state.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1850-L1972】
+* Welcome administration:
+  * `!welcome` (cooldown 10s) validates template state, renders embeds, pings the recruit if configured, posts to the clan channel, and optionally announces in general chat.【F:AUDIT/20251010_src/MM/welcome.py†L303-L405】
+  * `!welcome-refresh`, `!welcome-on`, `!welcome-off`, `!welcome-status` mutate the welcome cog cache/enable flags and all require the configured role set.【F:AUDIT/20251010_src/MM/welcome.py†L407-L443】
+* Maintenance/admin:
+  * `!help [topic]` provides command descriptions grouped by audience.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1566-L1669】
+  * `!ping`, `!health`, and `!reload` require admin/lead roles and surface liveness, connection latency, sheet status, and clear cached rows.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2045-L2091】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1122-L1148】
+  * `!mmhealth` echoes environment metadata for platform probes.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1799-L1803】
+
+## Workflow — intake → screening → queueing → placement → escalation
+1. **Intake**: Recruiters summon a private panel with `!clanmatch`, which records the panel per user and resolves the delivery channel based on fixed-thread configuration; unauthorized users are denied upfront.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1678-L1797】
+2. **Screening**: Within `ClanMatchView`, recruiters choose raid difficulties, playstyle, CvC/Siege toggles, and roster filters; changes update UI state and can auto-refresh existing result embeds.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1161-L1364】
+3. **Queueing**: Search execution pulls cached sheet rows, applies `row_matches`, enforces roster criteria, caps results, and stores the results message/view so subsequent tweaks update the same panel.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L232-L315】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1365-L1559】
+4. **Placement**: Recruiters review embeds (with pagination where necessary), drill into profiles or entry criteria via reaction flips, and can trigger the welcome cog to publish onboarding messages once a clan decision is made.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L760-L1559】【F:AUDIT/20251010_src/MM/welcome.py†L303-L405】
+5. **Escalation**: Failures log to a central channel via `log_to_channel`, admin commands provide runtime status, and the watchdog restarts the bot if gateway activity stalls; daily summaries broadcast open-slot counts to recruiter threads.【F:AUDIT/20251010_src/MM/welcome.py†L17-L33】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L699-L2297】
+
+## Data flows and persistence
+* Recruitment data is read from a Google Sheet identified by `GOOGLE_SHEET_ID` and `WORKSHEET_NAME`, using cached `get_rows()` values with configurable TTL and service-account credentials from `GSPREAD_CREDENTIALS`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L64-L149】
+* Welcome templates load from a dedicated worksheet (default `WelcomeTemplates`) via `get_welcome_rows()`, caching per-clan rows and a C1C default fallback merged by `_merge_text_fields`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2506-L2513】【F:AUDIT/20251010_src/MM/welcome.py†L160-L247】
+* Reaction flips maintain in-memory `REACT_INDEX` keyed by message ID, cleared when messages delete.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1086-L1092】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2039-L2041】
+* Web health endpoints expose live status derived from connection timestamps, supporting platform probes without external storage.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2303-L2350】
+
+## Channels and roles touched
+* Recruiter summaries post into `RECRUITERS_THREAD_ID`, tagging coordinator and scout role IDs pulled from the environment.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L98-L121】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L699-L721】
+* Panels optionally relocate into a fixed recruiter thread (`PANEL_THREAD_MODE`/`PANEL_FIXED_THREAD_ID`) instead of the invoking channel.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L103-L1795】
+* The welcome cog routes messages to per-clan `TARGET_CHANNEL_ID` values from the sheet, optionally pinging recruits and posting general notices into `WELCOME_GENERAL_CHANNEL_ID`.【F:AUDIT/20251010_src/MM/welcome.py†L212-L405】
+* Role gates for recruiters, leads, and admins are configured via `RECRUITER_ROLE_IDS`, `LEAD_ROLE_IDS`, and `ADMIN_ROLE_IDS`, intersecting against member roles and admin permissions.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1122-L1148】
+
+## Scheduling and background jobs
+* `sheets_refresh_scheduler()` clears and warms the sheet cache at configurable times-of-day using the optional log channel for refresh announcements.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L620-L657】
+* `daily_recruiters_update()` posts the recruiter thread summary at 17:30 UTC each day, including optional role mentions.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L660-L721】
+* `scheduled_cleanup()` periodically purges the bot’s own messages older than `CLEANUP_AGE_HOURS` from configured channels or threads.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2093-L2170】
+* `_watchdog` runs every `WATCHDOG_CHECK_SEC`, restarting the process if gateway events cease or disconnects exceed `WATCHDOG_MAX_DISCONNECT_SEC`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2258-L2297】
+
+## External integrations
+* Google Sheets provides recruitment data and welcome templates via `gspread` authenticated with a service-account JSON blob supplied in `GSPREAD_CREDENTIALS`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L64-L149】
+* The aiohttp server exposes `/health`, `/healthz`, and `/emoji-pad` endpoints; the latter fetches Discord emoji assets, enforces host allowlists, trims, pads, and serves PNGs to stabilize embed thumbnails.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2303-L2457】
+
+## Error handling, retries, and health hooks
+* Command handlers and sheet loaders wrap operations in `try/except`, logging structured errors to the configured log channel and returning user-facing explanations; missing clan rows or channels short-circuit welcome posting with explicit replies.【F:AUDIT/20251010_src/MM/welcome.py†L212-L405】
+* `row_matches` filtering and panel refresh logic guard against malformed sheet rows, ignoring headers and continuing on evaluation errors.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L232-L315】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1257-L1364】
+* Watchdog telemetry and health commands surface connectivity, latency, uptime, and last-event age, ensuring operators can detect zombie states before forced restarts.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2054-L2297】
+
+## Environment separation
+Configuration relies exclusively on environment variables for tokens, sheet IDs, channel/role IDs, scheduling knobs, and feature flags, allowing distinct dev/test/prod deployments by swapping env values without code changes.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L64-L121】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2258-L2297】
+
+## Feature toggles and operational knobs
+* `STRICT_PROBE`, `SHOW_TAG_IN_CLASSIC`, `SEARCH_RESULTS_SOFT_CAP`, and panel thread modes tune bot presentation and hosting behavior.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L44-L112】
+* Welcome behavior toggles via `WELCOME_ENABLED`, `WELCOME_ALLOWED_ROLES`, `WELCOME_GENERAL_CHANNEL_ID`, and sheet tab overrides, plus runtime overrides through the welcome cog’s commands.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2497-L2523】【F:AUDIT/20251010_src/MM/welcome.py†L303-L443】
+* Cleanup cadence, roster filtering defaults, and emoji padding geometry are adjustable through dedicated env variables documented at the top of the module.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L80-L121】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2093-L2170】
+
+## Assumptions and invariants
+* Discord tokens must be at least 50 characters and set via `DISCORD_TOKEN`, otherwise startup aborts.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2530-L2538】
+* Welcome templates require numeric `TARGET_CHANNEL_ID` entries per clan; missing or non-digit values block welcome posting.【F:AUDIT/20251010_src/MM/welcome.py†L326-L338】
+* Reaction flips rely on message IDs staying stable; deletions clear state to avoid editing unrelated messages.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1989-L2041】
+* Recruiter panels remain owner-locked; interaction checks reject other users and instruct them to spawn their own panel.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L760-L1559】
+
+## Mermaid sequence — Application submitted → placed
+```mermaid
+sequenceDiagram
+    participant Recruiter
+    participant Matchmaker
+    participant Sheets
+    participant Discord
+    participant Welcome
+    Recruiter->>Matchmaker: `!clanmatch`
+    Matchmaker->>Discord: Spawn ClanMatchView panel (owner-locked)
+    Recruiter->>Matchmaker: Set filters & click Search
+    Matchmaker->>Sheets: get_rows() with cached Google Sheet data
+    Sheets-->>Matchmaker: Filtered clan rows
+    Matchmaker->>Discord: Send embeds / pager with clan options
+    Recruiter->>Matchmaker: Choose clan & run `!welcome`
+    Matchmaker->>Welcome: Delegate welcome command
+    Welcome->>Sheets: Load template rows (clan + default)
+    Welcome->>Discord: Post welcome embed & general notice
+```
+*Sequence references: panel creation, sheet access, and welcome publishing all stem from the cited command implementations.*【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1678-L1797】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1365-L1559】【F:AUDIT/20251010_src/MM/welcome.py†L212-L405】
+
+## Runtime prerequisites checklist
+* Discord bot token in `DISCORD_TOKEN` (>=50 chars) and `intents.message_content` enabled.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L89-L95】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1090-L1092】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2530-L2538】
+* Google service-account JSON (`GSPREAD_CREDENTIALS`) and sheet identifiers (`GOOGLE_SHEET_ID`, `WORKSHEET_NAME`, `WELCOME_SHEET_TAB`) accessible to the bot user.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L64-L149】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2506-L2513】
+* Discord role IDs for recruiters, leads, admins, and welcome command access configured in the environment, matching server roles.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L103-L121】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1122-L1148】【F:AUDIT/20251010_src/MM/welcome.py†L197-L280】
+* Channel/thread IDs for recruiter summaries, panel threads, and welcome/general destinations defined and the bot granted send/manage permissions in those locations.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L98-L121】【F:AUDIT/20251010_src/MM/welcome.py†L212-L405】
+* Optional web server port (`PORT`) reachable for health probes if deploying with platform monitoring.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2465-L2495】

--- a/AUDIT/SUMMARY_MM_WC/OVERVIEW_2025-10-14.md
+++ b/AUDIT/SUMMARY_MM_WC/OVERVIEW_2025-10-14.md
@@ -1,0 +1,15 @@
+# C1C Matchmaker & WelcomeCrew Overview — 2025-10-14
+
+## Detailed references
+* [Matchmaker functionality](MATCHMAKER_FUNCTIONALITY_2025-10-14.md)
+* [WelcomeCrew functionality](WELCOME_FUNCTIONALITY_2025-10-14.md)
+
+## Side-by-side summary
+| Area | Matchmaker | WelcomeCrew |
+| --- | --- | --- |
+| Core role | Recruiter/member panel bot that filters Google Sheet clan data, surfaces embeds, and orchestrates templated welcomes via the shared `Welcome` cog.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1161-L1797】【F:AUDIT/20251010_src/MM/welcome.py†L303-L405】 | Thread watcher that logs welcome/promo closures to Sheets, prompting for missing data and renaming threads to the canonical closed format.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L732-L1803】 |
+| Data sources | Reads recruitment rows from `GOOGLE_SHEET_ID`/`WORKSHEET_NAME` and welcome templates from `WELCOME_SHEET_TAB`, caching results with configurable TTL.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L64-L149】【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L2506-L2513】 | Uses Sheet1/Sheet4 for ticket logging and the clanlist tab for tag inference, with cached worksheet handles and clan tag regexes.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L115-L381】 |
+| User commands | `!clanmatch`, `!clansearch`, `!clan`, and welcome/admin commands gated by recruiter/lead roles and interaction ownership checks.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1678-L2091】【F:AUDIT/20251010_src/MM/welcome.py†L303-L443】 | `!env_check`, `!backfill_tickets`, `!watch_status`, and health/maintenance commands toggled via `ENABLE_CMD_*` flags.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1007-L1297】 |
+| Automation | Scheduled sheet cache refresh, daily recruiter summary posts, channel cleanup, and watchdog restarts keep recruiting flows current.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L620-L2297】 | Scheduled clan-tag refreshes, live close detection, dropdown prompts, and watchdog restarts ensure sheet parity and prompt resolution.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1350-L1600】 |
+| Integrations | Discord UI views plus aiohttp `/health` & `/emoji-pad` endpoints for monitoring and emoji padding; depends on Google Sheets via `gspread`.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L760-L2495】 | Discord thread APIs with fallback notify channel usage and aiohttp health probes; interacts with Google Sheets via `gspread` for writes and dedupe.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L1596】 |
+| Operational guardrails | Role-based access checks, reaction flip registry cleanup, and watchdog-triggered exits mitigate misuse and zombie states.【F:AUDIT/20251010_src/MM/bot_clanmatch_prefix.py†L1086-L2297】 | Backoff throttling, notify fallbacks, and ticket index caching avoid sheet abuse while surfacing incomplete records to staff.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L400-L815】 |

--- a/AUDIT/SUMMARY_MM_WC/WELCOME_FUNCTIONALITY_2025-10-14.md
+++ b/AUDIT/SUMMARY_MM_WC/WELCOME_FUNCTIONALITY_2025-10-14.md
@@ -1,0 +1,118 @@
+# C1C WelcomeCrew Functionality — 2025-10-14
+
+## Overview
+C1C WelcomeCrew automates welcome and promotion thread management: it watches Discord threads for closure markers, infers clan tags, prompts staff when data is missing, and upserts ticket records into Google Sheets while offering maintenance commands and health endpoints.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L55-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1398-L1809】It focuses on logging welcome/promotion outcomes and keeping sheets tidy; application intake, manual moderation, or DM onboarding flows remain out-of-scope.
+
+## Entry points and startup flow
+* `_boot()` validates the Discord token, launches the aiohttp web server, and starts the bot client.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1805-L1812】
+* `start_webserver()` exposes `/`, `/ready`, `/health`, and `/healthz` endpoints with optional strict probing, sharing an aiohttp session for future integrations.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1473-L1596】
+* `setup_hook()` syncs slash commands and preloads clan tags so dropdowns have data immediately.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L281-L299】
+* `on_ready()` starts the watchdog loop and schedules the timed refresh task that reloads clan tags and warms worksheet handles.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1414-L1600】
+
+## Function map
+| Symbol | Responsibility |
+| --- | --- |
+| `env_bool` and environment constants | Centralize environment-driven toggles, IDs, and sheet configuration (welcome, promo, notify).【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L32-L88】 |
+| `get_ws`, `gs_client`, `_run_blocking`, `_with_backoff` | Manage Google Sheets connections with cached worksheet handles, thread offloading, and exponential backoff on transient errors.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L115-L181】 |
+| Clan tag utilities (`_load_clan_tags`, `_match_tag_in_text`, `_pick_tag_by_suffix`) | Fetch and normalize clan tags from the clanlist sheet, supplying regex-based inference for thread names and messages.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L300-L431】 |
+| Upsert helpers (`upsert_welcome`, `upsert_promo`, `dedupe_sheet`) | Locate or append sheet rows with throttling, diff tracking, and duplicate pruning logic.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L400-L564】 |
+| Thread parsing & tagging (`parse_welcome_thread_name_allow_missing`, `parse_promo_thread_name`, `infer_clantag_from_thread`) | Extract ticket numbers, usernames, and clan tags from thread names or message content, optionally joining threads to inspect history.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L572-L655】 |
+| Finalizers (`_finalize_welcome`, `_finalize_promo`, `_rename_welcome_thread_if_needed`) | Rename threads to canonical `Closed-####-username-TAG`, log actions, and write rows into Sheet1/Sheet4 with timestamps.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L732-L815】 |
+| Backfill scanners (`scan_welcome_channel`, `scan_promo_channel`, `_handle_*`) | Traverse active and archived threads to reconcile sheet data, collecting metrics and reasons for skipped records.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L816-L940】 |
+| Command suite (`env_check`, `sheetstatus`, `backfill_tickets`, etc.) | Operational commands gated by feature toggles for environment validation, sheet stats, dedupe, cache clearing, health, and restarts.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1007-L1277】 |
+| Live watchers (`on_message`, `on_thread_update`, tag picker views) | Detect close markers, maintain pending tag prompts, and log completion events or fallback notifications.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1362-L1803】 |
+| Scheduling (`scheduled_refresh_loop`, `_watchdog`) | Refresh clan tags three times daily and restart on prolonged disconnect or zombie conditions.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1600】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1398-L1471】 |
+
+## Event handlers and background tasks
+* `on_message` drives the live watcher: it detects close markers, stores pending prompts when tags are missing, auto-joins threads when mentioned, and finalizes tickets when tags appear in follow-up messages.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1626-L1721】
+* `on_thread_update` reacts to archive/lock transitions, triggering prompts or finalizing data when threads close or reopen.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1726-L1803】
+* `scheduled_refresh_loop` repeatedly loads clan tags and sheet handles at configured local times, optionally announcing refreshes in `LOG_CHANNEL_ID`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1600】
+* `_watchdog` monitors gateway idleness or extended disconnects to restart the process proactively.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1398-L1471】
+
+## Commands and permissions
+* Help:
+  * `!help [topic]` sends the mobile-friendly embed or topic-specific descriptions; `/help` slash command mirrors the embed.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L191-L276】
+* Environment & health:
+  * `!env_check` verifies required environment variables, toggles, and offers hints for misconfiguration.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1007-L1096】
+  * `!sheetstatus`, `!checksheet`, and `!health` inspect sheet connectivity, row counts, and bot latency.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1107-L1252】
+  * `!ping` reacts with 🏓 for a lightweight liveness check.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1098-L1105】
+* Backfill & maintenance:
+  * `!backfill_tickets` scans welcome/promo channels (respecting feature toggles), updating sheets while streaming progress; `!backfill_stop` cancels mid-run and `!backfill_details` exports diffs.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1120-L1204】
+  * `!dedupe_sheet` prunes duplicate tickets in both sheets, while `!reload` clears caches for sheets and tag data.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1205-L1241】
+  * `!reboot` exits the process after a short delay to trigger a platform restart.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1272-L1276】
+* Watcher diagnostics:
+  * `!watch_status` reports watcher on/off state and the last five logged actions.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1278-L1297】
+
+## Workflow — member joins → onboarding/logging
+1. **Thread creation & monitoring**: The bot auto-joins relevant threads and watches for close markers in messages, building normalized ticket/user/tag data from thread titles or content.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L340-L655】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1626-L1708】
+2. **Tag inference & prompting**: When a close marker appears without a clan tag, the watcher records pending metadata and schedules a dropdown prompt (with reload option) once the thread archives/locks.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1350-L1395】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1668-L1739】
+3. **Finalization**: Tag selections (from dropdown or message inference) call `_finalize_welcome`/`_finalize_promo` to rename threads, log actions, and upsert Sheet1/Sheet4 rows with timestamps and promo types.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L732-L815】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1689-L1719】
+4. **Fallbacks & notifications**: If prompts fail (e.g., private threads), the bot attempts to join threads, pings configured notify channels/roles, and records actions in `WATCH_LOG`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L781】
+
+## Data flows
+* Sheets: `get_ws()` opens or creates Sheet1 and Sheet4 with enforced headers, caches worksheet handles, and indexes tickets for fast lookups before updates.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L115-L387】
+* Clan tags: `_load_clan_tags()` caches tags for `CLAN_TAGS_CACHE_TTL_SEC`, builds regexes for inference, and is refreshed both on setup and via the scheduled loop.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L300-L381】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1571】
+* Backfill state: `backfill_state` holds counters, updated IDs, diff text, and skip reasons used for progress reporting and optional summary files.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L420-L489】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L816-L1005】
+* Watch log: `WATCH_LOG` stores the 50 most recent actions for diagnostics via `!watch_status`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L689-L724】
+
+## Channels, roles, and notifications
+* Environment-provided IDs determine the welcome and promo parent channels, optional notify channel/role, and the role ping included in fallback notifications.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L38-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L781】
+* The bot auto-joins threads in those channels on creation and when mentioned to ensure it can send prompts or updates.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1608-L1652】
+* Thread renaming standardizes the `Closed-####-username-TAG` pattern, ensuring channel viewers can identify status at a glance.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L732-L786】
+
+## Scheduling and timed jobs
+* `scheduled_refresh_loop` repeats indefinitely, computing the next refresh timestamp (default 02:00/10:00/18:00) in the configured timezone and, after refreshing caches, posts a log message if `LOG_CHANNEL_ID` is set.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1595】
+* `_watchdog` executes every `WATCHDOG_CHECK_SEC` (default 60s), restarting on zombie latency or disconnect durations beyond `WATCHDOG_MAX_DISCONNECT_SEC`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1398-L1471】
+
+## External integrations
+* Google Sheets access uses `gspread` with a service-account JSON payload (`GOOGLE_SERVICE_ACCOUNT_JSON`) to read/write Sheet1, Sheet4, and the clanlist tab, including worksheet creation when missing.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L115-L213】
+* The aiohttp server provides platform-friendly health endpoints but no additional outbound integrations; placeholders exist for future HTTP usage via the shared session.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1473-L1596】
+
+## Error handling, retries, and health reporting
+* `_with_backoff` retries transient Sheets failures (429/5xx/timeouts) with exponential delay and jitter, while `_sleep_ms` throttles writes via `SHEETS_THROTTLE_MS`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L158-L181】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L432-L503】
+* Watcher logic captures exceptions when joining threads, sending messages, or renaming, logging fallback actions and preserving state without crashing the bot.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L815】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1626-L1803】
+* Health endpoints surface connection status, uptime, and last event age, while `!health` exposes Discord latency and sheet connectivity to operators.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1398-L1471】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1234-L1252】
+
+## Environment separation
+The bot’s behavior is entirely governed by environment variables—channel IDs, sheet names, toggle flags, refresh times, and notify settings—allowing separate staging or production deployments without code changes.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L32-L160】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1600】
+
+## Feature flags and operational knobs
+* Command availability (`ENABLE_CMD_*`), scanners (`ENABLE_WELCOME_SCAN`, `ENABLE_PROMO_SCAN`), live watchers, fallback notifications, and close-marker enforcement are all switchable via env flags processed by `env_bool`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L55-L88】
+* Scheduled refresh timing and clan tag caching TTL adjust with `REFRESH_TIMES`, `TIMEZONE`, and `CLAN_TAGS_CACHE_TTL_SEC`.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L38-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1600】
+* Backfill auto-posting and notify behavior toggles (`AUTO_POST_BACKFILL_DETAILS`, `POST_BACKFILL_SUMMARY`, `ENABLE_NOTIFY_FALLBACK`) control operational messaging noise.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L70-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1120-L1204】
+
+## Assumptions and invariants
+* Thread names must contain a four-digit ticket number; parsers fall back to regex extraction but skip threads lacking numeric identifiers.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L588-L655】
+* Sheet headers are normalized on first access—if they diverge from expectations, the bot rewrites row 1 to the required structure.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L139-L155】
+* The bot refrains from DM notifications; all fallback messaging routes through configured channels or role mentions.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L70-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L781】
+* Welcome threads renamed by humans are normalized to the canonical `Closed-` prefix to avoid duplicate prefixes or stale labels.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L732-L786】
+
+## Mermaid sequence — Member joins → onboarding/logging
+```mermaid
+sequenceDiagram
+    participant Thread
+    participant WelcomeCrew
+    participant Sheets
+    participant Notify
+    Thread->>WelcomeCrew: Close marker message detected
+    WelcomeCrew->>Thread: Infer ticket/user/tag from name/content
+    alt Tag present
+        WelcomeCrew->>Sheets: upsert ticket row (Sheet1/Sheet4)
+        WelcomeCrew->>Thread: Rename to Closed-####-username-TAG
+    else Tag missing
+        WelcomeCrew->>Thread: Queue dropdown prompt / reload view
+        Thread->>WelcomeCrew: Tag selected or typed
+        WelcomeCrew->>Sheets: upsert row & rename thread
+    end
+    opt Failure or private thread
+        WelcomeCrew->>Notify: Post fallback ping in notify channel
+    end
+```
+*Diagram derived from watcher logic, finalizers, and fallback notification helpers.*【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L700-L815】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1350-L1721】
+
+## Runtime prerequisites checklist
+* Discord token (`DISCORD_TOKEN`/`TOKEN`) with `intents.message_content` enabled.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L38-L93】
+* Google Sheets access: `GSHEET_ID`, `GOOGLE_SERVICE_ACCOUNT_JSON`, sheet names (`SHEET1_NAME`, `SHEET4_NAME`, `CLANLIST_TAB_NAME`) configured and shared with the service account.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L38-L213】
+* Channel IDs: `WELCOME_CHANNEL_ID`, `PROMO_CHANNEL_ID`, optional `NOTIFY_CHANNEL_ID`, and any log channel for refresh announcements.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L38-L88】【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1517-L1595】
+* Optional notify role (`NOTIFY_PING_ROLE_ID`) and feature toggles aligned with operational policies.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L70-L88】
+* Hosting environment exposing the aiohttp health endpoints if external monitoring is required.【F:AUDIT/20251010_src/WC/bot_welcomecrew.py†L1473-L1545】


### PR DESCRIPTION
## Summary
- add dated Matchmaker functionality documentation covering workflows, commands, and data flows
- add dated WelcomeCrew functionality documentation describing watchers, commands, and sheet integration
- provide a concise combined overview linking both detailed reports

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ee0eb5bd908323a02972e4b5200a5a