### PR TITLE
Phase 2: plural role gates and staff gating for welcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - CoreOps cog with commands: ping, help, health, env, digest.
 - Help embed with footer: "Bot v{BOT_VERSION} • CoreOps v1.0.0 • <Vienna or UTC time>".
-- Role-based RBAC: ADMIN_ROLE_ID (single), STAFF_ROLE_IDS (list). No user-ID gating.
+- Role-based RBAC: ADMIN_ROLE_IDS (list), STAFF_ROLE_IDS (list). No user-ID gating.
 - Admin "bang" shortcuts: !health, !env, !digest, !help (Admin role only).
 - Prefix handling: supports !rec, !rec␣, rec, rec␣ and @mention.
 - Watchdog mirrored from legacy: keepalive cadence, stall, disconnect grace; connection-aware.

--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ from shared import health as health_srv
 from shared import watchdog
 from shared.coreops_prefix import detect_admin_bang_command
 from shared.coreops_rbac import (
-    get_admin_role_id,
+    get_admin_role_ids,
     get_staff_role_ids,
     is_admin_member,
 )
@@ -69,8 +69,8 @@ async def on_ready():
     hb.note_ready()  # mark as fresh as soon as we're ready
     log.info(f"Bot ready as {bot.user} | env={get_env_name()} | prefix={BOT_PREFIX}")
     log.info(
-        "CoreOps RBAC: admin_role_id=%s staff_role_ids=%s",
-        get_admin_role_id(),
+        "CoreOps RBAC: admin_role_ids=%s staff_role_ids=%s",
+        sorted(get_admin_role_ids()),
         sorted(get_staff_role_ids()),
     )
     bot._c1c_started_mono = _STARTED_MONO  # expose uptime for CoreOps

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Discord Gateway
   ↳ Event handlers (on_ready, on_message, on_connect, on_disconnect)
       ↳ Socket heartbeat tracker (READY / connect / disconnect timestamps, snapshots)
       ↳ Command layer (discord.py command tree with CoreOps cog)
-          ↳ RBAC helper (parses ADMIN_ROLE_ID and STAFF_ROLE_IDS role memberships)
+          ↳ RBAC helper (parses ADMIN_ROLE_IDS and STAFF_ROLE_IDS role memberships)
 
 Watchdog loop
   ↳ Keepalive cadence probe (keepalive interval, stall detection)

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -5,7 +5,7 @@ Infra must provide reliable runtime, deployment, and observability surfaces whil
 
 ## Inputs (Env / Secrets)
 - `DISCORD_TOKEN` (required)
-- `ADMIN_ROLE_ID` (single numeric)
+- `ADMIN_ROLE_IDS` (comma/space numeric; supports single or multiple values)
 - `STAFF_ROLE_IDS` (comma/space numeric)
 - `KEEPALIVE_INTERVAL_SEC` (prod default 360; non-prod 60)
 - `WATCHDOG_STALL_SEC` (defaults to keepalive*3+30 if unset)

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -3,7 +3,8 @@
 ## Environment configuration
 Set these variables in Render:
 
-- `ADMIN_ROLE_ID` — Single numeric Discord role ID with admin access.
+- `ADMIN_ROLE_IDS` — Comma or space separated Discord role IDs with admin access
+  (single or multiple IDs supported).
 - `BOT_NAME` — Name of the Bot for later cross-bot shared modules
 - `BOT_VERSION` — Version string included in the help footer.
 - `COMMAND_PREFIX` — Version string included in the help footer.

--- a/docs/ops_coreops.md
+++ b/docs/ops_coreops.md
@@ -4,7 +4,7 @@ CoreOps gives staff and admins a quick view into the bot's health without leavin
 Discord channel.
 
 ## Access levels
-- **Admin role (`ADMIN_ROLE_ID`)** — Full access. Can run every CoreOps command and use
+- **Admin roles (`ADMIN_ROLE_IDS`)** — Full access. Can run every CoreOps command and use
   the bang shortcuts.
 - **Staff roles (`STAFF_ROLE_IDS`)** — Access to the standard `!rec` commands only.
 

--- a/modules/coreops/README.md
+++ b/modules/coreops/README.md
@@ -22,7 +22,8 @@ shortcut. Examples:
 - `!rec ping` — Responds immediately so you can confirm reachability.
 
 ## Role-based access control
-- **Admin** access is granted by the single Discord role ID in `ADMIN_ROLE_ID`.
+- **Admin** access is granted by the Discord role IDs in `ADMIN_ROLE_IDS`
+  (single or multiple IDs supported).
 - **Staff** access is granted by the comma or space separated role IDs in
   `STAFF_ROLE_IDS`.
 - The build does not use individual user IDs for gating.
@@ -52,6 +53,6 @@ Use this checklist if CoreOps feels unresponsive:
    bot mention).
 2. Verify the Admin or Staff role IDs are present on the member in Discord.
 3. Ensure the bot has the Members intent enabled so role data is delivered.
-4. Check that required environment variables (`ADMIN_ROLE_ID`, `STAFF_ROLE_IDS`,
+4. Check that required environment variables (`ADMIN_ROLE_IDS`, `STAFF_ROLE_IDS`,
    watchdog intervals) are set in the deployment environment.
 5. Review logs for watchdog notices about stalls or reconnect attempts.

--- a/shared/coreops_rbac.py
+++ b/shared/coreops_rbac.py
@@ -1,4 +1,4 @@
-"""Role helpers for CoreOps gating (Phase 1).
+"""Role helpers for CoreOps gating (Phase 2).
 
 These mirror the legacy bots' behavior: staff/admin gating is done via role IDs
 from the environment instead of user IDs. The helpers here intentionally ignore
@@ -36,25 +36,25 @@ def _safe_int(tok: str) -> Optional[int]:
         return None
 
 
-@lru_cache(maxsize=1)
-def get_admin_role_id() -> Optional[int]:
-    """Return the single admin role id, or None if unset/invalid."""
-    for tok in _parse_role_tokens(os.getenv("ADMIN_ROLE_ID", "")):
+def _load_role_ids(env_key: str) -> Set[int]:
+    ids: Set[int] = set()
+    for tok in _parse_role_tokens(os.getenv(env_key, "")):
         value = _safe_int(tok)
         if value is not None:
-            return value
-    return None
+            ids.add(value)
+    return ids
+
+
+@lru_cache(maxsize=1)
+def get_admin_role_ids() -> Set[int]:
+    """Return the (possibly empty) set of admin role ids."""
+    return _load_role_ids("ADMIN_ROLE_IDS")
 
 
 @lru_cache(maxsize=1)
 def get_staff_role_ids() -> Set[int]:
     """Return the (possibly empty) set of staff role ids."""
-    ids: Set[int] = set()
-    for tok in _parse_role_tokens(os.getenv("STAFF_ROLE_IDS", "")):
-        value = _safe_int(tok)
-        if value is not None:
-            ids.add(value)
-    return ids
+    return _load_role_ids("STAFF_ROLE_IDS")
 
 
 def _member_role_ids(member: discord.abc.User | discord.Member) -> Set[int]:
@@ -75,15 +75,18 @@ def is_staff_member(member: discord.abc.User | discord.Member) -> bool:
     member_roles = _member_role_ids(member)
     if not member_roles:
         return False
-    admin_role_id = get_admin_role_id()
-    if admin_role_id is not None and admin_role_id in member_roles:
+    admin_ids = get_admin_role_ids()
+    if admin_ids and admin_ids.intersection(member_roles):
         return True
     staff_ids = get_staff_role_ids()
     return bool(staff_ids.intersection(member_roles))
 
 
 def is_admin_member(member: discord.abc.User | discord.Member) -> bool:
-    admin_role_id = get_admin_role_id()
-    if admin_role_id is None:
+    admin_ids = get_admin_role_ids()
+    if not admin_ids:
         return False
-    return admin_role_id in _member_role_ids(member)
+    member_roles = _member_role_ids(member)
+    if not member_roles:
+        return False
+    return bool(admin_ids.intersection(member_roles))


### PR DESCRIPTION
## Summary
- switch CoreOps RBAC helper to load ADMIN_ROLE_IDS as a set while preserving staff checks
- log pluralized admin roles during startup and keep staff detection recognizing admins as staff
- refresh docs to reference the ADMIN_ROLE_IDS environment variable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee46ed25a483239360f9169c189210