### PR TITLE
Use WATCHDOG_CHECK_SEC for watchdog interval

### DIFF
--- a/config/runtime.py
+++ b/config/runtime.py
@@ -55,23 +55,23 @@ def _coerce_int(value: Optional[str], fallback: int) -> int:
         return fallback
 
 
-def get_keepalive_interval_sec(
+def get_watchdog_check_sec(
     default_prod: int = 360,
     default_nonprod: int = 60,
 ) -> int:
     """
-    Interval (seconds) between watchdog keepalive checks.
+    Interval (seconds) between watchdog health checks.
 
     Defaults:
         - prod-like envs → 360s (6 min) within the 300–600s window.
         - dev/test/stage → 60s for quicker feedback.
-    Override via KEEPALIVE_INTERVAL_SEC.
+    Override via WATCHDOG_CHECK_SEC.
     """
 
     env = get_env_name().lower()
     fallback = default_nonprod if env in {"dev", "development", "test", "qa", "stage"} else default_prod
 
-    override = os.getenv("KEEPALIVE_INTERVAL_SEC")
+    override = os.getenv("WATCHDOG_CHECK_SEC")
     if override is not None:
         return _coerce_int(override, fallback)
 
@@ -88,10 +88,10 @@ def get_watchdog_stall_sec(default: Optional[int] = None) -> int:
 
     override = os.getenv("WATCHDOG_STALL_SEC")
     if override is not None:
-        fallback = default if default is not None else get_keepalive_interval_sec() * 3 + 30
+        fallback = default if default is not None else get_watchdog_check_sec() * 3 + 30
         return _coerce_int(override, fallback)
 
-    keepalive = get_keepalive_interval_sec()
+    keepalive = get_watchdog_check_sec()
     derived = keepalive * 3 + 30
     if default is not None:
         return derived if derived else default

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -7,7 +7,7 @@ Infra must provide reliable runtime, deployment, and observability surfaces whil
 - `DISCORD_TOKEN` (required)
 - `ADMIN_ROLE_IDS` (comma/space numeric)
 - `STAFF_ROLE_IDS` (comma/space numeric)
-- `KEEPALIVE_INTERVAL_SEC` (prod default 360; non-prod 60)
+- `WATCHDOG_CHECK_SEC` (prod default 360; non-prod 60)
 - `WATCHDOG_STALL_SEC` (defaults to keepalive*3+30 if unset)
 - `WATCHDOG_DISCONNECT_GRACE_SEC` (defaults to stall)
 - `BOT_VERSION` (optional)
@@ -27,7 +27,7 @@ Infra must provide reliable runtime, deployment, and observability surfaces whil
 ## Watchdog & Heartbeat
 - Heartbeat source: gateway events (connect/ready/socket receive).
 - Config:
-  - check interval = `KEEPALIVE_INTERVAL_SEC`
+  - check interval = `WATCHDOG_CHECK_SEC`
   - stall = `WATCHDOG_STALL_SEC` (or derived)
   - disconnect grace = `WATCHDOG_DISCONNECT_GRACE_SEC` (or stall)
 - Exit conditions:

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -11,7 +11,7 @@ Set these variables in Render:
 - `DISCORD_TOKEN` — your apps discord token
 - `ENV_NAME` — test/prod
 - `HEALTH_PORT` — Port exposed for the aiohttp health server.
-- `KEEPALIVE_INTERVAL_SEC` — Default 360 in production, 60 in non-production.
+- `WATCHDOG_CHECK_SEC` — Default 360 in production, 60 in non-production.
 - `STAFF_ROLE_IDS` — Comma or space separated list of numeric staff role IDs.
 - `WATCHDOG_STALL_SEC` — Optional; defaults based on keepalive interval when unset.
 - `WATCHDOG_DISCONNECT_GRACE_SEC` — Optional; defaults to the stall interval.

--- a/modules/coreops/cog.py
+++ b/modules/coreops/cog.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 from config.runtime import (
     get_env_name, get_bot_name, get_command_prefix,
-    get_keepalive_interval_sec, get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
+    get_watchdog_check_sec, get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
 )
 from shared import socket_heartbeat as hb
 from shared.coreops_render import (
@@ -61,7 +61,7 @@ class CoreOps(commands.Cog):
         uptime = _uptime_sec(self.bot)
         latency = _latency_sec(self.bot)
         last_age = await hb.age_seconds()
-        keepalive = get_keepalive_interval_sec()
+        keepalive = get_watchdog_check_sec()
         stall = get_watchdog_stall_sec()
         dgrace = get_watchdog_disconnect_grace_sec(stall)
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_port",
     "get_env_name",
     "get_bot_name",
-    "get_keepalive_interval_sec",
+    "get_watchdog_check_sec",
     "get_watchdog_stall_sec",
     "get_watchdog_disconnect_grace_sec",
     "get_command_prefix",
@@ -74,7 +74,7 @@ def _int_set(raw: str) -> Set[int]:
 
 
 def _load_config() -> Dict[str, object]:
-    keepalive = _runtime.get_keepalive_interval_sec()
+    keepalive = _runtime.get_watchdog_check_sec()
     stall = _runtime.get_watchdog_stall_sec()
     disconnect_grace = _runtime.get_watchdog_disconnect_grace_sec(stall)
 
@@ -103,7 +103,7 @@ def _load_config() -> Dict[str, object]:
         "ENV_NAME": _runtime.get_env_name(),
         "BOT_NAME": _runtime.get_bot_name(),
         "COMMAND_PREFIX": _runtime.get_command_prefix(),
-        "KEEPALIVE_INTERVAL_SEC": keepalive,
+        "WATCHDOG_CHECK_SEC": keepalive,
         "WATCHDOG_STALL_SEC": stall,
         "WATCHDOG_DISCONNECT_GRACE_SEC": disconnect_grace,
         "ADMIN_IDS": _runtime.get_admin_ids(),
@@ -159,11 +159,11 @@ def get_bot_name(default: str = "C1C-Recruitment") -> str:
     return str(value) if isinstance(value, str) and value else default
 
 
-def get_keepalive_interval_sec(
+def get_watchdog_check_sec(
     default_prod: int = 360, default_nonprod: int = 60
 ) -> int:
-    fallback = _runtime.get_keepalive_interval_sec(default_prod, default_nonprod)
-    return int(_CONFIG.get("KEEPALIVE_INTERVAL_SEC", fallback))
+    fallback = _runtime.get_watchdog_check_sec(default_prod, default_nonprod)
+    return int(_CONFIG.get("WATCHDOG_CHECK_SEC", fallback))
 
 
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -50,7 +50,7 @@ def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str
     e.add_field(name="config", value=f"{src} ({status})", inline=True)
     # Show a few safe vars for sanity (no secrets)
     safe = []
-    for k in ("COMMAND_PREFIX", "KEEPALIVE_INTERVAL_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
+    for k in ("COMMAND_PREFIX", "WATCHDOG_CHECK_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
         v = os.getenv(k)
         if v:
             safe.append(f"{k}={v}")

--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -19,7 +19,7 @@ from shared.config import (
     get_port,
     get_env_name,
     get_bot_name,
-    get_keepalive_interval_sec,
+    get_watchdog_check_sec,
     get_watchdog_stall_sec,
     get_watchdog_disconnect_grace_sec,
     get_log_channel_id,
@@ -166,7 +166,7 @@ class Runtime:
 
     async def _health_payload(self) -> tuple[dict, bool]:
         stall = get_watchdog_stall_sec()
-        keepalive = get_keepalive_interval_sec()
+        keepalive = get_watchdog_check_sec()
         snapshot = hb.snapshot()
         age = snapshot.last_event_age
         healthy = age <= stall
@@ -232,7 +232,7 @@ class Runtime:
         disconnect_grace: Optional[int] = None,
         delay_sec: float = 0.0,
     ) -> tuple[bool, int, int, int]:
-        check = check_sec or get_keepalive_interval_sec()
+        check = check_sec or get_watchdog_check_sec()
         stall = stall_sec or get_watchdog_stall_sec()
         disconnect = disconnect_grace or get_watchdog_disconnect_grace_sec(stall)
 


### PR DESCRIPTION
## Summary
- replace the keepalive interval helpers to source WATCHDOG_CHECK_SEC across runtime and config
- update core ops modules and documentation to use the new watchdog check environment variable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eeae2d9a10832392e6792643f53913