### PR TITLE
Add configuration accessors for watchdog check interval

### DIFF
--- a/config/runtime.py
+++ b/config/runtime.py
@@ -78,6 +78,22 @@ def get_keepalive_interval_sec(
     return fallback
 
 
+def get_watchdog_check_sec(
+    default_prod: int = 120,
+    default_nonprod: int = 60,
+) -> int:
+    """Interval (seconds) between watchdog polling iterations."""
+
+    env = get_env_name().lower()
+    fallback = default_nonprod if env in {"dev", "development", "test", "qa", "stage"} else default_prod
+
+    override = os.getenv("WATCHDOG_CHECK_SEC")
+    if override is not None:
+        return _coerce_int(override, fallback)
+
+    return fallback
+
+
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:
     """
     Returns the watchdog stall threshold.

--- a/shared/config.py
+++ b/shared/config.py
@@ -15,6 +15,7 @@ __all__ = [
     "get_env_name",
     "get_bot_name",
     "get_keepalive_interval_sec",
+    "get_watchdog_check_sec",
     "get_watchdog_stall_sec",
     "get_watchdog_disconnect_grace_sec",
     "get_command_prefix",
@@ -75,6 +76,7 @@ def _int_set(raw: str) -> Set[int]:
 
 def _load_config() -> Dict[str, object]:
     keepalive = _runtime.get_keepalive_interval_sec()
+    watchdog_check = _runtime.get_watchdog_check_sec()
     stall = _runtime.get_watchdog_stall_sec()
     disconnect_grace = _runtime.get_watchdog_disconnect_grace_sec(stall)
 
@@ -104,6 +106,7 @@ def _load_config() -> Dict[str, object]:
         "BOT_NAME": _runtime.get_bot_name(),
         "COMMAND_PREFIX": _runtime.get_command_prefix(),
         "KEEPALIVE_INTERVAL_SEC": keepalive,
+        "WATCHDOG_CHECK_SEC": watchdog_check,
         "WATCHDOG_STALL_SEC": stall,
         "WATCHDOG_DISCONNECT_GRACE_SEC": disconnect_grace,
         "ADMIN_IDS": _runtime.get_admin_ids(),
@@ -164,6 +167,13 @@ def get_keepalive_interval_sec(
 ) -> int:
     fallback = _runtime.get_keepalive_interval_sec(default_prod, default_nonprod)
     return int(_CONFIG.get("KEEPALIVE_INTERVAL_SEC", fallback))
+
+
+def get_watchdog_check_sec(
+    default_prod: int = 120, default_nonprod: int = 60
+) -> int:
+    fallback = _runtime.get_watchdog_check_sec(default_prod, default_nonprod)
+    return int(_CONFIG.get("WATCHDOG_CHECK_SEC", fallback))
 
 
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -50,7 +50,13 @@ def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str
     e.add_field(name="config", value=f"{src} ({status})", inline=True)
     # Show a few safe vars for sanity (no secrets)
     safe = []
-    for k in ("COMMAND_PREFIX", "KEEPALIVE_INTERVAL_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
+    for k in (
+        "COMMAND_PREFIX",
+        "KEEPALIVE_INTERVAL_SEC",
+        "WATCHDOG_CHECK_SEC",
+        "WATCHDOG_STALL_SEC",
+        "WATCHDOG_DISCONNECT_GRACE_SEC",
+    ):
         v = os.getenv(k)
         if v:
             safe.append(f"{k}={v}")

--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -19,7 +19,7 @@ from shared.config import (
     get_port,
     get_env_name,
     get_bot_name,
-    get_keepalive_interval_sec,
+    get_watchdog_check_sec,
     get_watchdog_stall_sec,
     get_watchdog_disconnect_grace_sec,
     get_log_channel_id,
@@ -166,7 +166,7 @@ class Runtime:
 
     async def _health_payload(self) -> tuple[dict, bool]:
         stall = get_watchdog_stall_sec()
-        keepalive = get_keepalive_interval_sec()
+        keepalive = get_watchdog_check_sec()
         snapshot = hb.snapshot()
         age = snapshot.last_event_age
         healthy = age <= stall
@@ -232,7 +232,7 @@ class Runtime:
         disconnect_grace: Optional[int] = None,
         delay_sec: float = 0.0,
     ) -> tuple[bool, int, int, int]:
-        check = check_sec or get_keepalive_interval_sec()
+        check = check_sec or get_watchdog_check_sec()
         stall = stall_sec or get_watchdog_stall_sec()
         disconnect = disconnect_grace or get_watchdog_disconnect_grace_sec(stall)
 


### PR DESCRIPTION
## Summary
- add a runtime helper for WATCHDOG_CHECK_SEC with environment override support
- expose the watchdog check interval through the shared config cache and runtime consumers
- list the new watchdog check setting in the CoreOps environment embed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeae35a4b88323bed4d7beee782c45