### PR TITLE
Add runtime getter for watchdog check interval

### DIFF
--- a/config/runtime.py
+++ b/config/runtime.py
@@ -78,6 +78,26 @@ def get_keepalive_interval_sec(
     return fallback
 
 
+def get_watchdog_check_sec(
+    default_prod: int = 120,
+    default_nonprod: int = 60,
+) -> int:
+    """Interval (seconds) between watchdog heartbeat checks."""
+
+    env = get_env_name().lower()
+    fallback = (
+        default_nonprod
+        if env in {"dev", "development", "test", "qa", "stage"}
+        else default_prod
+    )
+
+    override = os.getenv("WATCHDOG_CHECK_SEC")
+    if override is not None:
+        return _coerce_int(override, fallback)
+
+    return fallback
+
+
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:
     """
     Returns the watchdog stall threshold.

--- a/modules/coreops/cog.py
+++ b/modules/coreops/cog.py
@@ -7,7 +7,8 @@ from discord.ext import commands
 
 from config.runtime import (
     get_env_name, get_bot_name, get_command_prefix,
-    get_keepalive_interval_sec, get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
+    get_keepalive_interval_sec, get_watchdog_check_sec,
+    get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
 )
 from shared import socket_heartbeat as hb
 from shared.coreops_render import (
@@ -62,6 +63,7 @@ class CoreOps(commands.Cog):
         latency = _latency_sec(self.bot)
         last_age = await hb.age_seconds()
         keepalive = get_keepalive_interval_sec()
+        watchdog_check = get_watchdog_check_sec()
         stall = get_watchdog_stall_sec()
         dgrace = get_watchdog_disconnect_grace_sec(stall)
 
@@ -73,6 +75,7 @@ class CoreOps(commands.Cog):
             latency_s=latency,
             last_event_age=last_age,
             keepalive_sec=keepalive,
+            watchdog_check_sec=watchdog_check,
             stall_after_sec=stall,
             disconnect_grace_sec=dgrace,
         )

--- a/shared/config.py
+++ b/shared/config.py
@@ -15,6 +15,7 @@ __all__ = [
     "get_env_name",
     "get_bot_name",
     "get_keepalive_interval_sec",
+    "get_watchdog_check_sec",
     "get_watchdog_stall_sec",
     "get_watchdog_disconnect_grace_sec",
     "get_command_prefix",
@@ -75,6 +76,7 @@ def _int_set(raw: str) -> Set[int]:
 
 def _load_config() -> Dict[str, object]:
     keepalive = _runtime.get_keepalive_interval_sec()
+    watchdog_check = _runtime.get_watchdog_check_sec()
     stall = _runtime.get_watchdog_stall_sec()
     disconnect_grace = _runtime.get_watchdog_disconnect_grace_sec(stall)
 
@@ -104,6 +106,7 @@ def _load_config() -> Dict[str, object]:
         "BOT_NAME": _runtime.get_bot_name(),
         "COMMAND_PREFIX": _runtime.get_command_prefix(),
         "KEEPALIVE_INTERVAL_SEC": keepalive,
+        "WATCHDOG_CHECK_SEC": watchdog_check,
         "WATCHDOG_STALL_SEC": stall,
         "WATCHDOG_DISCONNECT_GRACE_SEC": disconnect_grace,
         "ADMIN_IDS": _runtime.get_admin_ids(),
@@ -164,6 +167,13 @@ def get_keepalive_interval_sec(
 ) -> int:
     fallback = _runtime.get_keepalive_interval_sec(default_prod, default_nonprod)
     return int(_CONFIG.get("KEEPALIVE_INTERVAL_SEC", fallback))
+
+
+def get_watchdog_check_sec(
+    default_prod: int = 120, default_nonprod: int = 60
+) -> int:
+    fallback = _runtime.get_watchdog_check_sec(default_prod, default_nonprod)
+    return int(_CONFIG.get("WATCHDOG_CHECK_SEC", fallback))
 
 
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -22,6 +22,7 @@ def build_health_embed(
     latency_s: float|None,
     last_event_age: float,
     keepalive_sec: int,
+    watchdog_check_sec: int,
     stall_after_sec: int,
     disconnect_grace_sec: int,
 ) -> discord.Embed:
@@ -33,6 +34,7 @@ def build_health_embed(
     e.add_field(name="latency", value=("—" if latency_s is None else f"{latency_s*1000:.0f} ms"), inline=True)
     e.add_field(name="last event", value=f"{int(last_event_age)} s", inline=True)
     e.add_field(name="keepalive", value=f"{keepalive_sec}s", inline=True)
+    e.add_field(name="watchdog", value=f"{watchdog_check_sec}s", inline=True)
 
     e.add_field(name="stall after", value=f"{stall_after_sec}s", inline=True)
     e.add_field(name="disconnect grace", value=f"{disconnect_grace_sec}s", inline=True)
@@ -50,7 +52,13 @@ def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str
     e.add_field(name="config", value=f"{src} ({status})", inline=True)
     # Show a few safe vars for sanity (no secrets)
     safe = []
-    for k in ("COMMAND_PREFIX", "KEEPALIVE_INTERVAL_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
+    for k in (
+        "COMMAND_PREFIX",
+        "KEEPALIVE_INTERVAL_SEC",
+        "WATCHDOG_CHECK_SEC",
+        "WATCHDOG_STALL_SEC",
+        "WATCHDOG_DISCONNECT_GRACE_SEC",
+    ):
         v = os.getenv(k)
         if v:
             safe.append(f"{k}={v}")

--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -20,6 +20,7 @@ from shared.config import (
     get_env_name,
     get_bot_name,
     get_keepalive_interval_sec,
+    get_watchdog_check_sec,
     get_watchdog_stall_sec,
     get_watchdog_disconnect_grace_sec,
     get_log_channel_id,
@@ -167,6 +168,7 @@ class Runtime:
     async def _health_payload(self) -> tuple[dict, bool]:
         stall = get_watchdog_stall_sec()
         keepalive = get_keepalive_interval_sec()
+        watchdog_check = get_watchdog_check_sec()
         snapshot = hb.snapshot()
         age = snapshot.last_event_age
         healthy = age <= stall
@@ -178,6 +180,7 @@ class Runtime:
             "age_seconds": round(age, 3),
             "stall_after_sec": stall,
             "keepalive_sec": keepalive,
+            "watchdog_check_sec": watchdog_check,
             "connected": snapshot.connected,
             "disconnect_age": (
                 None if snapshot.disconnect_age is None else round(snapshot.disconnect_age, 3)
@@ -232,7 +235,7 @@ class Runtime:
         disconnect_grace: Optional[int] = None,
         delay_sec: float = 0.0,
     ) -> tuple[bool, int, int, int]:
-        check = check_sec or get_keepalive_interval_sec()
+        check = check_sec or get_watchdog_check_sec()
         stall = stall_sec or get_watchdog_stall_sec()
         disconnect = disconnect_grace or get_watchdog_disconnect_grace_sec(stall)
 


### PR DESCRIPTION
## Summary
- add a runtime config helper for `WATCHDOG_CHECK_SEC` with environment-aware defaults
- surface the watchdog check cadence in the shared config snapshot and CoreOps health output
- run the watchdog loop using the dedicated check interval

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eeae3f6cb48323ba6a869bbe384997