### PR TITLE
Replace keepalive runtime getter with watchdog check interval

### DIFF
--- a/config/runtime.py
+++ b/config/runtime.py
@@ -55,44 +55,31 @@ def _coerce_int(value: Optional[str], fallback: int) -> int:
         return fallback
 
 
-def get_keepalive_interval_sec(
-    default_prod: int = 360,
-    default_nonprod: int = 60,
-) -> int:
-    """
-    Interval (seconds) between watchdog keepalive checks.
+def get_watchdog_check_sec(default: int = 30) -> int:
+    """Interval (seconds) between watchdog health checks."""
 
-    Defaults:
-        - prod-like envs → 360s (6 min) within the 300–600s window.
-        - dev/test/stage → 60s for quicker feedback.
-    Override via KEEPALIVE_INTERVAL_SEC.
-    """
-
-    env = get_env_name().lower()
-    fallback = default_nonprod if env in {"dev", "development", "test", "qa", "stage"} else default_prod
-
-    override = os.getenv("KEEPALIVE_INTERVAL_SEC")
+    override = os.getenv("WATCHDOG_CHECK_SEC")
     if override is not None:
-        return _coerce_int(override, fallback)
+        return _coerce_int(override, default)
 
-    return fallback
+    return default
 
 
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:
     """
     Returns the watchdog stall threshold.
 
-    If WATCHDOG_STALL_SEC is unset we derive it from the keepalive cadence:
-        stall = keepalive * 3 + 30 (matches the legacy watchdog heuristics)
+    If WATCHDOG_STALL_SEC is unset we derive it from the watchdog check cadence:
+        stall = check * 3 + 30 (matches the legacy watchdog heuristics)
     """
 
     override = os.getenv("WATCHDOG_STALL_SEC")
     if override is not None:
-        fallback = default if default is not None else get_keepalive_interval_sec() * 3 + 30
+        fallback = default if default is not None else get_watchdog_check_sec() * 3 + 30
         return _coerce_int(override, fallback)
 
-    keepalive = get_keepalive_interval_sec()
-    derived = keepalive * 3 + 30
+    check = get_watchdog_check_sec()
+    derived = check * 3 + 30
     if default is not None:
         return derived if derived else default
     return derived

--- a/modules/coreops/cog.py
+++ b/modules/coreops/cog.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 from config.runtime import (
     get_env_name, get_bot_name, get_command_prefix,
-    get_keepalive_interval_sec, get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
+    get_watchdog_check_sec, get_watchdog_stall_sec, get_watchdog_disconnect_grace_sec,
 )
 from shared import socket_heartbeat as hb
 from shared.coreops_render import (
@@ -61,7 +61,7 @@ class CoreOps(commands.Cog):
         uptime = _uptime_sec(self.bot)
         latency = _latency_sec(self.bot)
         last_age = await hb.age_seconds()
-        keepalive = get_keepalive_interval_sec()
+        check_interval = get_watchdog_check_sec()
         stall = get_watchdog_stall_sec()
         dgrace = get_watchdog_disconnect_grace_sec(stall)
 
@@ -72,7 +72,7 @@ class CoreOps(commands.Cog):
             uptime_sec=uptime,
             latency_s=latency,
             last_event_age=last_age,
-            keepalive_sec=keepalive,
+            watchdog_check_sec=check_interval,
             stall_after_sec=stall,
             disconnect_grace_sec=dgrace,
         )

--- a/shared/config.py
+++ b/shared/config.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_port",
     "get_env_name",
     "get_bot_name",
-    "get_keepalive_interval_sec",
+    "get_watchdog_check_sec",
     "get_watchdog_stall_sec",
     "get_watchdog_disconnect_grace_sec",
     "get_command_prefix",
@@ -74,7 +74,7 @@ def _int_set(raw: str) -> Set[int]:
 
 
 def _load_config() -> Dict[str, object]:
-    keepalive = _runtime.get_keepalive_interval_sec()
+    check = _runtime.get_watchdog_check_sec()
     stall = _runtime.get_watchdog_stall_sec()
     disconnect_grace = _runtime.get_watchdog_disconnect_grace_sec(stall)
 
@@ -103,7 +103,7 @@ def _load_config() -> Dict[str, object]:
         "ENV_NAME": _runtime.get_env_name(),
         "BOT_NAME": _runtime.get_bot_name(),
         "COMMAND_PREFIX": _runtime.get_command_prefix(),
-        "KEEPALIVE_INTERVAL_SEC": keepalive,
+        "WATCHDOG_CHECK_SEC": check,
         "WATCHDOG_STALL_SEC": stall,
         "WATCHDOG_DISCONNECT_GRACE_SEC": disconnect_grace,
         "ADMIN_IDS": _runtime.get_admin_ids(),
@@ -159,11 +159,9 @@ def get_bot_name(default: str = "C1C-Recruitment") -> str:
     return str(value) if isinstance(value, str) and value else default
 
 
-def get_keepalive_interval_sec(
-    default_prod: int = 360, default_nonprod: int = 60
-) -> int:
-    fallback = _runtime.get_keepalive_interval_sec(default_prod, default_nonprod)
-    return int(_CONFIG.get("KEEPALIVE_INTERVAL_SEC", fallback))
+def get_watchdog_check_sec(default: int = 30) -> int:
+    fallback = _runtime.get_watchdog_check_sec(default)
+    return int(_CONFIG.get("WATCHDOG_CHECK_SEC", fallback))
 
 
 def get_watchdog_stall_sec(default: Optional[int] = None) -> int:

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -21,7 +21,7 @@ def build_health_embed(
     uptime_sec: float,
     latency_s: float|None,
     last_event_age: float,
-    keepalive_sec: int,
+    watchdog_check_sec: int,
     stall_after_sec: int,
     disconnect_grace_sec: int,
 ) -> discord.Embed:
@@ -32,7 +32,7 @@ def build_health_embed(
 
     e.add_field(name="latency", value=("—" if latency_s is None else f"{latency_s*1000:.0f} ms"), inline=True)
     e.add_field(name="last event", value=f"{int(last_event_age)} s", inline=True)
-    e.add_field(name="keepalive", value=f"{keepalive_sec}s", inline=True)
+    e.add_field(name="watchdog check", value=f"{watchdog_check_sec}s", inline=True)
 
     e.add_field(name="stall after", value=f"{stall_after_sec}s", inline=True)
     e.add_field(name="disconnect grace", value=f"{disconnect_grace_sec}s", inline=True)
@@ -50,7 +50,7 @@ def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str
     e.add_field(name="config", value=f"{src} ({status})", inline=True)
     # Show a few safe vars for sanity (no secrets)
     safe = []
-    for k in ("COMMAND_PREFIX", "KEEPALIVE_INTERVAL_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
+    for k in ("COMMAND_PREFIX", "WATCHDOG_CHECK_SEC", "WATCHDOG_STALL_SEC", "WATCHDOG_DISCONNECT_GRACE_SEC"):
         v = os.getenv(k)
         if v:
             safe.append(f"{k}={v}")

--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -19,7 +19,7 @@ from shared.config import (
     get_port,
     get_env_name,
     get_bot_name,
-    get_keepalive_interval_sec,
+    get_watchdog_check_sec,
     get_watchdog_stall_sec,
     get_watchdog_disconnect_grace_sec,
     get_log_channel_id,
@@ -166,7 +166,7 @@ class Runtime:
 
     async def _health_payload(self) -> tuple[dict, bool]:
         stall = get_watchdog_stall_sec()
-        keepalive = get_keepalive_interval_sec()
+        check_interval = get_watchdog_check_sec()
         snapshot = hb.snapshot()
         age = snapshot.last_event_age
         healthy = age <= stall
@@ -177,7 +177,7 @@ class Runtime:
             "version": os.getenv("BOT_VERSION", "dev"),
             "age_seconds": round(age, 3),
             "stall_after_sec": stall,
-            "keepalive_sec": keepalive,
+            "watchdog_check_sec": check_interval,
             "connected": snapshot.connected,
             "disconnect_age": (
                 None if snapshot.disconnect_age is None else round(snapshot.disconnect_age, 3)
@@ -232,7 +232,7 @@ class Runtime:
         disconnect_grace: Optional[int] = None,
         delay_sec: float = 0.0,
     ) -> tuple[bool, int, int, int]:
-        check = check_sec or get_keepalive_interval_sec()
+        check = check_sec or get_watchdog_check_sec()
         stall = stall_sec or get_watchdog_stall_sec()
         disconnect = disconnect_grace or get_watchdog_disconnect_grace_sec(stall)
 


### PR DESCRIPTION
## Summary
- replace the keepalive runtime helper with a watchdog check interval that reads WATCHDOG_CHECK_SEC
- propagate the new getter through shared config/runtime helpers and CoreOps health rendering
- update health payload metadata to report watchdog_check_sec instead of keepalive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eeae46dd608323bb742a7274acda96