### PR TITLE
Remove legacy keepalive interval fallback

### DIFF
--- a/config/runtime.py
+++ b/config/runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 # config/runtime.py
-import logging
 import os
 from typing import Iterable, List, Optional
 
@@ -65,8 +64,7 @@ def get_watchdog_check_sec(
 
     Priority order:
         1. WATCHDOG_CHECK_SEC (primary)
-        2. KEEPALIVE_INTERVAL_SEC (deprecated; emits warning)
-        3. Defaults: prod-like envs → 360s, non-prod envs → 60s
+        2. Defaults: prod-like envs → 360s, non-prod envs → 60s
     """
 
     env = get_env_name().lower()
@@ -75,20 +73,6 @@ def get_watchdog_check_sec(
     override = os.getenv("WATCHDOG_CHECK_SEC")
     if override is not None:
         return _coerce_int(override, fallback)
-
-    legacy = os.getenv("KEEPALIVE_INTERVAL_SEC")
-    if legacy is not None:
-        try:
-            legacy_val = int(legacy)
-        except (TypeError, ValueError):
-            pass
-        else:
-            logging.getLogger("c1c.config").warning(
-                "KEEPALIVE_INTERVAL_SEC is deprecated; use WATCHDOG_CHECK_SEC instead. "
-                "Using legacy value %ss.",
-                legacy_val,
-            )
-            return legacy_val
 
     return fallback
 


### PR DESCRIPTION
## Summary
- drop the deprecated KEEPALIVE_INTERVAL_SEC fallback in the runtime watchdog interval helper
- remove the unused logging import that only supported the legacy path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eebbb114248323a8532bad69063be5