### PR TITLE
Adjust watchdog check fallback

### DIFF
--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -232,7 +232,7 @@ class Runtime:
         disconnect_grace: Optional[int] = None,
         delay_sec: float = 0.0,
     ) -> tuple[bool, int, int, int]:
-        check = check_sec or get_watchdog_check_sec()
+        check = check_sec if check_sec is not None else get_watchdog_check_sec()
         stall = stall_sec or get_watchdog_stall_sec()
         disconnect = disconnect_grace or get_watchdog_disconnect_grace_sec(stall)
 


### PR DESCRIPTION
## Summary
- ensure the runtime watchdog only falls back to configuration defaults when the caller does not supply an explicit interval override

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eec9a188a883239196cd5631e324d7