### PR TITLE
Fix milestone helper parameter naming

### DIFF
--- a/.github/workflows/auto-pr-admin.yml
+++ b/.github/workflows/auto-pr-admin.yml
@@ -98,16 +98,16 @@ jobs:
             }
 
             // ---- Ensure milestone exists -------------------------------------
-            const getOrCreateMilestone = async (title) => {
+            const getOrCreateMilestone = async (msTitle) => {
               // Try open first, then all
               let ms = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: "open", per_page: 100 });
-              let found = ms.find(m => m.title === title);
+              let found = ms.find(m => m.title === msTitle);
               if (!found) {
                 ms = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: "all", per_page: 100 });
-                found = ms.find(m => m.title === title);
+                found = ms.find(m => m.title === msTitle);
               }
               if (found) return found;
-              const { data } = await github.rest.issues.createMilestone({ owner, repo, title });
+              const { data } = await github.rest.issues.createMilestone({ owner, repo, title: msTitle });
               return data;
             };
 


### PR DESCRIPTION
## Summary
- rename the auto PR admin milestone helper parameter to avoid shadowing the outer constant
- ensure the created milestone uses the new parameter name when calling the GitHub API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef72d907648323a8d48abddfa3f5a7