### PR TITLE
Phase 3 · PR-1: Async Sheets wrappers (+ async backoff) — non-breaking

### DIFF
--- a/shared/sheets/async_core.py
+++ b/shared/sheets/async_core.py
@@ -70,6 +70,9 @@ async def _retry_with_backoff_async(
             # Execute the sync function in a thread
             return await asyncio.to_thread(func, *args, **kwargs)
         except BaseException as e:  # gspread raises various exceptions
+            # Respect task cancellation — don't swallow CancelledError
+            if isinstance(e, asyncio.CancelledError):
+                raise
             last_exc = e
             if attempt >= max_attempts:
                 break


### PR DESCRIPTION
## Summary
- add shared.sheets.async_core with asyncio.to_thread wrappers around the existing sync sheets client
- provide async retry helper that performs backoff using asyncio.sleep to avoid blocking the event loop
- expose async variants for open_by_key, get_worksheet, fetch_records, fetch_values, and call_with_backoff while leaving existing callers untouched

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef814369948323a994339ea4193fd9