### PR TITLE
Phase 3 · PR-3: Shared CoreOps refresh commands (admin + staff)

### DIFF
--- a/shared/coreops_refresh.py
+++ b/shared/coreops_refresh.py
@@ -13,11 +13,23 @@ from typing import Optional
 import discord
 from discord.ext import commands
 
-from .coreops_rbac import is_admin, is_staff
+from .coreops_rbac import is_admin_member, is_staff_member
 from .sheets import cache_service
 
 UTC = dt.timezone.utc
 _CACHE = cache_service.cache
+
+# --- RBAC decorator wrappers (use coreops_rbac helpers) ----------------------
+
+def is_admin():
+    return commands.check(lambda ctx: is_admin_member(getattr(ctx, "author", None)))
+
+def is_staff():
+    # Staff includes admins
+    return commands.check(
+        lambda ctx: is_staff_member(getattr(ctx, "author", None))
+        or is_admin_member(getattr(ctx, "author", None))
+    )
 
 # --- helpers ---------------------------------------------------------
 


### PR DESCRIPTION
Adds shared CoreOps commands to refresh cached Google Sheets data.
- Admin: !refresh all (alias: !rec refresh all)
- Staff: !rec refresh clansinfo (if bot_info cache older than 60min)
- All refreshes use shared.sheets.cache_service and log to LOG_CHANNEL_ID.
- Commands available to every bot importing shared.coreops_refresh.


------
https://chatgpt.com/codex/tasks/task_e_68efa903f8a88323bfee2c38c9fa281e