### PR TITLE
Use onboarding helper for welcome watcher

### DIFF
--- a/sheets/onboarding.py
+++ b/sheets/onboarding.py
@@ -98,6 +98,12 @@ def _promo_tab() -> str:
     )
 
 
+def _resolve_onboarding_and_welcome_tab() -> tuple[str, str]:
+    """Return the onboarding sheet ID and configured welcome tab name."""
+
+    return _sheet_id(), _welcome_tab()
+
+
 def _clanlist_tab() -> str:
     return _config_lookup("clanlist_tab", "ClanList") or "ClanList"
 


### PR DESCRIPTION
## Summary
- resolve the onboarding sheet ID and welcome tab via the onboarding helper when enabling the welcome watcher
- allow the watcher base class to accept a tab override so the configured tab name is used in logs
- expose a helper in sheets.onboarding that returns the onboarding sheet ID and welcome tab name together

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68efd84c34988323ad4dde247697e811