### PR TITLE
Refactor CoreOps refresh command groups

### DIFF
--- a/shared/sheets/cache_service.py
+++ b/shared/sheets/cache_service.py
@@ -137,3 +137,8 @@ class CacheService:
             pass
 
 cache = CacheService()
+
+
+def capabilities() -> Dict[str, Dict[str, Any]]:
+    """Expose cache capabilities for convenience imports."""
+    return cache.capabilities()


### PR DESCRIPTION
## Summary
- convert the refresh command entry points into explicit admin and recruitment command groups
- enumerate cache buckets from the cache service capabilities and trigger refreshes via the public API
- expose a cache_service.capabilities() helper for callers that only import the module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efdb56e5508323a3ca684018a4353c