### PR TITLE
Clarify staff_only Administrator fallback docstring

### DIFF
--- a/recruitment/welcome.py
+++ b/recruitment/welcome.py
@@ -11,7 +11,10 @@ from sheets.recruitment import get_cached_welcome_templates
 
 
 def staff_only() -> commands.check:
-    """Allow staff/admin via CoreOps roles with Discord Administrator fallback."""
+    """
+    Allow staff/admin via CoreOps roles. Also allow Discord 'Administrator'
+    permission as fallback (useful on fresh/dev guilds).
+    """
 
     async def predicate(ctx: commands.Context) -> bool:
         author = getattr(ctx, "author", None)


### PR DESCRIPTION
## Summary
- clarify the staff_only helper docstring to explicitly mention the Administrator fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efecaadb2c832393d56585c5749e8e