### PR TITLE
Make coreops refresh setup async

### DIFF
--- a/shared/coreops_refresh.py
+++ b/shared/coreops_refresh.py
@@ -126,5 +126,5 @@ class CoreOpsRefresh(commands.Cog):
 
 # --- setup ------------------------------------------------------------
 
-def setup(bot: commands.Bot):
-    bot.add_cog(CoreOpsRefresh(bot))
+async def setup(bot: commands.Bot):
+    await bot.add_cog(CoreOpsRefresh(bot))


### PR DESCRIPTION
## Summary
- update the CoreOpsRefresh cog setup to use the asynchronous discord.py interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68effa37287c83239ef84185c0e3adb7