### PR TITLE
CoreOps: explicit disable when admin roles not configured (+ boot warning)

### DIFF
--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -378,6 +378,16 @@ class Runtime:
                     ]
                 },
             )
+            try:
+                from shared.coreops_rbac import admin_roles_configured  # type: ignore
+
+                if callable(admin_roles_configured) and not admin_roles_configured():  # type: ignore
+                    await self.send_log_message(
+                        "[coreops] warning: admin refresh commands disabled — ADMIN_ROLE_IDS not configured"
+                    )
+            except Exception:
+                # Probe unavailable or errored; ignore to avoid noisy boot logs
+                pass
         except Exception:
             log.exception("failed to load coreops refresh commands")
 


### PR DESCRIPTION
## Summary
- add a probe helper that checks for ADMIN_ROLE_IDS configuration (with safe fallbacks)
- guard admin refresh commands so they short-circuit with a clear message when admin roles are missing
- emit a boot-time warning when admin roles are unconfigured to explain why the commands are disabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f00dc57af88323987ea8260e24d09a