### PR TITLE
Refactor auto-label workflow to use PR metadata

### DIFF
--- a/.github/workflows/auto-pr-admin.yml
+++ b/.github/workflows/auto-pr-admin.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
@@ -14,109 +14,172 @@ jobs:
     if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: true
       - name: Apply labels and milestone
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
+            const core = require('@actions/core');
+            const fs = require('fs');
+            const path = require('path');
+            const { execFileSync } = require('child_process');
 
-            // ---- Settings ----------------------------------------------------
-            const MILESTONE_TITLE = "Harmonize v1.0";
+            const DEFAULT_MILESTONE = 'Harmonize v1.0';
+            const LABELS_RELATIVE_PATH = '.github/labels/labels.json';
+            const labelsPath = path.join(process.env.GITHUB_WORKSPACE, LABELS_RELATIVE_PATH);
 
-            // Canonical labels from your repo (name -> {color, description})
-            const CANON = {
-              "comp:data-sheets": { color: "168700", description: "Google Sheets schema, reads/writes, adapters" },
-              "comp:cache":       { color: "0e8a16", description: "Caching layers / TTL / cold start" },
-              "config":           { color: "006b75", description: "Env vars, toggles, YAML/JSON config, secrets" },
-              "data":             { color: "168700", description: "Sheets schema, caching, adapters, migrations" },
-              "docs":             { color: "0b75a8", description: "README, guides, runbooks" },
-              "bug":              { color: "d73a4a", description: "Broken behavior or incorrect output" },
-              "bot:welcomecrew":  { color: "0052cc", description: "WelcomeCrew bot" },
-              "bot:matchmaker":   { color: "0052cc", description: "Matchmaker bot" }
-            };
+            const want = new Set(['bot:matchmaker', 'bot:welcomecrew']);
 
-            // ---- Collect desired labels --------------------------------------
-            const want = new Set(["comp:data-sheets","comp:cache","config","data"]);
-
-            const title = pr.title.toLowerCase();
-            const headRef = pr.head.ref.toLowerCase();
-
-            // Heuristic: bug vs docs
-            if (title.startsWith("fix:") || title.includes("[fix]")) {
-              want.add("bug");
+            const title = (pr.title || '').trim();
+            if (/^AUDIT:/i.test(title)) {
+              want.add('AUDIT');
             }
 
-            // Determine changed files to detect docs-only PRs
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: pr.number, per_page: 100
-            });
-
-            const nonDocsChanged = files.some(f => {
-              const p = (f.filename || "").toLowerCase();
-              const isDoc = p.startsWith("docs/") || p.endsWith(".md") || p.endsWith(".mdx") || p === "readme.md";
-              return !isDoc;
-            });
-
-            if (!nonDocsChanged) {
-              want.add("docs");
+            let milestoneTitle = DEFAULT_MILESTONE;
+            const body = pr.body || '';
+            const metaMatch = body.match(/\[meta\]([\s\S]*?)\[\/meta\]/i);
+            if (metaMatch) {
+              const metaBlock = metaMatch[1];
+              const labelsMatch = metaBlock.match(/^\s*labels:\s*(.+)$/im);
+              if (labelsMatch) {
+                labelsMatch[1]
+                  .split(',')
+                  .map(label => label.trim())
+                  .filter(Boolean)
+                  .forEach(label => want.add(label));
+              }
+              const milestoneMatch = metaBlock.match(/^\s*milestone:\s*(.+)$/im);
+              if (milestoneMatch) {
+                const extracted = milestoneMatch[1].trim();
+                if (extracted) {
+                  milestoneTitle = extracted;
+                }
+              }
             }
 
-            // Heuristic: bot labels by branch/title
-            if (headRef.includes("welcome") || title.includes("welcome")) {
-              want.add("bot:welcomecrew");
-            }
-            if (headRef.includes("matchmaker") || title.includes("matchmaker")) {
-              want.add("bot:matchmaker");
+            if (!milestoneTitle) {
+              milestoneTitle = DEFAULT_MILESTONE;
             }
 
-            // ---- Ensure labels exist (create if missing) ---------------------
             const ensureLabel = async (name) => {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name });
-              } catch (e) {
-                if (e.status === 404) {
-                  const spec = CANON[name] || { color: "cccccc", description: "" };
-                  await github.rest.issues.createLabel({
-                    owner, repo, name, color: spec.color, description: spec.description
-                  });
-                } else {
-                  throw e;
+                return;
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
                 }
+              }
+
+              let spec = { color: 'cccccc', description: '' };
+              let attemptedSync = false;
+              let syncFailed = false;
+
+              try {
+                let existing = [];
+                try {
+                  const raw = await fs.promises.readFile(labelsPath, 'utf8');
+                  existing = JSON.parse(raw);
+                  if (!Array.isArray(existing)) {
+                    throw new Error('labels.json must contain an array');
+                  }
+                } catch (readError) {
+                  if (readError.code !== 'ENOENT') {
+                    attemptedSync = true;
+                    throw readError;
+                  }
+                  existing = [];
+                }
+
+                const already = existing.find(label => label.name === name);
+                if (already) {
+                  spec = {
+                    color: already.color || 'cccccc',
+                    description: already.description || ''
+                  };
+                } else {
+                  attemptedSync = true;
+                  existing.push({ name, color: spec.color, description: spec.description });
+                  existing.sort((a, b) => a.name.localeCompare(b.name));
+                  await fs.promises.mkdir(path.dirname(labelsPath), { recursive: true });
+                  await fs.promises.writeFile(labelsPath, JSON.stringify(existing, null, 2) + '\n');
+
+                  try {
+                    execFileSync('git', ['config', 'user.name', 'github-actions[bot]']);
+                    execFileSync('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
+                    execFileSync('git', ['add', LABELS_RELATIVE_PATH]);
+                    execFileSync('git', ['commit', '-m', `ci: sync labels.json (auto-create ${name})`]);
+                    execFileSync('git', ['push', 'origin', `HEAD:${pr.head.ref}`]);
+                  } catch (gitError) {
+                    syncFailed = true;
+                    core.warning(`Failed to sync labels.json for ${name}: ${gitError.message}`);
+                  }
+                }
+              } catch (fileError) {
+                syncFailed = true;
+                core.warning(`Unable to update labels.json for ${name}: ${fileError.message}`);
+              }
+
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color: spec.color, description: spec.description });
+              } catch (createError) {
+                if (createError.status !== 422) {
+                  throw createError;
+                }
+              }
+
+              if (attemptedSync && syncFailed) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: `Label '${name}' auto-created via API. Please run label sync to update .github/labels/labels.json.`
+                });
               }
             };
 
-            for (const name of want) {
-              await ensureLabel(name);
+            for (const label of want) {
+              await ensureLabel(label);
             }
 
-            // ---- Apply labels (merge, don't replace) -------------------------
             if (want.size > 0) {
               await github.rest.issues.addLabels({
-                owner, repo, issue_number: pr.number, labels: Array.from(want)
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: Array.from(want)
               });
             }
 
-            // ---- Ensure milestone exists -------------------------------------
             const getOrCreateMilestone = async (msTitle) => {
-              // Try open first, then all
-              let ms = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: "open", per_page: 100 });
-              let found = ms.find(m => m.title === msTitle);
+              let milestones = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: 'open', per_page: 100 });
+              let found = milestones.find(m => m.title === msTitle);
               if (!found) {
-                ms = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: "all", per_page: 100 });
-                found = ms.find(m => m.title === msTitle);
+                milestones = await github.paginate(github.rest.issues.listMilestones, { owner, repo, state: 'all', per_page: 100 });
+                found = milestones.find(m => m.title === msTitle);
               }
-              if (found) return found;
+              if (found) {
+                return found;
+              }
               const { data } = await github.rest.issues.createMilestone({ owner, repo, title: msTitle });
               return data;
             };
 
-            const milestone = await getOrCreateMilestone(MILESTONE_TITLE);
+            const milestone = await getOrCreateMilestone(milestoneTitle || DEFAULT_MILESTONE);
 
-            // ---- Attach milestone to PR (PRs are issues underneath) ----------
             await github.rest.issues.update({
-              owner, repo, issue_number: pr.number, milestone: milestone.number
+              owner,
+              repo,
+              issue_number: pr.number,
+              milestone: milestone.number
             });
 
-            core.info(`Applied labels: ${Array.from(want).join(", ")}`);
-            core.info(`Set milestone: ${MILESTONE_TITLE}`);
+            core.info(`Applied labels: ${Array.from(want).join(', ')}`);
+            core.info(`Set milestone: ${milestone.title}`);


### PR DESCRIPTION
## Summary
- update the auto-label workflow to parse PR body metadata for desired labels and milestone
- ensure bot and AUDIT labels are applied, creating missing labels and syncing labels.json when possible
- add checkout and write permissions so the workflow can commit label metadata and apply milestones reliably

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f0ea808e008323a93b62464c8ab41f