### PR TITLE
Fix core redeclaration in auto PR admin workflow

### DIFF
--- a/.github/workflows/auto-pr-admin.yml
+++ b/.github/workflows/auto-pr-admin.yml
@@ -26,7 +26,6 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
-            const core = require('@actions/core');
             const fs = require('fs');
             const path = require('path');
             const { execFileSync } = require('child_process');


### PR DESCRIPTION
## Summary
- remove the redundant core require from the PR admin workflow so github-script globals are used

## Testing
- not run (workflow change)

[meta]
labels: devx, infra, P1, severity:low
milestone: Harmonize v1.0
[/meta]


------
https://chatgpt.com/codex/tasks/task_e_68f0f3336e2883238184d764cca48270