### PR TITLE
Runtime: add gspread to enable templates refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.9.3] — Phase 3 rollout (Shared CoreOps refresh)
 
 - CoreOps: unify refresh commands in shared cog; removed duplicate definitions.
+- Runtime: add gspread dependency to enable templates bucket refresh.
 
 ## [0.9.2] — Phase 2 complete (Per-Environment Configuration)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Core libs
 discord.py>=2.3,<3
 aiohttp>=3.13,<4
+gspread>=5,<6


### PR DESCRIPTION
## Summary
- add the gspread dependency to the runtime requirements to support templates cache refresh
- document the new runtime dependency in the changelog

## Testing
- not run (not requested)

[meta]
labels: infra, comp:data-sheets, comp:cache, P1, severity:medium
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f0fb8a242083239a4f0f4232bd496f