### PR TITLE
Update CoreOps health next refresh display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - CoreOps: unify refresh commands in shared cog; removed duplicate definitions.
 - Runtime: add gspread dependency to enable templates bucket refresh.
 - Cache: improved refresh failure diagnostics — both first and retry errors are logged.
+- Health: 'next' now shows full UTC date + time (YYYY-MM-DD HH:MM UTC).
 
 ## [0.9.2] — Phase 2 complete (Per-Environment Configuration)
 

--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -174,7 +174,7 @@ class CoreOpsCog(commands.Cog):
             next_text = "-"
             if isinstance(next_refresh, dt.datetime):
                 nr = next_refresh if next_refresh.tzinfo else next_refresh.replace(tzinfo=UTC)
-                next_text = nr.astimezone(UTC).strftime("%H:%M UTC")
+                next_text = nr.astimezone(UTC).strftime("%Y-%m-%d %H:%M UTC")
 
             embed.add_field(
                 name=bucket,


### PR DESCRIPTION
## Summary
- display full UTC date and time for CoreOps health embed bucket refresh schedule
- document the health embed change in the changelog entry for v0.9.3

## Testing
- not run (not requested)

[meta]
labels: docs, observability, comp:health, P3, severity:low
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f114bdd06883238215a468bf701e07