### PR TITLE
Normalize CoreOps RBAC gating for ops commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from shared.coreops_rbac import (
     get_admin_role_ids,
     get_staff_role_ids,
     is_admin_member,
+    ops_gate,
 )
 
 logging.basicConfig(
@@ -177,7 +178,7 @@ async def on_message(message: discord.Message):
     )
 
     cmd_name = detect_admin_bang_command(
-        message, commands=COREOPS_COMMANDS, is_admin=is_admin_member
+        message, commands=COREOPS_COMMANDS, is_admin=ops_gate
     )
     if cmd_name:
         ctx = await bot.get_context(message)


### PR DESCRIPTION
## Summary
- add a reusable ops gate in `shared/coreops_rbac.py` that honors admin/staff roles, Manage Server/Administrator permissions, clean DM denials, and throttled logging
- apply the new `guild_only_denied_msg` + `ops_only` decorators to CoreOps env/config/refresh commands so destructive actions share the same guild-only RBAC gate and Manage Server fallback
- switch the admin bang shortcut detector in `app.py` to the shared ops gate so Manage Server members without configured roles can still invoke the commands

## Testing
- `pytest`
- Manual matrix (simulated via helper checks):
  | Context | Member (no roles) | Manage Server | Staff/Admin role |
  | --- | --- | --- | --- |
  | Guild | "Staff only." denial + log | ✅ runs | ✅ runs |
  | DM | "This command can only be used in servers." | same | same |

## Files Changed
- app.py
- shared/coreops_cog.py
- shared/coreops_rbac.py


------
https://chatgpt.com/codex/tasks/task_e_68f12b8665c883238f757714b66546c1