### PR TITLE
Standardize CoreOps embed headers and footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Phase 3: Sheets Access Layer + CoreOps Refresh
 – !health embed now displays cache ages, TTLs, and next refresh times (UTC date + time).
 – Refresher telemetry captures retry counts and error text across attempts.
 – Enhanced observability for manual vs scheduled triggers.
+– Embeds standardized: versions moved to footer; inline date/time removed (embed timestamp used).
 
 • Runtime Reliability
 – Gspread dependency added to enable template bucket refresh.

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -60,7 +60,8 @@ Infra must provide reliable runtime, deployment, and observability surfaces whil
 
 ## Change Management
 - Backwards-compatible env keys; no behavior changes without CHANGELOG entry.
-- Timezone in help footer: Europe/Vienna with UTC fallback.
+- Embed footer standardized: `Bot vX.Y.Z · CoreOps vA.B.C` (Discord timestamp replaces
+  inline timezone text).
 
 ---
 

--- a/docs/ops_coreops.md
+++ b/docs/ops_coreops.md
@@ -32,8 +32,9 @@ Admins can use the `!health`, `!env`, `!digest`, `!help`, and `!ping` aliases wi
 
 - **Access** — Admin roles take precedence; Administrator permission is a fallback when
   no configured role is present. Direct messages receive a friendly denial.
-- **Embed header** — `Bot Name · Version · ENV_NAME`, with a UTC timestamp footer and
-  `values from ENV and Sheet Config` label.
+- **Embed header** — `Bot Name · env: ENV_NAME · Guild: …`. Versions now live in the
+  shared footer (`Bot vX.Y.Z · CoreOps vA.B.C • source: ENV + Sheet Config`) with the
+  embed timestamp set to the current time.
 - **Environment table** — Reads the cached runtime config keys plus relevant environment
   variables, masking secrets (keeps the last four characters) and resolving guild,
   channel, and role IDs using a 10-minute in-memory cache. Missing lookups render as
@@ -72,12 +73,19 @@ Phase 3b shared Ops work resumes after this fix, once refresh command coverage i
 
   ```
   Cache
-  clans: age 00:47:12 • TTL 03:00:00 • next 2025-10-16 18:00 UTC
-  templates: age 05d 04:00 • TTL 07d 00:00 • next 2025-10-20 06:00 UTC
+  clans: age 47m • TTL 3h • next in 2h
+  templates: age 5d • TTL 7d • next overdue by 6h
   ```
 - **Digest** — One-line summary: bot version, watchdog state, last heartbeat age.
-- **Help footer** — `Bot v{BOT_VERSION} • CoreOps v1.0.0 • 2025-10-14 12:00 Vienna` (falls
-  back to UTC if the Vienna timezone is unavailable).
+- **Help footer** — `Bot v{BOT_VERSION} · CoreOps v1.0.0` (timestamp supplied by the
+  embed).
+
+## Embed footer
+
+All CoreOps/admin embeds share the same footer format: `Bot v{BOT_VERSION} · CoreOps
+v1.0.0` plus optional notes (e.g., ` • source: ENV + Sheet Config`). Absolute timestamps
+are no longer printed inline; rely on the embed timestamp Discord displays beneath the
+message.
 
 ## Common issues
 1. **Prefix mismatch** — Ensure commands start with `!rec`, `rec`, or a bot mention. Admin

--- a/modules/coreops/README.md
+++ b/modules/coreops/README.md
@@ -43,9 +43,10 @@ These shortcuts require the Admin role and map to the same CoreOps command handl
 `!ping` is available because it is included in the default `COREOPS_COMMANDS` list for
 this release.
 
-## Help footer timezone
-The help embed footer displays: `Bot v{BOT_VERSION} • CoreOps v1.0.0 • <time>`. The bot
-uses Europe/Vienna time when tzdata is available and falls back to UTC if it is not.
+## Embed footer
+All CoreOps/admin embeds share the footer `Bot v{BOT_VERSION} · CoreOps v1.0.0` with
+optional notes (for example, ` • source: ENV + Sheet Config`). Discord shows the
+timestamp automatically; no inline datetime is appended to the footer text.
 
 ## Troubleshooting
 Use this checklist if CoreOps feels unresponsive:

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -1,7 +1,12 @@
 # shared/coreops_render.py
 from __future__ import annotations
-import os, platform, time
+import datetime as dt
+import os
+import platform
+import time
 import discord
+
+from shared.help import build_coreops_footer
 
 def _hms(seconds: float) -> str:
     s = int(max(0, seconds))
@@ -38,7 +43,9 @@ def build_health_embed(
     e.add_field(name="disconnect grace", value=f"{disconnect_grace_sec}s", inline=True)
     e.add_field(name="pid", value=str(os.getpid()), inline=True)
 
-    e.set_footer(text=f"{platform.system()} {platform.release()}")
+    footer_notes = f" • {platform.system()} {platform.release()}"
+    e.set_footer(text=build_coreops_footer(bot_version=version, notes=footer_notes))
+    e.timestamp = dt.datetime.now(dt.timezone.utc)
     return e
 
 def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str, object]) -> discord.Embed:
@@ -55,4 +62,6 @@ def build_env_embed(*, bot_name: str, env: str, version: str, cfg_meta: dict[str
         if v:
             safe.append(f"{k}={v}")
     e.add_field(name="settings", value="\n".join(safe) if safe else "—", inline=False)
+    e.set_footer(text=build_coreops_footer(bot_version=version))
+    e.timestamp = dt.datetime.now(dt.timezone.utc)
     return e

--- a/shared/help.py
+++ b/shared/help.py
@@ -1,25 +1,27 @@
 # shared/help.py
 from __future__ import annotations
 import discord
-from datetime import datetime
-from zoneinfo import ZoneInfo
+import datetime as dt
+
+COREOPS_VERSION = "1.0.0"
 
 
-def _vienna_now_str() -> str:
-    """Return 'YYYY-MM-DD HH:MM Europe/Vienna' (fallback to UTC on any issue)."""
-    try:
-        if ZoneInfo is not None:
-            tz = ZoneInfo("Europe/Vienna")
-            return datetime.now(tz).strftime("%Y-%m-%d %H:%M Europe/Vienna")
-    except Exception:
-        pass
-    # Fallback (should rarely happen)
-    return datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+def build_coreops_footer(
+    *, bot_version: str, coreops_version: str = COREOPS_VERSION, notes: str | None = None
+) -> str:
+    footer = f"Bot v{bot_version} · CoreOps v{coreops_version}"
+    if notes:
+        trimmed = notes.strip()
+        if trimmed:
+            # Preserve the caller's chosen separator (bullet, middot, etc.).
+            footer = f"{footer}{notes}"
+    return footer
 
 
 def build_help_footer(*, bot_version: str) -> str:
-    footer_time = _vienna_now_str()
-    return f"Bot v{bot_version} • CoreOps v1.0.0 • {footer_time}"
+    """Backward-compatible alias for callers expecting the legacy name."""
+
+    return build_coreops_footer(bot_version=bot_version)
 
 
 def build_help_embed(*, prefix: str, is_staff: bool, bot_version: str) -> discord.Embed:
@@ -39,6 +41,7 @@ def build_help_embed(*, prefix: str, is_staff: bool, bot_version: str) -> discor
     e.add_field(name="Everyone", value=fmt(user_cmds) or "—", inline=False)
     if is_staff:
         e.add_field(name="Staff", value=fmt(staff_cmds) or "—", inline=False)
-    footer_text = build_help_footer(bot_version=bot_version)
+    footer_text = build_coreops_footer(bot_version=bot_version)
     e.set_footer(text=footer_text)
+    e.timestamp = dt.datetime.now(dt.timezone.utc)
     return e


### PR DESCRIPTION
## Summary
- centralize the CoreOps embed footer builder and add shared timestamp handling
- remove inline datetime strings from health/env outputs while keeping relative durations
- document the updated embed footer conventions across CoreOps references

## Testing
- pytest

[meta]
labels: P3, comp:commands, devx, docs, bot:matchmaker, bot:welcomecrew, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f1612aff708323a085501f591d8451