### PR TITLE
Summarize refresh all into single embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Phase 3: Sheets Access Layer + CoreOps Refresh
 – Admin and Staff roles now use !rec refresh all and !rec refresh clansinfo.
 – RBAC guard logic preserved; clear permission errors surfaced.
 – Refresher logs record bucket, trigger, actor, duration, result, error.
+– `!rec refresh all` now posts a single summary embed listing all buckets with duration/result/retries.
 
 • Diagnostics & Health
 – !health embed now displays cache ages, TTLs, and next refresh times (UTC date + time).

--- a/shared/sheets/cache_service.py
+++ b/shared/sheets/cache_service.py
@@ -19,8 +19,16 @@ Loader = Callable[[], Awaitable[Any]]
 
 class CacheBucket:
     __slots__ = (
-        "name", "ttl_sec", "loader", "value", "last_refresh",
-        "refreshing", "last_latency_ms", "last_result", "last_error",
+        "name",
+        "ttl_sec",
+        "loader",
+        "value",
+        "last_refresh",
+        "refreshing",
+        "last_latency_ms",
+        "last_result",
+        "last_error",
+        "last_retries",
     )
     def __init__(self, name: str, ttl_sec: int, loader: Loader):
         self.name = name
@@ -32,6 +40,7 @@ class CacheBucket:
         self.last_latency_ms: Optional[int] = None
         self.last_result: Optional[str] = None
         self.last_error: Optional[str] = None
+        self.last_retries: int = 0
 
     def age_sec(self) -> Optional[int]:
         if not self.last_refresh:
@@ -146,6 +155,7 @@ class CacheService:
             b.last_latency_ms = rt.monotonic_ms() - t0
             b.last_result = result
             b.last_error = err_text
+            b.last_retries = retries
             await self._log_refresh(b, trigger=trigger, actor=actor, retries=retries)
             # clear marker
             b.refreshing = None


### PR DESCRIPTION
## Summary
- replace the refresh-all command chatter with a single embed that summarizes each bucket outcome
- capture duration, retries, and error data after every manual refresh and render it in a tabular embed field
- record the new behavior in the changelog and persist retry counts in cache buckets for reporting

## Testing
- not run (not requested)

[meta]
labels: P2, comp:commands, observability, comp:cache, bot:matchmaker, bot:welcomecrew, ready
milestone: Harmonize v1.0
[/meta]


------
https://chatgpt.com/codex/tasks/task_e_68f166e012c08323ad35db4c2abe19ce