### PR TITLE
Add help command parity with health

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ from shared.coreops_rbac import (
     is_admin_member,
     ops_gate,
 )
-from shared.redaction import sanitize_text
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -171,12 +170,6 @@ async def on_message(message: discord.Message):
     )
 
     content = (message.content or "").strip()
-    if content.lower() == "!help" and not ops_gate(message.author):
-        try:
-            await message.channel.send(str(sanitize_text("Use !rec help")))
-        except Exception:
-            pass
-        return
 
     cmd_name = detect_admin_bang_command(
         message, commands=COREOPS_COMMANDS, is_admin=ops_gate

--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -415,6 +415,26 @@ class CoreOpsCog(commands.Cog):
             return
         await ctx.send(str(sanitize_text("Use !rec help")))
 
+    async def _help_impl(self, ctx: commands.Context) -> None:
+        bot_name = get_bot_name()
+        env = get_env_name()
+        version = os.getenv("BOT_VERSION", "dev")
+
+        description = (
+            "CoreOps provides staff-only operational insights and controls for our "
+            f"{env} deployment. Use `!rec <command>` to access grouped tools such as "
+            "health, digest, and env."
+        )
+
+        embed = discord.Embed(
+            title=f"{bot_name} · help",
+            colour=discord.Color.blurple(),
+            description=description,
+        )
+        embed.set_footer(text=build_coreops_footer(bot_version=version))
+
+        await ctx.reply(embed=sanitize_embed(embed))
+
     async def _health_impl(self, ctx: commands.Context) -> None:
         env = get_env_name()
         bot_name = get_bot_name()
@@ -484,10 +504,20 @@ class CoreOpsCog(commands.Cog):
     async def rec_health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
 
+    @rec.command(name="help")
+    @staff_only()
+    async def rec_help(self, ctx: commands.Context) -> None:
+        await self._help_impl(ctx)
+
     @commands.command(name="health", hidden=True)
     @staff_only()
     async def health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
+
+    @commands.command(name="help", hidden=True)
+    @staff_only()
+    async def help(self, ctx: commands.Context) -> None:
+        await self._help_impl(ctx)
 
     async def _digest_impl(self, ctx: commands.Context) -> None:
         line = build_digest_line(


### PR DESCRIPTION
## Summary
- add a staff-gated help command that mirrors health routing and embed usage
- remove the custom message hook so !help shares the admin dispatcher path with !health

## Testing
- not run (not requested)

[meta]
labels: commands, comp:ops-contract, P2
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f23c99c2e8832388a17825b27a073e