### PR TITLE
Fix help command dispatch and reuse renderer

### DIFF
--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -414,26 +414,6 @@ class CoreOpsCog(commands.Cog):
             return
         await ctx.send(str(sanitize_text("Use !rec help")))
 
-    async def _help_impl(self, ctx: commands.Context) -> None:
-        bot_name = get_bot_name()
-        env = get_env_name()
-        version = os.getenv("BOT_VERSION", "dev")
-
-        description = (
-            "CoreOps provides staff-only operational insights and controls for our "
-            f"{env} deployment. Use `!rec <command>` to access grouped tools such as "
-            "health, digest, and env."
-        )
-
-        embed = discord.Embed(
-            title=f"{bot_name} · help",
-            colour=discord.Color.blurple(),
-            description=description,
-        )
-        embed.set_footer(text=build_coreops_footer(bot_version=version))
-
-        await ctx.reply(embed=sanitize_embed(embed))
-
     async def _health_impl(self, ctx: commands.Context) -> None:
         env = get_env_name()
         bot_name = get_bot_name()
@@ -503,22 +483,11 @@ class CoreOpsCog(commands.Cog):
     async def rec_health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
 
-    @rec.command(name="help")
-    @staff_only()
-    async def rec_help(self, ctx: commands.Context) -> None:
-        await self._help_impl(ctx)
-
     @commands.command(name="health", hidden=True)
     @guild_only_denied_msg()
     @admin_only()
     async def health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
-
-    @commands.command(name="help", hidden=True)
-    @guild_only_denied_msg()
-    @admin_only()
-    async def help(self, ctx: commands.Context) -> None:
-        await self._help_impl(ctx)
 
     async def _digest_impl(self, ctx: commands.Context) -> None:
         line = build_digest_line(
@@ -590,16 +559,13 @@ class CoreOpsCog(commands.Cog):
     async def env(self, ctx: commands.Context) -> None:
         await self._env_impl(ctx)
 
-    @commands.command(name="help")
-    @guild_only_denied_msg()
-    @admin_only()
-    async def help_(
-        self, ctx: commands.Context, *, query: str | None = None
-    ) -> None:
-        await self._render_help(ctx, query=query)
-
     @rec.command(name="help")
     async def rec_help(
+        self, ctx: commands.Context, *, query: str | None = None
+    ) -> None:
+        await self.render_help(ctx, query=query)
+
+    async def render_help(
         self, ctx: commands.Context, *, query: str | None = None
     ) -> None:
         await self._render_help(ctx, query=query)


### PR DESCRIPTION
## Summary
- remove the duplicate top-level help command and expose a reusable renderer
- update the admin bang dispatcher to route !help queries through the shared renderer

## Testing
- python -m compileall app.py shared/coreops_cog.py

[meta]
labels: commands, comp:ops-contract, robustness, P1
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f248794d0c832397a00db83497b274