### PR TITLE
Preserve command tiers across discord.py cloning

### DIFF
--- a/shared/coreops/helpers/tiers.py
+++ b/shared/coreops/helpers/tiers.py
@@ -1,11 +1,67 @@
-"""Helper for assigning visibility tiers to commands for dynamic help rendering."""
+"""
+Tier tagging for commands that survives discord.py command cloning.
 
+We store the tier in three places:
+1) cmd.extras["tier"]           — preserved by discord.py copy()
+2) cmd._tier                    — convenient attribute for current object
+3) _TIER_REGISTRY[qualified]    — fallback registry, rehydrated after cogs load
+"""
 
-def tier(level: str):
-    """Attach a visibility tier for help rendering ('user', 'staff', 'admin')."""
+from typing import Callable, Dict
+
+# Qualified name -> tier (e.g., "rec help", "health")
+_TIER_REGISTRY: Dict[str, str] = {}
+
+def _set_tier(cmd, level: str):
+    # Extras is stable across Command.copy() since discord.py 2.x.
+    try:
+        extras = getattr(cmd, "extras", None)
+        if isinstance(extras, dict):
+            extras["tier"] = level
+    except Exception:
+        pass
+    # Also stamp an attribute for convenience on the current object.
+    try:
+        setattr(cmd, "_tier", level)
+    except Exception:
+        pass
+
+    # Record in registry using the current qualified_name if available.
+    qn = getattr(cmd, "qualified_name", None) or getattr(cmd, "name", None)
+    if isinstance(qn, str):
+        _TIER_REGISTRY[qn] = level
+
+def tier(level: str) -> Callable:
+    """Decorator: attach a visibility tier ('user' | 'staff' | 'admin') to a command."""
 
     def wrapper(cmd):
-        cmd._tier = level
+        _set_tier(cmd, level)
         return cmd
 
     return wrapper
+
+def rehydrate_tiers(bot) -> None:
+    """
+    Reapply tiers to commands after cogs/extensions load.
+    Useful because Command.copy() can drop ad-hoc attributes.
+    """
+    for cmd in bot.walk_commands():
+        # Prefer extras if already present
+        level = None
+        try:
+            extras = getattr(cmd, "extras", None)
+            if isinstance(extras, dict):
+                level = extras.get("tier")
+        except Exception:
+            level = None
+
+        if not level:
+            # Fallback to registry by qualified_name, then name.
+            qn = getattr(cmd, "qualified_name", None)
+            if qn and qn in _TIER_REGISTRY:
+                level = _TIER_REGISTRY[qn]
+            elif getattr(cmd, "name", None) in _TIER_REGISTRY:
+                level = _TIER_REGISTRY[getattr(cmd, "name")]
+
+        if level:
+            _set_tier(cmd, level)

--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -139,6 +139,19 @@ def _admin_roles_configured() -> bool:
         return True
 
 
+def _get_cmd_tier(cmd: commands.Command[Any, Any, Any]) -> str:
+    level: Optional[str] = None
+    try:
+        extras = getattr(cmd, "extras", None)
+        if isinstance(extras, dict):
+            level = extras.get("tier")
+    except Exception:
+        level = None
+    if not level:
+        level = getattr(cmd, "_tier", None)
+    return level or "user"
+
+
 def _admin_check() -> commands.Check[Any]:
     async def predicate(ctx: commands.Context) -> bool:
         if not _admin_roles_configured():
@@ -878,7 +891,7 @@ class CoreOpsCog(commands.Cog):
             seen.add(base_name)
             if not await self._can_display_command(command, ctx):
                 continue
-            level = getattr(command, "_tier", "user")
+            level = _get_cmd_tier(command)
             if level not in grouped:
                 level = "user"
             grouped[level].append(command)

--- a/shared/runtime.py
+++ b/shared/runtime.py
@@ -27,6 +27,7 @@ from shared.config import (
     get_refresh_times,
     get_refresh_timezone,
 )
+from shared.coreops.helpers.tiers import rehydrate_tiers
 
 log = logging.getLogger("c1c.runtime")
 
@@ -364,6 +365,7 @@ class Runtime:
     async def start(self, token: str) -> None:
         await self.start_webserver()
         await self.load_extensions()
+        rehydrate_tiers(self.bot)
         from shared.sheets.cache_scheduler import schedule_default_jobs
 
         schedule_default_jobs(self)


### PR DESCRIPTION
## Summary
- replace the tier decorator helper with a registry-backed implementation that records tier metadata in command extras
- refresh command tier metadata after extensions load to ensure cloned commands retain their tier
- read tiers from command extras in the help renderer so grouping survives command cloning

## Testing
- pytest

[meta]
labels: commands, comp:ops-contract, devx, robustness, P1
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f26cfba0f88323b0138a7b77a47fe6