### PR TITLE
Retag CoreOps admin commands and polish help output

### DIFF
--- a/recruitment/welcome.py
+++ b/recruitment/welcome.py
@@ -36,12 +36,12 @@ class WelcomeBridge(commands.Cog):
         self.bot = bot
 
     @tier("staff")
-    @commands.command(name="welcome")
+    @commands.command(name="welcome", usage="[clan] @mention")
     @staff_only()
     async def welcome(self, ctx: commands.Context, clan: Optional[str] = None, *, note: Optional[str] = None):
         """
         Post a templated welcome. Template rows are read from the cached 'templates' bucket.
-        Usage: !welcome <CLAN_TAG> [note...]
+        Usage: !welcome [CLAN] @mention
         """
         templates = get_cached_welcome_templates()
         if not templates:

--- a/shared/help.py
+++ b/shared/help.py
@@ -60,8 +60,14 @@ def build_help_overview_embed(
     )
 
     description_lines = [bot_description.strip()]
-    tip_usage = _format_usage(prefix, "help", "<command>")
-    description_lines.append(f"Tip: Use {tip_usage} for an extended description.")
+    usage_all = _format_usage(prefix, "help", None)
+    usage_command = _format_usage(prefix, "help", "<command>")
+    usage_subcommand = _format_usage(prefix, "help", "<command> <subcommand>")
+    description_lines.append(
+        "Usage: "
+        f"`{usage_all}` • `{usage_command}` • `{usage_subcommand}`"
+    )
+    description_lines.append("Tip: Use the forms above for an extended description.")
     embed.description = "\n\n".join(line for line in description_lines if line)
 
     for section in sections:


### PR DESCRIPTION
## Summary
- retag !rec health, !rec refresh, and !rec refresh all to display under the admin tier while keeping clansinfo staff-only
- update the help overview copy to highlight explicit !rec help usage forms and deduplicate commands across tiers
- align the welcome command help usage with the expected `!welcome [clan] @mention` format

## Testing
- pytest

[meta]
labels: commands, comp:ops-contract, devx, P2
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f27c75f82483239e365e5311b19d1d