### PR TITLE
Fix !rec help permission spam

### DIFF
--- a/recruitment/welcome.py
+++ b/recruitment/welcome.py
@@ -19,6 +19,8 @@ def staff_only():
         # CoreOps roles OR server Administrator (fallback)
         if is_staff_member(author) or is_admin_member(author):
             return True
+        if getattr(ctx, "_coreops_suppress_denials", False):
+            raise commands.CheckFailure("Staff only.")
         try:
             await ctx.reply("Staff only.")
         except Exception:

--- a/shared/coreops_rbac.py
+++ b/shared/coreops_rbac.py
@@ -111,6 +111,18 @@ def is_admin_member(target: ContextOrMember | None) -> bool:
     return _has_administrator_permission(member)
 
 
+def can_view_admin(target: ContextOrMember | None) -> bool:
+    """Return True if the target should see admin-tier commands."""
+
+    return is_admin_member(target)
+
+
+def can_view_staff(target: ContextOrMember | None) -> bool:
+    """Return True if the target should see staff-tier commands."""
+
+    return bool(is_staff_member(target) or is_admin_member(target))
+
+
 def is_recruiter(target: ContextOrMember | None) -> bool:
     member = _resolve_member(target)
     if member is None:


### PR DESCRIPTION
## Summary
- add silent can_view_admin/can_view_staff helpers for RBAC checks
- update CoreOps help rendering to rely on pure visibility checks and respect suppression flags
- suppress staff-only deny messages when help rendering inspects restricted commands

## Testing
- pytest
[meta]
labels: commands, comp:ops-contract, robustness, P1
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f280b445a08323979a9e749bce5085