### PR TITLE
docs: clarify watcher vs cron terminology

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -1,38 +1,45 @@
 # Configuration Reference — Phase 3b
 
 ## Environment keys
-| Group | Key | Description |
-| --- | --- | --- |
-| Core | `DISCORD_TOKEN` | Bot token for the Discord application (masked in logs). |
-| Core | `ENV_NAME` | Environment label (`dev`, `test`, `prod`). |
-| Core | `GUILD_IDS` | Comma-separated guild IDs allowed to load the bot. |
-| Core | `TIMEZONE` | Olson timezone used for embeds and scheduling. |
-| Core | `REFRESH_TIMES` | Optional daily refresh windows (HH:MM, comma separated). |
-| Sheets | `GSPREAD_CREDENTIALS` | Base64-encoded service-account JSON. |
-| Sheets | `RECRUITMENT_SHEET_ID` | Google Sheet ID for recruitment data. |
-| Sheets | `ONBOARDING_SHEET_ID` | Google Sheet ID for onboarding trackers. |
-| Roles | `ADMIN_ROLE_IDS` | CSV of admin role IDs with elevated access. |
-| Roles | `STAFF_ROLE_IDS` | CSV of staff role IDs (welcome + refresh tools). |
-| Roles | `RECRUITER_ROLE_IDS` | CSV of recruiter role IDs (panels, digests). |
-| Roles | `LEAD_ROLE_IDS` | CSV of lead roles for escalations. |
-| Channels | `RECRUITERS_THREAD_ID` | Thread receiving recruitment updates. |
-| Channels | `WELCOME_GENERAL_CHANNEL_ID` | Public welcome channel ID (optional). |
-| Channels | `WELCOME_CHANNEL_ID` | Private welcome ticket channel ID. |
-| Channels | `PROMO_CHANNEL_ID` | Promo ticket channel ID. |
-| Channels | `LOG_CHANNEL_ID` | Primary log channel ID (#bot-production). |
-| Channels | `NOTIFY_CHANNEL_ID` | Fallback alert channel ID. |
-| Channels | `NOTIFY_PING_ROLE_ID` | Role pinged for urgent alerts. |
-| Toggles | `WELCOME_ENABLED` | Enables welcome command + watchers. |
-| Toggles | `ENABLE_WELCOME_WATCHER` | Enables welcome watcher hooks. |
-| Toggles | `ENABLE_PROMO_WATCHER` | Enables promo watcher hooks. |
-| Toggles | `ENABLE_NOTIFY_FALLBACK` | Sends alerts to fallback channel when true. |
-| Toggles | `STRICT_PROBE` | Enforces guild allow-list before startup completes. |
-| Toggles | `SEARCH_RESULTS_SOFT_CAP` | Soft limit on search results per query. |
-| Watchdog | `WATCHDOG_CHECK_SEC` | Interval between watchdog polls. |
-| Watchdog | `WATCHDOG_STALL_SEC` | Connected stall threshold in seconds. |
-| Watchdog | `WATCHDOG_DISCONNECT_GRACE_SEC` | Disconnect grace period before restart. |
-| Cache | `CLAN_TAGS_CACHE_TTL_SEC` | TTL for cached clan tags. |
-| Cleanup | `CLEANUP_AGE_HOURS` | Age threshold for cleanup jobs. |
+| Group | Key | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| Core | `DISCORD_TOKEN` | secret | — | Bot token for the Discord application (masked in logs). |
+| Core | `ENV_NAME` | string | `dev` | Environment label (`dev`, `test`, `prod`). |
+| Core | `GUILD_IDS` | csv | — | Comma-separated guild IDs allowed to load the bot. |
+| Core | `TIMEZONE` | string | `UTC` | Olson timezone used for embeds and scheduling. |
+| Core | `REFRESH_TIMES` | csv | — | Optional daily refresh windows (HH:MM, comma separated). |
+| Sheets | `GSPREAD_CREDENTIALS` | secret | — | Base64-encoded service-account JSON. |
+| Sheets | `RECRUITMENT_SHEET_ID` | string | — | Google Sheet ID for recruitment data. |
+| Sheets | `ONBOARDING_SHEET_ID` | string | — | Google Sheet ID for onboarding trackers. |
+| Roles | `ADMIN_ROLE_IDS` | csv | — | Elevated admin role IDs. |
+| Roles | `STAFF_ROLE_IDS` | csv | — | Staff role IDs (welcome + refresh tools). |
+| Roles | `RECRUITER_ROLE_IDS` | csv | — | Recruiter role IDs (panels, digests). |
+| Roles | `LEAD_ROLE_IDS` | csv | — | Lead role IDs for escalations. |
+| Channels | `RECRUITERS_THREAD_ID` | snowflake | — | Thread receiving recruitment updates. |
+| Channels | `WELCOME_GENERAL_CHANNEL_ID` | snowflake | — | Public welcome channel ID (optional). |
+| Channels | `WELCOME_CHANNEL_ID` | snowflake | — | Private welcome ticket channel ID. |
+| Channels | `PROMO_CHANNEL_ID` | snowflake | — | Promo ticket channel ID. |
+| Channels | `LOG_CHANNEL_ID` | snowflake | — | Primary log channel ID (#bot-production). |
+| Channels | `NOTIFY_CHANNEL_ID` | snowflake | — | Fallback alert channel ID. |
+| Channels | `NOTIFY_PING_ROLE_ID` | snowflake | — | Role pinged for urgent alerts. |
+| Toggles | `WELCOME_ENABLED` | bool | `true` | Enables welcome command plus automation. |
+| Toggles | `ENABLE_NOTIFY_FALLBACK` | bool | `true` | Sends alerts to fallback channel when true. |
+| Toggles | `STRICT_PROBE` | bool | `false` | Enforces guild allow-list before startup completes. |
+| Toggles | `SEARCH_RESULTS_SOFT_CAP` | int | `25` | Soft limit on search results per query. |
+| Watchdog | `WATCHDOG_CHECK_SEC` | int | `30` | Interval between watchdog polls. |
+| Watchdog | `WATCHDOG_STALL_SEC` | int | `45` | Connected stall threshold in seconds. |
+| Watchdog | `WATCHDOG_DISCONNECT_GRACE_SEC` | int | `300` | Disconnect grace period before restart. |
+| Cache | `CLAN_TAGS_CACHE_TTL_SEC` | int | `900` | TTL for cached clan tags. |
+| Cleanup | `CLEANUP_AGE_HOURS` | int | `48` | Age threshold for cleanup jobs. |
+
+### Automation listeners & cron jobs
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `ENABLE_WELCOME_LISTENERS` | bool | `true` | Event listeners for welcomes. Alias (deprecated): `ENABLE_WELCOME_WATCHER`. |
+| `ENABLE_PROMO_LISTENERS` | bool | `true` | Event listeners for promos. Alias (deprecated): `ENABLE_PROMO_WATCHER`. |
+| `CRON_REFRESH_CLAN_TAGS` | cron | `15m` | Scheduled clan tag refresh job (logged as `[cron]`). |
+| `CRON_REFRESH_SHEETS` | cron | `30m` | Sheets sync cadence (logged as `[cron]`). |
+| `CRON_REFRESH_CACHE` | cron | `60m` | Cache warmers and daily roll-up (logged as `[cron]`). |
 
 ## Sheet config tabs
 Both Google Sheets referenced above must expose a `Config` worksheet with **Key** and

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -2,8 +2,16 @@
 
 ## Daily expectations
 - Confirm the bot is online and responding to `!ping` in production.
-- Review scheduled refresh logs (`[refresh]`) for duration anomalies.
+- Review scheduled refresh logs via `[cron]` entries for duration anomalies.
 - Check the welcome and promo ticket channels for stuck threads or duplicate posts.
+
+### Logs to check
+1. `[ops]` — service lifecycle messages (boot, shutdown, deploy tags).
+2. `[watcher]` — event listeners (toggles, hook errors, ticket IDs).
+3. `[cron]` — scheduled jobs (start/result/retry/summary for refresh cycles).
+
+_If `[cron]` lines stop appearing for longer than the configured cadence, assume the
+scheduler is stalled and inspect `/healthz` before triggering manual refresh commands._
 
 ## Deployment checklist
 1. Ship through the Render pipeline (GitHub Actions handles image builds).
@@ -21,7 +29,8 @@
 | Cache stale | Run `!rec refresh all`, confirm `[refresh]` completion | Monitor next scheduled refresh |
 
 ## Logging quick reference
-- `[refresh]` — cache warmers (bucket, actor, duration, result).
+- `[ops]` — deployment lifecycle, watchdog notices, and manual overrides.
+- `[cron]` — cron job lifecycle (start/result/retry/summary, duration, target cache).
 - `[watcher]` — watcher lifecycle messages (toggles, errors, thread IDs).
 - `[command]` — execution context for CoreOps commands (caller, guild, result).
 

--- a/docs/ops/Troubleshooting.md
+++ b/docs/ops/Troubleshooting.md
@@ -1,11 +1,17 @@
 # Troubleshooting & Redaction — Phase 3b
 
 ## Quick triage
+- **Cron quiet** → confirm the latest `[cron result]` within the expected interval before
+  triggering manual refreshes. If missing, inspect `/healthz` and deployment logs.
 - **Command fails for staff** → confirm roles, then rerun with admin watching logs.
 - **Watcher quiet** → check toggles in `!rec config` and verify `/healthz` for stale
   timestamps.
-- **Cache stale** → run `!rec refresh all`; if it fails, capture the `[refresh]` log.
+- **Cache stale** → run `!rec refresh all`; if it fails, capture the `[cron result]` and
+  `[watcher]` lines around the attempt.
 - **Sheets error** → switch to manual spreadsheet updates and note the outage window.
+
+Refer to the automation keys listed in [`Config.md`](Config.md#automation-listeners--cron-jobs)
+when adjusting cadences or toggles.
 
 ## Redaction policy
 - Secrets display as `(masked)` with only the final four characters visible.
@@ -18,8 +24,9 @@
 - `!health` — Mirrors `/healthz` output in Discord for admins.
 
 ## Log taxonomy
-- `[refresh]` — cache warmers (bucket, trigger, duration, result, error).
+- `[cron]` — scheduled jobs (start/result/retry/summary, duration, error).
 - `[watcher]` — watcher lifecycle notices and failure reports.
+- `[refresh]` — manual cache warmers (bucket, trigger, duration, result, error).
 - `[command]` — RBAC checks and command outcomes.
 
 ## Escalation notes

--- a/docs/ops/Watchers.md
+++ b/docs/ops/Watchers.md
@@ -1,51 +1,71 @@
 # Watchers & Schedules — Phase 3b
 
 ## Overview
-Watchers automate welcome and promo ticket hygiene. They load configuration and Sheets
-references on startup and register only when toggles enable them.
+Watchers coordinate Discord-side automation for recruitment and onboarding. They load
+configuration, warm Sheets caches, then register whichever listeners and cron jobs are
+enabled for the deployment.
+
+## Terminology (important)
+- **Watcher** → *event-driven listener* registered on the Discord gateway. These respond
+  immediately to welcome/promo activity and log using the `[watcher]` prefix.
+- **Cron** → *scheduled job* triggered by the runtime scheduler. Cron runs are logged with
+  the `[cron]` prefix (start/result/retry/summary).
+- Legacy environment keys ending in `_WATCHER` still work but are **deprecated**. Prefer
+  the new `*_LISTENERS` and `CRON_*` keys documented in [`Config.md`](Config.md).
 
 ## Load order
 1. `shared.config` — env snapshot (IDs, toggles, sheet metadata).
 2. `shared.runtime` — logging, scheduler, watchdog wiring.
 3. `shared.sheets.core` — Google API client + worksheet cache.
 4. `sheets.recruitment` / `sheets.onboarding` — TTL caches for clan data and templates.
-5. Feature modules — watchers register event hooks and scheduled jobs.
+5. Feature modules — watchers register event hooks and cron jobs based on toggles.
 
 _If steps 1–4 fail, abort boot. If a watcher fails to load, continue without it and emit a
 single structured log._
 
-## Data flows
-- **Reads**: watchers consume clan tags, templates, and ticket rows via Sheets adapters.
-- **Writes**: onboarding watchers write to `WelcomeTickets` / `PromoTickets` using bounded
-  retry helpers that invalidate only the affected cache bucket.
+## Current Watchers (event listeners)
+- **Welcome listeners** (`ENABLE_WELCOME_LISTENERS`) — greet new members, open tickets, and
+  sync sheet rows.
+- **Promo listeners** (`ENABLE_PROMO_LISTENERS`) — track promo requests, tag recruiters, and
+  update onboarding tabs.
+
+Watchers read clan tags, templates, and ticket rows via the Sheets adapters listed above.
+Writes go back to `WelcomeTickets` / `PromoTickets` using bounded retry helpers that
+invalidate only the affected cache bucket. Role gates come from
+`shared.coreops_rbac` (`ADMIN_ROLE_IDS`, `STAFF_ROLE_IDS`, `RECRUITER_ROLE_IDS`,
+`LEAD_ROLE_IDS`).
+
+## Current Cron Jobs (scheduled)
+- **Clan tag refresh** (`CRON_REFRESH_CLAN_TAGS`, default 15m) — invalidates and warms the
+  clan tag cache.
+- **Sheets sync** (`CRON_REFRESH_SHEETS`, default 30m) — reconciles Sheets metadata and logs
+  durations.
+- **Cache warmers** (`CRON_REFRESH_CACHE`, default 60m) — sweeps remaining caches and writes
+  a daily roll-up summary to `[cron]`.
+
+Cron jobs run even if corresponding listeners are disabled (for example, refresh cycles can
+stay active while promo listeners are paused).
 
 ## Caches & invalidation
 - `shared.sheets.core` caches worksheet handles (no TTL).
 - `sheets.recruitment` / `sheets.onboarding` keep TTL caches for values.
 - `!reload` reloads config, clears TTL caches, and can optionally evict worksheet handles.
-- Scheduled refresh (3× daily) clears TTL caches, then warms them.
-
-## Toggles & roles
-| Toggle | Purpose |
-| --- | --- |
-| `WELCOME_ENABLED` | Master enable for welcome command + watchers. |
-| `ENABLE_WELCOME_WATCHER` | Registers welcome watcher hooks when true. |
-| `ENABLE_PROMO_WATCHER` | Registers promo watcher hooks when true. |
-
-Role gates come from `shared.coreops_rbac` using `ADMIN_ROLE_IDS`, `STAFF_ROLE_IDS`,
-`RECRUITER_ROLE_IDS`, and `LEAD_ROLE_IDS`.
+- Cron refreshes clear TTL caches before warming them; manual `!rec refresh` commands share
+  the same helpers.
 
 ## Scheduler responsibilities
-- Sheets refresh cycle (invalidate → warm → log).
-- Daily recruiter digest distribution.
-- Cleanup or hygiene jobs registered by watcher modules.
+- Dispatch cron jobs on their configured cadence and log `[cron start]`, `[cron result]`,
+  `[cron retry]`, and `[cron summary]` events.
+- Deliver the daily recruiter digest.
+- Register cleanup or hygiene jobs supplied by watcher modules.
 
 ## Failure handling & health
 - Read failure → serve stale cache (if present) and log error.
 - Write failure → log structured error (ticket, tab, row, reason) and enqueue bounded
   retry.
-- `/healthz` reports watcher toggle state, last refresh, and watchdog timers.
-- `LOG_CHANNEL_ID` receives all watcher lifecycle logs (`[watcher]`).
+- `/healthz` reports watcher toggle state, last cron run, and watchdog timers.
+- `LOG_CHANNEL_ID` receives all watcher lifecycle logs (`[watcher]`) plus cron notices
+  (`[cron]`).
 
 ---
 


### PR DESCRIPTION
## Summary
- align ops docs on watcher (listener) vs cron (scheduler) terminology and highlight deprecated env aliases
- document new `[cron]` logging expectations across runbook, troubleshooting, and watchers guides
- update architecture legend to call out `[watcher]` and `[cron]` markers in the runtime map

## Testing
- not run (docs-only change)

[meta]
labels: docs, comp:ops-contract, P2
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f36a57b4348323b7e57bed170398ac