### PR TITLE
Add Phase 3 ADR records

### DIFF
--- a/docs/adr/ADR-0000-template.md
+++ b/docs/adr/ADR-0000-template.md
@@ -1,0 +1,19 @@
+# ADR-0000 — Architectural Decision Record Template
+
+- Date: 2025-10-18
+
+## Context
+
+Use this template when documenting a new architectural decision. Summarize the background, constraints, and forces that motivated the decision.
+
+## Decision
+
+Record the chosen direction and the primary rationale. Include a brief list of rejected alternatives when helpful.
+
+## Consequences
+
+Call out follow-up work, trade-offs, and operational impact so future readers understand the implications.
+
+## Status
+
+Draft

--- a/docs/adr/ADR-0001-sheets-access-layer.md
+++ b/docs/adr/ADR-0001-sheets-access-layer.md
@@ -1,0 +1,22 @@
+# ADR-0001 — Sheets Access Layer (Async + Cached)
+
+- Date: 2025-10-18
+
+## Context
+
+Phase 3 introduced a shared asynchronous cache to make Google Sheets access non-blocking across the deployment. The goal was to provide deterministic response times while consolidating telemetry for all Sheets interactions.
+
+## Decision
+
+- All Sheets calls must go through `shared/sheets/cache_service.py`.
+- Caches preload on worker boot and refresh asynchronously.
+- The public API surface remains limited to `capabilities()`, `refresh_now()`, `get_ttl()`, and `get_age()`.
+- Hot paths never await direct Sheets I/O operations.
+
+## Consequences
+
+Adopting the shared cache delivers predictable latency while ensuring a single telemetry source for Sheets usage and refresh health.
+
+## Status
+
+Accepted — 2025-10-18

--- a/docs/adr/ADR-0002-per-environment-configuration.md
+++ b/docs/adr/ADR-0002-per-environment-configuration.md
@@ -1,0 +1,21 @@
+# ADR-0002 — Per-Environment Configuration
+
+- Date: 2025-10-18
+
+## Context
+
+Phase 3 removed hard-coded identifiers so deployments can maintain parity between production and test environments while simplifying secret rotation.
+
+## Decision
+
+- Tokens, guild, channel, role, and Sheet identifiers are sourced from environment variables or `SheetConfig`.
+- `shared/settings.py` centralizes loading and validation.
+- Defaults never assume production values; only safe null fallbacks are permitted.
+
+## Consequences
+
+Deployments become reproducible across environments, and rotating credentials or IDs no longer requires code changes.
+
+## Status
+
+Accepted — 2025-10-18

--- a/docs/adr/ADR-0003-coreops-contract.md
+++ b/docs/adr/ADR-0003-coreops-contract.md
@@ -1,0 +1,36 @@
+# ADR-0003 — CoreOps Contract (Command Surface and Guardrails)
+
+- Date: 2025-10-18
+
+## Context
+
+Phase 3b established a shared CoreOps module to deliver a unified operational surface across all bots.
+
+## Decision
+
+- Supported commands:
+  - `!help`
+  - `!ping`
+  - `!config`
+  - `!digest`
+  - `!health`
+  - `!env`
+  - `!reload`
+  - `!checksheet`
+  - `!refresh all`
+- Cogs export `async def setup(bot)` only.
+- Role-based access control uses decorators from `coreops_rbac.py` (`@ops_only`, `@admin_only`).
+- External I/O is fail-soft; calls log once and never block hot paths.
+- Outputs use the Achievements-bot embed style.
+- No hard-coded identifiers; values are sourced from environment variables or `SheetConfig`.
+- Consumers use only the public cache and Sheets APIs (`capabilities()`, `refresh_now()`).
+- Optional cooldowns (around 30 seconds) may be applied.
+- Absolute timestamps are expressed in UTC.
+
+## Consequences
+
+All bots share the same operational contract, improving consistency and reducing support variance. Feature-specific admin commands within CoreOps were considered but rejected to preserve a common surface.
+
+## Status
+
+Accepted — 2025-10-18

--- a/docs/adr/ADR-0004-ops-command-rbac.md
+++ b/docs/adr/ADR-0004-ops-command-rbac.md
@@ -1,0 +1,21 @@
+# ADR-0004 — Ops Command RBAC and Cooldowns
+
+- Date: 2025-10-18
+
+## Context
+
+Operations commands required consistent security guardrails and rate limiting to prevent spam during incident response.
+
+## Decision
+
+- Standardize `@ops_only()` and `@admin_only()` decorators in `coreops_rbac.py`.
+- Allow an optional `@cooldown()` decorator to reduce repeated command invocations.
+- Source admin role identifiers from environment variables.
+
+## Consequences
+
+Command security is consistent across bots, and audit trails for operational usage are easier to maintain.
+
+## Status
+
+Accepted — 2025-10-18

--- a/docs/adr/ADR-0005-docs-and-pr-metadata-workflow.md
+++ b/docs/adr/ADR-0005-docs-and-pr-metadata-workflow.md
@@ -1,0 +1,21 @@
+# ADR-0005 — Docs and PR Metadata Workflow
+
+- Date: 2025-10-18
+
+## Context
+
+Phase 3b stabilized automation expectations for Codex-generated pull requests and documentation workflows.
+
+## Decision
+
+- Every PR body ends with an exact `[meta] … [/meta]` block.
+- No text may follow the closing tag.
+- ADRs are logged for every architectural or behavior-scope change.
+
+## Consequences
+
+Automation can reliably parse PR metadata for labeling and milestone assignment, and historical decisions remain traceable.
+
+## Status
+
+Accepted — 2025-10-18

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architectural Decision Records
+
+This directory contains the architectural decision records (ADRs) that document significant design and operational choices.
+
+## Index
+
+- [ADR-0000 — Architectural Decision Record Template](ADR-0000-template.md)
+- [ADR-0001 — Sheets Access Layer (Async + Cached)](ADR-0001-sheets-access-layer.md)
+- [ADR-0002 — Per-Environment Configuration](ADR-0002-per-environment-configuration.md)
+- [ADR-0003 — CoreOps Contract (Command Surface and Guardrails)](ADR-0003-coreops-contract.md)
+- [ADR-0004 — Ops Command RBAC and Cooldowns](ADR-0004-ops-command-rbac.md)
+- [ADR-0005 — Docs and PR Metadata Workflow](ADR-0005-docs-and-pr-metadata-workflow.md)


### PR DESCRIPTION
## Summary
- add ADR records for the Phase 3 and 3b architectural decisions
- introduce an ADR template and index in docs/adr/README.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f37f1d57f48323bee9a907059aeaf3