### PR TITLE
Import field for DigestEmbedData timestamp

### DIFF
--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -5,7 +5,7 @@ import datetime as dt
 import os
 import platform
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 import discord


### PR DESCRIPTION
## Summary
- import dataclasses.field alongside dataclass so DigestEmbedData can set default timestamps

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3a5518670832386050f5421113d4b