### PR TITLE
Fix missing DigestCacheSummary reference for !digest

### DIFF
--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -31,12 +31,16 @@ class DigestCacheError:
 
 @dataclass(frozen=True)
 class DigestCacheSummary:
-    total: int | None
-    stale: int | None
-    recent_errors: int | None
-    next_refresh_at: dt.datetime | None
-    next_refresh_delta: int | None
-    errors: Sequence[DigestCacheError]
+    bucket: str = ""
+    ttl: str = ""
+    retries: int = 0
+    last_result: str = ""
+    total: int | None = None
+    stale: int | None = None
+    recent_errors: int | None = None
+    next_refresh_at: dt.datetime | None = None
+    next_refresh_delta: int | None = None
+    errors: Sequence[DigestCacheError] = ()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- add the DigestCacheSummary dataclass fields used by the digest embed to avoid missing references

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3a826f3348323a91bbaafaa334f35