### PR TITLE
Fix digest cache summary dataclass and import for digest command

### DIFF
--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -35,7 +35,11 @@ from shared.config import (
     redact_value,
 )
 from shared.coreops_render import (
+    DigestCacheError,
+    DigestCacheSummary,
+    DigestEmbedData,
     RefreshEmbedRow,
+    build_digest_embed,
     build_digest_line,
     build_health_embed,
     build_refresh_embed,

--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -32,9 +32,10 @@ class DigestCacheError:
 @dataclass(frozen=True)
 class DigestCacheSummary:
     bucket: str = ""
-    ttl: str = ""
+    ttl: str | None = None
     retries: int = 0
-    last_result: str = ""
+    last_result: str | None = None
+    error: str | None = None
     total: int | None = None
     stale: int | None = None
     recent_errors: int | None = None


### PR DESCRIPTION
## Summary
- update the digest cache summary dataclass to include the optional fields used by the digest command
- import the digest embed helpers so the digest command can construct cache summaries without NameError

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3b0bb38b883239cdee40d91ea6d80