### PR TITLE
Remove timestamps from refresh embed

### DIFF
--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -137,7 +137,6 @@ def build_refresh_embed(
     coreops_version: str = COREOPS_VERSION,
     now_utc: dt.datetime | None = None,
 ) -> discord.Embed:
-    timestamp = now_utc or dt.datetime.now(dt.timezone.utc)
     embed = discord.Embed(
         title=f"Refresh • {scope}",
         colour=getattr(discord.Colour, "dark_theme", discord.Colour.dark_teal)(),
@@ -177,13 +176,10 @@ def build_refresh_embed(
         table = "no buckets"
 
     embed.add_field(name="Buckets", value=f"```{table}```", inline=False)
-    footer_notes = f" · total: {total_ms}ms · {timestamp:%Y-%m-%d %H:%M:%S} UTC"
-    embed.timestamp = timestamp
-    embed.set_footer(
-        text=build_coreops_footer(
-            bot_version=bot_version,
-            coreops_version=coreops_version,
-            notes=footer_notes,
-        )
+    footer_text = (
+        f"Bot v{bot_version} · CoreOps v{coreops_version} · total: {total_ms} ms"
+        if bot_version and coreops_version
+        else f"total: {total_ms} ms"
     )
+    embed.set_footer(text=footer_text)
     return embed


### PR DESCRIPTION
## Summary
- stop setting a timestamp on the refresh embed so Discord no longer shows the "Today at" line
- update the refresh footer to only include versions and total duration without a UTC suffix

## Testing
- not run (not requested)

[meta]
labels: bug, commands, comp:ops-contract, P1, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f3beb9de708323850c76b2af904a54