### PR TITLE
Fix DigestSheetsSummary usage in digest command

### DIFF
--- a/shared/coreops_render.py
+++ b/shared/coreops_render.py
@@ -65,13 +65,12 @@ class DigestCacheSummary:
 
 @dataclass(frozen=True)
 class DigestSheetsSummary:
-    last_success_age: int | None
-    latency_ms: int | None
-    retries: int | None
-    next_refresh_at: dt.datetime | None
-    next_refresh_delta: int | None
-    last_error: str | None
-    last_result: str | None
+    # Keep fields optional so we can fail-soft if any signal isn't available
+    last_success: str | None = None
+    last_error: str | None = None
+    latency_ms: int | None = None
+    retries: int | None = None
+    next_refresh: str | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- define DigestSheetsSummary with optional fail-soft fields in the render helpers
- compute human-readable sheet cache summary strings and import the dataclass in the CoreOps cog

## Testing
- not run (not requested)

[meta]
labels: bug, commands, comp:ops-contract, P1, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f3cdeb43a083238df6c4693d5e50f6