### PR TITLE
Replace staff-only RBAC decorator with ops-only

### DIFF
--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -66,7 +66,6 @@ from .coreops_rbac import (
     is_admin_member,
     is_staff_member,
     ops_only,
-    staff_only,
 )
 
 UTC = dt.timezone.utc
@@ -245,22 +244,6 @@ def _staff_check() -> commands.Check[Any]:
     async def predicate(ctx: commands.Context) -> bool:
         author = getattr(ctx, "author", None)
         return bool(is_staff_member(author) or is_admin_member(author))
-
-    return commands.check(predicate)
-
-
-def staff_only() -> commands.Check[Any]:
-    async def predicate(ctx: commands.Context) -> bool:
-        author = getattr(ctx, "author", None)
-        if is_staff_member(author) or is_admin_member(author):
-            return True
-        if getattr(ctx, "_coreops_suppress_denials", False):
-            raise commands.CheckFailure("Staff only.")
-        try:
-            await ctx.reply("Staff only.")
-        except Exception:
-            pass
-        raise commands.CheckFailure("Staff only.")
 
     return commands.check(predicate)
 
@@ -711,7 +694,7 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @rec.command(name="health")
-    @staff_only()
+    @ops_only()
     async def rec_health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
 
@@ -974,7 +957,7 @@ class CoreOpsCog(commands.Cog):
     @tier("staff")
     @rec.command(name="checksheet")
     @guild_only_denied_msg()
-    @staff_only()
+    @ops_only()
     async def rec_checksheet(self, ctx: commands.Context) -> None:
         await self._checksheet_impl(ctx)
 
@@ -1113,7 +1096,7 @@ class CoreOpsCog(commands.Cog):
 
     @tier("staff")
     @rec.command(name="digest")
-    @staff_only()
+    @ops_only()
     async def rec_digest(self, ctx: commands.Context) -> None:
         await self._digest_impl(ctx)
 


### PR DESCRIPTION
## Summary
- drop the unused `staff_only` helper and stop importing the nonexistent decorator from `coreops_rbac`
- gate staff-facing CoreOps commands with the shared `ops_only` RBAC decorator so ops can still run them

## Testing
- not run (not requested)

[meta]
labels: bug, comp:ops-contract, commands, P1, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f40ef36b6483238a6ab5f48a3659ed