### PR TITLE
Fix CoreOps staff checks to use ops_only decorator

### DIFF
--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -66,7 +66,6 @@ from .coreops_rbac import (
     is_admin_member,
     is_staff_member,
     ops_only,
-    staff_only,
 )
 
 UTC = dt.timezone.utc
@@ -958,7 +957,7 @@ class CoreOpsCog(commands.Cog):
     @tier("staff")
     @rec.command(name="checksheet")
     @guild_only_denied_msg()
-    @staff_only()
+    @ops_only()
     async def rec_checksheet(self, ctx: commands.Context) -> None:
         await self._checksheet_impl(ctx)
 


### PR DESCRIPTION
## Summary
- replace the CoreOps staff decorator import with ops_only to match the available RBAC helpers
- gate the recruitment checksheet command with ops_only so the bot starts successfully

## Testing
- not run (not requested)

[meta]
labels: bug, comp:ops-contract, commands, P1, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f4139f9a7c8323aba7e1fe69ed533c