### PR TITLE
Help: move !checksheet to Admin (grouping only)

### DIFF
--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -2363,6 +2363,13 @@ class CoreOpsCog(commands.Cog):
             if not await self._can_display_command(command, ctx):
                 continue
             level = _get_tier(command)
+            metadata = (
+                lookup_help_metadata(command.qualified_name)
+                or lookup_help_metadata(command.name)
+                or None
+            )
+            if metadata and metadata.tier:
+                level = metadata.tier
             if level not in grouped:
                 level = "user"
             grouped[level].append(command)

--- a/shared/help.py
+++ b/shared/help.py
@@ -141,7 +141,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
             "⚠️ If you use `checksheet` without the prefix, all bots with the same command will answer. Always use `!rec checksheet`.\n"
             "Tip: Quick sanity check before troubleshooting a missing clan."
         ),
-        tier="staff",
+        tier="admin",
     ),
     "rec checksheet": _metadata(
         short="Shows loaded tabs and headers.",


### PR DESCRIPTION
# Help: move `!checksheet` to Admin (grouping only)

## What
- Re-group `!checksheet` under **Admin** in the main help embed.
- Keep `!rec checksheet` under **Recruiter/Staff**.
- No RBAC or command behavior changes; detailed help remains the same.

## Why
`!checksheet` inspects diagnostic state and was meant to be admin-gated. The main help list was showing it in the Staff section, which didn’t match the contract.

## Acceptance
- `!rec help` shows:
  - **Admin**: includes `!checksheet`.
  - **Recruiter/Staff**: includes `!rec checksheet` (not `!checksheet`).
- `!help checksheet` and `!rec help checksheet` still render Usage + Detailed text.
- No new env or sheet keys.

[meta]
labels: commands, devx, comp:ops-contract, P2, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f4d42ad2448323af4959a1c0ced77c