### PR TITLE
Scheduler: align cron cadences (clans=3h, templates/clan_tags=7d) + boot scheduling logs

### DIFF
--- a/shared/sheets/cache_scheduler.py
+++ b/shared/sheets/cache_scheduler.py
@@ -2,84 +2,256 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
-from typing import Awaitable, Callable, List
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from modules.coreops.cronlog import cron_task
+
+from shared.cache import telemetry as cache_telemetry
+from shared.cache.telemetry import RefreshResult
+from shared.config import get_config_snapshot
+from shared.coreops_cog import resolve_ops_log_channel_id
 
 from .cache_service import cache
 from .. import runtime as rt
 
 UTC = dt.timezone.utc
+log = logging.getLogger("c1c.cache.scheduler")
 
 
-CRON_JOB_NAMES = [
+CRON_JOB_NAMES: Tuple[str, ...] = (
     "refresh_clans",
     "refresh_templates",
     "refresh_clan_tags",
-]
+)
 
 
-async def _safe_refresh(bucket: str, *, trigger: str) -> None:
-    try:
-        await cache.refresh_now(bucket, trigger=trigger)
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:  # pragma: no cover - defensive guard
-        await rt.send_log_message(
-            f"[refresh] bucket={bucket} trigger={trigger} unexpected_error={exc}"
-        )
+@dataclass(frozen=True)
+class _JobSpec:
+    bucket: str
+    interval: dt.timedelta
+    cadence_label: str
 
 
-def _every_three_hours_utc() -> List[str]:
-    return [f"{hour:02d}:00" for hour in range(0, 24, 3)]
+_JOB_SPECS: Tuple[_JobSpec, ...] = (
+    _JobSpec(bucket="clans", interval=dt.timedelta(hours=3), cadence_label="3h"),
+    _JobSpec(bucket="templates", interval=dt.timedelta(days=7), cadence_label="7d"),
+    _JobSpec(bucket="clan_tags", interval=dt.timedelta(days=7), cadence_label="7d"),
+)
+
+_SPEC_BY_BUCKET: Dict[str, _JobSpec] = {spec.bucket: spec for spec in _JOB_SPECS}
+_REGISTERED: Dict[str, Tuple[Any, asyncio.Task]] = {}
 
 
-def _if_monday(fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:
-    async def _wrapped() -> None:
-        now = dt.datetime.now(UTC)
-        if now.weekday() == 0:  # Monday
-            await fn()
-
-    return _wrapped
+def _format_exception(exc: BaseException) -> str:
+    message = str(exc).strip().strip("\"")
+    if message:
+        return f"{type(exc).__name__}: {message}"
+    return type(exc).__name__
 
 
-@cron_task("refresh_clans")
-async def _scheduled_refresh_clans() -> None:
-    await _safe_refresh("clans", trigger="schedule")
-
-
-@cron_task("refresh_templates")
-async def _scheduled_refresh_templates() -> None:
-    await _safe_refresh("templates", trigger="schedule")
-
-
-@cron_task("refresh_clan_tags")
-async def _scheduled_refresh_clan_tags() -> None:
-    await _safe_refresh("clan_tags", trigger="schedule")
-
-
-def schedule_default_jobs(runtime: "rt.Runtime") -> None:
+def _ensure_cache_registration() -> None:
     if cache.get_bucket("clans") is None or cache.get_bucket("templates") is None:
         from sheets import recruitment  # noqa: F401  # ensures cache registration
 
     if cache.get_bucket("clan_tags") is None:
         from sheets import onboarding  # noqa: F401  # ensures cache registration
+def _safe_bucket(name: str) -> str:
+    cleaned = name.strip()
+    if not cleaned:
+        raise ValueError("bucket name must be non-empty")
+    return cleaned
 
-    runtime.schedule_at_times(
-        _scheduled_refresh_clans,
-        times=_every_three_hours_utc(),
-        timezone="UTC",
-        name="sheets_cache_clans",
+
+async def _send_ops_message(runtime: "rt.Runtime", message: str) -> None:
+    content = message.strip()
+    if not content:
+        return
+    snapshot = get_config_snapshot()
+    channel_id = resolve_ops_log_channel_id(bot=runtime.bot, snapshot=snapshot)
+    if not channel_id:
+        log.info("[cron] ops channel missing: %s", content)
+        return
+    try:
+        await runtime.bot.wait_until_ready()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        pass
+    channel = runtime.bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await runtime.bot.fetch_channel(channel_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.warning("[cron] ops channel fetch failed: %s", _format_exception(exc))
+            channel = None
+    if channel is None:
+        log.info("[cron] ops channel unavailable: %s", content)
+        return
+    try:
+        await channel.send(content)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        log.warning("[cron] ops channel send failed: %s", _format_exception(exc))
+
+
+def _format_duration(duration_ms: Optional[int]) -> int:
+    if duration_ms is None:
+        return 0
+    try:
+        return int(duration_ms)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _format_retries(value: Optional[int]) -> int:
+    if value is None:
+        return 0
+    try:
+        retries = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, retries)
+
+
+def _format_cache_message(bucket: str, result: RefreshResult) -> str:
+    status = "OK" if result.ok else "FAIL"
+    duration = _format_duration(result.duration_ms)
+    retries = _format_retries(result.retries)
+    parts = [f"[cache] {bucket} — {status}", f"• {duration}ms", f"• retries={retries}"]
+    if not result.ok:
+        err = (result.error or "").strip()
+        if err:
+            parts.append(f"• err={err}")
+    return " ".join(parts)
+
+
+async def _run_refresh(runtime: "rt.Runtime", spec: _JobSpec) -> None:
+    bucket = _safe_bucket(spec.bucket)
+    try:
+        result = await cache_telemetry.refresh_now(name=bucket, actor="cron")
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log.exception("[cron] refresh job crashed", extra={"bucket": bucket})
+        await _send_ops_message(
+            runtime,
+            f"[cache] {bucket} — FAIL • 0ms • retries=0 • err={_format_exception(exc)}",
+        )
+    else:
+        await _send_ops_message(runtime, _format_cache_message(bucket, result))
+
+
+@cron_task("refresh_clans")
+async def _cron_refresh_clans(runtime: "rt.Runtime") -> None:
+    await _run_refresh(runtime, _SPEC_BY_BUCKET["clans"])
+
+
+@cron_task("refresh_templates")
+async def _cron_refresh_templates(runtime: "rt.Runtime") -> None:
+    await _run_refresh(runtime, _SPEC_BY_BUCKET["templates"])
+
+
+@cron_task("refresh_clan_tags")
+async def _cron_refresh_clan_tags(runtime: "rt.Runtime") -> None:
+    await _run_refresh(runtime, _SPEC_BY_BUCKET["clan_tags"])
+
+
+_JOB_HANDLERS = {
+    "clans": _cron_refresh_clans,
+    "templates": _cron_refresh_templates,
+    "clan_tags": _cron_refresh_clan_tags,
+}
+
+
+def _ensure_job(runtime: "rt.Runtime", spec: _JobSpec):
+    bucket = _safe_bucket(spec.bucket)
+    existing = _REGISTERED.get(bucket)
+    if existing:
+        job, task = existing
+        if task.done():
+            _REGISTERED.pop(bucket, None)
+        else:
+            return job
+    interval_seconds = spec.interval.total_seconds()
+    job = runtime.scheduler.every(
+        seconds=interval_seconds,
+        tag="cache",
+        name=f"cache_refresh:{bucket}",
     )
-    runtime.schedule_at_times(
-        _if_monday(_scheduled_refresh_templates),
-        times=["06:00"],
-        timezone="UTC",
-        name="sheets_cache_templates",
-    )
-    runtime.schedule_at_times(
-        _if_monday(_scheduled_refresh_clan_tags),
-        times=["06:10"],
-        timezone="UTC",
-        name="sheets_cache_clan_tags",
+
+    handler = _JOB_HANDLERS[bucket]
+
+    async def runner() -> None:
+        await handler(runtime)
+
+    task = job.do(runner)
+    _REGISTERED[bucket] = (job, task)
+    log.info("[cron] registered job: %s interval=%s", job.name or bucket, spec.cadence_label)
+    return job
+
+
+def _format_next_run(job: Any) -> str:
+    next_run = getattr(job, "next_run", None)
+    if next_run is None:
+        return "pending"
+    try:
+        as_utc = next_run.astimezone(UTC)
+    except Exception:
+        return "pending"
+    return as_utc.replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
+
+
+async def _emit_schedule_log(
+    runtime: "rt.Runtime",
+    successes: Iterable[Tuple[_JobSpec, Any]],
+    failure: Optional[Tuple[str, BaseException]],
+) -> None:
+    try:
+        if failure is not None:
+            bucket, exc = failure
+            message = f"[cron] schedule FAIL • job={bucket} • err={_format_exception(exc)}"
+            log.warning(message)
+            await _send_ops_message(runtime, message)
+            return
+        success_list = list(successes)
+        if not success_list:
+            log.info("[cron] no cache refresh jobs registered")
+            return
+        cadence_parts = [f"{spec.bucket}={spec.cadence_label}" for spec, _ in success_list]
+        next_parts = [f"{spec.bucket}={_format_next_run(job)}" for spec, job in success_list]
+        message = (
+            "[cron] scheduled • "
+            + " • ".join(cadence_parts)
+            + " • next: "
+            + "; ".join(next_parts)
+        )
+        log.info(message)
+        await _send_ops_message(runtime, message)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # pragma: no cover - defensive guard
+        log.exception("failed to emit cron schedule log")
+
+
+def schedule_default_jobs(runtime: "rt.Runtime") -> None:
+    _ensure_cache_registration()
+    successes: List[Tuple[_JobSpec, Any]] = []
+    failure: Optional[Tuple[str, BaseException]] = None
+    for spec in _JOB_SPECS:
+        try:
+            job = _ensure_job(runtime, spec)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log.exception("failed to schedule cache refresh", extra={"bucket": spec.bucket})
+            if failure is None:
+                failure = (spec.bucket, exc)
+            continue
+        successes.append((spec, job))
+    runtime.scheduler.spawn(
+        _emit_schedule_log(runtime, successes, failure),
+        name="cache_refresh_schedule_log",
     )

--- a/shared/sheets/cache_service.py
+++ b/shared/sheets/cache_service.py
@@ -163,6 +163,8 @@ class CacheService:
     async def _log_refresh(self, b: CacheBucket, *, trigger: str, actor: Optional[str], retries: int) -> None:
         # Format: [refresh] bucket=clans trigger=schedule actor=@user duration=842ms result=ok hits=?,misses=?,retries=1
         error_text = b.last_error or "-"
+        if actor == "cron":
+            return
         msg = (
             f"[refresh] bucket={b.name} trigger={trigger} "
             f"actor={actor or '-'} duration={b.last_latency_ms or 0}ms "


### PR DESCRIPTION
Align scheduled refresh jobs with the ops contract and add boot-time scheduling logs.

## What changed
- Registered recurring jobs (audit: previously scheduled via `shared/sheets/cache_scheduler.py` using `runtime.schedule_at_times` — clans every 3h at the top of the hour; templates/clan_tags Mondays at 06:00/06:10 UTC):
  - clans — every 3 hours
  - templates — every 7 days
  - clan_tags — every 7 days
- Boot now logs one consolidated scheduling line (or a single FAIL with the offending job).
- Each cron run still logs a single OK/FAIL line with duration and retries.
- Public cache APIs only; idempotent scheduler; no new env/sheet keys.

## Why
Ensures predictable cache freshness and gives operators an immediate confirmation at restart that jobs are active (or a clear error to fix), without blocking boot.

## Acceptance
- After restart, ops channel shows one schedule summary with next-run times.
- Cron runs log exactly one line per execution.
- `!digest`/`!health` show non-`n/a` ages once cron has run.
- No duplicate jobs after hot reload.
- No hard-coded IDs; public APIs only.

[meta]
labels: observability, comp:scheduler, comp:ops-contract, robustness, P2, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f4e29d85e88323835afd3817df6198