### PR TITLE
Scheduler: remove bot_info; add weekly clan_tags/templates; keep 3h clans

### DIFF
--- a/shared/sheets/cache_scheduler.py
+++ b/shared/sheets/cache_scheduler.py
@@ -20,13 +20,6 @@ UTC = dt.timezone.utc
 log = logging.getLogger("c1c.cache.scheduler")
 
 
-CRON_JOB_NAMES: Tuple[str, ...] = (
-    "refresh_clans",
-    "refresh_templates",
-    "refresh_clan_tags",
-)
-
-
 @dataclass(frozen=True)
 class _JobSpec:
     bucket: str
@@ -34,13 +27,7 @@ class _JobSpec:
     cadence_label: str
 
 
-_JOB_SPECS: Tuple[_JobSpec, ...] = (
-    _JobSpec(bucket="clans", interval=dt.timedelta(hours=3), cadence_label="3h"),
-    _JobSpec(bucket="templates", interval=dt.timedelta(days=7), cadence_label="7d"),
-    _JobSpec(bucket="clan_tags", interval=dt.timedelta(days=7), cadence_label="7d"),
-)
-
-_SPEC_BY_BUCKET: Dict[str, _JobSpec] = {spec.bucket: spec for spec in _JOB_SPECS}
+_SPEC_BY_BUCKET: Dict[str, _JobSpec] = {}
 _REGISTERED: Dict[str, Tuple[Any, asyncio.Task]] = {}
 
 
@@ -51,12 +38,14 @@ def _format_exception(exc: BaseException) -> str:
     return type(exc).__name__
 
 
-def _ensure_cache_registration() -> None:
+def ensure_cache_registration() -> None:
     if cache.get_bucket("clans") is None or cache.get_bucket("templates") is None:
         from sheets import recruitment  # noqa: F401  # ensures cache registration
 
     if cache.get_bucket("clan_tags") is None:
         from sheets import onboarding  # noqa: F401  # ensures cache registration
+ 
+
 def _safe_bucket(name: str) -> str:
     cleaned = name.strip()
     if not cleaned:
@@ -195,6 +184,19 @@ def _ensure_job(runtime: "rt.Runtime", spec: _JobSpec):
     return job
 
 
+def register_refresh_job(
+    runtime: "rt.Runtime",
+    *,
+    bucket: str,
+    interval: dt.timedelta,
+    cadence_label: str,
+) -> Tuple[_JobSpec, Any]:
+    spec = _JobSpec(bucket=_safe_bucket(bucket), interval=interval, cadence_label=cadence_label)
+    _SPEC_BY_BUCKET[spec.bucket] = spec
+    job = _ensure_job(runtime, spec)
+    return spec, job
+
+
 def _format_next_run(job: Any) -> str:
     next_run = getattr(job, "next_run", None)
     if next_run is None:
@@ -206,7 +208,7 @@ def _format_next_run(job: Any) -> str:
     return as_utc.replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
 
 
-async def _emit_schedule_log(
+async def emit_schedule_log(
     runtime: "rt.Runtime",
     successes: Iterable[Tuple[_JobSpec, Any]],
     failure: Optional[Tuple[str, BaseException]],
@@ -239,11 +241,19 @@ async def _emit_schedule_log(
 
 
 def schedule_default_jobs(runtime: "rt.Runtime") -> None:
-    _ensure_cache_registration()
+    """Legacy helper that schedules the standard cache refresh jobs."""
+
+    ensure_cache_registration()
+    specs = (
+        _JobSpec(bucket="clans", interval=dt.timedelta(hours=3), cadence_label="3h"),
+        _JobSpec(bucket="templates", interval=dt.timedelta(days=7), cadence_label="7d"),
+        _JobSpec(bucket="clan_tags", interval=dt.timedelta(days=7), cadence_label="7d"),
+    )
     successes: List[Tuple[_JobSpec, Any]] = []
     failure: Optional[Tuple[str, BaseException]] = None
-    for spec in _JOB_SPECS:
+    for spec in specs:
         try:
+            _SPEC_BY_BUCKET[spec.bucket] = spec
             job = _ensure_job(runtime, spec)
         except Exception as exc:  # pragma: no cover - defensive guard
             log.exception("failed to schedule cache refresh", extra={"bucket": spec.bucket})
@@ -252,6 +262,6 @@ def schedule_default_jobs(runtime: "rt.Runtime") -> None:
             continue
         successes.append((spec, job))
     runtime.scheduler.spawn(
-        _emit_schedule_log(runtime, successes, failure),
+        emit_schedule_log(runtime, successes, failure),
         name="cache_refresh_schedule_log",
     )


### PR DESCRIPTION
## Summary
- remove the legacy bot_info cron runner and depend solely on the cache scheduler for cache warming
- keep the cache scheduler focused on clans/templates/clan_tags buckets and align the boot summary message format

## Scheduler audit
- runtime previously registered `refresh:bot_info` every 3h in addition to scheduler defaults
- cache scheduler registers `cache_refresh:clans` (3h), `cache_refresh:templates` (7d), and `cache_refresh:clan_tags` (7d)

## Testing
- `python -m compileall shared/runtime.py shared/sheets/cache_scheduler.py`

## Smoke checks
- Reboot → not run (local environment without bot runtime)
- Wait for clans cron tick → not run (local environment without scheduler loop)
- `!rec refresh templates` → not run (command dispatch unavailable in local environment)
- `!rec refresh clan_tags` → not run (command dispatch unavailable in local environment)
- `!digest`/`!health` after weekly cron → not run (local environment without scheduler loop)

[meta]
labels: comp:scheduler, comp:cache, observability, robustness, P2, ready
milestone: Harmonize v1.0
[/meta]


------
https://chatgpt.com/codex/tasks/task_e_68f500d5cf508323bdac9ac083020076