### PR TITLE
docs: add ADR-0007 — Feature Toggles & Recruitment Module Boundaries

### DIFF
--- a/docs/adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md
+++ b/docs/adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md
@@ -1,0 +1,100 @@
+# ADR-0007 — Feature Toggles & Recruitment Module Boundaries
+
+- **Date:** 2025-10-19
+- **Status:** Draft
+
+---
+
+## Context
+The unified C1C bot now operates on a stable core platform that provides async Sheets
+access with caching and telemetry, a runtime scheduler and watchdog, a health server and
+RBAC enforcement, plus structured logging and fail-soft I/O. These components are
+considered foundational services and not user-facing features.
+
+Phase 4 introduces user-facing recruitment and placement features drawn from the legacy
+Matchmaker and WelcomeCrew bots. We need a way to enable or disable these features on a
+per-environment basis (test vs prod) without impacting platform stability or cache
+registration.
+
+---
+
+## Decision
+
+### 1. Platform vs Feature
+The bot distinguishes between platform modules (always on) and feature modules
+(toggleable).
+
+- **Platform modules**: `coreops`, `shared.runtime`, `shared.sheets`, `scheduler`,
+  `cache`, `health`, `rbac`, and logging utilities.
+- **Feature modules**: user-facing cogs, commands, and scheduled posts that interact with
+  Discord or Sheets.
+
+### 2. Feature Registry
+A new `FeatureToggles` worksheet exists in both environment Sheets with the following
+schema:
+
+| feature_name | enabled_in_test | enabled_in_prod |
+|--------------|-----------------|-----------------|
+
+Values are case-insensitive `TRUE`/`FALSE`, `YES`/`NO`, `1`/`0`. A blank cell means the
+feature is enabled.
+
+### 3. Implementation
+A new module `shared/features.py` loads and caches the `FeatureToggles` worksheet. It
+exposes a helper:
+
+```python
+from shared.features import is_enabled
+
+if is_enabled("feature_key"):
+    await module.setup(bot)
+```
+
+`shared/runtime.load_extensions` wraps each recruitment module registration with this
+check. If the Sheet or worksheet fails to load, all features default to enabled and a
+single warning is logged at startup.
+
+### 4. Approved Feature Modules (Phase 4)
+
+| Key | Description |
+|-----|-------------|
+| `member_panel` | Member-facing clan browser (`!clansearch`), owner-locked panels. |
+| `recruiter_panel` | Recruiter-only clan match tool (`!clanmatch`) with filters and thread routing. |
+| `recruitment_welcome` | Template-based welcome messages; staff-tier only. |
+| `recruitment_reports` | Daily recruiter digest post (v1 scope only). |
+| `placement_target_select` | Recruiter-only clan picker modal, using cached clan tags. |
+| `placement_reservations` | Recruiter reservation workflow; explicit duration required; writes reserved entries to `bot_info` (to be refactored later). |
+
+### 5. Default Behavior
+If a row is missing or the worksheet is unreachable:
+
+- `is_enabled()` returns `True`.
+- A single warning is logged: "FeatureToggles unavailable; assuming enabled".
+- Startup continues without retries.
+
+### 6. Documentation & Operations
+
+- `docs/ops/Config.md` documents how to flip toggles.
+- `docs/contracts/feature_toggles.md` describes the schema, cache behavior, and failure
+  modes.
+- Each new or changed feature must declare its key in code and update the worksheet prior
+  to deployment.
+
+---
+
+## Consequences
+
+- Safe per-environment rollout from test to production.
+- Prevents regressions by gating new recruitment modules independently.
+- Core services remain unaffected by feature status.
+- Disabling a feature suppresses its commands, listeners, and schedulers while cache
+  warmers, telemetry, and health endpoints remain active.
+- Adds one cached Sheet read per boot.
+- Future features (e.g., reservation-expiry sweeper) will declare their own toggle key.
+
+---
+
+## Status
+
+**Draft — pending implementation of `shared/features.py` and loader integration.**
+

--- a/docs/contracts/feature_toggles.md
+++ b/docs/contracts/feature_toggles.md
@@ -1,0 +1,42 @@
+# Feature Toggle Contract
+
+## Overview
+Phase 4 introduces environment-aware feature toggles for recruitment and placement
+modules. Toggles are defined in a shared Google Sheets worksheet named `FeatureToggles`.
+The bot treats the worksheet as the source of truth for deciding whether to load
+user-facing modules.
+
+## Schema
+| Column | Type | Notes |
+| --- | --- | --- |
+| `feature_name` | string | Unique key that matches the module declaration (see ADR-0007). |
+| `enabled_in_test` | tri-state | Accepts `TRUE/FALSE`, `YES/NO`, `1/0` (case-insensitive). Blank → enabled. |
+| `enabled_in_prod` | tri-state | Same semantics as `enabled_in_test`. |
+
+Rows may appear in any order. The loader performs a case-insensitive comparison on the
+`feature_name` column.
+
+## Runtime behavior
+- Module loaders call `shared.features.is_enabled(key)` before registering extensions.
+- When the worksheet is reachable, the helper resolves the environment-specific column
+  (based on `ENV_NAME`). Any blank or truthy cell yields `True`; explicit falsey cells
+  yield `False`.
+- If the worksheet or Sheet cannot be loaded, all features default to enabled and the bot
+  logs a single startup warning: `FeatureToggles unavailable; assuming enabled`.
+
+## Caching & refresh
+- The worksheet is cached using the standard Sheets cache layer.
+- Cache invalidation follows the same refresh cadence as other Sheets tabs; a manual
+  refresh via the runtime cache commands also clears the toggle cache.
+- Operators can toggle features by editing the worksheet and forcing a cache refresh (or
+  waiting for the next scheduled refresh).
+
+## Operational guidance
+1. Add or update the `feature_name` row in both environment Sheets.
+2. Set the environment-specific column to `FALSE`/`NO`/`0` to disable the feature.
+3. Leave the cell blank or set it to `TRUE`/`YES`/`1` to enable.
+4. Save the Sheet; the bot picks up the change on the next cache refresh.
+
+## Approved keys (Phase 4)
+Refer to ADR-0007 for the authoritative list of feature keys and descriptions. Future
+features must document their keys in both the ADR and code modules.

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -49,6 +49,7 @@ Meta: Cache age 42s · Next refresh 02:15 UTC · Actor startup
 | Toggles | `ENABLE_NOTIFY_FALLBACK` | bool | `true` | Sends alerts to fallback channel when true. |
 | Toggles | `STRICT_PROBE` | bool | `false` | Enforces guild allow-list before startup completes. |
 | Toggles | `SEARCH_RESULTS_SOFT_CAP` | int | `25` | Soft limit on search results per query. |
+| Toggles | _Feature toggles_ | sheet | `enabled` | Recruitment/placement modules use the `FeatureToggles` worksheet described below. |
 | Watchdog | `WATCHDOG_CHECK_SEC` | int | `30` | Interval between watchdog polls. |
 | Watchdog | `WATCHDOG_STALL_SEC` | int | `45` | Connected stall threshold in seconds. |
 | Watchdog | `WATCHDOG_DISCONNECT_GRACE_SEC` | int | `300` | Disconnect grace period before restart. |
@@ -71,6 +72,7 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 ### Recruitment sheet keys
 - `CLANS_TAB`
 - `WELCOME_TEMPLATES_TAB`
+- `FeatureToggles`
 
 ### Onboarding sheet keys
 - `WELCOME_TICKETS_TAB`
@@ -78,6 +80,15 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 - `CLANLIST_TAB`
 
 Leave values blank only if a module is disabled via toggles.
+
+### Feature toggles worksheet
+- Worksheet name: `FeatureToggles`
+- Columns: `feature_name`, `enabled_in_test`, `enabled_in_prod`
+- Accepted values: `TRUE/FALSE`, `YES/NO`, `1/0` (case-insensitive). Leave blank to treat the
+  feature as enabled.
+- Missing worksheet or lookup failures default to **enabled** for all features. Startup logs a
+  single warning: `FeatureToggles unavailable; assuming enabled`.
+- Feature keys must match the module declarations listed in ADR-0007.
 
 ---
 


### PR DESCRIPTION
# ADR-0007 — Feature Toggles & Recruitment Module Boundaries  
**Date:** 2025-10-19  
**Status:** Draft  

---

## Context
The unified C1C bot now operates on a stable core platform:
- async Sheets access with caching and telemetry,
- runtime scheduler and watchdog,
- health server and RBAC,
- structured logging and fail-soft I/O.

These are *foundational services*, not user-facing features.  
Phase 4 introduces user-facing **recruitment and placement features** drawn from the legacy Matchmaker and WelcomeCrew bots.  
The goal is to enable/disable these features per environment (test / prod) without affecting platform stability or cache registration.

---

## Decision

### 1. Platform vs Feature
The bot distinguishes:
- **Platform modules** (always on):  
  `coreops`, `shared.runtime`, `shared.sheets`, `scheduler`, `cache`, `health`, `rbac`, logging utilities.  
- **Feature modules** (toggleable):  
  user-facing cogs, commands, and scheduled posts interacting with Discord or Sheets.

### 2. Feature Registry
A new **FeatureToggles** tab exists in both environment Sheets.  

| feature_name | enabled_in_test | enabled_in_prod |
|---------------|----------------|-----------------|

Values: case-insensitive `TRUE/FALSE/YES/NO/1/0`; blank = **enabled**.

### 3. Implementation
- New module `shared/features.py` loads + caches this tab.  
- Helper:
  ```py
  from shared.features import is_enabled
  if is_enabled("feature_key"):
      await module.setup(bot)
  ```

* `shared/runtime.load_extensions` wraps each recruitment module registration with this check.
* If the Sheet or tab fails to load: all features → **enabled**, single warning logged at startup.

### 4. Approved Feature Modules (Phase 4)

| Key                       | Description                                                                                                                 |
| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `member_panel`            | Member-facing clan browser (`!clansearch`), owner-locked panels.                                                            |
| `recruiter_panel`         | Recruiter-only clan match tool (`!clanmatch`) with filters and thread routing.                                              |
| `recruitment_welcome`     | Template-based welcome messages; staff-tier only.                                                                           |
| `recruitment_reports`     | Daily recruiter digest post (v1 scope only).                                                                                |
| `placement_target_select` | Recruiter-only clan picker modal, using cached clan tags.                                                                   |
| `placement_reservations`  | Recruiter reservation workflow; explicit duration required; writes reserved entries to `bot_info` (to be refactored later). |

### 5. Default Behavior

If a row is missing or the tab is unreachable:

* `is_enabled()` → **True**
* Log once: *FeatureToggles unavailable; assuming enabled*
* No blocking/retry; startup continues normally.

### 6. Documentation & Operations

* `docs/ops/config.md` → how to flip toggles.
* `docs/contracts/feature_toggles.md` → schema, cache behavior, failure modes.
* Each new/changed feature must declare its key in code + update the tab upon deployment.

---

## Consequences

* Safe per-environment rollout (test → prod).
* Prevents regressions by gating new recruitment modules independently.
* Core services remain unaffected by feature status.
* Disabling a feature only suppresses its commands/listeners/schedulers; cache warmers, telemetry, and health endpoints remain active.
* Adds one cached Sheet read per boot.
* Future features (e.g., reservation-expiry sweeper) will declare their own toggle key.

---

## Status

**Draft — pending implementation of `shared/features.py` and loader integration.**

---

[meta]
labels: docs, architecture, comp:config, comp:commands, comp:data-sheets, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f5275cce8083239e9c763682dac800