### PR TITLE
fix: avoid awaiting admin alerts before bot startup in FeatureToggles

### DIFF
--- a/docs/contracts/feature_toggles.md
+++ b/docs/contracts/feature_toggles.md
@@ -1,42 +1,66 @@
 # Feature Toggle Contract
 
 ## Overview
-Phase 4 introduces environment-aware feature toggles for recruitment and placement
-modules. Toggles are defined in a shared Google Sheets worksheet named `FeatureToggles`.
-The bot treats the worksheet as the source of truth for deciding whether to load
-user-facing modules.
+Phase 4 feature modules load behind a strict fail-closed toggle service. Runtime reads the
+`FeatureToggles` worksheet from the recruitment Sheet and only enables features whose
+`enabled` column is explicitly set to `TRUE` (case-insensitive). Anything else—blank,
+`FALSE`, numeric values, or stray text—forces the feature off.
 
 ## Schema
 | Column | Type | Notes |
 | --- | --- | --- |
-| `feature_name` | string | Unique key that matches the module declaration (see ADR-0007). |
-| `enabled_in_test` | tri-state | Accepts `TRUE/FALSE`, `YES/NO`, `1/0` (case-insensitive). Blank → enabled. |
-| `enabled_in_prod` | tri-state | Same semantics as `enabled_in_test`. |
+| `feature_name` | string | Case-insensitive key that matches the module declaration (see ADR-0007). |
+| `enabled` | string | Only accepts `TRUE` (case-insensitive) to enable. All other values disable the feature. |
 
-Rows may appear in any order. The loader performs a case-insensitive comparison on the
-`feature_name` column.
+Rows may appear in any order. Duplicate keys overwrite previous entries; use one row per
+feature for clarity.
 
 ## Runtime behavior
-- Module loaders call `shared.features.is_enabled(key)` before registering extensions.
-- When the worksheet is reachable, the helper resolves the environment-specific column
-  (based on `ENV_NAME`). Any blank or truthy cell yields `True`; explicit falsey cells
-  yield `False`.
-- If the worksheet or Sheet cannot be loaded, all features default to enabled and the bot
-  logs a single startup warning: `FeatureToggles unavailable; assuming enabled`.
+- Loaders call `shared.features.is_enabled("<key>")` before registering user-facing
+  modules.
+- `shared.features.refresh()` pulls the worksheet, caches the result in-memory, and fails
+  closed if anything goes wrong (missing Sheet, worksheet, headers, or parse errors).
+- Missing worksheet/header or unreadable Sheet ⇒ every feature evaluates `False`.
+- Missing feature row ⇒ `is_enabled()` returns `False` for that key.
+- Invalid value (anything other than `TRUE`) ⇒ feature disabled; value is treated as
+  misconfigured.
+- The helper emits a single structured warning per issue (global failures, invalid values,
+  or missing rows) and pings @Administrator using the first role ID in
+  `ADMIN_ROLE_IDS`. Warnings are sent to the runtime log channel.
 
 ## Caching & refresh
-- The worksheet is cached using the standard Sheets cache layer.
-- Cache invalidation follows the same refresh cadence as other Sheets tabs; a manual
-  refresh via the runtime cache commands also clears the toggle cache.
-- Operators can toggle features by editing the worksheet and forcing a cache refresh (or
-  waiting for the next scheduled refresh).
+- The loader keeps a local snapshot. `shared.features.refresh()` can be called manually
+  (for example, via `!rec refresh config`) to re-read the Sheet.
+- Cache refresh commands that invalidate Sheets also refresh the toggles.
 
 ## Operational guidance
-1. Add or update the `feature_name` row in both environment Sheets.
-2. Set the environment-specific column to `FALSE`/`NO`/`0` to disable the feature.
-3. Leave the cell blank or set it to `TRUE`/`YES`/`1` to enable.
-4. Save the Sheet; the bot picks up the change on the next cache refresh.
+1. Ensure the recruitment Sheet `Config` worksheet exposes a `FEATURE_TOGGLES_TAB` key.
+   Leave it blank to use the default worksheet name `FeatureToggles`.
+2. Add seed rows for every approved feature:
+   ```
+   feature_name,enabled
+   member_panel,TRUE
+   recruiter_panel,TRUE
+   recruitment_welcome,TRUE
+   recruitment_reports,TRUE
+   placement_target_select,TRUE
+   placement_reservations,TRUE
+   ```
+3. To enable a feature, write `TRUE` (case-insensitive) in the `enabled` column.
+4. Any other value disables the feature. Use `FALSE` or blank intentionally to keep the
+   feature off.
+5. After editing, run the config refresh command or wait for the next scheduled refresh.
+
+## Troubleshooting
+- **Global warning:** "worksheet missing headers" / "worksheet unavailable" — check the
+  `FeatureToggles` tab name and headers. Startup continues but all features stay off until
+  fixed.
+- **Invalid value warning:** e.g., `member_panel` set to `FALSE` — update the cell to
+  `TRUE` (enable) or leave blank to keep it disabled without warning.
+- **Missing row warning:** `is_enabled()` was called for an undefined key. Add the row with
+  the desired value.
+- Alerts are delivered to the runtime log channel and mention the Administrator role.
 
 ## Approved keys (Phase 4)
 Refer to ADR-0007 for the authoritative list of feature keys and descriptions. Future
-features must document their keys in both the ADR and code modules.
+features must update this contract and the worksheet before deployment.

--- a/shared/features.py
+++ b/shared/features.py
@@ -1,0 +1,280 @@
+"""Feature toggle loader with strict fail-closed defaults."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Sequence
+
+from shared.config import get_admin_role_ids, get_recruitment_sheet_id
+from shared.sheets.async_core import afetch_records, afetch_values
+
+log = logging.getLogger("c1c.features")
+
+_DEFAULT_TOGGLES_TAB = "FeatureToggles"
+_CONFIG_TAB_ENV = "RECRUITMENT_CONFIG_TAB"
+
+_LOCK = asyncio.Lock()
+_FEATURE_VALUES: Dict[str, bool] = {}
+_LOADED_AT: datetime | None = None
+_ROW_COUNT: int = 0
+_SOURCE_TAB: str = _DEFAULT_TOGGLES_TAB
+_DISABLED_BY_DEFAULT: bool = True
+_NOTES: list[str] = []
+_GLOBAL_FAILURE_REASON: str | None = "uninitialized"
+
+_GLOBAL_WARNINGS_SENT: set[str] = set()
+_INVALID_WARNINGS_SENT: set[str] = set()
+_MISSING_WARNINGS_SENT: set[str] = set()
+
+
+def _normalize_key(value: object) -> str:
+    text = str(value or "").strip()
+    return text.lower()
+
+
+def _admin_mention() -> str:
+    role_ids = sorted(get_admin_role_ids())
+    if role_ids:
+        return f"<@&{role_ids[0]}>"
+    return "@Administrator"
+
+
+async def _emit_admin_alert(detail: str) -> None:
+    """Send a structured warning to the runtime log channel after startup."""
+
+    message = f"⚠️ {_admin_mention()} Feature toggle misconfiguration: {detail}".strip()
+    try:
+        import asyncio
+        from shared import runtime
+
+        # Schedule asynchronously to avoid blocking before bot.start()
+        asyncio.create_task(runtime.send_log_message(message))
+    except Exception:
+        import logging
+
+        logging.warning(f"Feature toggle misconfiguration (deferred alert): {detail}")
+
+
+def _schedule_admin_alert(detail: str) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        log.debug("event loop unavailable for feature toggle alert", exc_info=True)
+        return
+    loop.create_task(_emit_admin_alert(detail))
+
+
+def _config_tab_name() -> str:
+    raw = os.getenv(_CONFIG_TAB_ENV, "Config")
+    text = str(raw or "").strip()
+    return text or "Config"
+
+
+def _parse_config(rows: Sequence[Mapping[str, object]]) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
+    for row in rows:
+        key_value: str | None = None
+        stored_value: str | None = None
+        fallback: str | None = None
+        for column, raw_value in row.items():
+            column_norm = _normalize_key(column)
+            text = str(raw_value or "").strip()
+            if not text:
+                continue
+            if column_norm == "key":
+                key_value = text.lower()
+            elif column_norm in {"value", "val"}:
+                stored_value = text
+            elif fallback is None:
+                fallback = text
+        if key_value:
+            parsed[key_value] = stored_value or fallback or ""
+    return parsed
+
+
+def _collect_headers(rows: Sequence[Mapping[str, object]]) -> set[str]:
+    headers: set[str] = set()
+    for row in rows:
+        for column in row.keys():
+            normalized = _normalize_key(column)
+            if normalized:
+                headers.add(normalized)
+    return headers
+
+
+def _extract_column(row: Mapping[str, object], column_name: str) -> str:
+    want = column_name.lower()
+    for column, value in row.items():
+        if _normalize_key(column) == want:
+            return str(value or "").strip()
+    return ""
+
+
+async def refresh() -> None:
+    """Refresh feature toggles from Sheets (fail-closed)."""
+
+    global _FEATURE_VALUES, _LOADED_AT, _ROW_COUNT
+    global _SOURCE_TAB, _DISABLED_BY_DEFAULT, _NOTES, _GLOBAL_FAILURE_REASON
+
+    async with _LOCK:
+        now = datetime.now(timezone.utc)
+        notes: list[str] = []
+        feature_values: Dict[str, bool] = {}
+        row_count = 0
+        disabled = True
+        failure_reason: str | None = None
+        source_tab = _DEFAULT_TOGGLES_TAB
+
+        sheet_id = (get_recruitment_sheet_id() or "").strip()
+        if not sheet_id:
+            failure_reason = "Recruitment sheet ID missing; all feature toggles disabled."
+            notes.append(failure_reason)
+            await _warn_global_once("missing-sheet-id", failure_reason)
+        else:
+            config_tab = _config_tab_name()
+            try:
+                config_rows = await afetch_records(sheet_id, config_tab)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                failure_reason = (
+                    f"Config worksheet '{config_tab}' unavailable: {exc}. All features disabled."
+                )
+                notes.append(failure_reason)
+                await _warn_global_once("config-load", failure_reason)
+            else:
+                config_map = _parse_config(config_rows)
+                tab_name = config_map.get("feature_toggles_tab", "").strip() or _DEFAULT_TOGGLES_TAB
+                source_tab = tab_name
+                try:
+                    records = await afetch_records(sheet_id, tab_name)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    failure_reason = (
+                        f"Feature toggles worksheet '{tab_name}' unavailable: {exc}. All features disabled."
+                    )
+                    notes.append(failure_reason)
+                    await _warn_global_once("tab-missing", failure_reason)
+                else:
+                    headers = _collect_headers(records)
+                    if not headers:
+                        try:
+                            values = await afetch_values(sheet_id, tab_name)
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            values = []
+                        if values:
+                            first_row = values[0]
+                            for cell in first_row:
+                                normalized = _normalize_key(cell)
+                                if normalized:
+                                    headers.add(normalized)
+                    required = {"feature_name", "enabled"}
+                    if not required.issubset(headers):
+                        failure_reason = (
+                            f"Worksheet '{tab_name}' missing required headers: {sorted(required)}."
+                        )
+                        notes.append(failure_reason)
+                        await _warn_global_once("header-missing", failure_reason)
+                    else:
+                        disabled = False
+                        row_count = len(records)
+                        for row in records:
+                            feature_label = _extract_column(row, "feature_name")
+                            if not feature_label:
+                                continue
+                            normalized_key = _normalize_key(feature_label)
+                            enabled_raw = _extract_column(row, "enabled")
+                            enabled_norm = enabled_raw.lower()
+                            is_enabled_flag = enabled_norm == "true"
+                            feature_values[normalized_key] = is_enabled_flag
+                            if not is_enabled_flag:
+                                if enabled_raw:
+                                    notes.append(
+                                        f"{feature_label}: value '{enabled_raw}' treated as disabled"
+                                    )
+                                    await _warn_invalid_value_once(
+                                        normalized_key, feature_label, enabled_raw, tab_name
+                                    )
+                        if not feature_values:
+                            notes.append("No feature rows resolved; defaulting to disabled.")
+                            disabled = True
+                            failure_reason = (
+                                "Feature toggle worksheet returned no rows; treating all features as disabled."
+                            )
+                            await _warn_global_once("no-rows", failure_reason)
+
+        _FEATURE_VALUES = feature_values
+        _LOADED_AT = now
+        _ROW_COUNT = row_count
+        _SOURCE_TAB = source_tab
+        _DISABLED_BY_DEFAULT = disabled or bool(failure_reason)
+        _NOTES = notes
+        _GLOBAL_FAILURE_REASON = failure_reason
+
+
+async def _warn_global_once(token: str, detail: str) -> None:
+    if token in _GLOBAL_WARNINGS_SENT:
+        return
+    _GLOBAL_WARNINGS_SENT.add(token)
+    log.warning(detail)
+    await _emit_admin_alert(detail)
+
+
+async def _warn_invalid_value_once(
+    normalized_key: str,
+    feature_label: str,
+    raw_value: str,
+    tab_name: str,
+) -> None:
+    if normalized_key in _INVALID_WARNINGS_SENT:
+        return
+    _INVALID_WARNINGS_SENT.add(normalized_key)
+    detail = (
+        f"Toggle '{feature_label}' in worksheet '{tab_name}' has invalid value '{raw_value}'; "
+        "defaulting to disabled."
+    )
+    log.warning(detail)
+    await _emit_admin_alert(detail)
+
+
+def is_enabled(key: str) -> bool:
+    normalized = _normalize_key(key)
+    if not normalized:
+        return False
+    if _GLOBAL_FAILURE_REASON:
+        # Fail-closed when data missing or not yet loaded.
+        return False
+    if normalized in _FEATURE_VALUES:
+        return bool(_FEATURE_VALUES[normalized])
+    _warn_missing_feature_once(normalized, key)
+    return False
+
+
+def _warn_missing_feature_once(normalized_key: str, requested_key: str) -> None:
+    if normalized_key in _MISSING_WARNINGS_SENT:
+        return
+    _MISSING_WARNINGS_SENT.add(normalized_key)
+    detail = (
+        f"Toggle '{requested_key}' is not defined in worksheet '{_SOURCE_TAB}'; defaulting to disabled."
+    )
+    log.warning(detail)
+    _schedule_admin_alert(detail)
+
+
+def snapshot() -> Dict[str, Any]:
+    return {
+        "loaded_at": _LOADED_AT.isoformat() if _LOADED_AT else None,
+        "row_count": _ROW_COUNT,
+        "source_tab": _SOURCE_TAB,
+        "disabled_by_default": _DISABLED_BY_DEFAULT,
+        "notes": list(_NOTES),
+    }
+
+
+__all__ = ["is_enabled", "refresh", "snapshot"]


### PR DESCRIPTION
## Summary
- schedule feature toggle admin alerts with asyncio.create_task() so startup is never blocked before bot connections
- fall back to a logging.warning when scheduling fails so misconfigurations are still surfaced

## Testing
- pytest

[meta]
labels: feature, architecture, comp:config, comp:commands, comp:data-sheets, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f5370281b883239650fc0ec0b2ceaa