### PR TITLE
Refactor recruiter panel for inline updates and fixed thread routing

### DIFF
--- a/recruitment/recruiter_panel.py
+++ b/recruitment/recruiter_panel.py
@@ -852,6 +852,11 @@ class RecruiterPanelCog(commands.Cog):
                 thread = ctx.guild.get_thread(int(fixed_id)) if ctx.guild else None
                 if not thread and ctx.bot:
                     thread = await ctx.bot.fetch_channel(int(fixed_id))
+                if isinstance(thread, discord.Thread) and thread.archived:
+                    try:
+                        await thread.edit(archived=False)
+                    except Exception:
+                        pass
         except Exception:
             thread = None
 


### PR DESCRIPTION
## Summary
- rebuild the recruiter panel view to edit the existing message in place, keep filters in sync, and remove attachment usage
- add integrated pagination controls with inline page toggles and status messaging for stale or empty results
- route the panel to a configured fixed thread when available and post a pointer reply in the invoking channel

## Testing
- python -m compileall recruitment/recruiter_panel.py

[meta]
labels: bug, commands, docs, comp:commands, P1
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f5e7be30948323b55bde11d56ef916