### PR TITLE
Add UltraNightmare option to Chimera recruiter filter

### DIFF
--- a/recruitment/recruiter_panel.py
+++ b/recruitment/recruiter_panel.py
@@ -107,6 +107,13 @@ def _cell_has_diff(cell_text: str, token: str | None) -> bool:
         return True
     if mapped == "BTL" and "BRUTAL" in cell:
         return True
+    if mapped == "UNM":
+        if "ULTRA NIGHTMARE" in cell:
+            return True
+        if "ULTRA-NIGHTMARE" in cell:
+            return True
+        if "ULTRANIGHTMARE" in cell:
+            return True
     return False
 
 


### PR DESCRIPTION
## Summary
- add the UltraNightmare option to the Chimera difficulty dropdown so recruiters can select it
- map the UltraNightmare label to the UNM token so filter predicates accept the new choice

## Testing
- not run (not requested)

[meta]
labels: bug, commands, ux, comp:commands, P1
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f6354f1e788323a0a000bb95b6db17