### PR TITLE
Add help entries and tiers for clanmatch and ping

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from shared.config import (
     get_config_snapshot,
 )
 from shared import socket_heartbeat as hb
+from shared.coreops.helpers.tiers import tier
 from shared.runtime import Runtime
 from shared.coreops_prefix import detect_admin_bang_command
 from shared.coreops_rbac import (
@@ -264,7 +265,12 @@ async def on_command_error(ctx: commands.Context, error: Exception):
         log.exception("failed to send command error to log channel")
 
 
-@bot.command(name="ping", hidden=True)
+@tier("admin")
+@bot.command(
+    name="ping",
+    hidden=True,
+    help="Quick admin check to confirm the bot is responsive.",
+)
 @admin_only()
 async def ping(ctx: commands.Context):
     try:

--- a/recruitment/recruiter_panel.py
+++ b/recruitment/recruiter_panel.py
@@ -20,6 +20,7 @@ from discord import InteractionResponded
 from recruitment import cards
 from sheets import recruitment as recruitment_sheets
 from shared import config
+from shared.coreops.helpers.tiers import tier
 from shared.coreops_rbac import is_admin_member, is_recruiter
 
 log = logging.getLogger(__name__)
@@ -894,7 +895,11 @@ class RecruiterPanelCog(commands.Cog):
     def _panel_for_owner(self, owner_id: int) -> Optional[Tuple[int, int]]:
         return self._owner_panels.get(owner_id)
 
-    @commands.command(name="clanmatch")
+    @tier("staff")
+    @commands.command(
+        name="clanmatch",
+        help="Open the recruiter panel to search clans (text-only).",
+    )
     @commands.cooldown(1, 2, commands.BucketType.user)
     async def clanmatch(self, ctx: commands.Context, *, extra: Optional[str] = None) -> None:
         """Open the recruiter panel to find clans for a recruit."""

--- a/shared/help.py
+++ b/shared/help.py
@@ -56,6 +56,15 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="admin",
     ),
+    "ping": _metadata(
+        short="Verifies the bot is awake with a quick pong reaction.",
+        detailed=(
+            "Adds a table-tennis reaction so admins can confirm the bot is online and responsive "
+            "before running deeper diagnostics.\n"
+            "Tip: Fire this right after deployments to make sure the shard is healthy."
+        ),
+        tier="admin",
+    ),
     "env": _metadata(
         short="Shows environment info (prod/test/etc.).",
         detailed=(
@@ -172,6 +181,15 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         detailed=(
             "Forces a refresh for the recruitment infos the `!clanmatch` panel uses, including open spots and clan requirements.\n"
             "Tip: Use right after a clan updates its recruitment data in Sheets."
+        ),
+        tier="staff",
+    ),
+    "clanmatch": _metadata(
+        short="Opens the recruiter clan-search panel.",
+        detailed=(
+            "Launches the text-only recruiter panel used to match recruits with clans. "
+            "Filter by open spots, raid bosses, and playstyle without leaving Discord.\n"
+            "Tip: Run it in recruiter channels so the panel stays private to staff."
         ),
         tier="staff",
     ),


### PR DESCRIPTION
## Summary
- add a staff-facing help string and tier to the clanmatch recruiter command
- tag the ping command with its admin tier and surface a concise help blurb
- register help metadata for clanmatch and ping so the startup tier audit passes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f73094308c83239e0b04abe05c1a6c