### PR TITLE
Show feature toggles in env summary

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -43,6 +43,7 @@ __all__ = [
     "get_enable_welcome_watcher",
     "get_enable_promo_watcher",
     "get_enable_notify_fallback",
+    "get_feature_toggles",
     "get_strict_probe",
     "get_search_results_soft_cap",
     "get_clan_tags_cache_ttl_sec",
@@ -508,6 +509,27 @@ def get_enable_promo_watcher() -> bool:
 
 def get_enable_notify_fallback() -> bool:
     return bool(_CONFIG.get("ENABLE_NOTIFY_FALLBACK", True))
+
+
+def get_feature_toggles() -> Dict[str, bool]:
+    """Return the merged feature toggles from the runtime loader."""
+
+    try:
+        from shared import features  # Local import to avoid circular dependency.
+    except Exception:
+        return {}
+
+    values = getattr(features, "_FEATURE_VALUES", None)
+    if isinstance(values, dict):
+        toggles: Dict[str, bool] = {}
+        for key, raw_value in values.items():
+            name = str(key).strip()
+            if not name:
+                continue
+            toggles[name] = bool(raw_value)
+        return toggles
+
+    return {}
 
 
 def get_strict_probe() -> bool:

--- a/shared/coreops_cog.py
+++ b/shared/coreops_cog.py
@@ -26,7 +26,13 @@ from config.runtime import (
     get_watchdog_stall_sec,
 )
 from shared import socket_heartbeat as hb
-from shared.config import get_allowed_guild_ids, get_config_snapshot, reload_config, redact_value
+from shared.config import (
+    get_allowed_guild_ids,
+    get_config_snapshot,
+    get_feature_toggles,
+    reload_config,
+    redact_value,
+)
 from shared.coreops_render import (
     ChecksheetEmbedData,
     ChecksheetSheetEntry,
@@ -2667,6 +2673,17 @@ class CoreOpsCog(commands.Cog):
                     lines.append("")
             while lines and not lines[-1].strip():
                 lines.pop()
+
+        toggles = get_feature_toggles()
+        if lines:
+            lines.append("")
+        lines.append("Feature Toggles:")
+        if toggles:
+            for name in sorted(toggles):
+                value = "ON" if toggles[name] else "OFF"
+                lines.append(f"  {name} = {value}")
+        else:
+            lines.append("  (none)")
 
         meta = _config_meta_from_app()
         source = str(meta.get("source", "runtime"))


### PR DESCRIPTION
## Summary
- add a config helper that exposes the merged feature toggle map
- surface the current feature toggles and their state in the `!rec env` sheets/config section

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f78337b9bc8323a9b2cab613448648