### PR TITLE
docs: sync recruitment docs for v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.9.5 — 2025-10-21
+
+### Phase 5 : Recruitment Module Updates
+
+**Added**
+- `!clan` command restored (public). Displays clan profile and entry criteria with crest thumbnail and 💡 reaction toggle.
+- `!clanmatch` command rebuilt as text-only recruiter panel for mobile performance.
+- `!rec env` now shows Feature Toggles under “Sheets / Config Keys”.
+- Feature toggles introduced: `clan_profile`, `recruiter_panel`.
+
+**Fixed**
+- Recruiter panel no longer spawns outside thread or stalls on update.
+- Search updates now confirm refresh instead of sending duplicates.
+
+**Documentation**
+- Updated: all command, ops, and user docs to reflect Phase 5 features.
+
 ## [v0.9.4] — 2025-10-20
 
 ### Added
@@ -149,4 +166,4 @@
 
 ---
 
-_Doc last updated: 2025-10-17 (v0.9.3-phase3b-rc4)_
+_Doc last updated: 2025-10-21 (v0.9.5)_

--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
 <!-- Keep README user-facing -->
-# C1C Recruitment Bot v0.9.4
-Welcome to the C1C recruitment helper. The bot keeps clan rosters healthy, helps new
-friends find a hall, and makes sure every welcome lands in the right place.
+C1C Recruitment Bot v0.9.5  
+Welcome to the C1C recruitment helper.  
+The bot keeps clan rosters healthy, helps new friends find their hall, and makes sure every welcome lands in the right place.
 
-## What you can do today
-- `!rec help` lists the commands available to you right now.
-- `!clan <tag>` shows a quick profile for any clan in the cluster.
-- `!welcome` posts the standard welcome note once staff place a recruit.
-- Recruitment Search surfaces matches straight from Sheets when staff flag a clan for
-  review.
+### What you can do today
+!rec help — lists all commands available to you.  
+!clan <tag> — shows a quick profile for any clan in the cluster.  
+!clanmatch — opens the recruiter panel where staff help players find a home.  
+!welcome — posts the standard welcome note once a recruit joins.  
 
-> Recruitment Search: pilot • backend active, panels pending release
+The bot pulls live data from the cluster sheets so info stays current.
 
-## Need help?
-- Ping the recruitment team in Discord for command walkthroughs.
-- Something seems off? Drop a note in #bot-production so staff can check the logs.
+### Need help?
+Ask the recruitment team in Discord for a quick walkthrough.  
+If something looks off, drop a note in #bot-production so staff can check the logs.
 
-## More reading (staff only)
-- [Architecture](docs/Architecture.md) — system map and data flows.
-- [Development](docs/development.md) — web deploy workflow, style rules, and doc map.
-- [Ops suite](docs/ops/Runbook.md) — runbooks, command matrix, config tables, and
-  troubleshooting references.
+### More reading (staff only)
+- **Architecture** — system map and data flows  
+- **Development** — deploy workflow, style rules, and doc map  
+- **Ops suite** — runbooks, command matrix, and troubleshooting references
 
 ---
 
-_Doc last updated: 2025-10-22 (v0.9.4)_
+_Doc last updated: 2025-10-21 (v0.9.5)_

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# C1C Recruitment Bot Documentation Overview (v0.9.4)
+# C1C Recruitment Bot Documentation Overview (v0.9.5)
 
 ## Purpose
 This index explains the intent and ownership of every file in the documentation tree.
@@ -35,10 +35,17 @@ It exists so that contributors update the correct references after each developm
 * `README.md` — user-facing overview, installation steps, and configuration guidance for the bot.
 * `CHANGELOG.md` — version history for the project.
 
+## Phase 5 — Recruitment Modules
+
+- **Phase 5 : Recruitment Modules**
+  - Updated: `!clan` — public profile/entry cards with crest and 💡 reaction toggle.
+  - Updated: `!clanmatch` — text-only recruiter panel for mobile use.
+  - Updated: `!rec env` — now lists Feature Toggles under Sheets / Config Keys.
+
 ## Maintenance Rules
 * Update this index whenever documentation files are added, renamed, or removed.
 * Any PR that modifies documentation must reflect its changes here and, if structural, call them out in the CollaborationContract.
-* Ensure the version shown in this index (currently v0.9.4) matches the bot version in the root `README.md`.
+* Ensure the version shown in this index (currently v0.9.5) matches the bot version in the root `README.md`.
 
 ## Cross-References
 * `docs/ops/CollaborationContract.md` documents contributor responsibilities and embeds this index under “Documentation Discipline.”

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -89,6 +89,20 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 
 Leave values blank only if a module is disabled via toggles.
 
+#### Feature Toggles
+Lists the current feature toggles loaded from the FeatureToggles sheet.
+
+Example:
+
+```
+Feature Toggles:
+  recruiter_panel = ON
+  member_panel = ON
+  placement_target_select = ON
+  placement_reservations = ON
+  clan_profile = ON
+```
+
 ### Feature toggles worksheet
 
 **Config key**
@@ -100,7 +114,7 @@ Leave values blank only if a module is disabled via toggles.
 **FeatureToggles tab (recruitment Sheet)**
 
 - Headers: `feature_name`, `enabled` (case-insensitive).
-- **Only `TRUE` enables a feature.** Any other value (`FALSE`, numbers, text, blank) disables it.
+- **Only `TRUE` (ON) enables a feature.** Any other value (`FALSE`, numbers, text, blank) disables it.
 - Seed rows:
   ```
   feature_name,enabled
@@ -133,4 +147,4 @@ Leave values blank only if a module is disabled via toggles.
 
 ---
 
-_Doc last updated: 2025-10-22 (v0.9.4 toggles rollout)_
+_Doc last updated: 2025-10-21 (v0.9.5 feature toggles refresh)_

--- a/docs/ops/commands.md
+++ b/docs/ops/commands.md
@@ -53,6 +53,27 @@ Detail: Report bot latency and shard status without hitting the cache.
 Tip: Ask staff to escalate if latency exceeds 250 ms for more than 5 minutes.
 ```
 
+## Recruitment commands — Phase 5 alignment
+
+### !clan `<tag>`
+
+Shows a clan’s profile and entry-criteria card.
+
+- **Access:** Public (no role restrictions)
+- **Behavior:** Posts in-channel. Displays the **Profile** card (with crest), adds 💡 reaction to toggle between Profile and Entry Criteria.
+- **Usage:** `!clan C1CE`
+- **Error Handling:** If tag not found, returns a small red embed.
+- **Feature Toggle:** `clan_profile`
+
+### !clanmatch
+
+Opens the text-only recruiter panel for filtering and matching clans.
+
+- **Access:** Staff / Recruiters
+- **Behavior:** Interactive panel, text-only for speed and mobile usability.
+- **Usage:** `!clanmatch`
+- **Feature Toggle:** `recruiter_panel`
+
 ---
 
-_Doc last updated: 2025-10-20 (Phase 3 + 3b consolidation)_
+_Doc last updated: 2025-10-21 (Phase 5 recruitment alignment)_

--- a/docs/ops/module-toggles.md
+++ b/docs/ops/module-toggles.md
@@ -1,15 +1,15 @@
 # Module toggles — Phase 5
 
 The FeatureToggles worksheet (see `docs/ops/Config.md`) governs which modules load
-at startup. Toggle values are case-insensitive; only `TRUE` enables a feature.
+at startup. Toggle values are case-insensitive; only `TRUE` (`ON`) enables a feature.
 
 ## Recruitment
 
 | Toggle | Default | Notes |
 | --- | --- | --- |
 | `member_panel` | `TRUE` | Enables member-facing search flows (future `!clansearch`). |
-| `recruiter_panel` | `TRUE` | Loads the recruiter-only `!clanmatch` panel. |
-| `clan_profile` | `FALSE` | Enables the public `!clan <tag>` command (in-channel crest card with 💡 reaction flip). |
+| `recruiter_panel` | `ON` | Enables the text-only recruiter panel (`!clanmatch`). |
+| `clan_profile` | `ON` | Enables the public `!clan` command with crest and 💡 reaction toggle. |
 | `recruitment_welcome` | `TRUE` | Welcome command and onboarding listeners. |
 | `recruitment_reports` | `TRUE` | Daily recruiter digest embed. |
 


### PR DESCRIPTION
## Summary
- document the public `!clan` profile card and recruiter `!clanmatch` panel in the ops command reference
- refresh env/config references with feature toggle output details and update the module toggle defaults
- bump README, docs index, and changelog to v0.9.5 with the new recruitment highlights

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f7c59fcf0c832383541f47ea63bd65