### PR TITLE
Move recruiter panel command registration into cog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.5-d — Command registration consolidation (no behavior change) — 2025-10-22
+
+- Move recruiter command registration to `cogs/recruitment_recruiter.py`.
+- Remove legacy in-module registration; preserve existing UX and flags.
+- Continue honoring `PANEL_THREAD_MODE`/`PANEL_FIXED_THREAD_ID` when redirecting the panel thread.
+
 ## v0.9.5-a — Structure tidy (no behavior change) — 2025-10-22
 
 * Consolidate CoreOps to `modules/coreops`; remove `shared/coreops`.

--- a/cogs/recruitment_recruiter.py
+++ b/cogs/recruitment_recruiter.py
@@ -1,8 +1,198 @@
-"""Recruiter panel cog entrypoint.
+"""Recruiter command registration cog.
 
-Symmetry with `cogs/recruitment_member.py`. This module ensures a stable import
-location for recruiter features without changing behavior.
+All recruiter-facing commands register here so modules remain side-effect free.
 """
-from modules.recruitment.views.recruiter_panel import *  # re-export if needed
-# NOTE: This file intentionally does not register new commands here.
-# Existing recruiter registration remains where it was; this provides a clear home.
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import discord
+from discord import InteractionResponded
+from discord.ext import commands
+
+from modules.common import config_access as config
+from modules.common import feature_flags
+from modules.coreops.helpers import tier
+from modules.recruitment.views.recruiter_panel import RecruiterPanelView
+from shared.coreops_rbac import is_admin_member, is_recruiter
+
+
+class RecruiterPanelCog(commands.Cog):
+    """Cog hosting the recruiter-facing `!clanmatch` command."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._panel_owners: Dict[int, int] = {}
+        self._owner_panels: Dict[int, Tuple[int, int]] = {}
+
+    def register_panel(self, *, message_id: int, owner_id: int, channel_id: int) -> None:
+        self._panel_owners[message_id] = owner_id
+        self._owner_panels[owner_id] = (channel_id, message_id)
+
+    def unregister_panel(self, message_id: int) -> None:
+        owner_id = self._panel_owners.pop(message_id, None)
+        if owner_id is not None:
+            existing = self._owner_panels.get(owner_id)
+            if existing and existing[1] == message_id:
+                self._owner_panels.pop(owner_id, None)
+
+    def _owner_for(self, message_id: int) -> Optional[int]:
+        return self._panel_owners.get(message_id)
+
+    def _panel_for_owner(self, owner_id: int) -> Optional[Tuple[int, int]]:
+        return self._owner_panels.get(owner_id)
+
+    async def _resolve_recruiter_panel_channel(
+        self, ctx: commands.Context
+    ) -> tuple[discord.abc.MessageableChannel, bool]:
+        """Locate the configured recruiter thread if available."""
+
+        mode = str(config.get_panel_thread_mode("channel")).strip().lower()
+        if mode != "fixed":
+            return ctx.channel, False
+
+        thread_id = config.get_panel_fixed_thread_id()
+        if not thread_id:
+            return ctx.channel, False
+
+        channel: discord.abc.MessageableChannel | None = None
+
+        if ctx.guild:
+            thread = ctx.guild.get_thread(thread_id)
+            if isinstance(thread, discord.Thread):
+                channel = thread
+
+        if channel is None and self.bot:
+            cached = self.bot.get_channel(thread_id)
+            if isinstance(cached, discord.abc.Messageable):
+                channel = cached  # type: ignore[assignment]
+
+        if channel is None and self.bot:
+            try:
+                fetched = await self.bot.fetch_channel(thread_id)
+            except Exception:
+                fetched = None
+            if isinstance(fetched, discord.abc.Messageable):
+                channel = fetched  # type: ignore[assignment]
+
+        if channel is None:
+            return ctx.channel, False
+
+        guild = getattr(channel, "guild", None)
+        if guild and ctx.guild and guild.id != ctx.guild.id:
+            return ctx.channel, False
+
+        if isinstance(channel, discord.Thread) and channel.archived:
+            try:
+                await channel.edit(archived=False)
+            except Exception:
+                pass
+
+        return channel, True
+
+    @tier("staff")
+    @commands.command(
+        name="clanmatch",
+        help="Launches the text-only recruiter panel used to match recruits with clans.",
+    )
+    @commands.cooldown(1, 2, commands.BucketType.user)
+    async def clanmatch(self, ctx: commands.Context) -> None:
+        """Open the recruiter panel to find clans for a recruit."""
+
+        if not isinstance(ctx.author, discord.Member):
+            await ctx.reply("⚠️ `!clanmatch` can only be used in a server.")
+            return
+
+        if not (is_recruiter(ctx) or is_admin_member(ctx)):
+            await ctx.reply(
+                "⚠️ Only **Recruitment Scouts/Coordinators** (or Admins) can use `!clanmatch`.",
+                mention_author=False,
+            )
+            return
+
+        view = RecruiterPanelView(self, ctx.author.id)
+        embeds, _ = await view._build_page()
+        view._last_embeds = [embed.copy() for embed in embeds]
+
+        existing_panel = self._panel_for_owner(ctx.author.id)
+        if existing_panel:
+            channel_id, message_id = existing_panel
+            channel = self.bot.get_channel(channel_id)
+            if channel is None:
+                try:
+                    channel = await self.bot.fetch_channel(channel_id)
+                except Exception:
+                    channel = None
+            if isinstance(channel, (discord.TextChannel, discord.Thread)):
+                try:
+                    message = await channel.fetch_message(message_id)
+                except Exception:
+                    self.unregister_panel(message_id)
+                else:
+                    view.message = message
+                    await message.edit(embeds=embeds, view=view)
+                    self.register_panel(
+                        message_id=message.id,
+                        owner_id=ctx.author.id,
+                        channel_id=channel.id,
+                    )
+                    if channel != ctx.channel:
+                        try:
+                            await ctx.reply(
+                                f"{ctx.author.mention} your recruiter panel is in {channel.mention}.",
+                                mention_author=False,
+                                allowed_mentions=discord.AllowedMentions(users=[ctx.author]),
+                                suppress_embeds=True,
+                            )
+                        except Exception:
+                            pass
+                    return
+
+        target, redirected = await self._resolve_recruiter_panel_channel(ctx)
+        sent = await target.send(embeds=embeds, view=view)
+        view.message = sent
+        self.register_panel(
+            message_id=sent.id,
+            owner_id=ctx.author.id,
+            channel_id=sent.channel.id,
+        )
+
+        if redirected and target is not ctx.channel:
+            try:
+                await ctx.reply(
+                    f"{ctx.author.mention} I opened your recruiter panel in {target.mention}.",
+                    mention_author=False,
+                    allowed_mentions=discord.AllowedMentions(users=[ctx.author]),
+                    suppress_embeds=True,
+                )
+            except Exception:  # pragma: no cover - pointer best effort
+                pass
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction) -> None:
+        message = getattr(interaction, "message", None)
+        if not message:
+            return
+        owner_id = self._owner_for(message.id)
+        if owner_id is None:
+            return
+        if interaction.user and interaction.user.id != owner_id:
+            try:
+                await interaction.response.send_message(
+                    "⚠️ Not your panel. Type **!clanmatch** to summon your own.",
+                    ephemeral=True,
+                )
+            except InteractionResponded:
+                try:
+                    await interaction.followup.send(
+                        "⚠️ Not your panel. Type **!clanmatch** to summon your own.",
+                        ephemeral=True,
+                    )
+                except Exception:
+                    pass
+
+
+async def setup(bot: commands.Bot) -> None:
+    if not feature_flags.is_enabled("recruiter_panel"):
+        return
+    await bot.add_cog(RecruiterPanelCog(bot))

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.9.5-a
+# Architecture — v0.9.5-d
 
 ## Runtime map
 ```
@@ -45,13 +45,17 @@ off in production until the panels ship._
 
 ## Recruitment visuals pipeline
 - `modules.recruitment.cards` & `modules.recruitment.views` compose embeds for clan panels.
-- `modules.recruitment.views.recruiter_panel` binds `!clanmatch` to those cards while staying
-  text-only (no `emoji_pipeline` dependency).
+- `cogs.recruitment_recruiter.RecruiterPanelCog` registers `!clanmatch` and embeds the
+  recruiter panel view while staying text-only (no `emoji_pipeline` dependency).
 - `modules.recruitment.emoji_pipeline` resolves guild emoji, falls back when proxies are strict,
   and builds attachment thumbnails when needed.
 - `/emoji-pad` (aiohttp) trims, pads, and caches PNG emoji when `PUBLIC_BASE_URL` or
   `RENDER_EXTERNAL_URL` is configured.
 - Sheets cache paths remain unchanged; data still flows through `sheets.recruitment`.
+
+### Command loading
+- All commands register under modules in `cogs/*`. Feature modules supply views, embeds,
+  and services without performing command registration on import.
 
 ## Feature toggles & gating
 - `modules.common.feature_flags.is_enabled(<key>)` runs during module boot; missing worksheets,
@@ -82,4 +86,4 @@ off in production until the panels ship._
 
 ---
 
-_Doc last updated: 2025-10-22 (v0.9.5-a)_
+_Doc last updated: 2025-10-22 (v0.9.5-d)_

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -690,14 +690,7 @@ class Runtime:
         await _load_feature_module(
             "modules.recruitment.services.search", ("member_panel", "recruiter_panel")
         )
-
-        if features.is_enabled("recruiter_panel"):
-            from modules.recruitment.views import recruiter_panel
-
-            await recruiter_panel.setup(self.bot)
-            log.info("modules: recruiter_panel enabled")
-        else:
-            log.info("modules: recruiter_panel disabled")
+        await _load_feature_module("cogs.recruitment_recruiter", ("recruiter_panel",))
 
         if features.is_enabled("clan_profile"):
             from modules.recruitment import clan_profile

--- a/modules/recruitment/views/recruiter_panel.py
+++ b/modules/recruitment/views/recruiter_panel.py
@@ -11,17 +11,17 @@ import asyncio
 import contextlib
 import logging
 import math
-from typing import Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import discord
-from discord.ext import commands
 from discord import InteractionResponded
 
 from .. import cards
 from modules.common import config_access as config
 from shared.sheets import recruitment as recruitment_sheets
-from modules.coreops.helpers import tier
-from shared.coreops_rbac import is_admin_member, is_recruiter
+
+if TYPE_CHECKING:
+    from cogs.recruitment_recruiter import RecruiterPanelCog
 
 log = logging.getLogger(__name__)
 
@@ -870,152 +870,3 @@ class RecruiterPanelView(discord.ui.View):
             self.cog.unregister_panel(self.message.id)
 
 
-class RecruiterPanelCog(commands.Cog):
-    """Cog hosting the recruiter-facing `!clanmatch` command."""
-
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot = bot
-        self._panel_owners: Dict[int, int] = {}
-        self._owner_panels: Dict[int, Tuple[int, int]] = {}
-
-    def register_panel(self, *, message_id: int, owner_id: int, channel_id: int) -> None:
-        self._panel_owners[message_id] = owner_id
-        self._owner_panels[owner_id] = (channel_id, message_id)
-
-    def unregister_panel(self, message_id: int) -> None:
-        owner_id = self._panel_owners.pop(message_id, None)
-        if owner_id is not None:
-            existing = self._owner_panels.get(owner_id)
-            if existing and existing[1] == message_id:
-                self._owner_panels.pop(owner_id, None)
-
-    def _owner_for(self, message_id: int) -> Optional[int]:
-        return self._panel_owners.get(message_id)
-
-    def _panel_for_owner(self, owner_id: int) -> Optional[Tuple[int, int]]:
-        return self._owner_panels.get(owner_id)
-
-    @tier("staff")
-    @commands.command(
-        name="clanmatch",
-        help="Launches the text-only recruiter panel used to match recruits with clans.",
-    )
-    @commands.cooldown(1, 2, commands.BucketType.user)
-    async def clanmatch(self, ctx: commands.Context) -> None:
-        """Open the recruiter panel to find clans for a recruit."""
-
-        if not isinstance(ctx.author, discord.Member):
-            await ctx.reply("⚠️ `!clanmatch` can only be used in a server.")
-            return
-
-        if not (is_recruiter(ctx) or is_admin_member(ctx)):
-            await ctx.reply(
-                "⚠️ Only **Recruitment Scouts/Coordinators** (or Admins) can use `!clanmatch`.",
-                mention_author=False,
-            )
-            return
-
-        view = RecruiterPanelView(self, ctx.author.id)
-        embeds, _ = await view._build_page()
-        view._last_embeds = [embed.copy() for embed in embeds]
-
-        existing_panel = self._panel_for_owner(ctx.author.id)
-        if existing_panel:
-            channel_id, message_id = existing_panel
-            channel = ctx.bot.get_channel(channel_id)
-            if channel is None:
-                try:
-                    channel = await ctx.bot.fetch_channel(channel_id)
-                except Exception:
-                    channel = None
-            if isinstance(channel, (discord.TextChannel, discord.Thread)):
-                try:
-                    message = await channel.fetch_message(message_id)
-                except Exception:
-                    self.unregister_panel(message_id)
-                else:
-                    view.message = message
-                    await message.edit(embeds=embeds, view=view)
-                    self.register_panel(
-                        message_id=message.id,
-                        owner_id=ctx.author.id,
-                        channel_id=channel.id,
-                    )
-                    if channel != ctx.channel:
-                        try:
-                            await ctx.reply(
-                                f"{ctx.author.mention} your recruiter panel is in {channel.mention}.",
-                                mention_author=False,
-                                allowed_mentions=discord.AllowedMentions(users=[ctx.author]),
-                                suppress_embeds=True,
-                            )
-                        except Exception:
-                            pass
-                    return
-
-        thread = None
-        try:
-            from modules.common import config_access as _cfg
-
-            mode = getattr(_cfg, "get_panel_thread_mode", lambda: "channel")()
-            fixed_id = getattr(_cfg, "get_panel_fixed_thread_id", lambda: None)()
-            if str(mode).lower() == "fixed" and fixed_id:
-                thread = ctx.guild.get_thread(int(fixed_id)) if ctx.guild else None
-                if not thread and ctx.bot:
-                    thread = await ctx.bot.fetch_channel(int(fixed_id))
-                if isinstance(thread, discord.Thread) and thread.archived:
-                    try:
-                        await thread.edit(archived=False)
-                    except Exception:
-                        pass
-        except Exception:
-            thread = None
-
-        target: discord.abc.MessageableChannel = (
-            thread if (thread and hasattr(thread, "send")) else ctx.channel
-        )
-        sent = await target.send(embeds=embeds, view=view)
-        view.message = sent
-        self.register_panel(
-            message_id=sent.id,
-            owner_id=ctx.author.id,
-            channel_id=sent.channel.id,
-        )
-
-        if target is not ctx.channel:
-            try:
-                await ctx.reply(
-                    f"{ctx.author.mention} I opened your recruiter panel in {target.mention}.",
-                    mention_author=False,
-                    allowed_mentions=discord.AllowedMentions(users=[ctx.author]),
-                    suppress_embeds=True,
-                )
-            except Exception:  # pragma: no cover - pointer best effort
-                pass
-
-    @commands.Cog.listener()
-    async def on_interaction(self, interaction: discord.Interaction) -> None:
-        message = getattr(interaction, "message", None)
-        if not message:
-            return
-        owner_id = self._owner_for(message.id)
-        if owner_id is None:
-            return
-        if interaction.user and interaction.user.id != owner_id:
-            try:
-                await interaction.response.send_message(
-                    "⚠️ Not your panel. Type **!clanmatch** to summon your own.",
-                    ephemeral=True,
-                )
-            except InteractionResponded:
-                try:
-                    await interaction.followup.send(
-                        "⚠️ Not your panel. Type **!clanmatch** to summon your own.",
-                        ephemeral=True,
-                    )
-                except Exception:
-                    pass
-
-
-async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(RecruiterPanelCog(bot))


### PR DESCRIPTION
## Summary
- register the recruiter panel command via `cogs/recruitment_recruiter.py` and keep the panel view module side-effect free
- clean up `modules/recruitment/views/recruiter_panel.py` so it exports UI only while keeping the panel redirect tied to the existing thread toggles
- update the runtime loader, architecture doc, and changelog to document cog-only command registration

## Testing
- python -m compileall cogs/recruitment_recruiter.py modules/recruitment/views/recruiter_panel.py

[meta]
labels: refactor, guardrails, comp:recruitment, commands, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68f932fa854083238b5dc5d7cdb45753