### PR TITLE
Add guardrails compliance checker and initial audit report

### DIFF
--- a/AUDIT/20251023_GUARDRAILS/report.md
+++ b/AUDIT/20251023_GUARDRAILS/report.md
@@ -1,0 +1,93 @@
+# Guardrails Compliance Report
+
+- Findings: 87 error(s)
+
+## Errors
+
+- S-01: legacy import outside modules/* → cogs/recruitment_recruiter.py:16: `from modules.recruitment.views.recruiter_panel import RecruiterPanelView`
+- S-01: legacy import outside modules/* → shared/help.py:141: `"Tip: Use with care — affects all modules, not just recruitment."`
+- S-05: coreops must not live under shared/* → app.py:22: `from shared.coreops_prefix import detect_admin_bang_command`
+- S-05: coreops must not live under shared/* → app.py:23: `from shared.coreops_rbac import (`
+- S-05: coreops must not live under shared/* → cogs/recruitment_recruiter.py:17: `from shared.coreops_rbac import is_admin_member, is_recruiter`
+- S-05: coreops must not live under shared/* → modules/coreops/cog.py:7: `from shared.coreops_cog import CoreOpsCog`
+- S-05: coreops must not live under shared/* → modules/recruitment/welcome.py:8: `from shared.coreops_rbac import is_staff_member, is_admin_member`
+- S-05: coreops must not live under shared/* → modules/recruitment/services/search.py:7: `from shared.coreops_rbac import is_lead, is_recruiter`
+- S-05: coreops must not live under shared/* → modules/common/runtime.py:56: `from shared.coreops_render import build_refresh_embed, RefreshEmbedRow`
+- S-05: coreops must not live under shared/* → shared/coreops_cog.py:36: `from shared.coreops_render import (`
+- S-05: coreops must not live under shared/* → shared/sheets/cache_scheduler.py:14: `from shared.coreops_cog import resolve_ops_log_channel_id`
+- S-03: command decorator outside cogs/* → app.py:269: `@bot.command(`
+- S-03: command decorator outside cogs/* → modules/recruitment/clan_profile.py:61: `@commands.command(`
+- S-03: command decorator outside cogs/* → modules/recruitment/welcome.py:41: `@commands.command(name="welcome", usage="[clan] @mention")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/welcome.py:303: `@commands.command(name="welcome")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/welcome.py:407: `@commands.command(name="welcome-refresh")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/welcome.py:419: `@commands.command(name="welcome-on")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/welcome.py:428: `@commands.command(name="welcome-off")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/welcome.py:437: `@commands.command(name="welcome-status")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:1566: `@bot.command(name="help")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:1709: `@bot.command(name="clanmatch")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:1799: `@bot.command()`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:1807: `@bot.command(name="clansearch")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:1936: `@bot.command(name="clan")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:2045: `@bot.command(name="ping")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:2054: `@bot.command(name="health", aliases=["status"])`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/MM/bot_clanmatch_prefix.py:2083: `@bot.command(name="reload")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:237: `@bot.command(name="help")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1022: `@bot.command(name="env_check")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1098: `@bot.command(name="ping")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1107: `@bot.command(name="sheetstatus")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1132: `@bot.command(name="backfill_tickets")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1190: `@bot.command(name="backfill_stop")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1198: `@bot.command(name="backfill_details")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1205: `@bot.command(name="clan_tags_debug")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1216: `@bot.command(name="dedupe_sheet")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1234: `@bot.command(name="reload")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1242: `@bot.command(name="health")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1253: `@bot.command(name="checksheet")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1272: `@bot.command(name="reboot")`
+- S-03: command decorator outside cogs/* → AUDIT/20251010_src/WC/bot_welcomecrew.py:1278: `@bot.command(name="watch_status")`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:1143: `@commands.command(name="health", hidden=True)`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:1694: `@commands.command(name="checksheet", hidden=True)`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:1815: `@commands.command(name="digest", hidden=True)`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:1866: `@commands.command(name="env", hidden=True)`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:2091: `@commands.command(name="config", hidden=True)`
+- S-03: command decorator outside cogs/* → shared/coreops_cog.py:2111: `@commands.command(name="reload", hidden=True)`
+- D-02: missing or malformed footer → docs/README.md
+- D-01: 'Phase' in title → docs/development.md
+- D-02: missing or malformed footer → docs/development.md
+- D-02: missing or malformed footer → docs/Architecture.md
+- D-01: 'Phase' in title → docs/ops/commands.md
+- D-02: missing or malformed footer → docs/ops/commands.md
+- D-01: 'Phase' in title → docs/ops/Config.md
+- D-02: missing or malformed footer → docs/ops/Config.md
+- D-01: 'Phase' in title → docs/ops/module-toggles.md
+- D-02: missing or malformed footer → docs/ops/module-toggles.md
+- D-01: 'Phase' in title → docs/ops/Troubleshooting.md
+- D-02: missing or malformed footer → docs/ops/Troubleshooting.md
+- D-01: 'Phase' in title → docs/ops/development.md
+- D-02: missing or malformed footer → docs/ops/development.md
+- D-01: 'Phase' in title → docs/ops/Runbook.md
+- D-02: missing or malformed footer → docs/ops/Runbook.md
+- D-01: 'Phase' in title → docs/ops/CommandMatrix.md
+- D-02: missing or malformed footer → docs/ops/CommandMatrix.md
+- D-01: 'Phase' in title → docs/ops/Architecture.md
+- D-02: missing or malformed footer → docs/ops/Architecture.md
+- D-01: 'Phase' in title → docs/ops/Watchers.md
+- D-02: missing or malformed footer → docs/ops/Watchers.md
+- D-02: missing or malformed footer → docs/adr/ADR-0000-template.md
+- D-02: missing or malformed footer → docs/adr/ADR-0004-help-system-short-vs-detailed.md
+- D-02: missing or malformed footer → docs/adr/ADR-0009-recruiter-panel-text-only.md
+- D-02: missing or malformed footer → docs/adr/ADR-0005-reload-vs-refresh.md
+- D-02: missing or malformed footer → docs/adr/ADR-0001-sheets-access-layer.md
+- D-02: missing or malformed footer → docs/adr/ADR-0010-clan-profile-with-emoji.md
+- D-02: missing or malformed footer → docs/adr/README.md
+- D-02: missing or malformed footer → docs/adr/ADR-0008-emoji-pipeline-port.md
+- D-02: missing or malformed footer → docs/adr/ADR-0011.md
+- D-02: missing or malformed footer → docs/adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md
+- D-02: missing or malformed footer → docs/adr/ADR-0003-coreops-command-contract.md
+- D-02: missing or malformed footer → docs/adr/ADR-0002-cache-telemetry-wrapper.md
+- D-02: missing or malformed footer → docs/adr/ADR-0006-startup-preloader-bot-info-cron.md
+- D-02: missing or malformed footer → docs/contracts/core_infra.md
+- D-02: missing or malformed footer → docs/contracts/CollaborationContract.md
+- D-02: missing or malformed footer → docs/compliance/REPORT_GUARDRAILS.md
+- D-03: keys in Config.md missing in .env.example → ['ADMIN_ROLE_IDS', 'CLANLIST_TAB', 'CLANS_TAB', 'CLAN_TAGS_CACHE_TTL_SEC', 'CLEANUP_AGE_HOURS', 'CRON_REFRESH_CACHE', 'CRON_REFRESH_CLAN_TAGS', 'CRON_REFRESH_SHEETS', 'DISCORD_TOKEN', 'EMOJI_MAX_BYTES', 'EMOJI_PAD_BOX', 'EMOJI_PAD_SIZE', 'ENABLE_NOTIFY_FALLBACK', 'ENABLE_PROMO_LISTENERS', 'ENABLE_PROMO_WATCHER', 'ENABLE_WELCOME_LISTENERS', 'ENABLE_WELCOME_WATCHER', 'ENV_NAME', 'FALSE', 'FEATURE_TOGGLES_TAB', 'GSPREAD_CREDENTIALS', 'GUILD_IDS', 'LEAD_ROLE_IDS', 'LOG_CHANNEL_ID', 'NOTIFY_CHANNEL_ID', 'NOTIFY_PING_ROLE_ID', 'ONBOARDING_SHEET_ID', 'PROMO_CHANNEL_ID', 'PROMO_TICKETS_TAB', 'PUBLIC_BASE_URL', 'RECRUITER_ROLE_IDS', 'RECRUITMENT_SHEET_ID', 'REFRESH_TIMES', 'RENDER_EXTERNAL_URL', 'SEARCH_RESULTS_SOFT_CAP', 'STAFF_ROLE_IDS', 'STRICT_EMOJI_PROXY', 'STRICT_PROBE', 'TAG_BADGE_BOX', 'TAG_BADGE_PX', 'TIMEZONE', 'TRUE', 'UTC', 'WATCHDOG_CHECK_SEC', 'WATCHDOG_DISCONNECT_GRACE_SEC', 'WATCHDOG_STALL_SEC', 'WELCOME_CHANNEL_ID', 'WELCOME_ENABLED', 'WELCOME_GENERAL_CHANNEL_ID', 'WELCOME_TEMPLATES_TAB', 'WELCOME_TICKETS_TAB']
+- D-03: keys in .env.example not documented in Config.md → ['MEMBER_PANEL_ALLOW_ROLES', 'MEMBER_PANEL_THREAD_ID']

--- a/scripts/ci/guardrails_check.py
+++ b/scripts/ci/guardrails_check.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import os, re, sys, time, pathlib, json
+from typing import List, Tuple
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "guardrails" / "RepositoryGuardrails.md"
+AUDIT_DIR = ROOT / f"AUDIT/{time.strftime('%Y%m%d')}_GUARDRAILS"
+AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+REPORT = AUDIT_DIR / "report.md"
+
+errors: List[str] = []
+notes: List[str] = []
+
+def glob(paths: List[str]) -> List[pathlib.Path]:
+    out=[]
+    for p in paths:
+        out.extend(ROOT.glob(p))
+    return [p for p in out if p.exists()]
+
+def has_phase_title(md: pathlib.Path) -> bool:
+    txt = md.read_text(encoding="utf-8", errors="ignore")
+    m = re.search(r"^#\s+.*phase", txt, flags=re.IGNORECASE|re.MULTILINE)
+    return bool(m)
+
+def footer_ok(md: pathlib.Path) -> bool:
+    lines = md.read_text(encoding="utf-8", errors="ignore").strip().splitlines()
+    if not lines: return False
+    return bool(re.match(r"^Doc last updated: \d{4}-\d{2}-\d{2} \(v0\.9\.\w+\)$", lines[-1]))
+
+def md_links(md: pathlib.Path) -> List[Tuple[str,str]]:
+    txt = md.read_text(encoding="utf-8", errors="ignore")
+    return re.findall(r"\[([^\]]+)\]\(([^)]+)\)", txt)
+
+def file_exists(rel: str) -> bool:
+    return (ROOT / rel).exists()
+
+def grep(patterns: List[str], in_paths: List[str]) -> List[Tuple[str,int,str]]:
+    outs=[]
+    for g in in_paths:
+        for p in ROOT.glob(g):
+            if p.is_dir() or not p.suffix in {".py",".md"}: continue
+            try:
+                for i,l in enumerate(p.read_text(encoding="utf-8", errors="ignore").splitlines(),1):
+                    for pat in patterns:
+                        if re.search(pat, l):
+                            outs.append((str(p.relative_to(ROOT)), i, l.strip()))
+            except Exception:
+                pass
+    return outs
+
+def section(title: str) -> str:
+    return f"\n## {title}\n"
+
+# 1) Structure checks
+bad_imports = grep(
+    [r"\brecruitment\.", r"\bonboarding\.", r"\bplacement\."],
+    ["**/*.py"]
+)
+# Allow only under modules/
+bad_imports = [t for t in bad_imports if not t[0].startswith("modules/")]
+
+legacy_coreops = grep(
+    [r"\bshared\.coreops", r"\bshared\.utils\.coreops_"],
+    ["**/*.py"]
+)
+
+for rel, ln, line in bad_imports:
+    errors.append(f"S-01: legacy import outside modules/* → {rel}:{ln}: `{line}`")
+
+for rel, ln, line in legacy_coreops:
+    errors.append(f"S-05: coreops must not live under shared/* → {rel}:{ln}: `{line}`")
+
+# Ensure packages exist
+for pkg in ["modules/recruitment", "modules/placement", "modules/onboarding", "shared/sheets"]:
+    if not file_exists(f"{pkg}/__init__.py"):
+        errors.append(f"S-08: missing __init__.py in {pkg}")
+
+# 2) Coding checks
+decorators_outside_cogs = grep(
+    [r"@(?:commands\.command|bot\.command|tree\.command|app_commands\.command)"],
+    ["**/*.py"]
+)
+decorators_outside_cogs = [t for t in decorators_outside_cogs if not t[0].startswith("cogs/")]
+for rel, ln, line in decorators_outside_cogs:
+    errors.append(f"S-03: command decorator outside cogs/* → {rel}:{ln}: `{line}`")
+
+# 3) Docs checks
+docs = [p for p in ROOT.glob("docs/**/*.md") if p.is_file()]
+for md in docs:
+    if has_phase_title(md):
+        errors.append(f"D-01: 'Phase' in title → {md.relative_to(ROOT)}")
+    if not footer_ok(md):
+        errors.append(f"D-02: missing or malformed footer → {md.relative_to(ROOT)}")
+
+# 4) ENV parity (SSoT)
+config_md = ROOT / "docs" / "ops" / "Config.md"
+env_example = ROOT / ".env.example"
+if config_md.exists() and env_example.exists():
+    md_txt = config_md.read_text(encoding="utf-8", errors="ignore")
+    keys_in_md = set(re.findall(r"`([A-Z][A-Z0-9_]+)`", md_txt))
+    env_txt = env_example.read_text(encoding="utf-8", errors="ignore")
+    keys_in_env = set(re.findall(r"^([A-Z][A-Z0-9_]+)=", env_txt, flags=re.MULTILINE))
+    missing_in_env = sorted(k for k in keys_in_md if k not in keys_in_env)
+    extra_in_env = sorted(k for k in keys_in_env if k not in keys_in_md)
+    if missing_in_env:
+        errors.append(f"D-03: keys in Config.md missing in .env.example → {missing_in_env}")
+    if extra_in_env:
+        errors.append(f"D-03: keys in .env.example not documented in Config.md → {extra_in_env}")
+else:
+    notes.append("ENV parity skipped: docs/ops/Config.md or .env.example missing")
+
+# Write report
+out = ["# Guardrails Compliance Report", "", f"- Findings: {len(errors)} error(s)"]
+if notes:
+    out.append(f"- Notes: {len(notes)}")
+    for n in notes: out.append(f"  - {n}")
+out.append(section("Errors"))
+out.extend([f"- {e}" for e in errors] or ["- None"])
+
+REPORT.write_text("\n".join(out) + "\n", encoding="utf-8")
+print(f"Wrote {REPORT}")
+sys.exit(1 if errors else 0)


### PR DESCRIPTION
## Summary
- add the guardrails compliance checker under `scripts/ci`
- run the one-time audit and commit `AUDIT/20251023_GUARDRAILS/report.md`

## Guardrails Audit
- Findings: 87 errors detected (see committed report for full details)

## Testing
- python scripts/ci/guardrails_check.py *(fails with exit code 1 because guardrail violations were found)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e45283e48323a501240b7c6eef19