### PR TITLE
Add explicit exports for CoreOps render module

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/render.py
+++ b/packages/c1c-coreops/src/c1c_coreops/render.py
@@ -620,3 +620,21 @@ def build_refresh_embed(
     )
     embed.set_footer(text=footer_text)
     return embed
+
+
+__all__ = [
+    "DigestEmbedData",
+    "DigestSheetEntry",
+    "DigestSheetsClientSummary",
+    "ChecksheetTabEntry",
+    "ChecksheetSheetEntry",
+    "ChecksheetEmbedData",
+    "RefreshEmbedRow",
+    "build_digest_line",
+    "build_digest_embed",
+    "build_checksheet_tabs_embed",
+    "build_health_embed",
+    "build_env_embed",
+    "build_refresh_embed",
+    "build_config_embed",
+]

--- a/tests/test_coreops_imports.py
+++ b/tests/test_coreops_imports.py
@@ -24,3 +24,12 @@ def test_imports() -> None:
     from c1c_coreops.cog import CoreOpsCog  # noqa: F401
 
     assert hasattr(rbac, "admin_only")
+
+
+def test_render_imports() -> None:
+    _ensure_src_on_path()
+
+    from c1c_coreops import render
+
+    assert hasattr(render, "build_env_embed")
+    assert hasattr(render, "DigestEmbedData")


### PR DESCRIPTION
## Summary
- add an explicit `__all__` in `c1c_coreops.render` covering the embed DTOs and builders consumed by the Cog
- extend the import smoke test suite to ensure the render module exposes the expected API

## Testing
- `pytest tests/test_coreops_imports.py`

| Old path | Symbol |
| --- | --- |
| shared/coreops_render.py | DigestEmbedData |
| shared/coreops_render.py | DigestSheetEntry |
| shared/coreops_render.py | DigestSheetsClientSummary |
| shared/coreops_render.py | ChecksheetTabEntry |
| shared/coreops_render.py | ChecksheetSheetEntry |
| shared/coreops_render.py | ChecksheetEmbedData |
| shared/coreops_render.py | RefreshEmbedRow |
| shared/coreops_render.py | build_digest_line |
| shared/coreops_render.py | build_digest_embed |
| shared/coreops_render.py | build_checksheet_tabs_embed |
| shared/coreops_render.py | build_health_embed |
| shared/coreops_render.py | build_env_embed |
| shared/coreops_render.py | build_refresh_embed |
| shared/coreops_render.py | build_config_embed |

[meta]
labels: comp:coreops, architecture 
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fa0d3271648323bbc400aa6be98f3f