### PR TITLE
Add workflow to sync labels from GitHub

### DIFF
--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  issues: read
   pull-requests: write
 
 jobs:
@@ -65,16 +66,16 @@ jobs:
           p = Path('docs/contracts/CollaborationContract.md')
           text = p.read_text(encoding='utf-8')
 
-          # Find section start
-          heading_pat = re.compile(r"^##\\s+Label Reference \\(Approved Set\\)\\s*$", re.M)
+          # Find section start (contract uses level-3 '###' and may include an emoji)
+          heading_pat = re.compile(r"^###\\s+.*Label Reference\\s*\\(Approved Set\\)\\s*$", re.M)
           m = heading_pat.search(text)
           if not m:
-            raise SystemExit("Heading '## Label Reference (Approved Set)' not found.")
+            raise SystemExit("Heading '### Label Reference (Approved Set)' not found.")
 
           start = m.end()
 
-          # Find next same-level heading or EOF
-          next_h_pat = re.compile(r"^##\\s+[^\\n]+\\n", re.M)
+          # Find next same-level (###) heading or EOF
+          next_h_pat = re.compile(r"^###\\s+[^\\n]+\\n", re.M)
           next_m = next_h_pat.search(text, start)
           end = next_m.start() if next_m else len(text)
 


### PR DESCRIPTION
## Summary
- add a dispatchable Sync Labels from GitHub workflow that mirrors live labels into repo files and opens a PR

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa14c9ebb48323a3b655a2562e7a5f