### PR TITLE
Extract admin bang prefix detector into c1c_coreops.prefix

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -70,6 +70,7 @@ from shared.sheets.async_core import (
     afetch_records,
 )
 
+from .prefix import detect_admin_bang_command
 from .rbac import (
     admin_only,
     can_view_admin,
@@ -2878,4 +2879,5 @@ __all__ = [
     "_admin_check",
     "_admin_roles_configured",
     "_staff_check",
+    "detect_admin_bang_command",
 ]

--- a/packages/c1c-coreops/src/c1c_coreops/prefix.py
+++ b/packages/c1c-coreops/src/c1c_coreops/prefix.py
@@ -6,6 +6,8 @@ from typing import Callable, Collection, Dict, Optional
 
 import discord
 
+__all__ = ["detect_admin_bang_command"]
+
 AdminCheck = Callable[[discord.abc.User | discord.Member], bool]
 _BANG_CMD_RE = re.compile(r"^!\s*([a-zA-Z]+)(?:\s|$)")
 

--- a/tests/test_coreops_imports.py
+++ b/tests/test_coreops_imports.py
@@ -33,3 +33,74 @@ def test_render_imports() -> None:
 
     assert hasattr(render, "build_env_embed")
     assert hasattr(render, "DigestEmbedData")
+
+
+def test_prefix_imports() -> None:
+    _ensure_src_on_path()
+
+    from c1c_coreops import prefix
+
+    assert hasattr(prefix, "detect_admin_bang_command")
+
+
+class _DummyAuthor:
+    def __init__(self, *, admin: bool) -> None:
+        self.is_admin = admin
+
+
+class _DummyMessage:
+    def __init__(self, content: str, author: _DummyAuthor) -> None:
+        self.content = content
+        self.author = author
+
+
+def _is_admin(user: object) -> bool:
+    return bool(getattr(user, "is_admin", False))
+
+
+def test_detect_admin_bang_command_for_admin() -> None:
+    _ensure_src_on_path()
+
+    from c1c_coreops.prefix import detect_admin_bang_command
+
+    author = _DummyAuthor(admin=True)
+    message = _DummyMessage(" !ENV  ", author)
+    result = detect_admin_bang_command(
+        message,
+        commands=("Env", "Reload"),
+        is_admin=_is_admin,
+    )
+
+    assert result == "Env"
+
+
+def test_detect_admin_bang_command_for_non_admin() -> None:
+    _ensure_src_on_path()
+
+    from c1c_coreops.prefix import detect_admin_bang_command
+
+    author = _DummyAuthor(admin=False)
+    message = _DummyMessage("!reload", author)
+    result = detect_admin_bang_command(
+        message,
+        commands=("Env", "Reload"),
+        is_admin=_is_admin,
+    )
+
+    assert result is None
+
+
+def test_detect_admin_bang_command_for_unknown() -> None:
+    _ensure_src_on_path()
+
+    from c1c_coreops.prefix import detect_admin_bang_command
+
+    author = _DummyAuthor(admin=True)
+    message = _DummyMessage("!unknown", author)
+    result = detect_admin_bang_command(
+        message,
+        commands=("Env", "Reload"),
+        is_admin=_is_admin,
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary
- expose `detect_admin_bang_command` via `c1c_coreops.prefix` with a public `__all__`
- re-export the detector from `CoreOpsCog` so the package Cog uses the shared helper
- add smoke coverage for the prefix module and detector behavior

## Testing
- `pytest tests/test_coreops_imports.py`

Before/After:
- `shared/coreops_prefix.py:detect_admin_bang_command` → `c1c_coreops/prefix.py:detect_admin_bang_command`

[meta]
labels: comp:ops, architecture
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fa1808f8d08323b938ee81aca9dbb0