### PR TITLE
Adjust c1c-coreops packaging configuration

### DIFF
--- a/packages/c1c-coreops/pyproject.toml
+++ b/packages/c1c-coreops/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,5 +18,9 @@ classifiers = [
 ]
 
 [tool.setuptools]
-packages = [{ include = "c1c_coreops", from = "src" }]
+package-dir = {"" = "src"}
 include-package-data = false
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["c1c_coreops*"]


### PR DESCRIPTION
## Summary
- include wheel alongside setuptools for building the package
- switch to setuptools package discovery for the src layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa3caf74dc8323b86a154ff693d135