### PR TITLE
Add annotations to docs and guardrails checks

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -12,5 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run docs checker
-        run: python scripts/ci/check_docs.py
+      - name: Run docs checker (capture output)
+        run: |
+          python scripts/ci/check_docs.py | tee docs_lint.out
+        shell: bash
+
+      - name: Annotate failures directly in PR
+        if: always()
+        run: |
+          python scripts/ci/emit_annotations.py --kind docs --input docs_lint.out
+        shell: bash

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -14,5 +14,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Run guardrails checker
-        run: python scripts/ci/guardrails_check.py
+      - name: Run guardrails checker (capture output)
+        run: |
+          python scripts/ci/guardrails_check.py | tee guardrails.out
+        shell: bash
+
+      - name: Annotate failures directly in PR
+        if: always()
+        run: |
+          python scripts/ci/emit_annotations.py --kind guardrails --input guardrails.out
+        shell: bash

--- a/scripts/ci/guardrails_check.py
+++ b/scripts/ci/guardrails_check.py
@@ -11,6 +11,20 @@ REPORT = AUDIT_DIR / "report.md"
 errors: List[str] = []
 notes: List[str] = []
 
+
+def _echo_violation(rule_id, message, file_path=None, line_no=None):
+    """
+    Standardized single-line output that our workflow parser can read.
+    Example:
+      VIOLATION: GR-001 No new labels without contract approval file: .github/labels.yml line: 14
+    """
+    parts = [f"VIOLATION: {rule_id}", message]
+    if file_path:
+        parts.append(f"file: {file_path}")
+    if line_no:
+        parts.append(f"line: {line_no}")
+    print(" ".join(parts))
+
 def glob(paths: List[str]) -> List[pathlib.Path]:
     out=[]
     for p in paths:
@@ -73,14 +87,17 @@ legacy_coreops = [
 ]
 
 for rel, ln, line in bad_imports:
+    _echo_violation("S-01", "legacy import outside modules/*", rel, ln)
     errors.append(f"S-01: legacy import outside modules/* → {rel}:{ln}: `{line}`")
 
 for rel, ln, line in legacy_coreops:
+    _echo_violation("S-05", "coreops must not live under shared/*", rel, ln)
     errors.append(f"S-05: coreops must not live under shared/* → {rel}:{ln}: `{line}`")
 
 # Ensure packages exist
 for pkg in ["modules/recruitment", "modules/placement", "modules/onboarding", "shared/sheets"]:
     if not file_exists(f"{pkg}/__init__.py"):
+        _echo_violation("S-08", "missing __init__.py", f"{pkg}/__init__.py")
         errors.append(f"S-08: missing __init__.py in {pkg}")
 
 # 2) Coding checks
@@ -90,15 +107,20 @@ decorators_outside_cogs = grep(
 )
 decorators_outside_cogs = [t for t in decorators_outside_cogs if not t[0].startswith("cogs/")]
 for rel, ln, line in decorators_outside_cogs:
+    _echo_violation("S-03", "command decorator outside cogs/*", rel, ln)
     errors.append(f"S-03: command decorator outside cogs/* → {rel}:{ln}: `{line}`")
 
 # 3) Docs checks
 docs = [p for p in ROOT.glob("docs/**/*.md") if p.is_file()]
 for md in docs:
     if has_phase_title(md):
-        errors.append(f"D-01: 'Phase' in title → {md.relative_to(ROOT)}")
+        rel_md = str(md.relative_to(ROOT))
+        _echo_violation("D-01", "'Phase' in title", rel_md)
+        errors.append(f"D-01: 'Phase' in title → {rel_md}")
     if not footer_ok(md):
-        errors.append(f"D-02: missing or malformed footer → {md.relative_to(ROOT)}")
+        rel_md = str(md.relative_to(ROOT))
+        _echo_violation("D-02", "missing or malformed footer", rel_md)
+        errors.append(f"D-02: missing or malformed footer → {rel_md}")
 
 # 4) ENV parity (SSoT)
 config_md = ROOT / "docs" / "ops" / "Config.md"
@@ -111,8 +133,10 @@ if config_md.exists() and env_example.exists():
     missing_in_env = sorted(k for k in keys_in_md if k not in keys_in_env)
     extra_in_env = sorted(k for k in keys_in_env if k not in keys_in_md)
     if missing_in_env:
+        _echo_violation("D-03", "keys in Config.md missing in .env.example", str(env_example.relative_to(ROOT)))
         errors.append(f"D-03: keys in Config.md missing in .env.example → {missing_in_env}")
     if extra_in_env:
+        _echo_violation("D-03", "keys in .env.example not documented in Config.md", str(config_md.relative_to(ROOT)))
         errors.append(f"D-03: keys in .env.example not documented in Config.md → {extra_in_env}")
 else:
     notes.append("ENV parity skipped: docs/ops/Config.md or .env.example missing")


### PR DESCRIPTION
## Summary
- capture docs and guardrails CI outputs so emit_annotations can process them
- add standardized guardrails violation logging to support workflow annotations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb4f5b48ec832394f8130943736e94