### PR TITLE
Fix audit workflow environment and docs indexing

### DIFF
--- a/.github/workflows/audit-coreops.yml
+++ b/.github/workflows/audit-coreops.yml
@@ -1,0 +1,27 @@
+name: audit-coreops
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Run CoreOps packaging audit
+        run: python scripts/audit_coreops_packaging.py
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coreops-packaging-audit
+          path: AUDIT/CoreOps-Packaging-Audit.md

--- a/AUDIT/CoreOps-Packaging-Audit.md
+++ b/AUDIT/CoreOps-Packaging-Audit.md
@@ -1,0 +1,56 @@
+# CoreOps Packaging Audit
+
+Generated: 2025-10-24T10:15:26Z
+Commit: unknown
+Total files scanned: 129
+Result: **FAIL** (22 offenses)
+
+## Docs/Config Drift
+
+| Path | Line | Snippet |
+| --- | --- | --- |
+| `CHANGELOG.md` | 18 | `* Consolidate CoreOps to `modules/coreops`; remove `shared/coreops`.` |
+| `docs/adr/ADR-0002-cache-telemetry-wrapper.md` | 13 | `- Introduce `shared/coreops/cache_public.py` as the only import surface for telemetry.` |
+| `docs/guardrails/RepositoryGuardrails.md` | 25 | `- **C-09 No Legacy Paths:** No imports from removed legacy paths (e.g., top-level `recruitment/`, `shared/coreops`, `shared/utils/coreops_*`).` |
+| `docs/ops/development.md` | 4 | `- Import telemetry data via `shared.coreops.cache_public` helpers (`list_buckets`,` |
+
+## Duplicate CoreOps Symbols
+
+| Path | Line | Snippet |
+| --- | --- | --- |
+| `shared/help.py` | 269 | `def build_help_overview_embed(` |
+| `shared/help.py` | 297 | `def build_help_detail_embed(` |
+
+## Shim/Re-export Bridges
+
+| Path | Line | Snippet |
+| --- | --- | --- |
+| `shared/coreops_cog.py` | 13 | `from c1c_coreops.cog import *  # noqa: F401,F403` |
+| `shared/coreops_prefix.py` | 13 | `from c1c_coreops.prefix import *  # noqa: F401,F403` |
+| `shared/coreops_rbac.py` | 13 | `from c1c_coreops.rbac import *  # noqa: F401,F403` |
+| `shared/coreops_render.py` | 13 | `from c1c_coreops.render import *  # noqa: F401,F403` |
+
+## Stray CoreOps Paths
+
+| Path | Line | Snippet |
+| --- | --- | --- |
+| `modules/coreops/__init__.py` | - | `Path contains coreops outside package` |
+| `modules/coreops/cog.py` | - | `Path contains coreops outside package` |
+| `modules/coreops/cron_summary.py` | - | `Path contains coreops outside package` |
+| `modules/coreops/cronlog.py` | - | `Path contains coreops outside package` |
+| `modules/coreops/helpers.py` | - | `Path contains coreops outside package` |
+| `modules/coreops/ops.py` | - | `Path contains coreops outside package` |
+| `shared/coreops_cog.py` | - | `Path contains coreops outside package` |
+| `shared/coreops_prefix.py` | - | `Path contains coreops outside package` |
+| `shared/coreops_rbac.py` | - | `Path contains coreops outside package` |
+| `shared/coreops_render.py` | - | `Path contains coreops outside package` |
+| `tests/test_coreops_basic.py` | - | `Path contains coreops outside package` |
+| `tests/test_coreops_imports.py` | - | `Path contains coreops outside package` |
+
+## Fix-It Checklist
+
+- Rewrite imports to use `c1c_coreops.*` directly.
+- Move or delete stray CoreOps files outside `packages/c1c-coreops`.
+- Remove shim files in `shared/` that re-export from `c1c_coreops`.
+- Delete duplicate CoreOps symbol definitions outside the package.
+- Update docs/configs to reference `c1c_coreops` paths only.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -19,6 +19,9 @@ Discord Gateway
 - `shared/coreops_*` — deprecated shims that re-export `c1c_coreops.*` for one release.
 - `shared.sheets.*` — Sheets adapters (recruitment, onboarding, cache core).
 
+CoreOps code exists **only** in `packages/c1c-coreops`. The `audit-coreops` workflow
+fails CI if any legacy imports, shims, or duplicate symbols live elsewhere.
+
 ## Monorepo workspaces
 - `shared/` — infrastructure plumbing that anchors this bot's runtime
   (Sheets adapters, cache, HTTP clients). Shared code here is tightly coupled to

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,30 +8,47 @@ It exists so that contributors update the correct references after each developm
 
 ### `/docs/adr/` — Architectural Decision Records
 * Each ADR (`ADR-XXXX`) captures an approved architectural or systemic decision.
-* `ADR-0000` serves as the template for new records.
+* [`ADR-0000`](adr/ADR-0000-template.md) serves as the template for new records.
+* [`ADR-0001`](adr/ADR-0001-sheets-access-layer.md) — Sheets access layer contract.
+* [`ADR-0002`](adr/ADR-0002-cache-telemetry-wrapper.md) — Cache telemetry wrapper.
+* [`ADR-0003`](adr/ADR-0003-coreops-command-contract.md) — CoreOps command contract.
+* [`ADR-0004`](adr/ADR-0004-help-system-short-vs-detailed.md) — Help system short vs detailed output.
+* [`ADR-0005`](adr/ADR-0005-reload-vs-refresh.md) — Reload vs refresh behaviour.
+* [`ADR-0006`](adr/ADR-0006-startup-preloader-bot-info-cron.md) — Startup preloader bot info cron.
+* [`ADR-0007`](adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md) — Feature toggles and module boundaries.
+* [`ADR-0008`](adr/ADR-0008-emoji-pipeline-port.md) — Emoji pipeline port.
+* [`ADR-0009`](adr/ADR-0009-recruiter-panel-text-only.md) — Recruiter panel text-only.
+* [`ADR-0010`](adr/ADR-0010-clan-profile-with-emoji.md) — Clan profile emoji policy.
+* [`ADR-0011`](adr/ADR-0011.md) — Member search indexing.
+* [`ADR-0012`](adr/ADR-0012-coreops-package.md) — CoreOps package structure.
+* [`ADR README`](adr/README.md) — Index for Architectural Decision Records.
 * File a new ADR for every major design or structural change.
 
 ### `/docs/compliance/`
 * Houses internal compliance and governance policies.
-* Example: `REPORT_GUARDRAILS.md` details report formatting and safety guardrail standards.
+* Example: [`REPORT_GUARDRAILS.md`](compliance/REPORT_GUARDRAILS.md) details report formatting and safety guardrail standards.
+
+### `/docs/_meta/`
+* [`DocStyle.md`](_meta/DocStyle.md) — documentation formatting conventions.
 
 ### `/docs/guardrails/`
-* `RepositoryGuardrails.md` — canonical guardrails specification covering structure, coding, documentation, and governance rules.
+* [`RepositoryGuardrails.md`](guardrails/RepositoryGuardrails.md) — canonical guardrails specification covering structure, coding, documentation, and governance rules.
 
 ### `/docs/contracts/`
 * Defines long-term, structural interfaces between components.
-* `core_infra.md` documents runtime, Sheets access, and cache relationships.
-* `CollaborationContract.md` — contributor standards, PR review flow, and Codex formatting instructions.
+* [`core_infra.md`](contracts/core_infra.md) documents runtime, Sheets access, and cache relationships.
+* [`CollaborationContract.md`](contracts/CollaborationContract.md) — contributor standards, PR review flow, and Codex formatting instructions.
 
 ### `/docs/ops/` — Operational Documentation
-* `Architecture.md` — detailed system flow, runtime design, and module topology.
-* `Config.md` — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
-* `CommandMatrix.md` — user/admin command catalogue with permissions, feature gates, and descriptions.
-* `Runbook.md` — operator actions for routine tasks and incident handling.
-* `Troubleshooting.md` — quick reference for diagnosing common issues.
-* `Watchers.md` — background jobs covering schedulers, refreshers, and watchdogs.
-* `development.md` — developer setup notes and contribution workflow guidance.
-* `commands.md` — supplemental command reference for operational usage.
+* [`Architecture.md`](ops/Architecture.md) — detailed system flow, runtime design, and module topology.
+* [`Config.md`](ops/Config.md) — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
+* [`CommandMatrix.md`](ops/CommandMatrix.md) — user/admin command catalogue with permissions, feature gates, and descriptions.
+* [`Runbook.md`](ops/Runbook.md) — operator actions for routine tasks and incident handling.
+* [`Troubleshooting.md`](ops/Troubleshooting.md) — quick reference for diagnosing common issues.
+* [`Watchers.md`](ops/Watchers.md) — background jobs covering schedulers, refreshers, and watchdogs.
+* [`development.md`](ops/development.md) — developer setup notes and contribution workflow guidance.
+* [`commands.md`](ops/commands.md) — supplemental command reference for operational usage.
+* [`module-toggles.md`](ops/module-toggles.md) — module-level feature toggle reference.
 
 ## Code Map
 
@@ -39,8 +56,9 @@ It exists so that contributors update the correct references after each developm
   Legacy `shared/coreops_*` modules temporarily re-export these symbols until import rewrites land.
 
 ### Root-Level Docs
-* `README.md` — user-facing overview, installation steps, and configuration guidance for the bot.
-* `CHANGELOG.md` — version history for the project.
+* [`Architecture.md`](Architecture.md) — high-level architecture overview and runtime map.
+* [`README.md`](../README.md) — user-facing overview, installation steps, and configuration guidance for the bot.
+* [`CHANGELOG.md`](../CHANGELOG.md) — version history for the project.
 
 ## Maintenance Rules
 * Update this index whenever documentation files are added, renamed, or removed.
@@ -48,4 +66,6 @@ It exists so that contributors update the correct references after each developm
 * Ensure the version shown in this index (currently v0.9.5) matches the bot version in the root `README.md`.
 
 ## Cross-References
-* `docs/contracts/CollaborationContract.md` documents contributor responsibilities and embeds this index under “Documentation Discipline.”
+* [`docs/contracts/CollaborationContract.md`](contracts/CollaborationContract.md) documents contributor responsibilities and embeds this index under “Documentation Discipline.”
+
+Doc last updated: 2025-10-24 (v0.9.5)

--- a/docs/contracts/CollaborationContract.md
+++ b/docs/contracts/CollaborationContract.md
@@ -246,3 +246,5 @@ DO not use any other labels unless approved by caillean first
 | tests | `#a2eeef` | Unit/integration/e2e tests |
 | typecheck | `#bfdadc` | mypy/pyright typing issues |
 | wontfix | `#ffffff` | This will not be worked on |
+
+Doc last updated: 2025-10-24 (v0.9.5)

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -52,9 +52,9 @@ Compliance script must check: structure (S), code (C), docs (D), governance (G) 
 
 ---
 
-Doc last updated: 2025-10-23 (v0.9.x)
-
 [meta]
 labels: docs, governance, guardrails, ready
 milestone: Harmonize v1.0
 [/meta]
+
+Doc last updated: 2025-10-24 (v0.9.5)

--- a/scripts/audit_coreops_packaging.py
+++ b/scripts/audit_coreops_packaging.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""CoreOps packaging audit script.
+
+This script scans the repository and flags legacy CoreOps packaging issues.
+"""
+from __future__ import annotations
+
+import ast
+import datetime as _dt
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Dict, Iterable, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AUDIT_DIR = REPO_ROOT / "AUDIT"
+REPORT_PATH = AUDIT_DIR / "CoreOps-Packaging-Audit.md"
+
+IGNORE_DIR_NAMES = {".git", ".venv", "venv", ".mypy_cache", "__pycache__"}
+PACKAGE_ROOT = REPO_ROOT / "packages" / "c1c-coreops"
+ALLOWED_PACKAGE_ROOT = PACKAGE_ROOT / "src" / "c1c_coreops"
+PATH_EXCEPTIONS = {REPO_ROOT / "scripts" / "audit_coreops_packaging.py"}
+TEXT_FILE_EXTENSIONS = {
+    ".py",
+    ".md",
+    ".rst",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+}
+
+DOC_EXTENSIONS = {".md", ".rst", ".json", ".yaml", ".yml", ".toml"}
+
+DOC_DRIFT_PATTERN = re.compile(r"shared[./]coreops(?!_)", re.IGNORECASE)
+COREOPS_PATH_PATTERN = re.compile(r"coreops(?:_|$)")
+BUILD_EMBED_PATTERN = re.compile(r"^build_.*_embed$")
+
+
+class Offense:
+    __slots__ = ("rule", "path", "line", "snippet")
+
+    def __init__(self, rule: str, path: Path, line: Optional[int], snippet: str) -> None:
+        self.rule = rule
+        self.path = path
+        self.line = line
+        self.snippet = snippet.strip()
+
+
+def is_under_allowed_package(path: Path) -> bool:
+    try:
+        path.resolve().relative_to(ALLOWED_PACKAGE_ROOT.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def should_ignore_path(path: Path) -> bool:
+    if path == REPORT_PATH:
+        return True
+    try:
+        path.relative_to(AUDIT_DIR)
+        return True
+    except ValueError:
+        return False
+
+
+def iter_repository_files(root: Path) -> Iterable[Path]:
+    for item in root.iterdir():
+        if item.is_dir():
+            if item.name in IGNORE_DIR_NAMES:
+                continue
+            if should_ignore_path(item):
+                continue
+            yield from iter_repository_files(item)
+        elif item.is_file():
+            if should_ignore_path(item):
+                continue
+            yield item
+
+
+def read_text_lines(path: Path) -> Optional[List[str]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return None
+    return text.splitlines()
+
+
+def check_legacy_imports(path: Path, lines: List[str], offenses: List[Offense]) -> None:
+    if path.suffix != ".py" or is_under_allowed_package(path):
+        return
+
+    try:
+        tree = ast.parse("\n".join(lines), filename=str(path))
+    except SyntaxError:
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("shared.coreops"):
+                    line_no = getattr(node, "lineno", None)
+                    snippet = lines[line_no - 1] if line_no and line_no <= len(lines) else "import shared.coreops"
+                    offenses.append(Offense("LEGACY_IMPORT", path, line_no, snippet))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.startswith("shared.coreops"):
+                line_no = getattr(node, "lineno", None)
+                snippet = lines[line_no - 1] if line_no and line_no <= len(lines) else f"from {module} import ..."
+                offenses.append(Offense("LEGACY_IMPORT", path, line_no, snippet))
+
+
+def check_path_offenses(path: Path, offenses: List[Offense]) -> None:
+    if is_under_allowed_package(path):
+        return
+    if path in PATH_EXCEPTIONS:
+        return
+    try:
+        path.resolve().relative_to(PACKAGE_ROOT.resolve())
+        return
+    except ValueError:
+        pass
+    relative_parts = path.relative_to(REPO_ROOT).parts
+    if any(COREOPS_PATH_PATTERN.search(part.lower() if isinstance(part, str) else "") for part in relative_parts):
+        offenses.append(Offense("STRAY_PATH", path, None, "Path contains coreops outside package"))
+
+
+def check_shim_offenses(path: Path, lines: List[str], offenses: List[Offense]) -> None:
+    if path.suffix != ".py" or is_under_allowed_package(path):
+        return
+    if "shared" not in path.relative_to(REPO_ROOT).parts:
+        return
+
+    try:
+        tree = ast.parse("\n".join(lines), filename=str(path))
+    except SyntaxError:
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.startswith("c1c_coreops"):
+                for alias in node.names:
+                    if alias.name == "*":
+                        line_no = getattr(node, "lineno", None)
+                        snippet = lines[line_no - 1] if line_no and line_no <= len(lines) else f"from {module} import *"
+                        offenses.append(Offense("COREOPS_BRIDGE", path, line_no, snippet))
+                        break
+
+
+def check_duplicate_symbols(path: Path, lines: List[str], offenses: List[Offense]) -> None:
+    if path.suffix != ".py" or is_under_allowed_package(path):
+        return
+
+    try:
+        tree = ast.parse("\n".join(lines), filename=str(path))
+    except SyntaxError:
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CoreOpsCog":
+            line_no = getattr(node, "lineno", None)
+            snippet = lines[line_no - 1] if line_no and line_no <= len(lines) else "class CoreOpsCog"
+            offenses.append(Offense("DUPLICATE_SYMBOL", path, line_no, snippet))
+        elif isinstance(node, ast.FunctionDef):
+            name = node.name
+            if name in {"resolve_ops_log_channel_id", "detect_admin_bang_command"} or BUILD_EMBED_PATTERN.match(name):
+                line_no = getattr(node, "lineno", None)
+                snippet = lines[line_no - 1] if line_no and line_no <= len(lines) else f"def {name}(...):"
+                offenses.append(Offense("DUPLICATE_SYMBOL", path, line_no, snippet))
+
+
+def check_doc_drift(path: Path, lines: List[str], offenses: List[Offense]) -> None:
+    if is_under_allowed_package(path):
+        return
+    if path.suffix not in DOC_EXTENSIONS:
+        return
+
+    for idx, line in enumerate(lines, start=1):
+        if DOC_DRIFT_PATTERN.search(line):
+            offenses.append(Offense("DOC_DRIFT", path, idx, line))
+
+
+def build_report(offenses: List[Offense], files_scanned: int) -> str:
+    timestamp = (
+        _dt.datetime.now(_dt.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+    commit_sha = (
+        os.environ.get("GITHUB_SHA")
+        if "GITHUB_SHA" in os.environ
+        else "unknown"
+    )
+    status = "PASS" if not offenses else "FAIL"
+    header = [
+        "# CoreOps Packaging Audit",
+        "",
+        f"Generated: {timestamp}",
+        f"Commit: {commit_sha}",
+        f"Total files scanned: {files_scanned}",
+        f"Result: **{status}** ({len(offenses)} offenses)",
+        "",
+    ]
+
+    offenses_by_rule: Dict[str, List[Offense]] = {}
+    for offense in offenses:
+        offenses_by_rule.setdefault(offense.rule, []).append(offense)
+
+    rule_titles = {
+        "LEGACY_IMPORT": "Legacy Imports",
+        "STRAY_PATH": "Stray CoreOps Paths",
+        "COREOPS_BRIDGE": "Shim/Re-export Bridges",
+        "DUPLICATE_SYMBOL": "Duplicate CoreOps Symbols",
+        "DOC_DRIFT": "Docs/Config Drift",
+    }
+
+    body: List[str] = []
+    for rule, rule_offenses in sorted(offenses_by_rule.items(), key=lambda item: rule_titles.get(item[0], item[0])):
+        body.append(f"## {rule_titles.get(rule, rule)}")
+        body.append("")
+        body.append("| Path | Line | Snippet |")
+        body.append("| --- | --- | --- |")
+        for offense in sorted(rule_offenses, key=lambda o: (str(o.path), o.line or 0)):
+            rel_path = offense.path.relative_to(REPO_ROOT)
+            line_str = str(offense.line) if offense.line is not None else "-"
+            snippet = offense.snippet.replace("|", "\\|")
+            body.append(f"| `{rel_path}` | {line_str} | `{snippet}` |")
+        body.append("")
+
+    checklist = [
+        "## Fix-It Checklist",
+        "",
+        "- Rewrite imports to use `c1c_coreops.*` directly.",
+        "- Move or delete stray CoreOps files outside `packages/c1c-coreops`.",
+        "- Remove shim files in `shared/` that re-export from `c1c_coreops`.",
+        "- Delete duplicate CoreOps symbol definitions outside the package.",
+        "- Update docs/configs to reference `c1c_coreops` paths only.",
+    ]
+
+    return "\n".join(header + body + checklist) + "\n"
+
+
+def main() -> int:
+    files_scanned = 0
+    offenses: List[Offense] = []
+
+    for path in iter_repository_files(REPO_ROOT):
+        if path.is_dir():
+            continue
+        files_scanned += 1
+        suffix = path.suffix.lower()
+        lines = None
+        if suffix in TEXT_FILE_EXTENSIONS:
+            lines = read_text_lines(path)
+        if suffix == ".py" and lines is not None:
+            check_legacy_imports(path, lines, offenses)
+            check_shim_offenses(path, lines, offenses)
+            check_duplicate_symbols(path, lines, offenses)
+        if lines is not None:
+            check_doc_drift(path, lines, offenses)
+        check_path_offenses(path, offenses)
+
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    report_content = build_report(offenses, files_scanned)
+    REPORT_PATH.write_text(report_content, encoding="utf-8")
+
+    if offenses:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except KeyboardInterrupt:
+        exit_code = 1
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- configure the audit workflow with actions/setup-python@v4 and an explicit pip upgrade step so CI uses a provisioned interpreter
- expand the documentation index to link every tracked doc and add the required footers for guardrail compliance
- refresh the guardrails metadata ordering and audit report timestamp while using a timezone-aware value to avoid UTC deprecation warnings

## Testing
- `python scripts/ci/check_docs.py`
- `python scripts/audit_coreops_packaging.py` *(fails with current CoreOps legacy layout, expected)*

[meta]
labels: AUDIT, comp:coreops, guardrails, architecture, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fb4b9fdffc8323babdb3e357c06bbc