### PR TITLE
Retain bare admin aliases when generic toggles are off

### DIFF
--- a/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
+++ b/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
@@ -77,16 +77,20 @@ def test_multi_bot_alias_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
         await bot.add_cog(CoreOpsCog(bot))
 
         try:
-            assert bot.get_command("env") is None
+            env_command = bot.get_command("env")
+            assert env_command is not None
             rec_env = bot.get_command("rec env")
             assert rec_env is not None
 
             non_admin_ctx = DummyContext(author=DummyMember(administrator=False))
             with pytest.raises(commands.CheckFailure):
                 await _run_checks(rec_env, non_admin_ctx)
+            with pytest.raises(commands.CheckFailure):
+                await _run_checks(env_command, non_admin_ctx)
 
             admin_ctx = DummyContext(author=DummyMember(administrator=True))
             await _run_checks(rec_env, admin_ctx)
+            await _run_checks(env_command, admin_ctx)
 
             settings = load_coreops_settings()
             variants = build_command_variants(settings, "env")
@@ -108,8 +112,18 @@ def test_generic_alias_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         await bot.add_cog(CoreOpsCog(bot))
 
         try:
-            assert bot.get_command("rec digest") is not None
-            assert bot.get_command("digest") is None
+            rec_digest = bot.get_command("rec digest")
+            assert rec_digest is not None
+            digest = bot.get_command("digest")
+            assert digest is not None
+
+            non_admin_ctx = DummyContext(author=DummyMember(administrator=False))
+            with pytest.raises(commands.CheckFailure):
+                await _run_checks(digest, non_admin_ctx)
+
+            admin_ctx = DummyContext(author=DummyMember(administrator=True))
+            await _run_checks(rec_digest, admin_ctx)
+            await _run_checks(digest, admin_ctx)
         finally:
             await bot.close()
 

--- a/packages/c1c-coreops/tests/test_help_admin_surface_complete.py
+++ b/packages/c1c-coreops/tests/test_help_admin_surface_complete.py
@@ -75,7 +75,7 @@ def _extract_fields(embed: discord.Embed) -> Mapping[str, str]:
 def test_admin_help_lists_bare_and_tagged(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TAG", "rec")
     monkeypatch.setenv("COREOPS_ENABLE_TAGGED_ALIASES", "1")
-    monkeypatch.setenv("COREOPS_ENABLE_GENERIC_ALIASES", "1")
+    monkeypatch.setenv("COREOPS_ENABLE_GENERIC_ALIASES", "0")
 
     async def runner() -> None:
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())


### PR DESCRIPTION
## Summary
- keep admin-tier commands registered when generic aliases are disabled while continuing to drop non-admin generics
- extend alias/bang tests to cover bare admin RBAC alongside tagged variants
- update admin help surface test to assert bare + tagged admin entries when generic aliases are disabled

## Testing
- pytest packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
- pytest packages/c1c-coreops/tests/test_help_admin_surface_complete.py

------
https://chatgpt.com/codex/tasks/task_e_68fbb8cd334c8323894ada1c7f055153