### PR TITLE
Add async health, config, and recruiter regression tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: 05-tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-asyncio aiohttp yarl
+      - name: Run tests
+        run: pytest -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning:aiohttp.*

--- a/tests/test_config_log_channel.py
+++ b/tests/test_config_log_channel.py
@@ -1,0 +1,53 @@
+import importlib
+import logging
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+
+@contextmanager
+def temp_env(**values):
+    original = {key: os.environ.get(key) for key in values}
+    try:
+        for key, value in values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in original.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.mark.usefixtures("caplog")
+def test_log_channel_disabled_when_env_missing(caplog):
+    caplog.set_level(logging.WARNING)
+    module_name = "shared.config"
+    original_value = os.environ.get("LOG_CHANNEL_ID")
+
+    with temp_env(LOG_CHANNEL_ID=None):
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        cfg = importlib.import_module(module_name)
+        cfg.reload_config()
+        cfg.reload_config()
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "Log channel disabled" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert cfg.get_log_channel_id() is None
+
+    if original_value is None:
+        os.environ.pop("LOG_CHANNEL_ID", None)
+    else:
+        os.environ["LOG_CHANNEL_ID"] = original_value
+    importlib.reload(cfg)

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -1,0 +1,74 @@
+import asyncio
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from modules.common import runtime as rt
+
+
+class DummyBot:
+    """Minimal bot stub for runtime wiring."""
+
+    async def wait_until_ready(self) -> None:  # pragma: no cover - defensive stub
+        return None
+
+    def get_channel(self, _channel_id):  # pragma: no cover - defensive stub
+        return None
+
+    async def fetch_channel(self, _channel_id):  # pragma: no cover - defensive stub
+        raise RuntimeError("not implemented")
+
+
+class _DummyRunner:
+    def __init__(self, app: web.Application) -> None:
+        self.app = app
+
+    async def setup(self) -> None:  # pragma: no cover - no side effects in tests
+        return None
+
+    async def cleanup(self) -> None:  # pragma: no cover - no side effects in tests
+        return None
+
+
+class _DummySite:
+    def __init__(self, runner: _DummyRunner, host: str, port: int) -> None:
+        self.runner = runner
+        self.host = host
+        self.port = port
+        self.started = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.started = False
+
+
+def test_health_endpoints_exist_and_return_json(monkeypatch):
+    async def runner() -> None:
+        monkeypatch.setattr(rt.web, "AppRunner", _DummyRunner)
+        monkeypatch.setattr(rt.web, "TCPSite", _DummySite)
+
+        runtime = rt.Runtime(bot=DummyBot())
+        await runtime.start_webserver(port=0)
+        try:
+            app = runtime._web_app
+            assert app is not None
+
+            async with TestServer(app) as server:
+                async with TestClient(server) as client:
+                    resp = await client.get("/")
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data.get("ok") is True
+                    assert "bot" in data and "env" in data and "version" in data
+
+                    for path in ("/health", "/healthz", "/ready"):
+                        resp = await client.get(path)
+                        assert resp.status == 200
+                        payload = await resp.json()
+                        assert payload.get("ok") is True
+        finally:
+            await runtime.shutdown_webserver()
+
+    asyncio.run(runner())

--- a/tests/test_recruiter_panel_nonblocking.py
+++ b/tests/test_recruiter_panel_nonblocking.py
@@ -1,0 +1,70 @@
+import asyncio
+
+from modules.recruitment.views import recruiter_panel as panel
+
+
+class DummyCog:
+    def unregister_panel(self, message_id: int) -> None:  # pragma: no cover - stub
+        return None
+
+
+class DummyResponse:
+    def is_done(self) -> bool:
+        return True
+
+
+class DummyFollowup:
+    async def send(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        return None
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+
+def _sample_rows() -> list[list[str]]:
+    header = ["header"] * (panel.IDX_AF_INACTIVES + 1)
+    row = [""] * (panel.IDX_AF_INACTIVES + 1)
+    row[panel.COL_B_CLAN] = "Clan"
+    row[panel.COL_C_TAG] = "#TAG"
+    row[panel.COL_E_SPOTS] = "5"
+    row[panel.IDX_AF_INACTIVES] = "1"
+    return [header, row]
+
+
+def test_recruiter_search_uses_to_thread(monkeypatch):
+    async def runner() -> None:
+        monkeypatch.setattr(panel.RecruiterPanelView, "_build_components", lambda self: None)
+        monkeypatch.setattr(panel.RecruiterPanelView, "_sync_visuals", lambda self: None)
+
+        view = panel.RecruiterPanelView(DummyCog(), author_id=1)
+        interaction = DummyInteraction()
+
+        captured = {"called": False, "fn": None}
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            captured["called"] = True
+            captured["fn"] = fn
+            return _sample_rows()
+
+        def fake_fetch(force: bool = False):
+            return _sample_rows()
+
+        async def fake_rebuild(self, interaction, *, ack_ephemeral=None):
+            self._busy = False
+            return None
+
+        monkeypatch.setattr(panel.asyncio, "to_thread", fake_to_thread)
+        monkeypatch.setattr(panel.recruitment_sheets, "fetch_clans", fake_fetch)
+        monkeypatch.setattr(
+            panel.RecruiterPanelView, "_rebuild_and_edit", fake_rebuild, raising=False
+        )
+
+        await view._run_search(interaction)
+
+        assert captured["called"] is True
+        assert captured["fn"] is fake_fetch
+
+    asyncio.run(runner())

--- a/tests/test_web_routes_https_only.py
+++ b/tests/test_web_routes_https_only.py
@@ -1,0 +1,57 @@
+import asyncio
+import io
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from PIL import Image
+
+from shared import web_routes
+
+
+def _png_bytes() -> bytes:
+    image = Image.new("RGBA", (2, 2), (255, 0, 0, 255))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_emoji_proxy_rejects_http():
+    async def runner() -> None:
+        app = web.Application()
+        web_routes.mount_emoji_pad(app)
+
+        async with TestServer(app) as server:
+            async with TestClient(server) as client:
+                resp = await client.get(
+                    "/emoji-pad",
+                    params={"u": "http://cdn.discordapp.com/emojis/123.png"},
+                )
+                assert resp.status == 400
+
+    asyncio.run(runner())
+
+
+def test_emoji_proxy_allows_https(monkeypatch):
+    async def runner() -> None:
+        app = web.Application()
+        web_routes.mount_emoji_pad(app)
+
+        png_data = _png_bytes()
+
+        async def fake_fetch(session, url, max_bytes):
+            assert url.startswith("https://")
+            return png_data
+
+        monkeypatch.setattr(web_routes, "_fetch_emoji_bytes", fake_fetch)
+
+        async with TestServer(app) as server:
+            async with TestClient(server) as client:
+                resp = await client.get(
+                    "/emoji-pad",
+                    params={"u": "https://cdn.discordapp.com/emojis/123.png"},
+                )
+                assert resp.status == 200
+                body = await resp.read()
+                assert body.startswith(b"\x89PNG")
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add asynchronous coverage for the runtime health endpoints and emoji proxy scheme handling
- verify config hardening and recruiter panel offloading via targeted regression tests
- wire pytest defaults and CI workflow to run the new async suite on pushes and pull requests

## Testing
- pytest tests -q

[meta]
labels: tests, robustness, comp:health, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fc99c1bafc8323a4260fc0567a170e