### PR TITLE
Add async Sheets facade and update async callers

### DIFF
--- a/docs/adr/ADR-0014-async-sheets-facade.md
+++ b/docs/adr/ADR-0014-async-sheets-facade.md
@@ -1,0 +1,19 @@
+# ADR-0014 — Async Sheets Facade for Event-Loop Safety
+Date: 2025-10-25
+
+## Context
+Synchronous Google Sheets helpers were invoked from async handlers, causing
+event-loop blocking (audit finding). Retries used blocking sleeps.
+
+## Decision
+Adopt `shared/sheets/async_facade.py` as the sole import path for Sheets access
+in async code. The facade executes sync client work via `asyncio.to_thread`.
+Update all async call sites to use the facade.
+
+## Consequences
+- UI responsiveness preserved; no blocking I/O on the event loop.
+- Slight overhead per call due to thread scheduling.
+- Sync scripts keep using sync helpers; async code uses the facade uniformly.
+
+## Status
+Accepted

--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -23,8 +23,9 @@ User (any tier) ──> Discord Cog ──> CoreOps telemetry fetch ──> Embe
   `refresh_now`). Private module attributes remain internal to the service.
 - **Google Sheets:** Recruitment and onboarding tabs are accessed asynchronously via the
   cached adapters. Preloader warms their handles and key buckets on startup.
-- **Sheets access:** Async command handlers delegate Google Sheets calls to worker
-  threads via `asyncio.to_thread`, keeping the event loop unblocked even on cache misses.
+- **Sheets access:** Async command handlers import `shared.sheets.async_facade`, which
+  routes synchronous helpers through `asyncio.to_thread` so the event loop stays
+  unblocked even on cache misses.
 - **Preloader:** Runs automatically during boot, logging `[refresh] startup` entries for
   each bucket.
 - **Scheduler:** Handles cron work including the 3-hour `bot_info` refresh, digest

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -51,6 +51,9 @@ Meta: Cache age 42s · Next refresh 02:15 UTC · Actor startup
 | `SHEETS_CACHE_TTL_SEC` | int | `900` | TTL for cached worksheet values. |
 | `SHEETS_CONFIG_CACHE_TTL_SEC` | int | matches `SHEETS_CACHE_TTL_SEC` | TTL for cached worksheet metadata; defaults to the value above. |
 
+Async handlers must import Sheets helpers from `shared.sheets.async_facade`; the
+sync modules remain available for non-async scripts and cache warmers.
+
 ### Role and channel routing
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |

--- a/modules/recruitment/clan_profile.py
+++ b/modules/recruitment/clan_profile.py
@@ -10,7 +10,7 @@ import discord
 from discord.ext import commands
 
 from . import cards, emoji_pipeline
-from shared.sheets import recruitment as recruitment_sheets
+from shared.sheets import async_facade as sheets
 
 _VALID_TAG_CHARS: frozenset[str] = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 _FLIP_EMOJI = "\N{ELECTRIC LIGHT BULB}"  # 💡
@@ -71,7 +71,7 @@ class ClanProfileCog(commands.Cog):
             await ctx.reply(embed=_error_embed(tag or "?"), mention_author=False)
             return
 
-        row = recruitment_sheets.get_clan_by_tag(normalized)
+        row = await sheets.get_clan_by_tag(normalized)
         if row is None:
             await ctx.reply(embed=_error_embed(normalized), mention_author=False)
             return

--- a/modules/recruitment/views/recruiter_panel.py
+++ b/modules/recruitment/views/recruiter_panel.py
@@ -18,7 +18,7 @@ from discord import InteractionResponded
 
 from .. import cards
 from modules.common import config_access as config
-from shared.sheets import recruitment as recruitment_sheets
+from shared.sheets import async_facade as sheets
 
 if TYPE_CHECKING:
     from cogs.recruitment_recruiter import RecruiterPanelCog
@@ -715,10 +715,7 @@ class RecruiterPanelView(discord.ui.View):
         current_task = asyncio.current_task()
         try:
             try:
-                rows = await asyncio.to_thread(
-                    recruitment_sheets.fetch_clans,
-                    force=False,
-                )
+                rows = await sheets.fetch_clans(force=False)
             except Exception as exc:  # pragma: no cover - defensive guard
                 log.exception("failed to fetch clan rows", exc_info=exc)
                 if self.matches:

--- a/modules/recruitment/welcome.py
+++ b/modules/recruitment/welcome.py
@@ -6,7 +6,7 @@ from modules.common import runtime as rt
 # NOTE: Do not import role ID constants from shared.config; not exported here.
 from modules.coreops.helpers import tier
 from c1c_coreops.rbac import is_staff_member, is_admin_member
-from shared.sheets.recruitment import get_cached_welcome_templates
+from shared.sheets import async_facade as sheets
 
 # --- RBAC decorator (staff with fallback) -------------------------------------
 def staff_only():
@@ -45,7 +45,7 @@ class WelcomeBridge(commands.Cog):
         Post a templated welcome. Template rows are read from the cached 'templates' bucket.
         Usage: !welcome [clan] @mention
         """
-        templates = get_cached_welcome_templates()
+        templates = await sheets.get_cached_welcome_templates()
         if not templates:
             await ctx.send("⚠️ No welcome templates found. Try again after the next refresh.")
             return

--- a/shared/sheets/async_facade.py
+++ b/shared/sheets/async_facade.py
@@ -1,0 +1,90 @@
+"""Async facade for Google Sheets helpers.
+
+This module mirrors the synchronous APIs exposed by ``shared.sheets.recruitment``
+and ``shared.sheets.core``. Each wrapper executes the synchronous helper in a
+worker thread via :func:`asyncio.to_thread` so that async callers never block the
+event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, ParamSpec, TypeVar
+
+from shared.sheets import core as _core_sync
+from shared.sheets import recruitment as _recruitment_sync
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+async def _to_thread(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """Run ``func`` in a worker thread using :func:`asyncio.to_thread`."""
+
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+# === Recruitment-facing async wrappers ===
+async def fetch_clans(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.fetch_clans, *args, **kwargs)
+
+
+async def fetch_templates(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.fetch_templates, *args, **kwargs)
+
+
+async def fetch_clan_rows(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.fetch_clan_rows, *args, **kwargs)
+
+
+async def fetch_welcome_templates(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.fetch_welcome_templates, *args, **kwargs)
+
+
+async def get_cached_welcome_templates(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.get_cached_welcome_templates, *args, **kwargs)
+
+
+async def fetch_clan_tags_index(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.fetch_clan_tags_index, *args, **kwargs)
+
+
+async def get_clan_by_tag(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_recruitment_sync.get_clan_by_tag, *args, **kwargs)
+
+
+# === Core helpers that touch network/files ===
+async def open_by_key(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_core_sync.open_by_key, *args, **kwargs)
+
+
+async def get_worksheet(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_core_sync.get_worksheet, *args, **kwargs)
+
+
+async def fetch_records(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_core_sync.fetch_records, *args, **kwargs)
+
+
+async def fetch_values(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_core_sync.fetch_values, *args, **kwargs)
+
+
+async def call_with_backoff(*args: Any, **kwargs: Any) -> Any:
+    return await _to_thread(_core_sync.call_with_backoff, *args, **kwargs)
+
+
+__all__ = [
+    "fetch_clans",
+    "fetch_templates",
+    "fetch_clan_rows",
+    "fetch_welcome_templates",
+    "get_cached_welcome_templates",
+    "fetch_clan_tags_index",
+    "get_clan_by_tag",
+    "open_by_key",
+    "get_worksheet",
+    "fetch_records",
+    "fetch_values",
+    "call_with_backoff",
+]

--- a/tests/test_sheets_async_facade.py
+++ b/tests/test_sheets_async_facade.py
@@ -1,0 +1,37 @@
+import asyncio
+from unittest.mock import patch
+
+from shared.sheets import async_facade as sheets
+
+
+class _Dummy:
+    def __init__(self) -> None:
+        self.called = 0
+
+    def fn(self, *args, **kwargs):
+        self.called += 1
+        return 42
+
+
+def test_facade_uses_to_thread(monkeypatch):
+    async def runner() -> None:
+        dummy = _Dummy()
+
+        with patch("asyncio.to_thread") as mocked_to_thread:
+            async def passthrough(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mocked_to_thread.side_effect = passthrough
+
+            from shared.sheets import recruitment as sync_recruitment
+
+            monkeypatch.setattr(sync_recruitment, "fetch_clans", dummy.fn, raising=True)
+
+            result = await sheets.fetch_clans(force=False)
+
+            assert result == 42
+            assert mocked_to_thread.called
+            assert dummy.called == 1
+
+    asyncio.run(runner())
+


### PR DESCRIPTION
## Summary
- add `shared/sheets/async_facade.py` to expose threadpool-backed async wrappers for the Sheets helpers
- switch async recruitment commands to import the facade and cover the new contract with focused tests
- document the facade in ops guides and record ADR-0014 for the architecture change

## Testing
- pytest *(fails: packages/c1c-coreops/tests/test_alias_and_bang_behavior.py::test_multi_bot_alias_behavior, packages/c1c-coreops/tests/test_alias_and_bang_behavior.py::test_generic_alias_disabled, packages/c1c-coreops/tests/test_help_admin_surface_complete.py::test_admin_help_lists_bare_and_tagged, caused by pre-existing CoreOps command registration expectations)*

[meta]
labels: perf, robustness, comp:data-sheets, comp:ops-contract, tests, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fca2be094c83238aa9dbeef9bd9406