### PR TITLE
Add structured JSON logging and refine health readiness checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from shared.config import (
     is_guild_allowed,
     get_config_snapshot,
 )
+from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from modules.coreops.helpers import tier
 from modules.common.runtime import Runtime
@@ -143,6 +144,7 @@ async def _enforce_guild_allow_list(
 @bot.event
 async def on_ready():
     hb.note_ready()
+    healthmod.set_component("discord", True)
     log.info(
         'Bot ready as %s | env=%s | prefixes=["%s", "@mention"]',
         bot.user,
@@ -218,6 +220,7 @@ except Exception:
 @bot.event
 async def on_disconnect():
     hb.note_disconnected()
+    healthmod.set_component("discord", False)
 
 
 @bot.event

--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -32,9 +32,15 @@ User (any tier) ──> Discord Cog ──> CoreOps telemetry fetch ──> Embe
   delivery, and template/watchers hygiene tasks.
 - **Telemetry → Embed renderer:** Command responses pull structured telemetry and render
   embeds without timestamps; version metadata lives solely in the footer.
-- **Runtime HTTP interface:** `/` returns the full status payload, `/ready` answers with
-  `{ "ok": true }`, and `/health` + `/healthz` remain the long-form liveness endpoints
-  with watchdog metadata.
+- **Runtime HTTP interface:** `/` returns the status payload and echoes the request
+  trace id, `/ready` exposes the readiness gate with component details, `/health`
+  combines the watchdog metrics with the component map, and `/healthz` remains the
+  bare liveness probe.
+- **Logging & observability:** All runtime logs emit JSON with
+  `ts`,`level`,`logger`,`msg`,`trace`,`env`,`bot` plus contextual extras. HTTP
+  access logs add `path`,`method`,`status`, and latency (`ms`).
+- **Request tracing:** Every web request receives a UUIDv4 trace id that flows
+  through the log context and `/` response for quick correlation.
 
 ### Module topology
 - CoreOps now lives in `packages/c1c-coreops/src/c1c_coreops/`.
@@ -58,4 +64,4 @@ User (any tier) ──> Discord Cog ──> CoreOps telemetry fetch ──> Embe
   - `placement_target_select` — placement targeting picker inside panels.
   - `placement_reservations` — reservation holds and release workflow.
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -22,6 +22,26 @@ Older GitHub Actions deploy runs may display "skipped by same-file supersession"
 > `[watcher|lifecycle]` this release. Update dashboards to accept `[lifecycle]` ahead of
 > the next release when the dual tag flips off.
 
+## Interpreting logs
+- Runtime logs are JSON. Each entry includes `ts`, `level`, `logger`, `msg`, `trace`,
+  `env`, and `bot` plus any contextual extras. Example:
+
+  ```json
+  {"ts":"2025-10-26T04:12:32.104Z","level":"INFO","logger":"access","msg":"http_request","trace":"0a6c...","env":"prod","bot":"c1c","path":"/ready","method":"GET","status":200,"ms":4}
+  ```
+- Filter structured logs with your aggregator using `logger:"access"` for request
+  summaries or `trace:<uuid>` to follow a specific request across service logs.
+- The root request handler also echoes the active `trace` in the JSON payload for quick
+  copy/paste when correlating downstream telemetry.
+
+## Readiness vs Liveness
+- `/ready` now reflects required components (`runtime`, `discord`). It returns
+  `{"ok": false}` until Discord connectivity triggers `health.set_component("discord", True)`.
+- `/health` returns the watchdog metrics plus a `components` map of `{name: {ok, ts}}`.
+  A non-200 indicates either the watchdog stalled or a component flipped `ok=False`.
+- `/healthz` remains the simple liveness check (`200` while the process and watchdog are
+  healthy).
+
 ## Refresh vs reload controls
 | Control | What it does | When to use | Logging & guardrails |
 | --- | --- | --- | --- |
@@ -64,4 +84,4 @@ tabs.
 - **Remediation:** Fix the Sheet, run `!rec refresh config` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/shared/health.py
+++ b/shared/health.py
@@ -1,87 +1,49 @@
+"""In-memory health component registry for readiness and diagnostics."""
+
 from __future__ import annotations
-# shared/health.py
-"""
-Tiny aiohttp health server with /ready and /healthz.
-- /ready  : always 200 once the server is up
-- /healthz: 200 if heartbeat is fresh, else 503
 
-You must inject a `heartbeat_probe` coroutine that returns "seconds since last
-gateway event". Keep it simple so this module stays testable.
+import time
+from typing import Dict, Mapping
 
-Example:
-    from shared import health
-    site = await health.start_server(
-        heartbeat_probe=hb.age_seconds,
-        bot_name="C1C-Recruitment",
-        env_name="test",
-        port=10000,
-        stale_after_sec=120,
-    )
-"""
-import json
-from datetime import datetime, timezone
-from typing import Awaitable, Callable, Dict, Any
+__all__ = [
+    "components_snapshot",
+    "overall_ready",
+    "required_components",
+    "set_component",
+]
 
-from aiohttp import web
+_components: Dict[str, bool] = {}
+_updated_at: Dict[str, float] = {}
+_required_components = {"runtime", "discord"}
 
-ProbeFn = Callable[[], Awaitable[float]]
 
-async def _ready(_: web.Request) -> web.Response:
-    return web.Response(text="ok")
+def required_components() -> frozenset[str]:
+    """Return the set of component names required for readiness."""
 
-def _json(data: Dict[str, Any], status: int = 200) -> web.Response:
-    return web.Response(
-        status=status,
-        text=json.dumps(data, separators=(",", ":")),
-        content_type="application/json",
-    )
+    return frozenset(_required_components)
 
-def _build_app(
-    heartbeat_probe: ProbeFn,
-    bot_name: str,
-    env_name: str,
-    stale_after_sec: int,
-) -> web.Application:
-    app = web.Application()
 
-    app.router.add_get("/ready", _ready)
+def set_component(name: str, ok: bool) -> None:
+    """Record the health of a component and timestamp the update."""
 
-    async def healthz(_: web.Request) -> web.Response:
-        age = await heartbeat_probe()
-        healthy = age <= stale_after_sec
-        payload = {
-            "ok": healthy,
-            "bot": bot_name,
-            "env": env_name,
-            "age_seconds": round(age, 3),
-            "stale_after_sec": stale_after_sec,
-            "at": datetime.now(timezone.utc).isoformat(),
-        }
-        return _json(payload, status=200 if healthy else 503)
+    _components[name] = bool(ok)
+    _updated_at[name] = time.time()
 
-    app.router.add_get("/healthz", healthz)
-    return app
 
-async def start_server(
-    *,
-    heartbeat_probe: ProbeFn,
-    bot_name: str,
-    env_name: str,
-    port: int,
-    stale_after_sec: int = 120,
-) -> web.TCPSite:
-    """
-    Creates and starts the aiohttp site. Returns the TCPSite so callers can
-    keep a handle (for tests or graceful shutdown).
-    """
-    app = _build_app(
-        heartbeat_probe=heartbeat_probe,
-        bot_name=bot_name,
-        env_name=env_name,
-        stale_after_sec=stale_after_sec,
-    )
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(runner, host="0.0.0.0", port=port)
-    await site.start()
-    return site
+def components_snapshot(include_required: bool = True) -> dict[str, Mapping[str, float | bool]]:
+    """Return a snapshot of component states with timestamps."""
+
+    snapshot: dict[str, Mapping[str, float | bool]] = {
+        key: {"ok": value, "ts": _updated_at.get(key, 0.0)} for key, value in _components.items()
+    }
+    if include_required:
+        for name in _required_components:
+            if name not in snapshot:
+                snapshot[name] = {"ok": False, "ts": 0.0}
+    return snapshot
+
+
+def overall_ready() -> bool:
+    """Return ``True`` when every required component is marked healthy."""
+
+    return all(_components.get(name, False) for name in _required_components)

--- a/shared/logging/structured.py
+++ b/shared/logging/structured.py
@@ -1,0 +1,59 @@
+"""Structured logging utilities for JSON-formatted runtime output."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import time
+import uuid
+from typing import Any, Mapping
+
+# Context variable that carries the current trace identifier.
+_trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("trace_id", default="")
+
+
+def set_trace_id(value: str | None = None) -> str:
+    """Assign a trace identifier for the current context.
+
+    When ``value`` is ``None`` a new UUIDv4 string is generated. The identifier is
+    returned so callers can reuse it when emitting log entries or HTTP responses.
+    """
+
+    trace = value or str(uuid.uuid4())
+    _trace_id_var.set(trace)
+    return trace
+
+
+def get_trace_id() -> str:
+    """Return the active trace identifier for the current context."""
+
+    return _trace_id_var.get()
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter that renders log records as JSON objects."""
+
+    def __init__(self, static: Mapping[str, Any] | None = None) -> None:
+        super().__init__()
+        self._static = dict(static or {})
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - docstring inherited
+        payload: dict[str, Any] = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created))
+            + f".{int(record.msecs):03d}Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "trace": getattr(record, "trace", "") or get_trace_id(),
+        }
+
+        payload.update(self._static)
+
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in payload:
+                continue
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                payload[key] = value
+
+        return json.dumps(payload, ensure_ascii=False)

--- a/tests/test_access_log_json.py
+++ b/tests/test_access_log_json.py
@@ -1,0 +1,42 @@
+import asyncio
+import io
+import json
+import logging
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from modules.common import runtime as rt
+from shared import health as healthmod
+
+
+class _Buffer(io.StringIO):
+    pass
+
+
+def test_access_log_json_contains_fields():
+    async def runner() -> None:
+        healthmod.set_component("discord", False)
+        buffer = _Buffer()
+        handler = logging.StreamHandler(buffer)
+        logging.getLogger().addHandler(handler)
+
+        try:
+            app = await rt.create_app()
+            async with TestServer(app) as server:
+                async with TestClient(server) as client:
+                    response = await client.get("/healthz")
+                    assert response.status == 200
+
+            lines = [line for line in buffer.getvalue().splitlines() if '"logger": "access"' in line]
+            assert lines, "expected at least one access log line"
+
+            payload = json.loads(lines[-1])
+            assert payload.get("logger") == "access"
+            assert payload.get("method") == "GET"
+            assert "ms" in payload
+            assert payload.get("trace")
+        finally:
+            logging.getLogger().removeHandler(handler)
+            healthmod.set_component("discord", False)
+
+    asyncio.run(runner())

--- a/tests/test_health_precision.py
+++ b/tests/test_health_precision.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from modules.common import runtime as rt
+from shared import health as healthmod
+
+
+def test_ready_false_until_required_components_ok():
+    async def runner() -> None:
+        healthmod.set_component("discord", False)
+        app = await rt.create_app()
+        async with TestServer(app) as server:
+            async with TestClient(server) as client:
+                try:
+                    response = await client.get("/ready")
+                    data = await response.json()
+                    assert response.status == 200
+                    assert data["ok"] is False
+                    assert data["components"]["discord"]["ok"] is False
+
+                    healthmod.set_component("discord", True)
+
+                    response = await client.get("/ready")
+                    data = await response.json()
+                    assert response.status == 200
+                    assert data["ok"] is True
+                    assert data["components"]["discord"]["ok"] is True
+                finally:
+                    healthmod.set_component("discord", False)
+
+    asyncio.run(runner())
+
+
+def test_root_includes_trace():
+    async def runner() -> None:
+        healthmod.set_component("discord", False)
+        app = await rt.create_app()
+        async with TestServer(app) as server:
+            async with TestClient(server) as client:
+                try:
+                    response = await client.get("/")
+                    payload = await response.json()
+                    assert response.status == 200
+                    assert isinstance(payload.get("trace"), str)
+                    assert payload["trace"]
+                finally:
+                    healthmod.set_component("discord", False)
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- introduce a shared JSON formatter with per-request trace IDs and install it during runtime app creation
- track runtime and Discord readiness via the new health registry while enriching HTTP endpoints with component status and traces
- update docs and add tests covering the refined health contract and JSON access logging

## Testing
- `pytest`

[meta]
labels: observability, robustness, comp:health, docs, tests, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fcc37dbc848323802f04da603738e5