### PR TITLE
Normalize JSON access logging and rate-limit watchdog noise

### DIFF
--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -38,9 +38,11 @@ User (any tier) ──> Discord Cog ──> CoreOps telemetry fetch ──> Embe
   bare liveness probe.
 - **Logging & observability:** All runtime logs emit JSON with
   `ts`,`level`,`logger`,`msg`,`trace`,`env`,`bot` plus contextual extras. HTTP
-  access logs add `path`,`method`,`status`, and latency (`ms`).
+  access logs are emitted under the canonical `aiohttp.access` logger with
+  `path`,`method`,`status`, and latency (`ms`).
 - **Request tracing:** Every web request receives a UUIDv4 trace id that flows
-  through the log context and `/` response for quick correlation.
+  through the log context, `/` response payload, and the `X-Trace-Id` response
+  header for quick correlation.
 
 ### Module topology
 - CoreOps now lives in `packages/c1c-coreops/src/c1c_coreops/`.

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -27,12 +27,14 @@ Older GitHub Actions deploy runs may display "skipped by same-file supersession"
   `env`, and `bot` plus any contextual extras. Example:
 
   ```json
-  {"ts":"2025-10-26T04:12:32.104Z","level":"INFO","logger":"access","msg":"http_request","trace":"0a6c...","env":"prod","bot":"c1c","path":"/ready","method":"GET","status":200,"ms":4}
+  {"ts":"2025-10-26T04:12:32.104Z","level":"INFO","logger":"aiohttp.access","msg":"http_request","trace":"0a6c...","env":"prod","bot":"c1c","path":"/ready","method":"GET","status":200,"ms":4}
   ```
-- Filter structured logs with your aggregator using `logger:"access"` for request
-  summaries or `trace:<uuid>` to follow a specific request across service logs.
-- The root request handler also echoes the active `trace` in the JSON payload for quick
-  copy/paste when correlating downstream telemetry.
+- Filter structured logs with your aggregator using `logger:"aiohttp.access"` for
+  request summaries or `trace:<uuid>` to follow a specific request across service logs.
+- The runtime echoes the active `trace` in both the JSON payload and the `X-Trace-Id`
+  response header for quick copy/paste when correlating downstream telemetry.
+- Healthy watchdog messages (heartbeat old but latency healthy) now log at INFO and are
+  rate-limited; WARN/ERROR entries remain reserved for actionable states.
 
 ## Readiness vs Liveness
 - `/ready` now reflects required components (`runtime`, `discord`). It returns

--- a/tests/test_access_log_json.py
+++ b/tests/test_access_log_json.py
@@ -1,42 +1,62 @@
 import asyncio
-import io
-import json
 import logging
+from typing import List
 
 from aiohttp.test_utils import TestClient, TestServer
 
 from modules.common import runtime as rt
 from shared import health as healthmod
+from shared.logging.structured import JsonFormatter
 
 
-class _Buffer(io.StringIO):
-    pass
+class _Collector(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self.records: List[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+        self.records.append(record)
 
 
 def test_access_log_json_contains_fields():
-    async def runner() -> None:
-        healthmod.set_component("discord", False)
-        buffer = _Buffer()
-        handler = logging.StreamHandler(buffer)
-        logging.getLogger().addHandler(handler)
+    healthmod.set_component("discord", False)
 
+    async def runner() -> tuple[list[logging.LogRecord], str | None]:
+        app = await rt.create_app()
+        access_logger = logging.getLogger("aiohttp.access")
+        collector = _Collector()
+        access_logger.addHandler(collector)
         try:
-            app = await rt.create_app()
             async with TestServer(app) as server:
                 async with TestClient(server) as client:
                     response = await client.get("/healthz")
                     assert response.status == 200
-
-            lines = [line for line in buffer.getvalue().splitlines() if '"logger": "access"' in line]
-            assert lines, "expected at least one access log line"
-
-            payload = json.loads(lines[-1])
-            assert payload.get("logger") == "access"
-            assert payload.get("method") == "GET"
-            assert "ms" in payload
-            assert payload.get("trace")
+                    header = response.headers.get("X-Trace-Id")
+            return list(collector.records), header
         finally:
-            logging.getLogger().removeHandler(handler)
-            healthmod.set_component("discord", False)
+            access_logger.removeHandler(collector)
 
-    asyncio.run(runner())
+    try:
+        records, trace_header = asyncio.run(runner())
+    finally:
+        healthmod.set_component("discord", False)
+
+    assert trace_header
+
+    http_records = [record for record in records if record.getMessage() == "http_request"]
+    assert http_records, "expected middleware http_request log"
+
+    record = http_records[-1]
+    assert record.name == "aiohttp.access"
+    assert record.method == "GET"
+    assert record.path == "/healthz"
+    assert record.status == 200
+    assert hasattr(record, "ms")
+    assert getattr(record, "trace", "")
+
+    access_logger = logging.getLogger("aiohttp.access")
+    assert not access_logger.propagate
+    assert access_logger.handlers, "expected access logger to have handlers"
+    for handler in access_logger.handlers:
+        assert isinstance(handler.formatter, JsonFormatter)
+        assert handler.level in (logging.NOTSET, logging.INFO)

--- a/tests/test_watchdog_noise.py
+++ b/tests/test_watchdog_noise.py
@@ -1,0 +1,54 @@
+import logging
+
+import pytest
+
+from shared import watchdog
+
+
+def test_watchdog_healthy_logs_info(caplog, monkeypatch):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    caplog.clear()
+    monkeypatch.setattr(watchdog, "_LAST_HEALTHY_INFO_EMIT", 0.0, raising=False)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(watchdog, "log", logging.getLogger("watchdog"))
+        ctx.setattr(watchdog.time, "time", lambda: 1_000_000.0)
+        watchdog._log_healthy(age=900.0, latency=0.1, since_ok=42.0, stall=600)
+
+    messages = [record.getMessage() for record in caplog.records if record.name == "watchdog"]
+    assert any("heartbeat old but latency healthy" in message for message in messages)
+
+
+@pytest.mark.parametrize("delta", [0.0, 100.0, 599.9])
+def test_watchdog_healthy_rate_limited(caplog, monkeypatch, delta):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    caplog.clear()
+    now = 2_000_000.0
+    monkeypatch.setattr(watchdog, "_LAST_HEALTHY_INFO_EMIT", now - delta, raising=False)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(watchdog, "log", logging.getLogger("watchdog"))
+        ctx.setattr(watchdog.time, "time", lambda: now)
+        watchdog._log_healthy(age=900.0, latency=0.1, since_ok=42.0, stall=600)
+
+    messages = [record.getMessage() for record in caplog.records if record.name == "watchdog"]
+    assert not messages
+    assert watchdog._LAST_HEALTHY_INFO_EMIT == pytest.approx(now - delta)
+
+
+def test_watchdog_healthy_resets_after_cooldown(caplog, monkeypatch):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    caplog.clear()
+    initial = 3_000_000.0
+    monkeypatch.setattr(watchdog, "_LAST_HEALTHY_INFO_EMIT", initial, raising=False)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(watchdog, "log", logging.getLogger("watchdog"))
+        ctx.setattr(watchdog.time, "time", lambda: initial + watchdog._HEALTHY_INFO_COOLDOWN + 1.0)
+        watchdog._log_healthy(age=900.0, latency=0.1, since_ok=42.0, stall=600)
+
+    messages = [record.getMessage() for record in caplog.records if record.name == "watchdog"]
+    assert any("heartbeat old but latency healthy" in message for message in messages)
+    assert watchdog._LAST_HEALTHY_INFO_EMIT == pytest.approx(
+        initial + watchdog._HEALTHY_INFO_COOLDOWN + 1.0
+    )


### PR DESCRIPTION
## Summary
- canonicalize HTTP access logging on `aiohttp.access` using the JSON formatter and surface the `X-Trace-Id` response header
- rate-limit the healthy watchdog branch at INFO and document the new logging semantics
- extend regression tests for access logging and watchdog noise control

## Testing
- pytest tests/test_access_log_json.py tests/test_watchdog_noise.py

[meta]
labels: observability, comp:health, tests, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fcd9a178848323b9ad74b1ff191e72