### PR TITLE
Relax guardrails for packaged commands

### DIFF
--- a/docs/ops/RecruiterPanel.md
+++ b/docs/ops/RecruiterPanel.md
@@ -14,3 +14,5 @@ place:
 Ephemeral messages are reserved for guard rails (for example preventing other
 users from pressing the controls); the panel refresh flow itself never emits
 "Updating…" or other transient notices.
+
+Doc last updated: 2025-10-26 (v0.9.6)


### PR DESCRIPTION
## Summary
- exclude the AUDIT exports from guardrail scanning and tighten the legacy import regex so prose no longer registers as a violation
- allow command decorators inside the packaged CoreOps module and in tests while keeping cogs enforcement elsewhere
- add the missing compliance footer to the recruiter panel ops guide

## Testing
- pytest
- python3 scripts/ci/guardrails_check.py
- python3 scripts/audit_coreops_packaging.py

------
https://chatgpt.com/codex/tasks/task_e_68fe4780f6008323828b17afb14be8ea