### PR TITLE
Remove legacy CoreOps help shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.9.5 — 2025-10-26
+
+### Fixed
+- Guardrails: removed the legacy `shared.help` re-export shim so the CoreOps packaging audit no longer flags shim bridges.
+
 ## v0.9.5 — 2025-10-23
 
 ### Changed

--- a/shared/help.py
+++ b/shared/help.py
@@ -1,5 +1,0 @@
-"""Compatibility shim for legacy CoreOps help imports."""
-
-from c1c_coreops.help import *  # noqa: F401,F403
-
-__all__ = [name for name in dir() if not name.startswith("_")]


### PR DESCRIPTION
## Summary
- delete the legacy shared.help compatibility shim so CoreOps guardrails stop flagging a bridge
- record the guardrail fix in the changelog for v0.9.5 (2025-10-26)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe732be6348323ba4cd265d2290616