### PR TITLE
Fix guardrails/docs annotation emitter

### DIFF
--- a/scripts/ci/emit_annotations.py
+++ b/scripts/ci/emit_annotations.py
@@ -1,87 +1,115 @@
-*** /dev/null
---- a/scripts/ci/emit_annotations.py
-@@
-+import os, re, sys, pathlib
-+
-+# Usage:
-+#   python scripts/ci/emit_annotations.py --kind docs --input path/to/output.log
-+#   python scripts/ci/emit_annotations.py --kind guardrails --input path/to/output.log
-+#
-+# Emits GitHub Annotations and writes a short checklist to $GITHUB_STEP_SUMMARY.
-+
-+DOCS_PATTERNS = [
-+    # e.g. "docs/README.md: footer missing or malformed."
-+    re.compile(r'^(?P<file>[\w\-/\.]+):\s*(?P<msg>footer missing or malformed)\.?$', re.I),
-+    # e.g. "docs/README.md: missing links for -> Architecture.md, _meta/DocStyle.md"
-+    re.compile(r'^(?P<file>[\w\-/\.]+):\s*missing links for\s*->\s*(?P<msg>.+)$', re.I),
-+]
-+
-+# Guardrails lines should be printed by the check script like:
-+# "VIOLATION: GR-001 No new labels without contract approval file: .github/labels.yml line: 14"
-+GR_PATTERNS = [
-+    re.compile(
-+        r'^VIOLATION:\s*(?P<rule>[A-Z0-9\-_.]+)\s+(?P<msg>.+?)\s+file:\s*(?P<file>[\w\-/\.]+)(?:\s+line:\s*(?P<line>\d+))?\s*$',
-+        re.I
-+    )
-+]
-+
-+def emit_error(file, line, title, msg):
-+    line = int(line) if (line and str(line).isdigit()) else 1
-+    print(f"::error file={file},line={line},title={title}::{msg}")
-+
-+def append_summary(lines):
-+    summ = os.getenv("GITHUB_STEP_SUMMARY")
-+    if not summ:
-+        return
-+    with open(summ, "a", encoding="utf-8") as fh:
-+        fh.write("### Check results\n\n")
-+        if not lines:
-+            fh.write("All clear.\n")
-+            return
-+        for l in lines:
-+            fh.write(f"- {l}\n")
-+
-+def parse(kind, text):
-+    out = []
-+    if kind == "docs":
-+        for raw in text.splitlines():
-+            for rx in DOCS_PATTERNS:
-+                m = rx.match(raw.strip())
-+                if m:
-+                    d = m.groupdict()
-+                    emit_error(d["file"], 1, "Docs check", d["msg"])
-+                    out.append(f"{d['file']}: {d['msg']}")
-+                    break
-+    elif kind == "guardrails":
-+        for raw in text.splitlines():
-+            for rx in GR_PATTERNS:
-+                m = rx.match(raw.strip())
-+                if m:
-+                    d = m.groupdict()
-+                    title = f"Guardrail {d['rule']}"
-+                    msg = d["msg"]
-+                    emit_error(d["file"], d.get("line") or 1, title, msg)
-+                    out.append(f"{d['rule']}: {msg} ({d['file']}{':' + d['line'] if d.get('line') else ''})")
-+                    break
-+    return out
-+
-+def main():
-+    kind = None
-+    inp = None
-+    args = sys.argv[1:]
-+    while args:
-+        a = args.pop(0)
-+        if a == "--kind":
-+            kind = args.pop(0)
-+        elif a == "--input":
-+            inp = args.pop(0)
-+    if not (kind and inp):
-+        print("usage: emit_annotations.py --kind <docs|guardrails> --input <file>", file=sys.stderr)
-+        sys.exit(2)
-+    text = pathlib.Path(inp).read_text(encoding="utf-8", errors="ignore")
-+    lines = parse(kind, text)
-+    append_summary(lines)
-+    # do not change exit code here; upstream step should determine success/failure
-+
-+if __name__ == "__main__":
-+    main()
+#!/usr/bin/env python3
+"""Emit GitHub annotations for docs and guardrails checks."""
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+from typing import Iterable
+
+DOCS_PATTERNS: list[re.Pattern[str]] = [
+    # e.g. "docs/README.md: footer missing or malformed."
+    re.compile(r"^(?P<file>[\w\-/\.]+):\s*(?P<msg>footer missing or malformed)\.?$", re.IGNORECASE),
+    # e.g. "docs/README.md: missing links for -> Architecture.md, _meta/DocStyle.md"
+    re.compile(r"^(?P<file>[\w\-/\.]+):\s*missing links for\s*->\s*(?P<msg>.+)$", re.IGNORECASE),
+]
+
+GR_PATTERNS: list[re.Pattern[str]] = [
+    # Guardrails output lines look like:
+    #   VIOLATION: S-01 legacy import outside modules/* file: modules/foo.py line: 12
+    re.compile(
+        r"^VIOLATION:\s*(?P<rule>[A-Z0-9\-_.]+)\s+(?P<msg>.+?)\s+file:\s*(?P<file>[\w\-/\.]+)"
+        r"(?:\s+line:\s*(?P<line>\d+))?\s*$",
+        re.IGNORECASE,
+    ),
+]
+
+
+def emit_error(file_path: str, line: str | int | None, title: str, message: str) -> None:
+    """Write a GitHub annotation to stdout."""
+    try:
+        line_no = int(line) if line is not None else 1
+    except (TypeError, ValueError):
+        line_no = 1
+    print(f"::error file={file_path},line={line_no},title={title}::{message}")
+
+
+def append_summary(entries: Iterable[str]) -> None:
+    """Append a short summary to the GitHub step summary if available."""
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write("### Check results\n\n")
+        entries = list(entries)
+        if not entries:
+            handle.write("All clear.\n")
+            return
+        for entry in entries:
+            handle.write(f"- {entry}\n")
+
+
+def parse_docs(text: str) -> list[str]:
+    findings: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        for pattern in DOCS_PATTERNS:
+            match = pattern.match(stripped)
+            if not match:
+                continue
+            data = match.groupdict()
+            emit_error(data["file"], 1, "Docs check", data["msg"])
+            findings.append(f"{data['file']}: {data['msg']}")
+            break
+    return findings
+
+
+def parse_guardrails(text: str) -> list[str]:
+    findings: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        for pattern in GR_PATTERNS:
+            match = pattern.match(stripped)
+            if not match:
+                continue
+            data = match.groupdict()
+            title = f"Guardrail {data['rule']}"
+            message = data["msg"]
+            emit_error(data["file"], data.get("line"), title, message)
+            location = data["file"]
+            if data.get("line"):
+                location = f"{location}:{data['line']}"
+            findings.append(f"{data['rule']}: {message} ({location})")
+            break
+    return findings
+
+
+def parse(kind: str, text: str) -> list[str]:
+    if kind == "docs":
+        return parse_docs(text)
+    if kind == "guardrails":
+        return parse_guardrails(text)
+    raise ValueError(f"unsupported kind: {kind}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kind", choices=("docs", "guardrails"), required=True)
+    parser.add_argument("--input", type=pathlib.Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        text = args.input.read_text(encoding="utf-8", errors="ignore")
+    except FileNotFoundError:
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+
+    findings = parse(args.kind, text)
+    append_summary(findings)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- replace the malformed scripts/ci/emit_annotations.py with a proper Python module that parses guardrails/docs logs
- keep emitting GitHub annotations and step summaries so the CI guardrails/docs workflows can succeed again

## Testing
- python scripts/ci/check_docs.py
- python scripts/ci/guardrails_check.py
- pytest tests/test_guardrails_summary.py::test_guardrails_doc_exists_and_lists_all_rules -q

------
https://chatgpt.com/codex/tasks/task_e_68fe79380a6c8323b6311406292b8865