### PR TITLE
Docs parity sweep — update all Markdown to v0.9.6 (2025-10-26), align with live code, exclude AUDIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.9.6 — 2025-10-26
+
+### Documentation
+- Sync documentation with live command set, feature toggles, and watcher behavior.
+- Updated configuration references, module toggle notes, and operator runbooks to reflect the current runtime.
+- Bumped doc footers and indices to v0.9.6 with the 2025-10-26 review date.
+
 ## v0.9.5 — 2025-10-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 <!-- Keep README user-facing -->
 <!-- Dev layout reference: recruitment modules now live in modules/recruitment/, -->
 <!-- shared sheet adapters consolidate under shared/sheets/. See docs/Architecture.md. -->
-# C1C Recruitment Bot v0.9.5
+# C1C Recruitment Bot v0.9.6
 Welcome to the C1C recruitment helper.  
 The bot keeps clan rosters healthy, helps new friends find their hall, and makes sure every welcome lands in the right place.
 
 ### What you can do today
-!rec help — lists all commands available to you.  
-!clan <tag> — shows a quick profile for any clan in the cluster.  
-!clanmatch — opens the recruiter panel where staff help players find a home.  
-!welcome — posts the standard welcome note once a recruit joins.  
+!rec help — lists the commands your role can use and tips for each.
+!clan <tag> — shows a quick profile for any clan in the cluster.
+!clansearch — opens the member search panel with the latest roster filters.
+!clanmatch — recruiter-only panel to match players with open clans.
+!welcome — staff command that posts the standard welcome note once a recruit joins.
 
 The bot pulls live data from the cluster sheets so info stays current.
 
@@ -20,4 +21,4 @@ The bot pulls live data from the cluster sheets so info stays current.
 
 ---
 
-_Doc last updated: 2025-10-25 (v0.9.5)_
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -12,7 +12,7 @@ flowchart TD
     SheetsAdapters --> Sheets[(Google Sheets)]
     Watchers --> SheetsAdapters
     CoreOpsCog --> SheetsAdapters
-    Scheduler --> HealthLogs[Digest & refresh logs]
+    Scheduler --> CacheJobs[Cache refresh jobs]
     Http[aiohttp health server] --> ReadyEndpoint[/ready/]
     Http --> HealthEndpoint[/health & healthz/]
     CoreOpsCog --> Http
@@ -65,8 +65,8 @@ off in production until the panels ship._
   features → Discord extensions. Abort boot if config or sheets layers fail.
 - Watchdog owns keepalive cadences, stall detection, reconnect timers, and feeds its
   metrics into the health server output.
-- Runtime scheduler handles cron refreshes, recruiter digest delivery, and any hygiene
-  jobs registered by feature modules.
+- Runtime scheduler handles cache refreshes (`clans`, `templates`, `clan_tags`) and posts
+  `[cache]` summaries to the ops channel.
 
 ## Data paths
 - Reads: commands and watcher listeners use `shared.sheets.recruitment` /
@@ -97,10 +97,10 @@ off in production until the panels ship._
 - Approved keys:
   - `member_panel` — member search panels.
   - `recruiter_panel` — recruiter dashboards and match tools.
-  - `recruitment_welcome` — welcome command plus onboarding listeners.
-  - `recruitment_reports` — daily recruiter digest watcher and manual digest command.
-  - `placement_target_select` — placement picker UI inside panels.
-  - `placement_reservations` — reservation workflow for recruiter holds.
+  - `recruitment_welcome` — welcome command (welcome/promo listeners remain env-gated).
+  - `recruitment_reports` — stub module that logs load/unload only.
+  - `placement_target_select` — stub module for future placement picker.
+  - `placement_reservations` — stub module for future reservation workflow.
 - Toggles live in the recruitment Sheet `FeatureToggles` worksheet; `TRUE`/`true`/`1`
   enable a feature, `FALSE`/`false`/`0` disable it. Misconfigurations post a single admin-ping warning to the runtime log
   channel.
@@ -116,4 +116,4 @@ off in production until the panels ship._
 - Failures fall back to stale caches when safe and always raise a structured log to
   `LOG_CHANNEL_ID`.
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# C1C Recruitment Bot Documentation Overview (v0.9.7)
+# C1C Recruitment Bot Documentation Overview (v0.9.6)
 
 ## Purpose
 This index explains the intent and ownership of every file in the documentation tree.
@@ -56,7 +56,7 @@ It exists so that contributors update the correct references after each developm
 * [`RecruiterPanel.md`](ops/RecruiterPanel.md) — interaction model for the recruiter panel UI and messaging cadence.
 * [`Runbook.md`](ops/Runbook.md) — operator actions for routine tasks and incident handling.
 * [`Troubleshooting.md`](ops/Troubleshooting.md) — quick reference for diagnosing common issues.
-* [`Watchers.md`](ops/Watchers.md) — background jobs covering schedulers, refreshers, and watchdogs.
+* [`Watchers.md`](ops/Watchers.md) — environment-gated welcome/promo listeners and cache refresh scheduler notes.
 * [`development.md`](ops/development.md) — developer setup notes and contribution workflow guidance.
 * [`commands.md`](ops/commands.md) — supplemental command reference for operational usage.
 * [`module-toggles.md`](ops/module-toggles.md) — module-level feature toggle reference.
@@ -74,9 +74,9 @@ It exists so that contributors update the correct references after each developm
 ## Maintenance Rules
 * Update this index whenever documentation files are added, renamed, or removed.
 * Any PR that modifies documentation must reflect its changes here and, if structural, call them out in the CollaborationContract.
-* Ensure the version shown in this index (currently v0.9.7) matches the bot version in the root `README.md`.
+* Ensure the version shown in this index (currently v0.9.6) matches the bot version in the root `README.md`.
 
 ## Cross-References
 * [`docs/contracts/CollaborationContract.md`](contracts/CollaborationContract.md) documents contributor responsibilities and embeds this index under “Documentation Discipline.”
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/_meta/DocStyle.md
+++ b/docs/_meta/DocStyle.md
@@ -7,7 +7,7 @@ This guide defines the documentation rules enforced by `scripts/ci/check_docs.py
 - H1 titles **must not** include delivery phases or transient project codes.
 
 ## Footer contract
-- The final line of every doc is the exact footer: `Doc last updated: 2025-10-22 (v0.9.5)`.
+- The final line of every doc is the exact footer: `Doc last updated: 2025-10-26 (v0.9.6)`.
 - Do not append extra whitespace or commentary after the footer.
 
 ## Environment source of truth
@@ -22,4 +22,4 @@ This guide defines the documentation rules enforced by `scripts/ci/check_docs.py
 - Run `python scripts/ci/check_docs.py` (or `make -f scripts/ci/Makefile docs-check`) before opening a PR.
 - The checker validates title rules, footers, index coverage, ENV parity, and in-doc links.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0000-template.md
+++ b/docs/adr/ADR-0000-template.md
@@ -18,4 +18,4 @@ Call out follow-up work, trade-offs, and operational impact so future readers un
 
 Draft
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0001-sheets-access-layer.md
+++ b/docs/adr/ADR-0001-sheets-access-layer.md
@@ -21,4 +21,4 @@ Adopting the shared cache delivers predictable latency while ensuring a single t
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0002-cache-telemetry-wrapper.md
+++ b/docs/adr/ADR-0002-cache-telemetry-wrapper.md
@@ -26,4 +26,4 @@ private cache structures.
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0003-coreops-command-contract.md
+++ b/docs/adr/ADR-0003-coreops-command-contract.md
@@ -39,4 +39,4 @@ environment.
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-24 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0004-help-system-short-vs-detailed.md
+++ b/docs/adr/ADR-0004-help-system-short-vs-detailed.md
@@ -29,4 +29,4 @@ usage without cluttering the main index.
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0005-reload-vs-refresh.md
+++ b/docs/adr/ADR-0005-reload-vs-refresh.md
@@ -28,4 +28,4 @@ trace who initiated reloads.
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0006-startup-preloader-bot-info-cron.md
+++ b/docs/adr/ADR-0006-startup-preloader-bot-info-cron.md
@@ -29,4 +29,4 @@ intervention.
 
 Accepted — 2025-10-20
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md
+++ b/docs/adr/ADR-0007-feature-toggles-recruitment-module-boundaries.md
@@ -99,4 +99,4 @@ If a row is missing or the worksheet is unreachable:
 
 **Draft — pending implementation of `modules/common/feature_flags.py` and loader integration.**
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0008-emoji-pipeline-port.md
+++ b/docs/adr/ADR-0008-emoji-pipeline-port.md
@@ -45,4 +45,4 @@ helpers while back-end caches and filters were restored.
 
 **Draft — awaiting command integration in subsequent Phase 5 PRs.**
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0009-recruiter-panel-text-only.md
+++ b/docs/adr/ADR-0009-recruiter-panel-text-only.md
@@ -26,4 +26,4 @@ loaded as part of the recruiter workflow.
 * Other recruitment commands (`!clansearch`, `!clan <tag>`) remain free to add
   crest rendering in follow-up work without affecting recruiter performance.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0010-clan-profile-with-emoji.md
+++ b/docs/adr/ADR-0010-clan-profile-with-emoji.md
@@ -37,4 +37,4 @@ entry criteria side remains text-only.
 * The owner-locked flip view allows future commands to supply custom embed
   builders, enabling richer toggles without duplicating UI code.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0011-Normalize-to-Modules-First.md
+++ b/docs/adr/ADR-0011-Normalize-to-Modules-First.md
@@ -34,4 +34,4 @@ Adopt a Modules-First layout:
 * The `member_panel` flag exists but does not enable new behavior yet; future PRs
   will register the cog when the sheet value is `TRUE`.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0012-coreops-package.md
+++ b/docs/adr/ADR-0012-coreops-package.md
@@ -32,4 +32,4 @@ working while we stage the follow-up import rewrite.
 * We must follow up with a PR to update imports to `c1c_coreops.*` and remove
   the shims once callers move over.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0013-config-io-hardening.md
+++ b/docs/adr/ADR-0013-config-io-hardening.md
@@ -24,4 +24,4 @@ An audit highlighted four regressions: Discord log posts could silently land in 
 
 Accepted
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0014-async-sheets-facade.md
+++ b/docs/adr/ADR-0014-async-sheets-facade.md
@@ -19,4 +19,4 @@ Update all async call sites to use the facade.
 Accepted
 
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0015-config-hygiene-and-secrets.md
+++ b/docs/adr/ADR-0015-config-hygiene-and-secrets.md
@@ -23,4 +23,4 @@ Accepted
 - CI parity check fails if docs and `.env.example` diverge; leak scan fails on Discord token patterns.
 
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0016-import-side-effects.md
+++ b/docs/adr/ADR-0016-import-side-effects.md
@@ -24,4 +24,4 @@ Runtime boot still fails fast when required env is missing (because `shared.conf
 Test suite passes in CI.
 
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/ADR-0017-Reservations-Placement-Schema.md
+++ b/docs/adr/ADR-0017-Reservations-Placement-Schema.md
@@ -93,4 +93,4 @@ labels: docs, architecture, comp:onboarding, comp:placement, comp:data-sheets, b
 milestone: Harmonize v1.0
 **[/meta]**
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,4 +25,4 @@ This directory contains the architectural decision records (ADRs) that document 
 | [ADR-0016](ADR-0016-import-side-effects.md) | Import-time side effects removal | Accepted |
 | [ADR-0017](ADR-0017-Reservations-Placement-Schema.md) | Reservations & placement schema | — |
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/compliance/REPORT_GUARDRAILS.md
+++ b/docs/compliance/REPORT_GUARDRAILS.md
@@ -67,4 +67,4 @@
 ## Risk scan
 * No blocking risks observed—extension contract, config sourcing, embed parity, and RBAC controls all validate cleanly in the current codebase.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/contracts/CollaborationContract.md
+++ b/docs/contracts/CollaborationContract.md
@@ -56,7 +56,7 @@ They apply to **all phases, PRs, and documentation changes**.
   * Make Codex **read** the relevant doc files first.
   * Add updates in the **existing format** and section.
   * Follow the structure in the current documentation tree (see `/docs` layout: `adr/`, `ops/`, `contracts/`, `compliance/`).
-  * **Documentation Index (v0.9.4):** This index explains the intent and ownership of every file in the documentation tree. It exists so that contributors update the correct references after each development phase or PR.
+  * **Documentation Index (v0.9.6):** This index explains the intent and ownership of every file in the documentation tree. It exists so that contributors update the correct references after each development phase or PR.
   * **Quality gate:** All docs must follow [`docs/_meta/DocStyle.md`](../_meta/DocStyle.md) and pass `scripts/ci/check_docs.py`. Environment keys are authoritative in [`docs/ops/Config.md`](../ops/Config.md); keep `.env.example` synchronized.
 
     * **`/docs/adr/` — Architectural Decision Records**
@@ -91,7 +91,7 @@ They apply to **all phases, PRs, and documentation changes**.
     * **Maintenance Rules**
       * Update this index whenever documentation files are added, renamed, or removed.
       * Any PR that modifies documentation must reflect its changes here and, if structural, call them out in the CollaborationContract.
-      * Ensure the version shown in this index (currently v0.9.4) matches the bot version in the root `README.md`.
+      * Ensure the version shown in this index (currently v0.9.6) matches the bot version in the root `README.md`.
 
     * **Cross-References**
       * `docs/ops/CollaborationContract.md` documents contributor responsibilities and embeds this index under “Documentation Discipline.”
@@ -230,4 +230,4 @@ AUDIT/legacy/clanmatch-welcomecrew/2025-10-10_code-export/WC   → WelcomeCrew l
 * Keep ENV + Sheet config consistent.
 * Stop and ask if unsure.
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -44,7 +44,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 
 ## Command Routing & Prefix
 - Supported: `!rec`, `!rec␣`, `rec`, `rec␣`, `@mention`.
-- Admin bang shortcuts: `!health|!env|!digest|!help` (Admin role only).
+- Admin bang shortcuts: `!env`, `!reload`, `!health`, `!digest`, `!checksheet`, `!config`, `!help`, `!ping`, `!refresh all` (Admin role only).
 - No bare-word shortcuts.
 
 ## CoreOps v1.5 contract
@@ -94,4 +94,4 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 - Embed footer standardized: `Bot vX.Y.Z · CoreOps vA.B.C` (Discord timestamp replaces
   inline timezone text).
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/epic/EPIC_WelcomePlacementV2.md
+++ b/docs/epic/EPIC_WelcomePlacementV2.md
@@ -197,4 +197,4 @@ labels: docs, comp:onboarding, comp:placement, comp:data-sheets, bot:recruitment
 milestone: Harmonize v1.0  
 **[/meta]**
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -19,4 +19,4 @@ This document consolidates the guardrail expectations enforced by CI.
 - The legacy **Guardrails Summary** for config/docs parity and Discord token scans
   remains in place; address any listed issues before requesting review.
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -57,4 +57,4 @@ labels: docs, governance, guardrails, ready
 milestone: Harmonize v1.0
 [/meta]
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -10,7 +10,7 @@ flowchart TD
     Renderer -->|embeds| Discord
     Preloader[Startup preloader] -->|warm buckets| CacheSvc
     Scheduler[Runtime scheduler] -->|cron refresh| CacheSvc
-    Scheduler --> Digest[Recruiter digest jobs]
+    Scheduler --> CacheJobs[Cache refresh jobs]
     User[Member/Admin requests] --> CoreOps
     Http[aiohttp runtime] --> Ready[/ready endpoint/]
     Http --> Health[/health & healthz/]
@@ -33,8 +33,8 @@ flowchart TD
   statuses for `/ready` and `/health` whenever Discord or the HTTP server changes state.
 - **Preloader:** Runs automatically during boot, logging `[refresh] startup` entries for
   each bucket.
-- **Scheduler:** Handles cron work including the 3-hour `bot_info` refresh, digest
-  delivery, and template/watchers hygiene tasks.
+- **Scheduler:** Handles cron work for cache refreshes (`clans`, `templates`,
+  `clan_tags`) and posts results to the ops channel.
 - **Telemetry → Embed renderer:** Command responses pull structured telemetry and render
   embeds without timestamps; version metadata lives solely in the footer.
 - **Runtime HTTP interface:** `/` returns the status payload and echoes the request
@@ -67,9 +67,9 @@ flowchart TD
 - **Feature map:**
   - `member_panel` — member view of recruitment roster/search panels.
   - `recruiter_panel` — recruiter dashboard, match queue, and escalations.
-  - `recruitment_welcome` — welcome command plus onboarding listeners.
-  - `recruitment_reports` — daily recruiter digest watcher and embeds.
-  - `placement_target_select` — placement targeting picker inside panels.
-  - `placement_reservations` — reservation holds and release workflow.
+  - `recruitment_welcome` — welcome command (welcome/promo listeners remain env-gated).
+  - `recruitment_reports` — stub module that logs load/unload events only.
+  - `placement_target_select` — stub module (no runtime surface yet).
+  - `placement_reservations` — stub module (no runtime surface yet).
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -7,39 +7,40 @@ short descriptions in `!help` and tier-specific listings; detailed blurbs live i
 [`commands.md`](commands.md).
 
 ## Admin — CoreOps & refresh controls
-_Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*` (commands unchanged).
+_Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*` (command behavior unchanged).
 
 | Command | Status | Short text | Usage |
 | --- | --- | --- | --- |
 | `!config` | ✅ | Admin embed of the live registry with guild names and sheet linkage. | `!config` |
-| `!digest` | ✅ | Post the admin digest with cache age, next run, retries, and actor. | `!digest` |
+| `!digest` | ✅ | Post the ops digest with cache age, next run, retries, and actor. | `!digest` |
 | `!env` | ✅ | Show masked environment snapshot for quick sanity checks. | `!env` |
-| `!health` | ✅ | Inspect cache/watchdog telemetry straight from the public API. | `!health` |
-| `!checksheet` | ✅ | Validate Sheets tabs, named ranges, and headers (debug preview optional). | `!checksheet [--debug]` |
-| `!rec refresh [bucket]` | 🧩 | Warm a specific cache bucket with actor, age, and retry logging. | `!rec refresh [bucket]` |
-| `!rec refresh all` | 🧩 | Warm every registered cache bucket and emit a consolidated summary. | `!rec refresh all` |
-| `!rec reload [--reboot]` | 🧩 | Rebuild the config registry; optionally schedule a soft reboot. | `!rec reload [--reboot]` |
+| `!health` | ✅ | Inspect cache/watchdog telemetry pulled from the public API. | `!health` |
+| `!checksheet` | ✅ | Validate Sheets tabs, named ranges, and headers (`--debug` preview optional). | `!checksheet [--debug]` |
 | `!refresh [bucket]` | ✅ | Admin bang alias for single-bucket refresh with the same telemetry. | `!refresh [bucket]` |
+| `!refresh all` | ✅ | Bang alias for the full cache sweep (same cooldown as the `!rec` variant). | `!refresh all` |
 | `!reload [--reboot]` | ✅ | Admin bang alias for config reload plus optional soft reboot. | `!reload [--reboot]` |
+| `!ping` | ✅ | Adds a 🏓 reaction so admins can confirm shard responsiveness. | `!ping` |
 
 ## Recruiter / Staff — recruitment workflows
 | Command | Status | Short text | Usage |
 | --- | --- | --- | --- |
-| `!rec checksheet` | 🧩 | Staff view of Sheets linkage for recruitment/onboarding tabs. | `!rec checksheet [--debug]` |
-| `!rec config` | 🧩 | Staff summary of guild routing, sheet IDs, and watcher toggles. | `!rec config` |
-| `!rec digest` | ✅ | Post the recruiter digest with cache age, next run, and retries. [gated: `recruitment_reports`] | `!rec digest` |
+| `!rec checksheet` | 🧩 | Staff view of Sheets linkage for recruitment/onboarding tabs (`--debug` prints sample rows). | `!rec checksheet [--debug]` |
+| `!rec config` | 🧩 | Staff summary of guild routing, sheet IDs, env toggles, and watcher states. | `!rec config` |
+| `!rec digest` | ✅ | Post the ops digest with cache age, next run, and retries. | `!rec digest` |
 | `!rec refresh clansinfo` | 🧩 | Refresh clan roster data when Sheets updates land. | `!rec refresh clansinfo` |
-| `!clanmatch` | 🧩 | Recruiter match workflow (reserved under toggle). [gated: `recruiter_panel`] | `!clanmatch` |
-| `!welcome [clan] @mention` | ✅ | Issue a welcome panel seeded from the cached templates. [gated: `recruitment_welcome`] | `!welcome [clan] @mention` |
+| `!rec refresh all` | 🧩 | Warm every registered cache bucket and emit a consolidated summary (30 s guild cooldown). | `!rec refresh all` |
+| `!rec reload [--reboot]` | 🧩 | Rebuild the config registry; optionally schedule a soft reboot. | `!rec reload [--reboot]` |
+| `!clanmatch` | 🧩 | Recruiter match workflow (requires recruiter/staff role). [gated: `recruiter_panel`] | `!clanmatch` |
+| `!welcome [clan] @mention` | ✅ | Post a cached welcome template for the chosen clan. [gated: `recruitment_welcome`] | `!welcome [clan] @mention` |
+| `!rec ping` | 🧩 | Prefix proxy for the admin ping command (still requires admin access). | `!rec ping` |
 
 ## User — general members
 | Command | Status | Short text | Usage |
 | --- | --- | --- | --- |
-| `!clan <tag>` | 🧩 | Public clan card with crest + 💡 reaction flip between profile and entry criteria. [gated: `clan_profile`] | `!clan <tag>` |
-| `!clansearch` | 🧩 | Member clan search with legacy filters + pager (new message per change). [gated: `member_panel`] | `!clansearch` |
 | `!rec help [command]` | 🧩 | List accessible commands or expand one with usage and tips. | `!rec help` / `!rec help <command>` |
-| `!rec ping` | ✅ | Report bot latency and shard status without hitting the cache. | `!rec ping` |
+| `!clan <tag>` | 🧩 | Public clan card with crest + 💡 reaction flip between profile and entry criteria. [gated: `clan_profile`] | `!clan <tag>` |
+| `!clansearch` | 🧩 | Member clan search with legacy filters + pager (edits the panel in place). [gated: `member_panel`] | `!clansearch` |
 
-> Daily recruiter digest watcher — [gated: `recruitment_reports`]
+> Feature toggle note — `recruitment_reports`, `placement_target_select`, and `placement_reservations` currently load stub modules that only log when enabled.
 
-Doc last updated: 2025-10-23 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -90,6 +90,8 @@ sync modules remain available for non-async scripts and cache warmers.
 | `STRICT_PROBE` | bool | `false` | Enforces guild allow-list before startup completes. |
 | `SEARCH_RESULTS_SOFT_CAP` | int | `25` | Soft limit on search results per query. |
 
+> Feature toggles `recruitment_reports`, `placement_target_select`, and `placement_reservations` currently load stub modules that only log whether they were enabled. They do **not** register commands or cron jobs yet.
+
 ### Watchdog, cache, and cleanup
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -119,13 +121,13 @@ sync modules remain available for non-async scripts and cache warmers.
 ## Automation listeners & cron jobs
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `ENABLE_WELCOME_HOOK` | bool | `true` | Event listeners for welcomes. Disable to pause ticket automation. |
-| `ENABLE_PROMO_WATCHER` | bool | `true` | Event listeners for promos. |
+| `ENABLE_WELCOME_HOOK` | bool | `true` | Event listeners for welcome thread closures that log to Sheets. |
+| `ENABLE_PROMO_WATCHER` | bool | `true` | Event listeners for promo thread closures that log to Sheets. |
 
 > `ENABLE_WELCOME_HOOK` is the only supported welcome toggle. Remove any lingering
 > 'ENABLE_WELCOME_WATCHER' entries from deployment environments.
 
-> Cron cadences are fixed in code today; update the scheduler directly if the defaults change.
+> Cron cadences are fixed in code today; the only scheduled jobs refresh the `clans`, `templates`, and `clan_tags` cache buckets and post `[cache]` summaries to the ops channel. Update the scheduler directly if the defaults change.
 
 ## Sheet config tabs
 Both Google Sheets referenced above must expose a `Config` worksheet with **Key** and **Value** columns.
@@ -185,6 +187,7 @@ Feature Toggles:
 - Missing feature row ⇒ that feature disabled; logs one admin-ping warning the first time the key is evaluated.
 - Invalid value ⇒ disabled; logs one admin-ping warning per feature key.
 - Startup continues regardless; platform services (cache, scheduler, watchdog, RBAC) are never gated.
+- The `recruitment_reports` and `placement_*` rows only control stub modules today; enabling them logs load state but does not expose new commands yet.
 
 **Operator flow**
 
@@ -198,4 +201,4 @@ Feature Toggles:
 - Verify the worksheet name matches the Config key and that headers are spelled correctly.
 - Use `!rec refresh config` (or the Ops equivalent) to force the bot to re-read the toggles after a fix.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/RecruiterPanel.md
+++ b/docs/ops/RecruiterPanel.md
@@ -15,4 +15,4 @@ Ephemeral messages are reserved for guard rails (for example preventing other
 users from pressing the controls); the panel refresh flow itself never emits
 "Updating…" or other transient notices.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -10,7 +10,7 @@ Older GitHub Actions deploy runs may display "skipped by same-file supersession"
 1. **Boot:** Render launches the container and the preloader runs before the CoreOps cog
    registers commands.
 2. **Warm-up:** The preloader calls `refresh_now(name, actor="startup")` for every
-   registered cache bucket (Sheets, templates, bot_info, digest payloads, etc.).
+   registered cache bucket (`clans`, `templates`, `clan_tags`).
 3. **Logging:** A single success/failure summary posts to the ops channel once warm-up
  completes. Individual `[refresh] startup` lines include bucket, duration, retries, and
   result.
@@ -91,4 +91,4 @@ tabs.
 - **Remediation:** Fix the Sheet, run `!rec refresh config` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Troubleshooting.md
+++ b/docs/ops/Troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting & Redaction
 
 ## Quick triage
-- **Cron quiet** → confirm the latest `[cron result]` within the expected interval before
+- **Cron quiet** → confirm the latest `[cache]` refresh summary within the expected interval before
   triggering manual refreshes. If missing, inspect `/healthz` and deployment logs.
 - **Command fails for staff** → confirm roles, then rerun with admin watching logs.
 - **Watcher quiet** → check toggles in `!rec config` and verify `/healthz` for stale
@@ -56,4 +56,4 @@ when adjusting cadences or toggles.
   opening an incident.
 - Ping #bot-production with the summary before filing a longer report.
 
-Doc last updated: 2025-10-22 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/commands.md
+++ b/docs/ops/commands.md
@@ -65,6 +65,15 @@ Shows a clan’s profile and entry-criteria card.
 - **Error Handling:** If tag not found, returns a small red embed.
 - **Feature Toggle:** `clan_profile`
 
+### !clansearch
+
+Launches the member-facing search panel.
+
+- **Access:** Public (no role restrictions)
+- **Behavior:** Opens an interactive panel that edits its own message whenever filters change so channels do not fill with duplicates.
+- **Usage:** `!clansearch`
+- **Feature Toggle:** `member_panel`
+
 ### !clanmatch
 
 Opens the text-only recruiter panel for filtering and matching clans.
@@ -75,4 +84,22 @@ Opens the text-only recruiter panel for filtering and matching clans.
 - **Usage:** `!clanmatch`
 - **Feature Toggle:** `recruiter_panel`
 
-Doc last updated: 2025-10-22 (v0.9.5)
+### !welcome `[clan] @mention`
+
+Posts the cached welcome template for the provided clan tag.
+
+- **Access:** Staff / Admin
+- **Behavior:** Pulls templates via `shared.sheets` cache; appends any additional note supplied after the mention.
+- **Usage:** `!welcome C1CE @Player`
+- **Feature Toggle:** `recruitment_welcome`
+
+### `!rec ping`
+
+Prefix proxy for the admin ping command.
+
+- **Access:** Admin (shares gating with the base `!ping` command)
+- **Behavior:** Delegates to the hidden admin command that reacts with 🏓; used to confirm shard responsiveness.
+- **Usage:** `!rec ping`
+- **Notes:** Because the proxy invokes the admin command directly, non-admins still receive the “Admins only.” denial message.
+
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/development.md
+++ b/docs/ops/development.md
@@ -26,7 +26,7 @@
 
 ## Testing commands
 - `!rec refresh all` — verify cache warmers and actor logging.
-- `!digest --debug` — confirm public telemetry includes age/next/retries.
+- `!rec digest` — confirm public telemetry includes age/next/retries and fallback text.
 - `!checksheet --debug` — inspect tab headers and template previews post-refresh.
 
 ## Command routing
@@ -34,4 +34,4 @@
   `COREOPS_ADMIN_BANG_ALLOWLIST`. Legacy `COMMAND_PREFIX` is unsupported and
   blocked in CI.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/module-toggles.md
+++ b/docs/ops/module-toggles.md
@@ -10,18 +10,18 @@ at startup. Toggle values are case-insensitive; only `TRUE` (`ON`) enables a fea
 | `member_panel` | `TRUE` | Enables prefix `!clansearch` for members (single-message results updated in-place). |
 | `recruiter_panel` | `ON` | Enables the text-only recruiter panel (`!clanmatch`). |
 | `clan_profile` | `ON` | Enables the public `!clan` command with crest and 💡 reaction toggle. |
-| `recruitment_welcome` | `TRUE` | Welcome command and onboarding listeners. |
-| `recruitment_reports` | `TRUE` | Daily recruiter digest embed. |
+| `recruitment_welcome` | `TRUE` | Enables the `!welcome` command; onboarding listeners remain env-gated. |
+| `recruitment_reports` | `TRUE` | Stub module that logs load/unload only (no digest command yet). |
 
 ## Placement
 
 | Toggle | Default | Notes |
 | --- | --- | --- |
-| `placement_target_select` | `TRUE` | Enables placement target picker inside recruiter workflows. |
-| `placement_reservations` | `TRUE` | Reservation holds and release workflow. |
+| `placement_target_select` | `TRUE` | Stub module for future placement picker. |
+| `placement_reservations` | `TRUE` | Stub module for future reservation workflow. |
 
 Set the desired value in the `FeatureToggles` tab, then run `!rec refresh config`
 to apply it. The runtime logs whether each module was loaded or skipped at boot. See
 [`Config.md`](Config.md#feature-toggles-worksheet) for the worksheet contract.
 
-Doc last updated: 2025-10-25 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)

--- a/packages/c1c-coreops/README.md
+++ b/packages/c1c-coreops/README.md
@@ -30,8 +30,7 @@ The cog currently imports several modules that are **not** shipped with this
 package:
 
 * `config.runtime` — provides bot identity, prefix, and watchdog settings.
-* `modules.coreops.helpers` — contributes the `tier` decorator used by the
-  help-surface integration tests.
+* `modules.common.feature_flags` / `modules.common.runtime` — feature toggle refresh and runtime scheduling helpers.
 * `shared.*` packages — supply cache, Sheets, telemetry, and redaction helpers
   relied upon by the command implementations.
 
@@ -64,4 +63,4 @@ to another project.
 Please keep this README up to date whenever dependencies change so other teams
 can evaluate the work required to adopt CoreOps.
 
-Doc last updated: 2025-10-26 (v0.9.5)
+Doc last updated: 2025-10-26 (v0.9.6)


### PR DESCRIPTION
## Summary
- bump user-facing and operational documentation to v0.9.6 with updated command coverage, scheduler behaviour, and feature toggle notes
- refresh ops references (Config, Runbook, Watchers, CommandMatrix, commands.md) to match the current CoreOps runtime and recruitment modules
- update package documentation footers and dependency notes to reflect the packaged CoreOps layout

## Testing
- `python scripts/ci/check_docs.py`

[meta]
labels: docs, ready, guardrails, comp:ops
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_68fe914a84dc8323aa697e28315866dd