### PR TITLE
Rename CoreOps command namespace to ops

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,16 +272,16 @@ async def on_message(message: discord.Message):
         if command_name == "help":
             cog = bot.get_cog("CoreOpsCog")
             if cog is not None and hasattr(cog, "render_help"):
-                rec_help_command = bot.get_command("rec help")
-                if rec_help_command is not None:
-                    ctx.command = rec_help_command
+                ops_help_command = bot.get_command("ops help")
+                if ops_help_command is not None:
+                    ctx.command = ops_help_command
                     ctx.invoked_with = "help"
                 await cog.render_help(ctx, query=remainder)
             return
         if command_name == "ping":
-            rec_ping_command = bot.get_command("rec ping")
-            if rec_ping_command is not None:
-                ctx.command = rec_ping_command
+            ops_ping_command = bot.get_command("ops ping")
+            if ops_ping_command is not None:
+                ctx.command = ops_ping_command
                 ctx.invoked_with = "ping"
                 await bot.invoke(ctx)
             else:
@@ -305,9 +305,9 @@ async def on_message(message: discord.Message):
         if base_name == "help":
             cog = bot.get_cog("CoreOpsCog")
             if cog is not None and hasattr(cog, "render_help"):
-                rec_help_command = bot.get_command("rec help")
-                if rec_help_command is not None:
-                    ctx.command = rec_help_command
+                ops_help_command = bot.get_command("ops help")
+                if ops_help_command is not None:
+                    ctx.command = ops_help_command
                     ctx.invoked_with = "help"
                 await cog.render_help(ctx, query=remainder)
             return

--- a/docs/adr/ADR-0003-coreops-command-contract.md
+++ b/docs/adr/ADR-0003-coreops-command-contract.md
@@ -12,8 +12,8 @@ environment.
 ## Decision
 
 - CoreOps v0.9.x ships the following supported commands: `@Bot help`, `@Bot ping`,
-  `!rec config`, `!rec digest`, `!rec health`, `!rec refresh <bucket>`, `!rec refresh all`,
-  `!rec reload`, `!checksheet`, `!perm bot <subcommand>`, and `!welcome-refresh`.
+  `!ops config`, `!ops digest`, `!ops health`, `!ops refresh <bucket>`, `!ops refresh all`,
+  `!ops reload`, `!checksheet`, `!perm bot <subcommand>`, and `!welcome-refresh`.
 - Cogs expose only `async def setup(bot)` and register commands through the shared loader.
 - RBAC is enforced with decorators from `c1c_coreops.rbac`, ensuring tier checks occur
   before cache access.

--- a/docs/adr/ADR-0005-reload-vs-refresh.md
+++ b/docs/adr/ADR-0005-reload-vs-refresh.md
@@ -5,7 +5,7 @@
 ## Context
 
 Operators requested clearer separation between cache refreshes and configuration reloads.
-Phase 3b added a soft reboot flag to `!rec reload` and tightened actor logging so ops can
+Phase 3b added a soft reboot flag to `!ops reload` and tightened actor logging so ops can
 trace who initiated reloads.
 
 ## Decision

--- a/docs/adr/ADR-0006-startup-preloader-bot-info-cron.md
+++ b/docs/adr/ADR-0006-startup-preloader-bot-info-cron.md
@@ -22,7 +22,7 @@ intervention.
 
 - Operators can rely on warm caches immediately after deploys without manual intervention.
 - `bot_info` embeds stay current even if no commands are executed for several hours.
-- Failed startup warmers become visible in logs, prompting manual `!rec refresh all` if
+- Failed startup warmers become visible in logs, prompting manual `!ops refresh all` if
   needed.
 
 ## Status

--- a/docs/compliance/REPORT_GUARDRAILS.md
+++ b/docs/compliance/REPORT_GUARDRAILS.md
@@ -35,11 +35,11 @@
 
 ### !config
 * Builds a rich embed summarizing env snapshot, allow-list resolution, sheet IDs, and ops channel status with sanitized output and footer metadata.
-* Staff can access via `!rec config` (`@ops_only`), while the legacy alias stays admin-only, satisfying gating expectations.
+* Staff can access via `!ops config` (`@ops_only`), while the legacy alias stays admin-only, satisfying gating expectations.
 
 ### !digest
 * Aggregates cache telemetry into a digest embed and falls back to a formatted text line if embed construction or send fails; logging throttled through sanitize helpers.
-* Staff-tier command exposed under both `!rec` and legacy admin alias, maintaining parity with spec.
+* Staff-tier command exposed under both `!ops` and legacy admin alias, maintaining parity with spec.
 
 ### !health
 * Produces a health embed combining runtime metrics and cache telemetry, with humanized durations and UTC-aware next refresh text.
@@ -51,7 +51,7 @@
 
 ### !reload
 * Handles `--reboot` flag parsing, logs failures once, and reports duration to the caller; errors return sanitized warnings instead of aborting.
-* Admin-only for both legacy and `!rec` entry points, respecting guardrail + cooldown expectations (no cooldown required here).
+* Admin-only for both legacy and `!ops` entry points, respecting guardrail + cooldown expectations (no cooldown required here).
 
 ### !checksheet
 * Iterates configured sheet targets, inspects tabs with backoff, and composes embeds listing results/warnings; errors logged once per sheet/tab context.

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -43,7 +43,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
   - Disconnected for > disconnect grace → `exit(1)`
 
 ## Command Routing & Prefix
-- Supported: `!rec`, `!rec␣`, `rec`, `rec␣`, `@mention`.
+- Supported: `!ops`, `!ops␣`, `rec`, `rec␣`, `@mention`.
 - Admin bang shortcuts: `!env`, `!reload`, `!health`, `!digest`, `!checksheet`, `!config`, `!help`, `!ping`, `!refresh all` (Admin role only).
 - No bare-word shortcuts.
 
@@ -52,7 +52,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
   `list_buckets()`, `get_snapshot(name)`, `refresh_now(name, actor=…)`, and telemetry helpers.
 - Private internals such as `_CONFIG_CACHE` or `_sheet_cache_snapshot` are considered
   implementation details and **must not** be imported or accessed directly.
-- Commands that render operational embeds (`!rec health`, `!rec digest`, `!checksheet`)
+- Commands that render operational embeds (`!ops health`, `!ops digest`, `!checksheet`)
   consume only public telemetry payloads.
 - Guardrails:
   - No hard-coded IDs in commands or watchers; everything resolves through the config

--- a/docs/epic/EPIC_WelcomePlacementV2.md
+++ b/docs/epic/EPIC_WelcomePlacementV2.md
@@ -81,7 +81,7 @@ Missing Config → log channel warning + safe disable.
 6. **Refresh & restart**  
    - On boot → rebuild timers from `Reservations`.  
    - Every **3 hours** (existing cron) → batch recompute AF & AI for all clans.  
-   - `!rec refresh clansinfo` / `!rec refresh all` → manual trigger.  
+   - `!ops refresh clansinfo` / `!ops refresh all` → manual trigger.  
 
 ---
 

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -20,7 +20,7 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `!health` | ✅ | Inspect cache/watchdog telemetry pulled from the public API. | `!health` |
 | `!checksheet` | ✅ | Validate Sheets tabs, named ranges, and headers (`--debug` preview optional). | `!checksheet [--debug]` |
 | `!refresh [bucket]` | ✅ | Admin bang alias for single-bucket refresh with the same telemetry. | `!refresh [bucket]` |
-| `!refresh all` | ✅ | Bang alias for the full cache sweep (same cooldown as the `!rec` variant). | `!refresh all` |
+| `!refresh all` | ✅ | Bang alias for the full cache sweep (same cooldown as the `!ops` variant). | `!refresh all` |
 | `!reload [--reboot]` | ✅ | Admin bang alias for config reload plus optional soft reboot. | `!reload [--reboot]` |
 | `!ping` | ✅ | Adds a 🏓 reaction so admins can confirm shard responsiveness. | `!ping` |
 | `!perm bot list` | ✅ | Show the current bot allow/deny lists with counts and IDs. | `!perm bot list [--json]` |
@@ -31,12 +31,12 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 ## Recruiter / Staff — recruitment workflows
 | Command | Status | Short text | Usage |
 | --- | --- | --- | --- |
-| `!rec checksheet` | 🧩 | Staff view of Sheets linkage for recruitment/onboarding tabs (`--debug` prints sample rows). | `!rec checksheet [--debug]` |
-| `!rec config` | 🧩 | Staff summary of guild routing, sheet IDs, env toggles, and watcher states. | `!rec config` |
-| `!rec digest` | ✅ | Post the ops digest with cache age, next run, and retries. | `!rec digest` |
-| `!rec refresh clansinfo` | 🧩 | Refresh clan roster data when Sheets updates land. | `!rec refresh clansinfo` |
-| `!rec refresh all` | 🧩 | Warm every registered cache bucket and emit a consolidated summary (30 s guild cooldown). | `!rec refresh all` |
-| `!rec reload [--reboot]` | 🧩 | Rebuild the config registry; optionally schedule a soft reboot. | `!rec reload [--reboot]` |
+| `!ops checksheet` | 🧩 | Staff view of Sheets linkage for recruitment/onboarding tabs (`--debug` prints sample rows). | `!ops checksheet [--debug]` |
+| `!ops config` | 🧩 | Staff summary of guild routing, sheet IDs, env toggles, and watcher states. | `!ops config` |
+| `!ops digest` | ✅ | Post the ops digest with cache age, next run, and retries. | `!ops digest` |
+| `!ops refresh clansinfo` | 🧩 | Refresh clan roster data when Sheets updates land. | `!ops refresh clansinfo` |
+| `!ops refresh all` | 🧩 | Warm every registered cache bucket and emit a consolidated summary (30 s guild cooldown). | `!ops refresh all` |
+| `!ops reload [--reboot]` | 🧩 | Rebuild the config registry; optionally schedule a soft reboot. | `!ops reload [--reboot]` |
 | `!clanmatch` | 🧩 | Recruiter match workflow (requires recruiter/staff role). [gated: `recruiter_panel`] | `!clanmatch` |
 | `!welcome <clan> [@member] [note]` | ✅ | Post the legacy welcome embed with crest, pings, and general notice routing. [gated: `recruitment_welcome`] | `!welcome <clan> [@member] [note]` |
 

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -195,13 +195,13 @@ Feature Toggles:
 **Operator flow**
 
 1. Edit the `FeatureToggles` worksheet in the environment’s Mirralith Sheet.
-2. Run `!rec refresh config` (or the admin bang alias) to pull the latest worksheet values.
+2. Run `!ops refresh config` (or the admin bang alias) to pull the latest worksheet values.
 3. Confirm the tab and headers with `!checksheet`; resolve any ⚠️ rows before retrying.
 
 **Troubleshooting**
 
 - Warnings mention the first role listed in `ADMIN_ROLE_IDS` and are posted to the runtime log channel.
 - Verify the worksheet name matches the Config key and that headers are spelled correctly.
-- Use `!rec refresh config` (or the Ops equivalent) to force the bot to re-read the toggles after a fix.
+- Use `!ops refresh config` (or the Ops equivalent) to force the bot to re-read the toggles after a fix.
 
 Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -19,7 +19,7 @@ Older GitHub Actions deploy runs may display "skipped by same-file supersession"
 3. **Logging:** A single success/failure summary posts to the ops channel once warm-up
  completes. Individual `[refresh] startup` lines include bucket, duration, retries, and
   result.
-4. **Action:** If any bucket fails to warm, rerun `!rec refresh all` after the bot is
+4. **Action:** If any bucket fails to warm, rerun `!ops refresh all` after the bot is
   online. Escalate to platform on-call if two consecutive startups fail for the same
   bucket.
 
@@ -72,7 +72,7 @@ logging the error for follow-up.
 - Emits the log line `Runtime rebooted via !reload --reboot` once the restart sequence completes.
 
 ## Digest & health telemetry
-When operators run `!rec digest` or `!rec health`, the embeds render the following fields
+When operators run `!ops digest` or `!ops health`, the embeds render the following fields
 from the public telemetry API:
 
 | Field | Meaning | Notes |
@@ -86,7 +86,7 @@ from the public telemetry API:
 `!checksheet` verifies the link between the configuration registry and the Google Sheets
 tabs.
 
-1. Run `!rec reload` after updating Sheet tab names or ranges.
+1. Run `!ops reload` after updating Sheet tab names or ranges.
 2. Trigger `!checksheet`.
 3. Review the embed for **Tabs**, **Named ranges**, and **Headers**. Missing entries show
    as ⚠️ with the key that failed validation.
@@ -100,7 +100,7 @@ tabs.
   match (`feature_name`, `enabled`), and each enabled row uses `TRUE` (case-insensitive).
 - **Signals:** Startup posts an admin-ping warning in the runtime log channel when the tab,
   headers, or row values are missing or invalid.
-- **Remediation:** Fix the Sheet, run `!rec refresh config` (or the admin bang alias), then
+- **Remediation:** Fix the Sheet, run `!ops refresh config` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
 Doc last updated: 2025-10-27 (v0.9.6)

--- a/docs/ops/Troubleshooting.md
+++ b/docs/ops/Troubleshooting.md
@@ -4,16 +4,16 @@
 - **Cron quiet** → confirm the latest `[cache]` refresh summary within the expected interval before
   triggering manual refreshes. If missing, inspect `/healthz` and deployment logs.
 - **Command fails for staff** → confirm roles, then rerun with admin watching logs.
-- **Watcher quiet** → check toggles in `!rec config` and verify `/healthz` for stale
+- **Watcher quiet** → check toggles in `!ops config` and verify `/healthz` for stale
   timestamps.
-- **Cache stale** → run `!rec refresh all`; if it fails, capture the `[cron result]` and
+- **Cache stale** → run `!ops refresh all`; if it fails, capture the `[cron result]` and
   `[watcher|lifecycle]` lines around the attempt (dropping to `[lifecycle]` next release).
 - **Sheets error** → switch to manual spreadsheet updates and note the outage window.
 
 ### Quick fixes
 | Symptom | Likely Cause | Check Command |
 | --- | --- | --- |
-| `n/a` ages in `!digest` | Bot restarted → cache not yet warmed | wait 5 min or run `!rec refresh all` |
+| `n/a` ages in `!digest` | Bot restarted → cache not yet warmed | wait 5 min or run `!ops refresh all` |
 | “No tabs listed in Config” | Missing key in Sheet Config tab | check sheet permissions + tab names |
 | “I can't find a configured welcome for **TAG**. Add it in the sheet.” | Row missing or inactive in `WelcomeTemplates`; confirm `ACTIVE` = `Y`. | Update the sheet then ask an admin to run `!welcome-refresh` |
 
@@ -25,13 +25,13 @@ when adjusting cadences or toggles.
   exists in the recruitment Sheet. Missing tabs fail closed and trigger a single
   admin-ping warning in the runtime log channel.
 - **Headers wrong?** The worksheet must expose `feature_name` and `enabled`. Fix the
-  headers, save, then run `!rec refresh config` and re-verify with `!checksheet`.
+  headers, save, then run `!ops refresh config` and re-verify with `!checksheet`.
 - **Row missing?** Add the feature row using the approved key and `enabled` value. Rows
   absent from the worksheet evaluate to disabled until present.
 - **Value ignored?** Only `TRUE` (case-insensitive) enables a feature. Any other value —
   including `FALSE`, blanks, or typos — keeps the module off and logs an admin-ping
   warning.
-- **Change not taking effect?** After editing the Sheet, run `!rec refresh config`, then
+- **Change not taking effect?** After editing the Sheet, run `!ops refresh config`, then
   confirm with `!checksheet` to ensure the worksheet and headers are clean.
 
 ## Redaction policy

--- a/docs/ops/Watchers.md
+++ b/docs/ops/Watchers.md
@@ -50,7 +50,7 @@ All jobs post `[cache]` summaries to the ops channel via `modules.common.runtime
 - `shared.sheets.core` caches worksheet handles (no TTL).
 - `shared.sheets.recruitment` / `shared.sheets.onboarding` keep TTL caches for values.
 - `!reload` reloads config, clears TTL caches, and can optionally evict worksheet handles.
-- Cron refreshes clear TTL caches before warming them; manual `!rec refresh` commands share
+- Cron refreshes clear TTL caches before warming them; manual `!ops refresh` commands share
   the same helpers.
 
 ## Scheduler responsibilities
@@ -61,7 +61,7 @@ All jobs post `[cache]` summaries to the ops channel via `modules.common.runtime
 ## Failure handling & health
 - Watcher read/write failure → log a structured warning (thread, tab, reason) and retry on the next event.
 - Cache refresh failure → `[cache]` summary includes `err=...`; manual refresh commands remain available.
-- `/healthz` reports watchdog metrics and cache timestamps; `!rec config` surfaces the active watcher toggles.
+- `/healthz` reports watchdog metrics and cache timestamps; `!ops config` surfaces the active watcher toggles.
 - `LOG_CHANNEL_ID` receives lifecycle notices plus watcher (`[welcome_watcher]`, `[promo_watcher]`) and `[cache]` refresh messages.
 
 Doc last updated: 2025-10-26 (v0.9.6)

--- a/docs/ops/commands.md
+++ b/docs/ops/commands.md
@@ -20,8 +20,8 @@ reports from staff and recruiters.
 ### Example (Admin embed excerpt)
 ```
 Admin / Operational — Config & Health
-• !rec env — Staff snapshot of environment name, guild IDs, and sheet linkage.
-• !rec health — Inspect cache/watchdog telemetry pulled from the public API.
+• !ops env — Staff snapshot of environment name, guild IDs, and sheet linkage.
+• !ops health — Inspect cache/watchdog telemetry pulled from the public API.
 ```
 
 ## `@Bot help <command>` — detailed view
@@ -42,8 +42,8 @@ Tip: Run after registry edits or onboarding template changes.
 
 ### Example (Recruiter / Staff)
 ```
-!rec refresh clansinfo
-Usage: !rec refresh clansinfo
+!ops refresh clansinfo
+Usage: !ops refresh clansinfo
 Tier: Staff (Recruiter role or higher required)
 Detail: Refresh clan roster data when Sheets updates land.
 Tip: Re-run if digest ages drift after clan merges.

--- a/docs/ops/development.md
+++ b/docs/ops/development.md
@@ -25,8 +25,8 @@
   cleanup; any remaining imports should be replaced with the async facade.
 
 ## Testing commands
-- `!rec refresh all` — verify cache warmers and actor logging.
-- `!rec digest` — confirm public telemetry includes age/next/retries and fallback text.
+- `!ops refresh all` — verify cache warmers and actor logging.
+- `!ops digest` — confirm public telemetry includes age/next/retries and fallback text.
 - `!checksheet --debug` — inspect tab headers and template previews post-refresh.
 
 ## Command routing

--- a/docs/ops/module-toggles.md
+++ b/docs/ops/module-toggles.md
@@ -20,7 +20,7 @@ at startup. Toggle values are case-insensitive; only `TRUE` (`ON`) enables a fea
 | `placement_target_select` | `TRUE` | Stub module for future placement picker. |
 | `placement_reservations` | `TRUE` | Stub module for future reservation workflow. |
 
-Set the desired value in the `FeatureToggles` tab, then run `!rec refresh config`
+Set the desired value in the `FeatureToggles` tab, then run `!ops refresh config`
 to apply it. The runtime logs whether each module was loaded or skipped at boot. See
 [`Config.md`](Config.md#feature-toggles-worksheet) for the worksheet contract.
 

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -620,7 +620,7 @@ def _get_tier(cmd: commands.Command[Any, Any, Any]) -> str:
 
 def _should_show(cmd: commands.Command[Any, Any, Any]) -> bool:
     # never show internals or the group container
-    if cmd.qualified_name == "rec" or cmd.name.startswith("_"):
+    if cmd.qualified_name == "ops" or cmd.name.startswith("_"):
         return False
 
     # respect explicit opt-out flag in extras
@@ -1035,7 +1035,7 @@ class CoreOpsCog(commands.Cog):
         self._log_coreops_settings()
 
     def _apply_tagged_alias_metadata(self) -> None:
-        command = getattr(self, "rec", None)
+        command = getattr(self, "ops", None)
         if not isinstance(command, commands.Group):
             self._tagged_aliases = tuple()
             return
@@ -1086,9 +1086,9 @@ class CoreOpsCog(commands.Cog):
         )
         logger.info(msg, extra=extra)
 
-    @commands.group(name="rec", invoke_without_command=True)
+    @commands.group(name="ops", invoke_without_command=True)
     @guild_only_denied_msg()
-    async def rec(self, ctx: commands.Context) -> None:
+    async def ops(self, ctx: commands.Context) -> None:
         """Recruitment toolkit commands for the C1C cluster."""
 
         if ctx.invoked_subcommand is not None:
@@ -1343,9 +1343,9 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(function_group="operational", section="config_health", access_tier="admin")
-    @rec.command(name="health")
+    @ops.command(name="health")
     @ops_only()
-    async def rec_health(self, ctx: commands.Context) -> None:
+    async def ops_health(self, ctx: commands.Context) -> None:
         await self._health_impl(ctx)
 
     @tier("admin")
@@ -1910,10 +1910,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("staff")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec.command(name="checksheet")
+    @ops.command(name="checksheet")
     @guild_only_denied_msg()
     @ops_only()
-    async def rec_checksheet(self, ctx: commands.Context) -> None:
+    async def ops_checksheet(self, ctx: commands.Context) -> None:
         await self._checksheet_impl(ctx, debug=self._has_debug_flag(ctx))
 
     @tier("staff")
@@ -2033,9 +2033,9 @@ class CoreOpsCog(commands.Cog):
 
     @tier("staff")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec.command(name="digest")
+    @ops.command(name="digest")
     @ops_only()
-    async def rec_digest(self, ctx: commands.Context) -> None:
+    async def ops_digest(self, ctx: commands.Context) -> None:
         await self._digest_impl(ctx)
 
     @tier("admin")
@@ -2084,10 +2084,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(function_group="operational", section="config_health", access_tier="admin")
-    @rec.command(name="env")
+    @ops.command(name="env")
     @guild_only_denied_msg()
     @admin_only()
-    async def rec_env(self, ctx: commands.Context) -> None:
+    async def ops_env(self, ctx: commands.Context) -> None:
         await self._env_impl(ctx)
 
     @tier("admin")
@@ -2098,8 +2098,8 @@ class CoreOpsCog(commands.Cog):
         await self._env_impl(ctx)
 
     @tier("user")
-    @rec.command(name="help", usage="[command]", extras={"hide_in_help": True})
-    async def rec_help(
+    @ops.command(name="help", usage="[command]", extras={"hide_in_help": True})
+    async def ops_help(
         self, ctx: commands.Context, *, query: str | None = None
     ) -> None:
         await self.render_help(ctx, query=query)
@@ -2110,8 +2110,8 @@ class CoreOpsCog(commands.Cog):
         await self._render_help(ctx, query=query)
 
     @tier("user")
-    @rec.command(name="ping", extras={"hide_in_help": True})
-    async def rec_ping(self, ctx: commands.Context) -> None:
+    @ops.command(name="ping", extras={"hide_in_help": True})
+    async def ops_ping(self, ctx: commands.Context) -> None:
         command = self.bot.get_command("ping")
         if command is None:
             await ctx.send(str(sanitize_text("Ping command unavailable.")))
@@ -2146,8 +2146,8 @@ class CoreOpsCog(commands.Cog):
 
         normalized_lookup = " ".join(lookup.lower().split())
         command = self.bot.get_command(normalized_lookup)
-        if command is None and not normalized_lookup.startswith("rec "):
-            command = self.bot.get_command(f"rec {normalized_lookup}")
+        if command is None and not normalized_lookup.startswith("ops "):
+            command = self.bot.get_command(f"ops {normalized_lookup}")
         if command is None:
             await ctx.reply(str(sanitize_text(f"Unknown command `{lookup}`.")))
             return
@@ -2313,10 +2313,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("staff")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec.command(name="config")
+    @ops.command(name="config")
     @guild_only_denied_msg()
     @ops_only()
-    async def rec_config(self, ctx: commands.Context) -> None:
+    async def ops_config(self, ctx: commands.Context) -> None:
         await self._config_impl(ctx)
 
     @tier("admin")
@@ -2355,10 +2355,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(function_group="operational", section="utilities", access_tier="admin")
-    @rec.command(name="reload")
+    @ops.command(name="reload")
     @guild_only_denied_msg()
     @ops_only()
-    async def rec_reload(self, ctx: commands.Context, *flags: str) -> None:
+    async def ops_reload(self, ctx: commands.Context, *flags: str) -> None:
         reboot, unknown = self._parse_reload_flags(flags)
         if unknown is not None:
             await ctx.send(
@@ -2384,10 +2384,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec.group(name="refresh", invoke_without_command=True)
+    @ops.group(name="refresh", invoke_without_command=True)
     @guild_only_denied_msg()
     @ops_only()
-    async def rec_refresh(
+    async def ops_refresh(
         self, ctx: commands.Context, *, bucket: Optional[str] = None
     ) -> None:
         if bucket and bucket.strip():
@@ -2462,11 +2462,11 @@ class CoreOpsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec_refresh.command(name="all")
+    @ops_refresh.command(name="all")
     @guild_only_denied_msg()
     @ops_only()
     @commands.cooldown(1, 30.0, commands.BucketType.guild)
-    async def rec_refresh_all(self, ctx: commands.Context) -> None:
+    async def ops_refresh_all(self, ctx: commands.Context) -> None:
         await self._refresh_all_impl(ctx)
 
     def _build_refresh_row(
@@ -2583,10 +2583,10 @@ class CoreOpsCog(commands.Cog):
 
     @tier("staff")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="staff")
-    @rec_refresh.command(name="clansinfo")
+    @ops_refresh.command(name="clansinfo")
     @guild_only_denied_msg()
     @ops_only()
-    async def rec_refresh_clansinfo(self, ctx: commands.Context) -> None:
+    async def ops_refresh_clansinfo(self, ctx: commands.Context) -> None:
         await self._refresh_clansinfo_impl(ctx)
 
     async def _gather_overview_tiers(
@@ -2707,15 +2707,15 @@ class CoreOpsCog(commands.Cog):
                 return can_view_staff(author)
             return True
 
-        help_meta = lookup_help_metadata("rec help")
+        help_meta = lookup_help_metadata("ops help")
         if (
-            "rec help" not in seen
+            "ops help" not in seen
             and help_meta is not None
             and _is_allowed(help_meta.tier)
         ):
             entries.append(
                 HelpCommandInfo(
-                    qualified_name="rec help",
+                    qualified_name="ops help",
                     signature="",
                     short=help_meta.short,
                     detailed=help_meta.detailed,
@@ -2727,15 +2727,15 @@ class CoreOpsCog(commands.Cog):
                 )
             )
 
-        ping_meta = lookup_help_metadata("rec ping")
+        ping_meta = lookup_help_metadata("ops ping")
         if (
-            "rec ping" not in seen
+            "ops ping" not in seen
             and ping_meta is not None
             and _is_allowed(ping_meta.tier)
         ):
             entries.append(
                 HelpCommandInfo(
-                    qualified_name="rec ping",
+                    qualified_name="ops ping",
                     signature="",
                     short=ping_meta.short,
                     detailed=ping_meta.detailed,
@@ -2760,7 +2760,7 @@ class CoreOpsCog(commands.Cog):
         top = command
         while top.parent is not None:
             top = top.parent
-        return top.qualified_name in {"rec", "perm"}
+        return top.qualified_name in {"ops", "perm"}
 
     async def _gather_subcommand_infos(
         self, command: commands.Command[Any, Any, Any], ctx: commands.Context

--- a/packages/c1c-coreops/src/c1c_coreops/config.py
+++ b/packages/c1c-coreops/src/c1c_coreops/config.py
@@ -89,9 +89,9 @@ def build_command_variants(
         if tagged and tagged not in variants:
             variants.append(tagged)
 
-    legacy = f"rec {cleaned}".strip()
-    if legacy and legacy not in variants:
-        variants.append(legacy)
+    namespace = f"ops {cleaned}".strip()
+    if namespace and namespace not in variants:
+        variants.append(namespace)
 
     return tuple(variants)
 

--- a/packages/c1c-coreops/src/c1c_coreops/help.py
+++ b/packages/c1c-coreops/src/c1c_coreops/help.py
@@ -46,7 +46,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
             "Displays which Google Sheets and tabs are currently linked, as defined in the Config tab. "
             "Helps confirm if all links are loaded correctly and readable.\n"
             "⚠️ If you type `config` without the prefix, **every bot** that has one may respond. "
-            "Always use `!rec config` to target this bot.\n"
+            "Always use `!ops config` to target this bot.\n"
             "Tip: Run this after setup or when something seems out of sync."
         ),
         tier="admin",
@@ -56,7 +56,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         detailed=(
             "Generates a status digest with version, environment, cache stats, and sheet sync info. "
             "Useful for spotting stale data or delayed updates.\n"
-            "⚠️ Running `digest` without `!rec` can trigger other bots’ digests too. Always include the prefix.\n"
+            "⚠️ Running `digest` without `!ops` can trigger other bots’ digests too. Always include the prefix.\n"
             "Tip: Use this before reporting an issue — it’s the quick “what’s the bot doing?” check."
         ),
         tier="admin",
@@ -122,7 +122,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         short="Shows environment info (prod/test/etc.).",
         detailed=(
             "Reveals which environment the bot is running in and which guild IDs, tokens, and configs it’s currently using.\n"
-            "⚠️ Calling `env` without `!rec` can wake multiple bots. Always include the prefix.\n"
+            "⚠️ Calling `env` without `!ops` can wake multiple bots. Always include the prefix.\n"
             "Tip: Helps confirm you’re not running test commands in the live cluster."
         ),
         tier="admin",
@@ -136,7 +136,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="admin",
     ),
-    "rec env": _metadata(
+    "ops env": _metadata(
         short="Shows environment info for this bot.",
         detailed=(
             "Displays which Sheets and tabs the bot is connected to, plus environment name and guild.\n"
@@ -144,7 +144,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="admin",
     ),
-    "rec health": _metadata(
+    "ops health": _metadata(
         short="Checks the bot’s internal health status.",
         detailed=(
             "Shows cache ages, refresh timings, and recent update status for all active data buckets.\n"
@@ -152,16 +152,16 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="admin",
     ),
-    "rec refresh": _metadata(
+    "ops refresh": _metadata(
         short="Refreshes a single data bucket from Google Sheets.",
         detailed=(
             "Forces an update for one specific bucket — `templates`, `clansinfo`, or `clantags` — to reload new data from Sheets "
             "immediately instead of waiting for the next scheduled sync.\n"
-            "Tip: Use `!rec refresh templates` after editing a Sheet tab."
+            "Tip: Use `!ops refresh templates` after editing a Sheet tab."
         ),
         tier="admin",
     ),
-    "rec refresh all": _metadata(
+    "ops refresh all": _metadata(
         short="Reloads all data from Sheets.",
         detailed=(
             "Performs a full refresh of every cached bucket — config, templates, clansinfo, and clantags. It can take a few seconds.\n"
@@ -169,7 +169,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="admin",
     ),
-    "rec reload": _metadata(
+    "ops reload": _metadata(
         short="Reloads runtime configs and command modules.",
         detailed=(
             "Reloads the bot’s runtime flags and command modules without restarting it. Good for applying config changes instantly.\n"
@@ -198,7 +198,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         detailed=(
             "Reloads the bot’s entire runtime setup — environment variables, sheet connections, and commands. "
             "Use `--reboot` to force a soft reboot of the bot.\n"
-            "⚠️ Running `reload` without `!rec` might make other bots react too. Always prefix it.\n"
+            "⚠️ Running `reload` without `!ops` might make other bots react too. Always prefix it.\n"
             "Tip: Use with care — affects all modules, not just recruitment."
         ),
         tier="admin",
@@ -224,12 +224,12 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         short="Shows what sheet and tabs are currently loaded.",
         detailed=(
             "Displays the linked sheet and verifies that tabs (like `Applicants`, `Clans`, `Needs`) are cached and accessible.\n"
-            "⚠️ If you use `checksheet` without the prefix, all bots with the same command will answer. Always use `!rec checksheet`.\n"
+            "⚠️ If you use `checksheet` without the prefix, all bots with the same command will answer. Always use `!ops checksheet`.\n"
             "Tip: Quick sanity check before troubleshooting a missing clan."
         ),
         tier="admin",
     ),
-    "rec checksheet": _metadata(
+    "ops checksheet": _metadata(
         short="Shows loaded tabs and headers.",
         detailed=(
             "Prints which tabs and headers the bot is reading, including row counts per tab.\n"
@@ -237,7 +237,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="staff",
     ),
-    "rec config": _metadata(
+    "ops config": _metadata(
         short="Shows current configuration values.",
         detailed=(
             "Displays all active configuration values — sheet IDs, refresh intervals, watcher toggles, and more.\n"
@@ -245,7 +245,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="staff",
     ),
-    "rec digest": _metadata(
+    "ops digest": _metadata(
         short="Shows the bot’s status summary.",
         detailed=(
             "Lists key operational stats: cached sheet names, last refresh time, and update latency.\n"
@@ -253,7 +253,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="staff",
     ),
-    "rec refresh clansinfo": _metadata(
+    "ops refresh clansinfo": _metadata(
         short="Updates the clan info list.",
         detailed=(
             "Forces a refresh for the recruitment infos the `!clanmatch` panel uses, including open spots and clan requirements.\n"
@@ -296,7 +296,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="user",
     ),
-    "rec help": _metadata(
+    "ops help": _metadata(
         short="Shows help for bot commands.",
         detailed=(
             "Lists all available commands or gives details for one specific command when you add its name.\n"
@@ -304,7 +304,7 @@ HELP_COMMAND_REGISTRY: dict[str, HelpCommandMetadata] = {
         ),
         tier="user",
     ),
-    "rec ping": _metadata(
+    "ops ping": _metadata(
         short="Checks if the bot is awake.",
         detailed=(
             "A simple test command that responds with “pong” to confirm the bot is online and responsive.\n"

--- a/packages/c1c-coreops/src/c1c_coreops/helpers.py
+++ b/packages/c1c-coreops/src/c1c_coreops/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict, Sequence
 
-# Qualified name -> tier (e.g., "rec help", "health")
+# Qualified name -> tier (e.g., "ops help", "health")
 _TIER_REGISTRY: Dict[str, str] = {}
 
 
@@ -118,7 +118,7 @@ def audit_tiers(bot, logger=None) -> None:
         except Exception:
             pass
         tier = tier or getattr(cmd, "_tier", None)
-        if not tier and cmd.qualified_name not in ("rec",):
+        if not tier and cmd.qualified_name not in ("ops",):
             missing.append(cmd.qualified_name)
     if missing and logger is not None:
         logger.warning("Help tiers missing for: %s", ", ".join(sorted(missing)))

--- a/packages/c1c-coreops/src/c1c_coreops/render.py
+++ b/packages/c1c-coreops/src/c1c_coreops/render.py
@@ -349,7 +349,7 @@ def build_config_embed(
 
 def _maybe_build_tip(entries: Sequence[DigestSheetEntry]) -> str | None:
     if entries:
-        return 'Need latest openings? run "!rec refresh clansinfo" and retry.'
+        return 'Need latest openings? run "!ops refresh clansinfo" and retry.'
     return None
 
 

--- a/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
+++ b/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
@@ -79,22 +79,22 @@ def test_multi_bot_alias_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
         try:
             env_command = bot.get_command("env")
             assert env_command is not None
-            rec_env = bot.get_command("rec env")
-            assert rec_env is not None
+            ops_env = bot.get_command("ops env")
+            assert ops_env is not None
 
             non_admin_ctx = DummyContext(author=DummyMember(administrator=False))
             with pytest.raises(commands.CheckFailure):
-                await _run_checks(rec_env, non_admin_ctx)
+                await _run_checks(ops_env, non_admin_ctx)
             with pytest.raises(commands.CheckFailure):
                 await _run_checks(env_command, non_admin_ctx)
 
             admin_ctx = DummyContext(author=DummyMember(administrator=True))
-            await _run_checks(rec_env, admin_ctx)
+            await _run_checks(ops_env, admin_ctx)
             await _run_checks(env_command, admin_ctx)
 
             settings = load_coreops_settings()
             variants = build_command_variants(settings, "env")
-            assert "rec env" in variants
+            assert "ops env" in variants
             assert variants[0] == "env"
         finally:
             await bot.close()
@@ -112,8 +112,8 @@ def test_generic_alias_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         await bot.add_cog(CoreOpsCog(bot))
 
         try:
-            rec_digest = bot.get_command("rec digest")
-            assert rec_digest is not None
+            ops_digest = bot.get_command("ops digest")
+            assert ops_digest is not None
             digest = bot.get_command("digest")
             assert digest is not None
 
@@ -122,7 +122,7 @@ def test_generic_alias_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
                 await _run_checks(digest, non_admin_ctx)
 
             admin_ctx = DummyContext(author=DummyMember(administrator=True))
-            await _run_checks(rec_digest, admin_ctx)
+            await _run_checks(ops_digest, admin_ctx)
             await _run_checks(digest, admin_ctx)
         finally:
             await bot.close()


### PR DESCRIPTION
## Summary
- rename the CoreOps command group from rec to ops and move all operational subcommands to the new namespace
- adjust command resolution, help metadata, and admin lookup paths to use ops
- update ops documentation to reference the new !ops commands

## Testing
- pytest packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
[meta]
labels: comp:commands, maintenance, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_690079d21ea4832395dccfba238f682f