### PR TITLE
Refactor help renderer for dynamic tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The bot keeps clan rosters healthy, helps new friends find their hall, and makes
 
 ### What you can do today
 @Bot help — lists the commands your role can use and tips for each.
+@Bot ping — quick pong reaction so you can confirm the bot is awake.
 !clan <tag> — shows a quick profile for any clan in the cluster.
 !clansearch — opens the member search panel with the latest roster filters.
 !clanmatch — recruiter-only panel to match players with open clans.

--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -57,7 +57,8 @@ flowchart TD
 ### Help metadata
 - Commands opt-in to the multi-embed help surface via the `help_metadata` decorator.
 - `@Bot help` dynamically discovers commands from the live registry and filters by
-  `access_tier` + `function_group`. Admin shows operational controls plus Welcome Templates, Staff shows recruitment + Sheet Tools + milestones, and User shows recruitment + milestones + general (including the mention-only `@Bot help` / `@Bot ping`). Valid `function_group` values: `operational`, `recruitment`, `milestones`, `reminder`, `general`.
+  `access_tier` + `function_group`. Admin viewers receive Overview + Admin + Staff + User, Staff see Overview + Staff + User, and members see Overview + User. Admin covers operational controls (including Welcome Templates + refresh/perm suites), Staff shows recruitment + Sheet Tools + milestones, and User shows recruitment + milestones + general (including the mention-only `@Bot help` / `@Bot ping`). Valid `function_group` values: `operational`, `recruitment`, `milestones`, `reminder`, `general`.
+- Bare admin aliases follow `COREOPS_ADMIN_BANG_ALLOWLIST`; non-allowlisted commands display as `!ops <command>`.
 - Empty sections collapse automatically; set `SHOW_EMPTY_SECTIONS=true` to render a
   “Coming soon” placeholder. The footer always reads `Bot v… · CoreOps v… • For details: @Bot help`.
 

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -3,10 +3,11 @@
 Legend: ✅ = active command · 🧩 = shared CoreOps surface (available across tiers)
 
 Each entry supplies the one-line copy that powers the refreshed help index. Use these
-short descriptions in the four-embed `@Bot help` layout; detailed blurbs live in
+short descriptions in the dynamic `@Bot help` layout; detailed blurbs live in
 [`commands.md`](commands.md).
 
-- **Audience map:** Admin surfaces operational controls plus the Welcome Templates bucket; Staff lists recruitment flows, Sheet Tools, and milestones; User lists recruitment, milestones, and general member commands (including mention-only entry points).
+- **Audience map:** The renderer discovers commands from the registry at runtime and maps them by `access_tier`/`function_group`. Admins see all four embeds (Overview + Admin + Staff + User), Staff see three (Overview + Staff + User), and members see two (Overview + User).
+- **Alias policy:** Bare bang aliases for admin commands come from `COREOPS_ADMIN_BANG_ALLOWLIST`. If a command is allowlisted *and* a bare alias exists, help shows `!command`; otherwise the entry renders as `!ops command`.
 - **Function groups:** Commands declare `function_group` metadata. Valid values are `operational`, `recruitment`, `milestones`, `reminder`, and `general`. The help renderer filters and groups strictly by this map so cross-tier leakage is impossible.
 
 ## Admin — CoreOps & refresh controls

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -7,8 +7,9 @@ workflows, and post-change validation.
 Older GitHub Actions deploy runs may display "skipped by same-file supersession" when a newer queued push touches overlapping files; treat this as expected sequencing.
 
 ## Help overview surfaces
-- `@Bot help` renders four embeds in a single response: Overview, Admin / Operational, Staff, and User.
-- Admin only lists operational commands plus the Welcome Templates refresh; Staff surfaces recruitment flows, Sheet Tools, and milestones; User lists recruitment, milestones, and general commands including the mention-only entry points (`@Bot help`, `@Bot ping`).
+- `@Bot help` adapts to the caller. Admins receive Overview + Admin / Operational + Staff + User, Staff see Overview + Staff + User, and members see Overview + User.
+- Admin covers the operational commands (including `welcome-refresh` and every `refresh*`/`perm*` control), Staff surfaces recruitment flows, Sheet Tools, and milestones, and User lists recruitment, milestones, and the mention-only entry points (`@Bot help`, `@Bot ping`).
+- Bare admin bang aliases follow the runtime `COREOPS_ADMIN_BANG_ALLOWLIST`; anything not allowlisted renders as `!ops <command>`.
 - The renderer reads each command’s `access_tier` and `function_group` metadata directly from the registry. Empty sections collapse unless `SHOW_EMPTY_SECTIONS=1`, which swaps in a “Coming soon” placeholder for parity checks.
 
 ## Startup preloader


### PR DESCRIPTION
## Summary
- rebuild the CoreOps help renderer to discover commands dynamically, derive tier sections from metadata, and honor runtime admin alias allowlists.
- tighten the help surface tests to patch RBAC dependencies, assert tier-specific embed contents, and verify the allowlist is read from the environment.
- document the dynamic four-embed layout, alias policy, and role coverage across the command matrix, runbook, architecture guide, and README.

## Testing
- `pytest packages/c1c-coreops/tests/test_help_admin_surface_complete.py`

[meta]
labels: comp:commands, comp:ops-contract, docs, tests, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_6900869ce968832392991e665608e2f4