### PR TITLE
Docs: add welcome dialog emoji fallback details

### DIFF
--- a/docs/adr/ADR-0017-Reservations-Placement-Schema.md
+++ b/docs/adr/ADR-0017-Reservations-Placement-Schema.md
@@ -27,6 +27,17 @@ Only AF & AC are bot-written; E and AG remain manual.
 All reads start at row 4 (headers = 1–3).
 Every `clan_tag` must exist in **ClanList (B)**.
 
+### Implementation Notes
+
+Implementation Notes — Manual Fallback Trigger
+A secondary manual trigger exists for environments without Ticket Tool integration. When welcome_dialog is active, a 🧭 reaction on the thread’s first message by a Recruiter, Staff, or Admin starts the same welcome dialog flow.
+
+Shares all validation and deduplication with the automated path.
+
+Parent channel must be a configured welcome/promo parent.
+
+Start/skip/reject outcomes are logged in the repository’s usual structured format.
+
 ---
 
 ## 3 · Data Schema
@@ -93,4 +104,4 @@ labels: docs, architecture, comp:onboarding, comp:placement, comp:data-sheets, b
 milestone: Harmonize v1.0
 **[/meta]**
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-28 (v0.9.7)

--- a/docs/compliance/REPORT_GUARDRAILS.md
+++ b/docs/compliance/REPORT_GUARDRAILS.md
@@ -12,6 +12,8 @@
 |7|UTC timestamps|Pass|
 |8|No new env/sheet keys|Pass|
 
+New exception (Phase 7 planning): The onboarding module supports a controlled manual fallback for welcome_dialog: a 🧭 reaction on the first message by Recruiter/Staff/Admin in a valid welcome/promo thread starts the identical dialog flow used by the Ticket Tool path. No additional configuration sources are introduced.
+
 ## Evidence Table
 | Guardrail | Status | Evidence | Notes |
 |-----------|--------|----------|-------|
@@ -67,4 +69,4 @@
 ## Risk scan
 * No blocking risks observed—extension contract, config sourcing, embed parity, and RBAC controls all validate cleanly in the current codebase.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-28 (v0.9.7)

--- a/docs/epic/EPIC_WelcomePlacementV2.md
+++ b/docs/epic/EPIC_WelcomePlacementV2.md
@@ -53,13 +53,24 @@ Missing Config → log channel warning + safe disable.
 
 ## 5 · Lifecycle
 
-1. **Thread creation**  
-   Ticket Tool opens thread → bot joins.  
+1. **Thread creation**
+   Ticket Tool opens thread → bot joins.
    If `welcome_dialog` enabled, the bot waits for the Ticket Tool **Close-button message**, reacts 👍, and starts the welcome dialog.
 
-2. **Questionnaire**  
-   Multi-page modal (per channel).  
-   On completion, bot posts **summary embed** with recruiter-only controls:  
+### Manual Fallback Trigger (Testing & Admin Use)
+If welcome_dialog is enabled and the Ticket Tool Close-button event is unavailable (e.g., on test servers), authorized users with the Recruiter, Staff, or Admin role may manually start the same dialog by reacting with the 🧭 emoji on the first message of a valid welcome or promo thread.
+
+Uses the identical dialog flow as the automated Ticket Tool path.
+
+Scope checks: parent channel must be one of the configured welcome/promo parents.
+
+Idempotent: if the dialog has already started in the thread, additional triggers are ignored.
+
+Logging: Start/skip/reject events are logged in the usual structured format for observability.
+
+2. **Questionnaire**
+   Multi-page modal (per channel).
+   On completion, bot posts **summary embed** with recruiter-only controls:
    *Reserve Spot*, *Change*, *Cancel*.
 
 3. **Reservation flow** (`placement_reservations`)  
@@ -197,4 +208,4 @@ labels: docs, comp:onboarding, comp:placement, comp:data-sheets, bot:recruitment
 milestone: Harmonize v1.0  
 **[/meta]**
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-28 (v0.9.7)

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -25,6 +25,9 @@ Every audit and CI check validates against this document.
 - **C-09 No Legacy Paths:** No imports from removed legacy paths (e.g., top-level `recruitment/`, deprecated shared CoreOps shims, `shared/utils/coreops_*`).
 - **C-10 Config Access:** Runtime config is accessed via the common config accessor (not scattered utility readers).
 
+### Feature Toggles and Config Policy
+- Onboarding emoji fallback: When welcome_dialog is TRUE, a controlled manual reaction trigger (🧭 on the first message in a valid welcome/promo thread) by Recruiter/Staff/Admin is permitted. This does not add new ENV or Sheet keys and must reuse existing channel scope.
+
 ## 3) Documentation
 - **D-01 Stable Titles:** No “Phase …” in any doc titles.
 - **D-02 Footer (exact):** Last line of every doc: `Doc last updated: YYYY-MM-DD (v0.9.x)`
@@ -57,4 +60,4 @@ labels: docs, governance, guardrails, ready
 milestone: Harmonize v1.0
 [/meta]
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-28 (v0.9.7)


### PR DESCRIPTION
## Summary
- document the 🧭 manual fallback trigger for the welcome dialog across the epic and supporting guardrail specs
- note the fallback in the reservations ADR and guardrail reports while updating footers to v0.9.7

## Testing
- n/a (docs only)

[meta]
labels: architecture, bot:welcomecrew, documentation
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_6900c720739083238898b116d7e00572