### PR TITLE
Reformat Summary Open Spots embed for readability

### DIFF
--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -101,6 +101,12 @@ tabs.
 5. If any validations fail, double-check Sheet permissions and the Config tab contents
    before escalating.
 
+### Daily recruiter summary embed
+- The “Summary Open Spots” card now renders as three distinct blocks: General Overview,
+  Per Bracket (one line per bracket with totals), and Bracket Details (per-clan rows).
+- Two zero-width divider fields containing `﹘﹘﹘` separate the blocks so desktop and
+  mobile layouts both show clear visual boundaries.
+
 ## Features unexpectedly disabled at startup
 - **Checks:** Confirm the `FEATURE_TOGGLES_TAB` value points to `FeatureToggles`, headers
   match (`feature_name`, `enabled`), and each enabled row uses `TRUE` (case-insensitive).
@@ -109,4 +115,4 @@ tabs.
 - **Remediation:** Fix the Sheet, run `!ops refresh config` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-10-28 (v0.9.6)
+Doc last updated: 2025-10-28 (v0.9.7)

--- a/tests/recruitment/test_daily_recruiter_update.py
+++ b/tests/recruitment/test_daily_recruiter_update.py
@@ -13,6 +13,9 @@ def _sample_rows():
         ["Ops Summary", "", "3", "1", "0"],
         ["Ops Idle", "", "0", "0", "0"],
         ["Per Bracket", "", "", "", ""],
+        ["Elite End Game", "", "2", "0", "1"],
+        ["Mid Game", "", "0", "0", "0"],
+        ["Bracket Details", "", "", "", ""],
         ["", "Elite End Game", "", "", ""],
         ["Clan Alpha", "", "5", "0", "1"],
         ["Clan Beta", "", "0", "0", "0"],
@@ -28,25 +31,35 @@ def test_build_embed_from_rows_filters_and_groups():
     embed = dru._build_embed_from_rows(rows, headers)
 
     assert isinstance(embed, Embed)
-    # One General Overview field plus one per non-empty bracket section
-    assert len(embed.fields) == 3
+    # Three logical blocks plus dividers and per-bracket detail sections
+    assert len(embed.fields) == 9
 
     general_field = embed.fields[0]
     assert general_field.name == "General Overview"
     assert "Ops Summary" in general_field.value
     assert "Ops Idle" not in general_field.value
 
-    elite_end_game = embed.fields[1]
-    assert (
-        elite_end_game.name
-        == "Elite End Game — open 5 | inactives 0 | reserved 1"
-    )
+    divider_field = embed.fields[1]
+    assert divider_field.name == "\u200B"
+    assert divider_field.value == "﹘﹘﹘"
+
+    per_bracket = embed.fields[3]
+    assert per_bracket.name == "**Per Bracket**"
+    assert "Elite End Game: open 2 | inactives 0 | reserved 1" in per_bracket.value
+    assert "Mid Game: open 0 | inactives 0 | reserved 0" in per_bracket.value
+
+    detail_header = embed.fields[6]
+    assert detail_header.name == "**Bracket Details**"
+    assert detail_header.value == "\u200B"
+
+    elite_end_game = embed.fields[7]
+    assert elite_end_game.name == "Elite End Game"
     assert elite_end_game.inline is False
     assert "Clan Alpha" in elite_end_game.value
     assert "Clan Beta" not in elite_end_game.value
 
-    mid_game = embed.fields[2]
-    assert mid_game.name == "Mid Game — open 2 | inactives 2 | reserved 0"
+    mid_game = embed.fields[8]
+    assert mid_game.name == "Mid Game"
     assert mid_game.inline is False
     assert "Clan Delta" in mid_game.value
 


### PR DESCRIPTION
## Summary
- restructure the Summary Open Spots renderer to add dedicated Per Bracket lines, visual dividers, and simplified bracket detail headers
- extend the recruiter summary unit test data to cover the new three-block layout and ensure dividers plus header-only bracket totals
- document the updated three-block embed breakdown in the ops runbook with the normalized footer

## Testing
- pytest tests/recruitment/test_daily_recruiter_update.py
[meta]
labels: enhancement, comp:recruitment, docs, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_6900ef9aacdc83238caf28cd74fc8160