### PR TITLE
Fix help command gating error and add regression test

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -3326,9 +3326,23 @@ class CoreOpsCog(commands.Cog):
         return _CommandAccessResult(can_run=True, reason=None)
 
     async def _can_display_command(
-        self, command: commands.Command[Any, Any, Any], ctx: commands.Context
+        self,
+        command: commands.Command[Any, Any, Any],
+        ctx: commands.Context,
+        *,
+        log_failures: bool = False,
     ) -> bool:
         result = await self._evaluate_command_access(command, ctx)
+        if log_failures and not result.can_run:
+            qualified = getattr(command, "qualified_name", None) or getattr(
+                command, "name", "<unknown>"
+            )
+            reason = result.reason or "unknown"
+            logger.debug(
+                "help gating suppressed command %s (%s)",
+                qualified,
+                reason,
+            )
         return result.can_run
 
     def _build_help_info(self, command: commands.Command[Any, Any, Any]) -> HelpCommandInfo:

--- a/tests/test_help_overview.py
+++ b/tests/test_help_overview.py
@@ -1,0 +1,32 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.cog import CoreOpsCog, _CommandAccessResult
+
+
+def test_can_display_command_logs_failures(monkeypatch, caplog):
+    intents = discord.Intents.none()
+    intents.message_content = True
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = CoreOpsCog(bot)
+
+    async def fake_evaluate(_command, _ctx):
+        return _CommandAccessResult(can_run=False, reason="blocked")
+
+    monkeypatch.setattr(cog, "_evaluate_command_access", fake_evaluate)
+
+    command = SimpleNamespace(qualified_name="ops test", name="test")
+    ctx = SimpleNamespace()
+
+    async def scenario() -> None:
+        with caplog.at_level(logging.DEBUG):
+            allowed = await cog._can_display_command(command, ctx, log_failures=True)
+        assert not allowed
+
+    asyncio.run(scenario())
+    assert "ops test" in caplog.text
+    assert "blocked" in caplog.text


### PR DESCRIPTION
## Summary
- allow `_can_display_command` to accept a `log_failures` flag and log hidden commands instead of raising
- add a regression test that exercises the new logging path for gated help entries

## Testing
- pytest tests/test_help_overview.py

------
https://chatgpt.com/codex/tasks/task_e_69010a2e2f108323870a698e60146a03