### PR TITLE
Fix coreops import path for welcome flow

### DIFF
--- a/modules/onboarding/welcome_flow.py
+++ b/modules/onboarding/welcome_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 import discord
 
 from modules.common import feature_flags
-from packages.c1c_coreops import rbac
+from c1c_coreops import rbac
 
 from . import thread_scopes
 


### PR DESCRIPTION
## Summary
- update the welcome flow to import `rbac` from the installed `c1c_coreops` package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69013a5e7c088323bbbd0a747f054737