### PR TITLE
Docs: Phase 7 welcome dialog trigger update

### DIFF
--- a/docs/adr/ADR-0017-Reservations-Placement-Schema.md
+++ b/docs/adr/ADR-0017-Reservations-Placement-Schema.md
@@ -32,6 +32,9 @@ Every `clan_tag` must exist in **ClanList (B)**.
 Implementation Notes — Manual Fallback Trigger
 A secondary manual trigger exists for environments without Ticket Tool integration. When welcome_dialog is active, a 🧭 reaction on the thread’s first message by a Recruiter, Staff, or Admin starts the same welcome dialog flow.
 
+Phase 7 adds the automated Ticket Tool trigger (source="ticket") and the manual 🧭 reaction trigger (source="emoji").
+Both call start_welcome_dialog, which performs gating, logging, and deduplication before the actual modal launches.
+
 Shares all validation and deduplication with the automated path.
 
 Parent channel must be a configured welcome/promo parent.

--- a/docs/compliance/REPORT_GUARDRAILS.md
+++ b/docs/compliance/REPORT_GUARDRAILS.md
@@ -14,6 +14,10 @@
 
 New exception (Phase 7 planning): The onboarding module supports a controlled manual fallback for welcome_dialog: a 🧭 reaction on the first message by Recruiter/Staff/Admin in a valid welcome/promo thread starts the identical dialog flow used by the Ticket Tool path. No additional configuration sources are introduced.
 
+Updated exception (Phase 7 progress):
+Both the Ticket Tool closure trigger and the 🧭 reaction fallback are now implemented for welcome_dialog.
+They share one entrypoint, identical gating, and structured JSON logging; modal functionality remains stubbed.
+
 ## Evidence Table
 | Guardrail | Status | Evidence | Notes |
 |-----------|--------|----------|-------|

--- a/docs/epic/EPIC_WelcomePlacementV2.md
+++ b/docs/epic/EPIC_WelcomePlacementV2.md
@@ -58,15 +58,15 @@ Missing Config → log channel warning + safe disable.
    If `welcome_dialog` enabled, the bot waits for the Ticket Tool **Close-button message**, reacts 👍, and starts the welcome dialog.
 
 ### Manual Fallback Trigger (Testing & Admin Use)
-If welcome_dialog is enabled and the Ticket Tool Close-button event is unavailable (e.g., on test servers), authorized users with the Recruiter, Staff, or Admin role may manually start the same dialog by reacting with the 🧭 emoji on the first message of a valid welcome or promo thread.
+When welcome_dialog is enabled, the Welcome Dialog can now start through two verified triggers:
 
-Uses the identical dialog flow as the automated Ticket Tool path.
+Automated Trigger (Ticket Tool) – When a welcome or promo thread is closed by Ticket Tool, the bot automatically starts the dialog (source="ticket").
 
-Scope checks: parent channel must be one of the configured welcome/promo parents.
+Manual Trigger (🧭 Reaction) – Recruiters, Staff, or Admins can manually start the same dialog by reacting with 🧭 on the first message of a valid welcome or promo thread (source="emoji").
 
-Idempotent: if the dialog has already started in the thread, additional triggers are ignored.
+Both paths call the shared entrypoint start_welcome_dialog(...), which manages scope checks, deduplication through a pinned marker, and structured logging.
 
-Logging: Start/skip/reject events are logged in the usual structured format for observability.
+The interactive dialog modal and summary embed are scheduled for the next phase.
 
 2. **Questionnaire**
    Multi-page modal (per channel).

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -27,6 +27,8 @@ Every audit and CI check validates against this document.
 
 ### Feature Toggles and Config Policy
 - Onboarding emoji fallback: When welcome_dialog is TRUE, a controlled manual reaction trigger (🧭 on the first message in a valid welcome/promo thread) by Recruiter/Staff/Admin is permitted. This does not add new ENV or Sheet keys and must reuse existing channel scope.
+- Ticket Tool closure events are now recognized as a valid automated source for welcome_dialog.
+- The same validation and logging policies apply; no additional configuration is introduced.
 
 ## 3) Documentation
 - **D-01 Stable Titles:** No “Phase …” in any doc titles.


### PR DESCRIPTION
## Summary
- align the welcome placement epic with the shared start_welcome_dialog entrypoint and dual trigger paths
- capture the ticket tool and emoji trigger details in the ADR and guardrail specifications
- record the Phase 7 welcome_dialog trigger progress in the compliance report

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_690148c04c4083239cc3ab80c7113950