### PR TITLE
feat: implement C1C onboarding summary embeds

### DIFF
--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -385,6 +385,7 @@ class BaseWelcomeController:
             session.answers,
             summary_author,
             session.schema_hash or "",
+            session.visibility,
         )
 
         await thread.send(embed=summary_embed)


### PR DESCRIPTION
## Summary
- add a shared C1C-branded summary embed builder for welcome and promo onboarding flows
- switch the confirmation step to post the new embed, ping @RecruitmentCoordinator, and tidy the preview message

## Testing
- python -m compileall modules/onboarding/ui/summary_embed.py modules/onboarding/controllers/welcome_controller.py

------
https://chatgpt.com/codex/tasks/task_e_69024828f36c8323b8ad73e63fb5ab7d