### PR TITLE
Update welcome fallback reaction handling

### DIFF
--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -1,7 +1,7 @@
 """Fallback handler for onboarding reaction triggers."""
 from __future__ import annotations
 
-import asyncio
+import logging
 from typing import Optional
 
 import discord
@@ -13,7 +13,10 @@ from modules.common import feature_flags
 from modules.onboarding import thread_scopes
 from modules.onboarding.welcome_flow import start_welcome_dialog
 
-FALLBACK_EMOJI = "🧭"
+# Fallback: 🎫 on the Ticket Tool close-button message
+FALLBACK_EMOJI = "🎫"  # :ticket:
+TRIGGER_PHRASE = "poke it awake by reacting with 🎫"
+TRIGGER_TOKEN = "[#welcome:ticket]"
 
 
 class OnboardingReactionFallbackCog(commands.Cog):
@@ -25,6 +28,10 @@ class OnboardingReactionFallbackCog(commands.Cog):
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: RawReactionActionEvent) -> None:
         if not feature_flags.is_enabled("welcome_dialog"):
+            logging.info(
+                "welcome.emoji.start %s",
+                {"rejected": "disabled", "emoji": str(payload.emoji)},
+            )
             return
 
         if str(payload.emoji) != FALLBACK_EMOJI:
@@ -32,13 +39,25 @@ class OnboardingReactionFallbackCog(commands.Cog):
 
         bot_user = getattr(self.bot, "user", None)
         if bot_user and payload.user_id == bot_user.id:
+            logging.info(
+                "welcome.emoji.start %s",
+                {"rejected": "self_reaction", "emoji": FALLBACK_EMOJI},
+            )
             return
 
         if payload.guild_id is None:
+            logging.info(
+                "welcome.emoji.start %s",
+                {"rejected": "no_guild_id", "emoji": FALLBACK_EMOJI},
+            )
             return
 
         guild = self.bot.get_guild(payload.guild_id)
         if guild is None:
+            logging.info(
+                "welcome.emoji.start %s",
+                {"rejected": "no_guild", "emoji": FALLBACK_EMOJI},
+            )
             return
 
         member: Optional[discord.Member] = payload.member
@@ -48,12 +67,32 @@ class OnboardingReactionFallbackCog(commands.Cog):
             try:
                 member = await guild.fetch_member(payload.user_id)
             except Exception:
+                logging.info(
+                    "welcome.emoji.start %s",
+                    {
+                        "rejected": "member_fetch_failed",
+                        "emoji": FALLBACK_EMOJI,
+                        "user_id": payload.user_id,
+                    },
+                )
                 return
 
         if not isinstance(member, discord.Member):
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "member_type",
+                    "emoji": FALLBACK_EMOJI,
+                    "user_id": payload.user_id,
+                },
+            )
             return
 
         if getattr(member, "bot", False):
+            logging.info(
+                "welcome.emoji.start %s",
+                {"rejected": "bot_member", "emoji": FALLBACK_EMOJI, "user_id": member.id},
+            )
             return
 
         thread: Optional[discord.Thread] = guild.get_thread(payload.channel_id)
@@ -65,45 +104,102 @@ class OnboardingReactionFallbackCog(commands.Cog):
                 try:
                     channel = await self.bot.fetch_channel(payload.channel_id)
                 except Exception:
+                    logging.info(
+                        "welcome.emoji.start %s",
+                        {
+                            "rejected": "channel_fetch_failed",
+                            "emoji": FALLBACK_EMOJI,
+                            "channel_id": payload.channel_id,
+                        },
+                    )
                     return
                 if isinstance(channel, discord.Thread):
                     thread = channel
         if thread is None:
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "wrong_scope:not_thread",
+                    "emoji": FALLBACK_EMOJI,
+                    "channel_id": payload.channel_id,
+                },
+            )
             return
 
         if not (
             thread_scopes.is_welcome_parent(thread)
             or thread_scopes.is_promo_parent(thread)
         ):
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "wrong_scope:parent",
+                    "emoji": FALLBACK_EMOJI,
+                    "thread_id": thread.id,
+                },
+            )
             return
 
         if not (rbac.is_admin_member(member) or rbac.is_recruiter(member)):
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "role_gate",
+                    "emoji": FALLBACK_EMOJI,
+                    "user_id": member.id,
+                    "thread_id": thread.id,
+                },
+            )
             return
 
-        starter_message = await _resolve_thread_starter_message(thread)
-        if starter_message is None:
+        try:
+            message = await thread.fetch_message(payload.message_id)
+        except Exception:
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "fetch_failed",
+                    "emoji": FALLBACK_EMOJI,
+                    "thread_id": thread.id,
+                    "message_id": payload.message_id,
+                },
+            )
             return
-        if starter_message.id != payload.message_id:
+
+        content = (getattr(message, "content", "") or "").strip()
+        match_details: Optional[dict[str, str]] = None
+        if TRIGGER_TOKEN in content:
+            match_details = {"match": "token", "token": TRIGGER_TOKEN}
+        elif TRIGGER_PHRASE in content:
+            match_details = {"match": "phrase", "needle": TRIGGER_PHRASE}
+        elif rbac.is_admin_member(member):
+            match_details = {"match": "override", "by_role": "admin"}
+        else:
+            logging.info(
+                "welcome.emoji.start %s",
+                {
+                    "rejected": "no_token_or_phrase",
+                    "emoji": FALLBACK_EMOJI,
+                    "thread_id": thread.id,
+                    "message_id": message.id,
+                },
+            )
             return
+
+        assert match_details is not None
+
+        logging.info(
+            "welcome.emoji.start %s",
+            {
+                "emoji": FALLBACK_EMOJI,
+                "thread_id": thread.id,
+                "message_id": message.id,
+                "user_id": member.id,
+                **match_details,
+            },
+        )
 
         await start_welcome_dialog(thread, member, source="emoji", bot=self.bot)
-
-
-async def _resolve_thread_starter_message(
-    thread: discord.Thread,
-) -> Optional[discord.Message]:
-    try:
-        starter = getattr(thread, "starter_message", None)
-        if starter is not None:
-            return starter
-
-        async for message in thread.history(limit=1, oldest_first=True):
-            return message
-    except asyncio.CancelledError:
-        raise
-    except Exception:
-        return None
-    return None
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/modules/onboarding/welcome_flow.py
+++ b/modules/onboarding/welcome_flow.py
@@ -70,6 +70,9 @@ async def start_welcome_dialog(
         async for message in thread.history(limit=10)
         if marker_text in getattr(message, "content", "")
     ]
+
+    flow = "welcome" if thread_scopes.is_welcome_parent(thread) else "promo"
+
     if existing_markers:
         logging.info(
             "onboarding.welcome.start %s",
@@ -77,6 +80,7 @@ async def start_welcome_dialog(
                 "skipped": "already_started",
                 "source": source,
                 "thread_id": getattr(thread, "id", None),
+                "flow": flow,
             },
         )
         return
@@ -89,8 +93,6 @@ async def start_welcome_dialog(
             "onboarding.welcome.start failed to pin marker",
             extra={"thread_id": getattr(thread, "id", None)},
         )
-
-    flow = "welcome" if thread_scopes.is_welcome_parent(thread) else "promo"
     schema_version: str | None = None
     questions = []
     try:


### PR DESCRIPTION
## Summary
- switch the onboarding fallback reaction to 🎫 and require the close-button message phrase or token, removing the starter-message restriction
- add detailed INFO logs for each early return, fetch the reacted message directly, and keep admin override support
- include the derived flow in the onboarding dedupe log entry for additional context

## Testing
- python -m compileall modules/onboarding

------
https://chatgpt.com/codex/tasks/task_e_69026fc159948323b6f32f553a0b1822