### PR TITLE
Adjust reaction fallback tests for unified logging

### DIFF
--- a/docs/epic/EPIC_WelcomePlacementV2.md
+++ b/docs/epic/EPIC_WelcomePlacementV2.md
@@ -63,7 +63,7 @@ When welcome_dialog is enabled, the Welcome Dialog can now start through two ver
 Automated Trigger (Ticket Tool) – When a welcome or promo thread is closed by Ticket Tool, the bot automatically starts the dialog (source="ticket").
 
 Manual fallback:
-Recruiters can react with 🎫 to the Ticket Tool close-button message. The bot starts if that message contains the phrase “by reacting with” (case-insensitive), or the explicit token [#welcome:ticket]. Admins may override if needed. Same gating and pin-based dedupe apply.
+Recruiters can react with 🎫 to any message in the welcome parent scope. The bot starts when that message contains the phrase “by reacting with” (case-insensitive) or the explicit token [#welcome:ticket]. Same gating and pin-based dedupe apply.
 
 Both paths call the shared entrypoint start_welcome_dialog(...), which manages scope checks, deduplication through a pinned marker, and structured logging.
 


### PR DESCRIPTION
## Summary
- update the onboarding reaction fallback tests to parse JSON-formatted info logs
- align expectations with the trigger/result fields emitted by the unified fallback logic

## Testing
- pytest tests/onboarding/test_reaction_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_690339d3f48483238723c6222fd58339