### PR TITLE
docs: consolidate architecture guidance and refresh ops steps

### DIFF
--- a/docs/adr/ADR-0018_DailyRecruiterUpdate.md
+++ b/docs/adr/ADR-0018_DailyRecruiterUpdate.md
@@ -84,6 +84,6 @@ We implemented a new **reporting pipeline** under `modules/recruitment/reporting
 ---
 
 ## Status
-Final. Shipped with **Phase 6 — Reporting v1**. Feature toggle `recruitment_reports` defaults OFF. Once validated in test, the scheduler will be enabled in production.
+Final. Shipped with **Phase 6 — Reporting v1**. Feature toggle `recruitment_reports` defaults ON (`TRUE`) and remains enabled across environments; disable it only when the Sheet or destination is misconfigured.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/epic/README.md
+++ b/docs/epic/README.md
@@ -6,4 +6,4 @@ This directory captures approved, phase-level epic specifications. Each entry sh
 - [Daily Recruiter Update (Reporting v1)](EPIC_DailyRecruiterUpdate.md)
 - [Welcome & Placement v2 — Thread-First Onboarding](EPIC_WelcomePlacementV2.md)
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/Architecture.md
+++ b/docs/ops/Architecture.md
@@ -1,80 +1,8 @@
 # CoreOps Architecture
 
-```mermaid
-flowchart TD
-    Discord[Discord Gateway] -->|events| CoreOps[CoreOps command handlers]
-    CoreOps -->|commands| CacheSvc[Cache Service]
-    CacheSvc --> Sheets[(Google Sheets)]
-    CoreOps --> Telemetry[Telemetry bus]
-    Telemetry --> Renderer[Embed renderer]
-    Renderer -->|embeds| Discord
-    Preloader[Startup preloader] -->|warm buckets| CacheSvc
-    Scheduler[Runtime scheduler] -->|cron refresh| CacheSvc
-    Scheduler --> CacheJobs[Cache refresh jobs]
-    User[Member/Admin requests] --> CoreOps
-    Http[aiohttp runtime] --> Ready[/ready endpoint/]
-    Http --> Health[/health & healthz/]
-    CoreOps -->|health hooks| Http
-```
+The CoreOps runtime now lives in the consolidated [Architecture overview](../Architecture.md).
+Use that document for diagrams, flow notes, toggle maps, and help-surface metadata. Operators
+should pair it with [`Runbook.md`](Runbook.md) and [`Config.md`](Config.md) for environment-
+specific procedures and recovery steps.
 
-### Flow notes
-- **Diagram legend:** CoreOps command handlers (purple) orchestrate Shared services (blue),
-  which expose async facades to feature modules (green).
-- **Discord Cog → CoreOps:** All commands funnel through the shared CoreOps cog. RBAC
-  decisions happen before touching cache APIs.
-- **Cache service:** Every cache interaction uses the public API (`get_snapshot`,
-  `refresh_now`). Private module attributes remain internal to the service.
-- **Google Sheets:** Recruitment and onboarding tabs are accessed asynchronously via the
-  cached adapters. Preloader warms their handles and key buckets on startup.
-- **Sheets access:** Async command handlers import `shared.sheets.async_facade`, which
-  routes synchronous helpers through `asyncio.to_thread` so the event loop stays
-  unblocked even on cache misses.
-- **Health system:** `shared.health` tracks component readiness; the runtime flips
-  statuses for `/ready` and `/health` whenever Discord or the HTTP server changes state.
-- **Preloader:** Runs automatically during boot, logging `[refresh] startup` entries for
-  each bucket.
-- **Scheduler:** Handles cron work for cache refreshes (`clans`, `templates`,
-  `clan_tags`) and posts results to the ops channel.
-- **Telemetry → Embed renderer:** Command responses pull structured telemetry and render
-  embeds without timestamps; version metadata lives solely in the footer.
-- **Runtime HTTP interface:** `/` returns the status payload and echoes the request
-  trace id, `/ready` exposes the readiness gate with component details, `/health`
-  combines the watchdog metrics with the component map, and `/healthz` remains the
-  bare liveness probe.
-- **Logging & observability:** All runtime logs emit JSON via
-  `shared.logging.structured.JsonFormatter` with
-  `ts`,`level`,`logger`,`msg`,`trace`,`env`,`bot` plus contextual extras. HTTP
-  access logs are emitted under the canonical `aiohttp.access` logger with
-  `path`,`method`,`status`, and latency (`ms`).
-- **Request tracing:** Every web request receives a UUIDv4 trace id that flows
-  through the log context, `/` response payload, and the `X-Trace-Id` response
-  header for quick correlation.
-
-### Module topology
-- CoreOps now lives in `packages/c1c-coreops/src/c1c_coreops/`.
-- CoreOps helpers ship only in the `c1c_coreops` package; no shared shims remain.
-
-### Help metadata
-- Commands opt-in to the multi-embed help surface via the `help_metadata` decorator.
-- `@Bot help` dynamically discovers commands from the live registry via `bot.walk_commands()` and filters each candidate with `command.can_run(ctx)` so RBAC decorators remain authoritative. Every reply includes Overview + Admin / Operational + Staff + User embeds; sections without runnable commands collapse unless `SHOW_EMPTY_SECTIONS=true` is set, which swaps in a “Coming soon” placeholder. Admin covers operational controls (including Welcome Templates + refresh/perm suites), Staff shows recruitment + Sheet Tools + milestones, and User shows recruitment + milestones + general (including the mention-only `@Bot help` / `@Bot ping`). Valid `function_group` values: `operational`, `recruitment`, `milestones`, `reminder`, `general`.
-- Bare admin aliases follow `COREOPS_ADMIN_BANG_ALLOWLIST`. Admins see `!command` when the allowlist authorizes a bare alias and a runnable bare command exists; otherwise they see `!ops command`. Staff always see `!ops …`, and members only see user-tier commands plus the mention routes. The footer always reads `Bot v… · CoreOps v… • For details: @Bot help`.
-
-### Feature gating at load
-- **Module wiring:** Feature modules call `modules.common.feature_flags.is_enabled(<key>)` during boot.
-  Disabled toggles block command registration and watcher wiring; the bot logs the skip
-  and continues.
-- **Backbone always-on:** Scheduler, cache service, health probes, RBAC helpers, and the
-  watchdog never consult feature toggles. They remain active even when every feature key
-  fails.
-- **Fail-closed behavior:** Missing worksheet, headers, or row values evaluate to
-  `False`. The runtime emits a single admin-ping warning per issue in the log channel and
-  leaves the module offline until the Sheet is fixed and refreshed.
-- **Feature map:**
-  - `member_panel` — member view of recruitment roster/search panels.
-  - `recruiter_panel` — recruiter dashboard, match queue, and escalations.
-  - `recruitment_welcome` — welcome command (welcome/promo listeners remain env-gated).
-  - `recruitment_reports` — Daily Recruiter Update (UTC scheduler + `!report recruiters`).
-  - `placement_target_select` — stub module (no runtime surface yet).
-  - `placement_reservations` — stub module (no runtime surface yet).
-
-Doc last updated: 2025-10-28 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -4,7 +4,9 @@ Legend: ✅ = active command · 🧩 = shared CoreOps surface (available
 
 Each entry supplies the one-line copy that powers the refreshed help index. Use these
 short descriptions in the dynamic `@Bot help` layout; detailed blurbs live in
-[`commands.md`](commands.md).
+[`commands.md`](commands.md). Treat [`../_meta/COMMAND_METADATA.md`](../_meta/COMMAND_METADATA.md)
+as the canonical export — regenerate or copy from that sheet when updating this table so
+the help system, matrix, and metadata stay synchronized.
 
 - **Audience map:** The renderer walks `bot.walk_commands()` at runtime and maps commands by `access_tier`/`function_group`. Every reply ships four embeds (Overview, Admin / Operational, Staff, User). Sections without runnable commands collapse automatically unless `SHOW_EMPTY_SECTIONS=1` is set, in which case the header renders with “Coming soon”.
 - **Alias policy:** Bare bang aliases for admin commands come from `COREOPS_ADMIN_BANG_ALLOWLIST`. Admins see `!command` when the allowlist authorizes a bare alias and a runnable bare command exists; otherwise they see `!ops command`. Staff always see `!ops …` entries, and members only see user-tier commands plus the mention routes (`@Bot help`, `@Bot ping`).
@@ -51,4 +53,4 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 
 > Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `placement_target_select` and `placement_reservations` remain stub modules that only log when enabled.
 
-Doc last updated: 2025-10-28 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -193,13 +193,15 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 **Operator flow**
 
 1. Edit the `FeatureToggles` worksheet in the environment’s Mirralith Sheet.
-2. Run `!ops refresh config` (or the admin bang alias) to pull the latest worksheet values.
+2. Run `!ops reload` (or the admin bang alias) to pull the latest worksheet values and rebuild the registry.
 3. Confirm the tab and headers with `!checksheet`; resolve any ⚠️ rows before retrying.
 
 **Troubleshooting**
 
 - Warnings mention the first role listed in `ADMIN_ROLE_IDS` and are posted to the runtime log channel.
 - Verify the worksheet name matches the Config key and that headers are spelled correctly.
-- Use `!ops refresh config` (or the Ops equivalent) to force the bot to re-read the toggles after a fix.
+- Use `!ops reload` (or the Ops equivalent) to force the bot to re-read the toggles after a fix.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+> **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
+
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -126,7 +126,7 @@ tabs.
   match (`feature_name`, `enabled`), and each enabled row uses `TRUE` (case-insensitive).
 - **Signals:** Startup posts an admin-ping warning in the runtime log channel when the tab,
   headers, or row values are missing or invalid.
-- **Remediation:** Fix the Sheet, run `!ops refresh config` (or the admin bang alias), then
+- **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-10-28 (v0.9.7)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/Troubleshooting.md
+++ b/docs/ops/Troubleshooting.md
@@ -25,13 +25,13 @@ when adjusting cadences or toggles.
   exists in the recruitment Sheet. Missing tabs fail closed and trigger a single
   admin-ping warning in the runtime log channel.
 - **Headers wrong?** The worksheet must expose `feature_name` and `enabled`. Fix the
-  headers, save, then run `!ops refresh config` and re-verify with `!checksheet`.
+  headers, save, then run `!ops reload` and re-verify with `!checksheet`.
 - **Row missing?** Add the feature row using the approved key and `enabled` value. Rows
   absent from the worksheet evaluate to disabled until present.
 - **Value ignored?** Only `TRUE` (case-insensitive) enables a feature. Any other value —
   including `FALSE`, blanks, or typos — keeps the module off and logs an admin-ping
   warning.
-- **Change not taking effect?** After editing the Sheet, run `!ops refresh config`, then
+- **Change not taking effect?** After editing the Sheet, run `!ops reload`, then
   confirm with `!checksheet` to ensure the worksheet and headers are clean.
 
 ## Redaction policy
@@ -56,4 +56,4 @@ when adjusting cadences or toggles.
   opening an incident.
 - Ping #bot-production with the summary before filing a longer report.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/commands.md
+++ b/docs/ops/commands.md
@@ -2,7 +2,9 @@
 
 The help surfaces pull from the command matrix and cache registry to render consistent
 copy across tiers. Use the following behavior notes when validating deploys or triaging
-reports from staff and recruiters.
+reports from staff and recruiters. Command copy and usage strings should originate from
+[`../_meta/COMMAND_METADATA.md`](../_meta/COMMAND_METADATA.md); update that export first, then
+mirror the changes here and in the matrix to keep a single source of truth.
 
 ## `@Bot help` — overview layout
 - **Audience:** Everyone; the embed set filters to the caller’s access tier.
@@ -107,4 +109,4 @@ Mention-style health check.
 - **Usage:** `@Bot ping`
 - **Notes:** Admins still have access to the hidden `!ping` reaction command; the mention route keeps user help consistent.
 
-Doc last updated: 2025-10-27 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/docs/ops/module-toggles.md
+++ b/docs/ops/module-toggles.md
@@ -28,8 +28,8 @@ at startup. Toggle values are case-insensitive; only `TRUE` (`ON`) enables a fea
 | `enable_welcome_hook` | `TRUE` | Enables the welcome thread watcher (`modules.onboarding.watcher_welcome`). |
 | `enable_promo_watcher` | `TRUE` | Enables the promo thread watcher (`modules.onboarding.watcher_promo`). |
 
-Set the desired value in the `FeatureToggles` tab, then run `!rec refresh config`
+Set the desired value in the `FeatureToggles` tab, then run `!ops reload`
 to apply it. The runtime logs whether each module was loaded or skipped at boot. See
 [`Config.md`](Config.md#feature-toggles-worksheet) for the worksheet contract.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-10-31 (v0.9.7)


### PR DESCRIPTION
## Summary
- merge the ops architecture content into the main overview and point operators to the shared doc
- update toggle workflows and troubleshooting guidance to call out the !ops reload command and reference the env template
- align command documentation with the canonical metadata export and reflect the recruitment_reports default in ADR-0018

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_6903658a86fc8323955dc4369e6abdc6