### PR TITLE
Improve guardrails reporting and workflow gating

### DIFF
--- a/.github/workflows/11-guardrails-suite.yml
+++ b/.github/workflows/11-guardrails-suite.yml
@@ -7,13 +7,24 @@ on:
 jobs:
   suite:
     runs-on: ubuntu-latest
+    outputs:
+      guardrails_status: ${{ steps.guardrails.outputs.guardrails_status }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Run Repository Guardrails suite
+        id: guardrails
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python scripts/ci/guardrails_suite.py --pr "${{ github.event.pull_request.number }}"
+          status_file=guardrails_status.txt
+          python scripts/ci/guardrails_suite.py --pr "${{ github.event.pull_request.number }}" --status-file "$status_file"
+          exit_code=$?
+          if [ -f "$status_file" ]; then
+            echo "guardrails_status=$(cat "$status_file")" >> "$GITHUB_OUTPUT"
+          else
+            echo "guardrails_status=fail" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$exit_code"

--- a/.github/workflows/auto-pr-admin.yml
+++ b/.github/workflows/auto-pr-admin.yml
@@ -11,9 +11,27 @@ permissions:
   issues: write
 
 jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    outputs:
+      guardrails_status: ${{ steps.extract.outputs.guardrails_status }}
+    steps:
+      - name: Determine guardrails status
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run || {};
+            let status = run.outputs && run.outputs.guardrails_status;
+            if (!status) {
+              status = run.conclusion === 'success' ? 'pass' : 'fail';
+            }
+            core.setOutput('guardrails_status', status || 'fail');
   run-admin:
+    needs: guardrails
     if: >-
       ${{
+        needs.guardrails.outputs.guardrails_status == 'pass' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.pull_requests[0] &&

--- a/scripts/ci/guardrails_labels.py
+++ b/scripts/ci/guardrails_labels.py
@@ -1,0 +1,97 @@
+"""Label compliance helper using Collaboration Contract."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+from urllib import error, request
+import re
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[1]
+CONTRACT_PATH = ROOT / "docs" / "contracts" / "CollaborationContract.md"
+
+
+@dataclass(slots=True)
+class LabelEvaluation:
+    details: List[str]
+    labels_ok: bool
+    error: str | None = None
+
+
+def _extract_section(text: str, heading: str) -> str:
+    pattern = re.compile(rf"^## +{re.escape(heading)}\s*$", re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        raise ValueError(f"Heading '{heading}' not found in contract")
+    start = match.end()
+    remainder = text[start:]
+    next_heading = re.search(r"^## +", remainder, re.MULTILINE)
+    if next_heading:
+        remainder = remainder[: next_heading.start()]
+    return remainder
+
+
+def _parse_approved_labels(contract_path: Path = CONTRACT_PATH) -> set[str]:
+    text = contract_path.read_text(encoding="utf-8")
+    section = _extract_section(text, "6) Label Reference (Approved Set — full list)")
+    lines = [line.strip() for line in section.splitlines() if line.strip().startswith("|")]
+    labels: set[str] = set()
+    for line in lines:
+        columns = [column.strip() for column in line.strip("|").split("|")]
+        if not columns or columns[0].lower() == "name" or set(columns[0]) <= {"-", ""}:
+            continue
+        name = columns[0]
+        if name:
+            labels.add(name)
+    if not labels:
+        raise ValueError("No labels found in approved label table")
+    return labels
+
+
+def _fetch_pr_labels(*, repo: str, number: int, token: str | None) -> List[str]:
+    url = f"https://api.github.com/repos/{repo}/issues/{number}"
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = request.Request(url, headers=headers)
+    try:
+        with request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        raise RuntimeError(f"GitHub API request failed with status {exc.code}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"Unable to reach GitHub API: {exc.reason}") from exc
+
+    labels = payload.get("labels", [])
+    names: List[str] = []
+    for label in labels:
+        if isinstance(label, dict) and "name" in label:
+            names.append(str(label["name"]))
+    return names
+
+
+def evaluate_labels(*, repo: str, number: int, token: str | None) -> LabelEvaluation:
+    try:
+        allowed = _parse_approved_labels()
+    except Exception as exc:  # pragma: no cover - defensive
+        return LabelEvaluation(details=[], labels_ok=False, error=str(exc))
+
+    try:
+        current = _fetch_pr_labels(repo=repo, number=number, token=token)
+    except Exception as exc:  # pragma: no cover - defensive
+        return LabelEvaluation(details=[], labels_ok=False, error=str(exc))
+
+    details: List[str] = []
+    labels_ok = True
+    if not current:
+        labels_ok = False
+        details.append("No labels assigned to the pull request.")
+
+    unknown = sorted({label for label in current if label not in allowed})
+    if unknown:
+        labels_ok = False
+        details.append("Unknown labels: " + ", ".join(unknown))
+
+    return LabelEvaluation(details=details, labels_ok=labels_ok)

--- a/scripts/ci/guardrails_report.py
+++ b/scripts/ci/guardrails_report.py
@@ -1,0 +1,91 @@
+"""Render aggregated guardrails report comments."""
+from __future__ import annotations
+
+from typing import List, Sequence
+
+
+_STATUS_METADATA = {
+    "FAIL": ("❌", "Fail"),
+    "PASS": ("✅", "Pass"),
+    "NA": ("⚪", "N/A"),
+}
+
+
+def _summarize_checks(checks: Sequence["CheckResult"], *, limit: int = 10) -> str:
+    names = [check.rule for check in checks]
+    if not names:
+        return "—"
+    display = names[:limit]
+    summary = ", ".join(display)
+    extra = len(names) - limit
+    if extra > 0:
+        summary += f", +{extra} more"
+    return summary
+
+
+def _format_block_reason(check: "CheckResult") -> str:
+    if check.details:
+        if check.area == "Labels":
+            return f"{check.rule}: {check.details[0]}"
+        count = len(check.details)
+        if all(":" in detail for detail in check.details):
+            noun = "file" if count == 1 else "files"
+            return f"{check.rule}: {count} {noun}"
+        return f"{check.rule}: {check.details[0]}"
+    return check.rule
+
+
+def _format_fail_details(checks: Sequence["CheckResult"]) -> List[str]:
+    lines: List[str] = []
+    for check in checks:
+        header = f"- **{check.rule}** ({check.area})"
+        lines.append(header)
+        for detail in check.details:
+            lines.append(f"  - {detail}")
+    return lines
+
+
+def render_report(
+    *,
+    results: Sequence["CheckResult"],
+    label_result: "CheckResult",
+    job_failed: bool,
+) -> str:
+    table_lines = ["| Status | Checks |", "| --- | --- |"]
+    grouped = {status: [] for status in _STATUS_METADATA}
+    for check in results:
+        grouped.setdefault(check.status, []).append(check)
+
+    for status in ("FAIL", "PASS", "NA"):
+        emoji, label = _STATUS_METADATA[status]
+        checks = grouped.get(status, [])
+        summary = _summarize_checks(checks)
+        table_lines.append(f"| {emoji} {label} ({len(checks)}) | {summary} |")
+
+    fail_checks = [check for check in results if check.status == "FAIL"]
+    combined_failures: List["CheckResult"] = list(fail_checks)
+    if label_result.status == "FAIL":
+        combined_failures.append(label_result)
+
+    body_lines: List[str] = ["## Repository Guardrails", "", *table_lines, ""]
+
+    if job_failed and combined_failures:
+        reasons = ", ".join(_format_block_reason(check) for check in combined_failures)
+        body_lines.append(f"**Why blocked:** {reasons}")
+        body_lines.append("")
+
+    if fail_checks:
+        body_lines.append("### Fail details")
+        body_lines.extend(_format_fail_details(fail_checks))
+        body_lines.append("")
+
+    body_lines.append("### Label Compliance")
+    if label_result.status == "PASS":
+        body_lines.append("✓ Labels match the approved set.")
+    else:
+        detail = "; ".join(label_result.details) if label_result.details else "Label check failed."
+        body_lines.append(f"✗ {detail}")
+    body_lines.append("")
+    body_lines.append("<!-- repository-guardrails -->")
+
+    return "\n".join(body_lines)


### PR DESCRIPTION
## Summary
- treat unwired scanners as N/A, propagate PASS/FAIL/NA status through guardrails suite, and render a grouped report
- add label compliance validation sourced from the collaboration contract and surface failures in the guardrails comment
- expose guardrails status as a reusable workflow output and gate the admin automation on a passing guardrails run

## Testing
- python -m compileall scripts/ci

[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_690390d26de483238aeef389799d2b59