### PR TITLE
Fix guardrails workflow status handling on failure

### DIFF
--- a/.github/workflows/11-guardrails-suite.yml
+++ b/.github/workflows/11-guardrails-suite.yml
@@ -20,8 +20,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           status_file=guardrails_status.txt
-          python scripts/ci/guardrails_suite.py --pr "${{ github.event.pull_request.number }}" --status-file "$status_file"
-          exit_code=$?
+          exit_code=0
+          python scripts/ci/guardrails_suite.py --pr "${{ github.event.pull_request.number }}" --status-file "$status_file" || exit_code=$?
           if [ -f "$status_file" ]; then
             echo "guardrails_status=$(cat "$status_file")" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- ensure the guardrails suite workflow records the status file before exiting on failure
- capture the guardrails script exit code without allowing the shell to terminate early

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6903bc499be88323b8cbe08bb7763426