### PR TITLE
Refactor logging initialization side effects

### DIFF
--- a/packages/c1c-coreops/tests/__init__.py
+++ b/packages/c1c-coreops/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker for c1c_coreops."""

--- a/shared/logging/__init__.py
+++ b/shared/logging/__init__.py
@@ -1,0 +1,8 @@
+"""Public logging helpers for the shared runtime package."""
+
+from __future__ import annotations
+
+from .config import setup_logging
+from .structured import JsonFormatter, get_trace_id, set_trace_id
+
+__all__ = ["JsonFormatter", "get_trace_id", "set_trace_id", "setup_logging"]

--- a/shared/logging/config.py
+++ b/shared/logging/config.py
@@ -1,0 +1,70 @@
+"""Runtime logging configuration utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+
+from .structured import JsonFormatter
+
+__all__ = ["setup_logging"]
+
+
+def _ensure_stream_handler(logger: logging.Logger, formatter: logging.Formatter) -> None:
+    """Ensure ``logger`` has a stream handler using ``formatter``."""
+
+    stream_handler_found = False
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            handler.setFormatter(formatter)
+            stream_handler_found = True
+    if not stream_handler_found:
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+
+def setup_logging(
+    *,
+    static_fields: Mapping[str, str] | None = None,
+    access_logger_name: str = "aiohttp.access",
+    access_static_fields: Mapping[str, str] | None = None,
+) -> logging.Logger:
+    """Configure JSON logging for the runtime.
+
+    Parameters
+    ----------
+    static_fields:
+        Base static fields included with every structured log event.
+    access_logger_name:
+        Name of the access logger that should emit HTTP request entries.
+    access_static_fields:
+        Additional static fields for the access logger; merged with
+        ``static_fields``.
+
+    Returns
+    -------
+    logging.Logger
+        The configured access logger instance.
+    """
+
+    base_static = dict(static_fields or {})
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    _ensure_stream_handler(root_logger, JsonFormatter(static=base_static))
+
+    access_static = dict(base_static)
+    access_static.update(access_static_fields or {})
+    access_static.setdefault("logger", access_logger_name)
+
+    access_logger = logging.getLogger(access_logger_name)
+    access_logger.propagate = False
+    access_logger.handlers.clear()
+
+    access_handler = logging.StreamHandler()
+    access_handler.setFormatter(JsonFormatter(static=access_static))
+    access_logger.addHandler(access_handler)
+    access_logger.setLevel(logging.INFO)
+
+    return access_logger

--- a/shared/obs/__init__.py
+++ b/shared/obs/__init__.py
@@ -1,0 +1,17 @@
+"""Observability helpers exposed via the package namespace."""
+
+from __future__ import annotations
+
+from .events import (
+    format_refresh_message,
+    refresh_bucket_results,
+    refresh_dedupe_key,
+    refresh_deduper,
+)
+
+__all__ = [
+    "format_refresh_message",
+    "refresh_bucket_results",
+    "refresh_dedupe_key",
+    "refresh_deduper",
+]

--- a/shared/permissions/__init__.py
+++ b/shared/permissions/__init__.py
@@ -1,0 +1,19 @@
+"""Permission helpers exposed as the public package surface."""
+
+from __future__ import annotations
+
+from .bot_access_profile import (
+    BOT_PERMISSION_MATRIX,
+    DEFAULT_THREADS_ENABLED,
+    build_allow_overwrite,
+    build_deny_overwrite,
+    serialize_overwrite,
+)
+
+__all__ = [
+    "BOT_PERMISSION_MATRIX",
+    "DEFAULT_THREADS_ENABLED",
+    "build_allow_overwrite",
+    "build_deny_overwrite",
+    "serialize_overwrite",
+]


### PR DESCRIPTION
## Summary
- add a shared.logging.config module that exposes setup_logging for JSON handler wiring
- update the runtime app factory to call setup_logging and leave package __init__ files as re-export only
- add minimal __init__.py shells for shared.permissions, shared.obs, and c1c-coreops tests packages to prevent side-effects

## Testing
- pytest

[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_6903bfd7ef408323a971fde8cfd302e4