### PR TITLE
Improve welcome panel access controls and logging

### DIFF
--- a/docs/ops/Logging.md
+++ b/docs/ops/Logging.md
@@ -58,11 +58,13 @@ Line mode:
 
 ### Welcome
 ```
-✅ **Welcome** — tag=C1CM • recruit=Eir • channel=#clans › martyrs-hall • result=ok • details: -
-⚠️ **Welcome** — tag=C1CM • recruit=Eir • channel=#clans › martyrs-hall • result=partial • details: general_notice=error (Missing Access)
-⚠️ **Welcome panel** — actor=@Recruiter • thread=#welcome › ticket-123 • result=denied_role • details: recruit_only
-⚠️ **Welcome panel** — actor=@Member • thread=#welcome › ticket-123 • result=denied_perms • details: missing send_messages_in_threads
-⚠️ **Welcome panel** — actor=@Recruiter • thread=#welcome › ticket-123 • result=ambiguous_target • details: greeting_missing_mention
+✅ **Welcome** — tag=C1CM • recruit=Eir (741852963014785236) • channel=#clans › martyrs-hall (369258147012369258) • result=ok • details: -
+⚠️ **Welcome** — tag=C1CM • recruit=Eir (741852963014785236) • channel=#clans › martyrs-hall (369258147012369258) • result=partial • details: general_notice=error (Missing Access)
+✅ **Welcome panel** — actor=@Recruit • thread=#welcome › ticket-123 (112233445566778899) • parent=#ops › welcome (998877665544332211) • result=allowed • details: view=welcome_panel; custom_id=welcome.panel.open; message=334455667788990011; thread_id=112233445566778899; parent_id=998877665544332211; actor_id=667788990011223344; target_user_id=667788990011223344; app_perms=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True; app_perms_flags=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True
+⚠️ **Welcome panel** — actor=@Recruiter • thread=#welcome › ticket-123 (112233445566778899) • parent=#ops › welcome (998877665544332211) • result=denied_role • details: view=welcome_panel; custom_id=welcome.panel.open; message=334455667788990011; thread_id=112233445566778899; parent_id=998877665544332211; actor_id=123456789012345678; app_perms=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True; app_perms_flags=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True; reason=missing_roles
+⚠️ **Welcome panel** — actor=@Member • thread=#welcome › ticket-123 (112233445566778899) • parent=#ops › welcome (998877665544332211) • result=denied_perms • details: view=welcome_panel; custom_id=welcome.panel.open; message=334455667788990011; thread_id=112233445566778899; parent_id=998877665544332211; actor_id=223344556677889900; app_perms=send_messages=True, send_messages_in_threads=False, embed_links=True, read_message_history=True; app_perms_flags=send_messages=True, send_messages_in_threads=False, embed_links=True, read_message_history=True; missing=send_messages_in_threads
+⚠️ **Welcome panel** — actor=@Recruiter • thread=#welcome › ticket-123 (112233445566778899) • parent=#ops › welcome (998877665544332211) • result=ambiguous_target • details: view=welcome_panel; custom_id=welcome.panel.open; message=334455667788990011; thread_id=112233445566778899; parent_id=998877665544332211; actor_id=123456789012345678; app_perms=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True; app_perms_flags=send_messages=True, send_messages_in_threads=True, embed_links=True, read_message_history=True; reason=greeting_missing_mention; target_message=445566778899001122
+🛈 **Welcome panel** — actor=@Recruiter • thread=#welcome › ticket-123 (112233445566778899) • parent=#ops › welcome (998877665544332211) • result=restarted • details: view=welcome_panel; custom_id=fallback.emoji; thread_id=112233445566778899; parent_id=998877665544332211; actor_id=123456789012345678; app_perms=-; app_perms_flags=-; trigger=phrase_match
 ```
 
 ## Dedupe policy
@@ -75,8 +77,8 @@ Line mode:
 
 ## Configuration knobs
 - `LOG_DEDUPE_WINDOW_S` (float, default `5`): adjusts the shared dedupe horizon for refresh, welcome, and permission sync events.
-- `LOG_REFRESH_RENDER_MODE` (`line` or `table`, default `line`): toggles between the compact one-line refresh summary and the code-block table layout.
-- `LOG_INCLUDE_NUMERIC_IDS` (`true`/`false`, default `false`): appends the raw numeric ID in parentheses after each label when enabled.
+- `LOG_REFRESH_RENDER_MODE` (`plain`, `line`, or `table`, default `plain`): toggles between the compact one-line refresh summary and the code-block table layout.
+- `LOG_INCLUDE_NUMERIC_IDS` (`true`/`false`, default `true`): appends the raw numeric ID in parentheses after each label when enabled.
 
 ## Operational rules
 - Do not call Discord `fetch_*` APIs purely for logging; the helpers rely on cached objects and gracefully degrade to `#unknown` placeholders.

--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -29,6 +29,24 @@ def _base_context(
     user_id: int | None = None,
 ) -> dict[str, Any]:
     context = logs.thread_context(thread)
+    context["view"] = "panel"
+    context["view_tag"] = panels.WELCOME_PANEL_TAG
+    context["custom_id"] = "fallback.emoji"
+    context["app_permissions"] = "-"
+    context["app_permissions_snapshot"] = "-"
+    if thread is not None:
+        thread_id = getattr(thread, "id", None)
+        if thread_id is not None:
+            try:
+                context["thread_id"] = int(thread_id)
+            except (TypeError, ValueError):
+                pass
+        parent_id = getattr(thread, "parent_id", None)
+        if parent_id is not None:
+            try:
+                context["parent_channel_id"] = int(parent_id)
+            except (TypeError, ValueError):
+                pass
     if member is not None:
         context["actor"] = logs.format_actor(member)
         actor_name = logs.format_actor_handle(member)

--- a/shared/config.py
+++ b/shared/config.py
@@ -494,18 +494,26 @@ def get_log_dedupe_window_s(default: float = 5.0) -> float:
         return float(default)
 
 
-def get_log_refresh_render_mode(default: str = "line") -> str:
+def get_log_refresh_render_mode(default: str = "plain") -> str:
     value = _CONFIG.get("LOG_REFRESH_RENDER_MODE")
     if isinstance(value, str) and value.strip():
         normalized = value.strip().lower()
-        if normalized in {"line", "table"}:
+        if normalized in {"line", "table", "plain"}:
             return normalized
     return default
 
 
 def get_log_include_numeric_ids() -> bool:
     value = _CONFIG.get("LOG_INCLUDE_NUMERIC_IDS")
-    return bool(value) if isinstance(value, bool) else _env_bool("LOG_INCLUDE_NUMERIC_IDS", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.strip():
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return _env_bool("LOG_INCLUDE_NUMERIC_IDS", True)
 
 
 def get_notify_channel_id() -> Optional[int]:

--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -374,6 +374,52 @@ class LogTemplates:
         )
 
     @staticmethod
+    def welcome_panel(
+        *,
+        actor: str,
+        actor_display: str | None,
+        thread: str,
+        parent: str | None,
+        result: str,
+        details: Sequence[str] | None = None,
+    ) -> str:
+        palette = {
+            "allowed": LOG_EMOJI["success"],
+            "launched": LOG_EMOJI["success"],
+            "saved": LOG_EMOJI["success"],
+            "submitted": LOG_EMOJI["success"],
+            "completed": LOG_EMOJI["success"],
+            "started": LOG_EMOJI["success"],
+            "reopened": LOG_EMOJI["success"],
+            "refreshed": LOG_EMOJI["success"],
+            "restarted": LOG_EMOJI["info"],
+            "emoji_received": LOG_EMOJI["info"],
+            "deduped": LOG_EMOJI["info"],
+            "feature_disabled": LOG_EMOJI["warning"],
+            "role_gate": LOG_EMOJI["warning"],
+            "scope_gate": LOG_EMOJI["warning"],
+            "denied_role": LOG_EMOJI["warning"],
+            "denied_perms": LOG_EMOJI["warning"],
+            "ambiguous_target": LOG_EMOJI["warning"],
+            "timeout": LOG_EMOJI["warning"],
+            "inactive": LOG_EMOJI["warning"],
+            "no_trigger": LOG_EMOJI["warning"],
+            "wrong_scope": LOG_EMOJI["warning"],
+            "panel_failed": LOG_EMOJI["error"],
+            "launch_failed": LOG_EMOJI["error"],
+            "error": LOG_EMOJI["error"],
+        }
+        emoji = palette.get(result, LOG_EMOJI["info"])
+        actor_text = actor_display or actor or "<unknown>"
+        thread_text = thread or "#unknown"
+        detail_text = "; ".join(details or []) if details else "-"
+        parent_text = f" • parent={parent}" if parent else ""
+        return (
+            f"{emoji} **Welcome panel** — actor={actor_text} • thread={thread_text}"
+            f"{parent_text} • result={result} • details: {detail_text}"
+        )
+
+    @staticmethod
     def select_refresh_template(scope: str, buckets: Sequence[BucketResult], total_s: float) -> str:
         mode = get_log_refresh_render_mode()
         if mode == "table":


### PR DESCRIPTION
## Summary
- ensure the welcome panel captures app permission snapshots, thread metadata, and logs consistent identifiers for each interaction
- tighten welcome controller access logging, cache recruit targets reliably, and avoid unnecessary defers during follow-ups
- route onboarding logs through the shared humanized formatter with deduplication and update documentation defaults and examples

## Testing
- pytest tests/onboarding/test_reaction_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_6903c0fb20bc8323b2d0d436362c33d8