### PR TITLE
Add async Google Sheets adapter and wrappers

### DIFF
--- a/shared/sheets/async_adapter.py
+++ b/shared/sheets/async_adapter.py
@@ -1,10 +1,4 @@
-"""Async adapter for Google Sheets operations.
-
-This module centralises offloading of blocking gspread calls into a bounded
-:class:`~concurrent.futures.ThreadPoolExecutor`. Both synchronous and
-``async`` helpers route through the same entry points so callers can migrate
-without duplicating wrapper logic.
-"""
+"""Async adapter for Google Sheets operations."""
 
 from __future__ import annotations
 
@@ -22,9 +16,12 @@ _logger = logging.getLogger(__name__)
 _EXECUTOR: ThreadPoolExecutor | None = None
 _EXECUTOR_LOCK = Lock()
 _MAX_WORKERS = 4
+_DEFAULT_TIMEOUT = 15.0
 
 
 def _get_executor() -> ThreadPoolExecutor:
+    """Return the lazily initialised executor used for Sheets I/O."""
+
     global _EXECUTOR
     if _EXECUTOR is None:
         with _EXECUTOR_LOCK:
@@ -33,9 +30,7 @@ def _get_executor() -> ThreadPoolExecutor:
                     max_workers=_MAX_WORKERS,
                     thread_name_prefix="sheets-io",
                 )
-                _logger.info(
-                    "SheetsAsyncAdapter initialized (max_workers=%d)", _MAX_WORKERS
-                )
+                _logger.info("SheetsAsyncAdapter init (max_workers=4)")
     return _EXECUTOR
 
 
@@ -43,129 +38,132 @@ def shutdown_executor(wait: bool = True) -> None:
     """Shut down the shared executor if it has been initialised."""
 
     global _EXECUTOR
-    if _EXECUTOR is not None:
-        with _EXECUTOR_LOCK:
-            if _EXECUTOR is not None:
-                _EXECUTOR.shutdown(wait=wait)
-                _EXECUTOR = None
-                _logger.info("SheetsAsyncAdapter executor shut down")
+    if _EXECUTOR is None:
+        return
+    with _EXECUTOR_LOCK:
+        if _EXECUTOR is None:
+            return
+        _EXECUTOR.shutdown(wait=wait)
+        _EXECUTOR = None
 
 
-async def _run_async(
+async def _to_thread(
     func: Callable[P, T],
     *args: P.args,
-    timeout: float | None = None,
+    timeout: float | None = _DEFAULT_TIMEOUT,
     **kwargs: P.kwargs,
 ) -> T:
     """Execute ``func`` in the adapter executor and await the result."""
 
     loop = asyncio.get_running_loop()
-    future = loop.run_in_executor(
-        _get_executor(), partial(func, *args, **kwargs)
-    )
-    if timeout is not None:
-        return await asyncio.wait_for(future, timeout)
-    return await future
-
-
-def _run_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-    """Execute ``func`` synchronously (for compatibility with sync callers)."""
-
-    return func(*args, **kwargs)
+    future = loop.run_in_executor(_get_executor(), partial(func, *args, **kwargs))
+    if timeout is None:
+        return await future
+    return await asyncio.wait_for(future, timeout)
 
 
 # ---------
-# Wrappers
+# Sync wrappers
 # ---------
 
 def open_spreadsheet(client: Any, key: str) -> Any:
     """Synchronously open a spreadsheet by ``key`` using ``client``."""
 
-    return _run_sync(client.open_by_key, key)
-
-
-async def aopen_spreadsheet(
-    client: Any, key: str, *, timeout: float | None = None
-) -> Any:
-    """Async variant of :func:`open_spreadsheet`."""
-
-    return await _run_async(client.open_by_key, key, timeout=timeout)
+    return client.open_by_key(key)
 
 
 def worksheet_by_title(workbook: Any, name: str) -> Any:
     """Return a worksheet from ``workbook`` by tab ``name``."""
 
-    return _run_sync(workbook.worksheet, name)
-
-
-async def aworksheet_by_title(
-    workbook: Any, name: str, *, timeout: float | None = None
-) -> Any:
-    """Async wrapper for :func:`worksheet_by_title`."""
-
-    return await _run_async(workbook.worksheet, name, timeout=timeout)
+    return workbook.worksheet(name)
 
 
 def worksheet_by_index(workbook: Any, index: int) -> Any:
     """Return a worksheet from ``workbook`` by numeric ``index``."""
 
-    return _run_sync(workbook.get_worksheet, index)
-
-
-async def aworksheet_by_index(
-    workbook: Any, index: int, *, timeout: float | None = None
-) -> Any:
-    """Async wrapper for :func:`worksheet_by_index`."""
-
-    return await _run_async(workbook.get_worksheet, index, timeout=timeout)
+    return workbook.get_worksheet(index)
 
 
 def worksheet_records_all(worksheet: Any) -> list[dict[str, Any]]:
     """Return all records from ``worksheet``."""
 
-    return _run_sync(worksheet.get_all_records)
-
-
-async def aworksheet_records_all(
-    worksheet: Any, *, timeout: float | None = None
-) -> list[dict[str, Any]]:
-    """Async wrapper for :func:`worksheet_records_all`."""
-
-    return await _run_async(worksheet.get_all_records, timeout=timeout)
+    return worksheet.get_all_records()
 
 
 def worksheet_values_all(worksheet: Any) -> list[list[Any]]:
     """Return all cell values from ``worksheet``."""
 
-    return _run_sync(worksheet.get_all_values)
-
-
-async def aworksheet_values_all(
-    worksheet: Any, *, timeout: float | None = None
-) -> list[list[Any]]:
-    """Async wrapper for :func:`worksheet_values_all`."""
-
-    return await _run_async(worksheet.get_all_values, timeout=timeout)
+    return worksheet.get_all_values()
 
 
 def worksheet_values_get(worksheet: Any, a1_range: str) -> Any:
     """Return the values for ``a1_range`` from ``worksheet``."""
 
-    return _run_sync(worksheet.get, a1_range)
-
-
-async def aworksheet_values_get(
-    worksheet: Any, a1_range: str, *, timeout: float | None = None
-) -> Any:
-    """Async wrapper for :func:`worksheet_values_get`."""
-
-    return await _run_async(worksheet.get, a1_range, timeout=timeout)
+    return worksheet.get(a1_range)
 
 
 def worksheet_values_update(worksheet: Any, a1_range: str, values: Any) -> Any:
     """Update ``worksheet`` values for ``a1_range``."""
 
-    return _run_sync(worksheet.update, a1_range, values)
+    return worksheet.update(a1_range, values)
+
+
+def batch_update(spreadsheet: Any, request_body: dict[str, Any]) -> Any:
+    """Execute ``batch_update`` on ``spreadsheet``."""
+
+    return spreadsheet.batch_update(request_body)
+
+
+# ---------
+# Async wrappers
+# ---------
+
+async def aopen_spreadsheet(
+    client: Any, key: str, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> Any:
+    """Async variant of :func:`open_spreadsheet`."""
+
+    return await _to_thread(client.open_by_key, key, timeout=timeout)
+
+
+async def aworksheet_by_title(
+    workbook: Any, name: str, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> Any:
+    """Async wrapper for :func:`worksheet_by_title`."""
+
+    return await _to_thread(workbook.worksheet, name, timeout=timeout)
+
+
+async def aworksheet_by_index(
+    workbook: Any, index: int, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> Any:
+    """Async wrapper for :func:`worksheet_by_index`."""
+
+    return await _to_thread(workbook.get_worksheet, index, timeout=timeout)
+
+
+async def aworksheet_records_all(
+    worksheet: Any, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> list[dict[str, Any]]:
+    """Async wrapper for :func:`worksheet_records_all`."""
+
+    return await _to_thread(worksheet.get_all_records, timeout=timeout)
+
+
+async def aworksheet_values_all(
+    worksheet: Any, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> list[list[Any]]:
+    """Async wrapper for :func:`worksheet_values_all`."""
+
+    return await _to_thread(worksheet.get_all_values, timeout=timeout)
+
+
+async def aworksheet_values_get(
+    worksheet: Any, a1_range: str, *, timeout: float | None = _DEFAULT_TIMEOUT
+) -> Any:
+    """Async wrapper for :func:`worksheet_values_get`."""
+
+    return await _to_thread(worksheet.get, a1_range, timeout=timeout)
 
 
 async def aworksheet_values_update(
@@ -173,36 +171,33 @@ async def aworksheet_values_update(
     a1_range: str,
     values: Any,
     *,
-    timeout: float | None = None,
+    timeout: float | None = _DEFAULT_TIMEOUT,
 ) -> Any:
     """Async wrapper for :func:`worksheet_values_update`."""
 
-    return await _run_async(worksheet.update, a1_range, values, timeout=timeout)
-
-
-def batch_update(spreadsheet: Any, request_body: dict[str, Any]) -> Any:
-    """Execute ``batch_update`` on ``spreadsheet``."""
-
-    return _run_sync(spreadsheet.batch_update, request_body)
+    return await _to_thread(worksheet.update, a1_range, values, timeout=timeout)
 
 
 async def abatch_update(
-    spreadsheet: Any, request_body: dict[str, Any], *, timeout: float | None = None
+    spreadsheet: Any,
+    request_body: dict[str, Any],
+    *,
+    timeout: float | None = _DEFAULT_TIMEOUT,
 ) -> Any:
     """Async wrapper for :func:`batch_update`."""
 
-    return await _run_async(spreadsheet.batch_update, request_body, timeout=timeout)
+    return await _to_thread(spreadsheet.batch_update, request_body, timeout=timeout)
 
 
 async def arun(
     func: Callable[P, T],
     *args: P.args,
-    timeout: float | None = None,
+    timeout: float | None = _DEFAULT_TIMEOUT,
     **kwargs: P.kwargs,
 ) -> T:
     """Generic adapter helper for executing arbitrary callables asynchronously."""
 
-    return await _run_async(func, *args, timeout=timeout, **kwargs)
+    return await _to_thread(func, *args, timeout=timeout, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add a lazily initialised ThreadPoolExecutor adapter with 15s wait_for semantics for Google Sheets helpers
- provide async counterparts in shared.sheets.core that reuse caches and async backoff, and delegate shared.sheets.async_core to them

## Testing
- python -m compileall shared/sheets/async_adapter.py shared/sheets/core.py shared/sheets/async_core.py

[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_6904794018e88323ab2440752ea1072e