### PR TITLE
Normalize imports for CoreOps and recruitment modules

### DIFF
--- a/modules/onboarding/__init__.py
+++ b/modules/onboarding/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from discord.ext import commands
 
-from .welcome_flow import start_welcome_dialog
+from modules.onboarding.welcome_flow import start_welcome_dialog
 
 __all__ = ["ensure_loaded", "start_welcome_dialog"]
 

--- a/modules/onboarding/controllers/promo_controller.py
+++ b/modules/onboarding/controllers/promo_controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from discord.ext import commands
 
-from .welcome_controller import BaseWelcomeController
+from modules.onboarding.controllers.welcome_controller import BaseWelcomeController
 
 
 class PromoController(BaseWelcomeController):

--- a/modules/onboarding/welcome_flow.py
+++ b/modules/onboarding/welcome_flow.py
@@ -10,14 +10,14 @@ from c1c_coreops import rbac
 from modules.common import feature_flags
 from modules.onboarding import logs
 
-from . import thread_scopes
-from .controllers.promo_controller import PromoController
-from .controllers.welcome_controller import (
+from modules.onboarding import thread_scopes
+from modules.onboarding.controllers.promo_controller import PromoController
+from modules.onboarding.controllers.welcome_controller import (
     WelcomeController,
     extract_target_from_message,
     locate_welcome_message,
 )
-from .ui import panels
+from modules.onboarding.ui import panels
 from shared.sheets import onboarding_questions
 
 __all__ = ["start_welcome_dialog"]

--- a/modules/recruitment/search.py
+++ b/modules/recruitment/search.py
@@ -15,8 +15,8 @@ from shared.sheets.recruitment import (
     RecruitmentClanRecord,
 )
 
-from . import search_helpers
-from .search_helpers import (
+from modules.recruitment import search_helpers
+from modules.recruitment.search_helpers import (
     parse_inactives_num,
     parse_spots_num,
     row_matches,

--- a/modules/recruitment/services/search.py
+++ b/modules/recruitment/services/search.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 
 from c1c_coreops.rbac import is_lead, is_recruiter
 
-from .. import ensure_loaded
+from modules.recruitment import ensure_loaded
 
 
 def recruiter_only(message: str = "Recruiter access only."):

--- a/modules/recruitment/views/__init__.py
+++ b/modules/recruitment/views/__init__.py
@@ -1,6 +1,9 @@
 """Recruitment view helpers."""
 
-from .member_panel_legacy import MemberPanelControllerLegacy, MemberPanelState
+from modules.recruitment.views.member_panel_legacy import (
+    MemberPanelControllerLegacy,
+    MemberPanelState,
+)
 
 __all__ = [
     "MemberPanelControllerLegacy",

--- a/modules/recruitment/views/filters_member.py
+++ b/modules/recruitment/views/filters_member.py
@@ -8,9 +8,12 @@ import discord
 from discord import InteractionResponded
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from .member_panel_legacy import MemberPanelControllerLegacy, MemberPanelState
+    from modules.recruitment.views.member_panel_legacy import (
+        MemberPanelControllerLegacy,
+        MemberPanelState,
+    )
 
-from .interaction_utils import defer_once
+from modules.recruitment.views.interaction_utils import defer_once
 
 
 CB_CHOICES = ["Easy", "Normal", "Hard", "Brutal", "NM", "UNM"]

--- a/modules/recruitment/views/member_panel.py
+++ b/modules/recruitment/views/member_panel.py
@@ -11,9 +11,9 @@ import discord
 from discord import Message
 from discord.ext import commands
 
-from .. import search as roster_search
-from ..search_helpers import format_filters_footer
-from .shared import MemberSearchPagedView
+from modules.recruitment import search as roster_search
+from modules.recruitment.search_helpers import format_filters_footer
+from modules.recruitment.views.shared import MemberSearchPagedView
 from shared import config as shared_config
 from shared.sheets.recruitment import RecruitmentClanRecord
 

--- a/modules/recruitment/views/member_panel_legacy.py
+++ b/modules/recruitment/views/member_panel_legacy.py
@@ -10,11 +10,11 @@ import discord
 from discord import InteractionResponded
 from discord.ext import commands
 
-from .. import search as roster_search
-from ..search_helpers import format_filters_footer
-from .filters_member import MemberFiltersView
-from .interaction_utils import defer_once
-from .shared_member import MemberSearchPagedView
+from modules.recruitment import search as roster_search
+from modules.recruitment.search_helpers import format_filters_footer
+from modules.recruitment.views.filters_member import MemberFiltersView
+from modules.recruitment.views.interaction_utils import defer_once
+from modules.recruitment.views.shared_member import MemberSearchPagedView
 from shared import config as shared_config
 from shared.sheets.recruitment import RecruitmentClanRecord
 

--- a/modules/recruitment/views/recruiter_panel.py
+++ b/modules/recruitment/views/recruiter_panel.py
@@ -16,12 +16,14 @@ from typing import TYPE_CHECKING, Optional, Sequence
 import discord
 from discord import InteractionResponded
 
-from .. import cards
-from .. import search as roster_search
-from ..search_helpers import format_filters_footer as _format_filters_footer
+from modules.recruitment import cards
+from modules.recruitment import search as roster_search
+from modules.recruitment.search_helpers import (
+    format_filters_footer as _format_filters_footer,
+)
 from modules.common import config_access as config
 from shared.sheets.recruitment import RecruitmentClanRecord
-from .results_pager import ResultsPagerView
+from modules.recruitment.views.results_pager import ResultsPagerView
 
 if TYPE_CHECKING:
     from cogs.recruitment_recruiter import RecruiterPanelCog

--- a/modules/recruitment/views/shared.py
+++ b/modules/recruitment/views/shared.py
@@ -7,7 +7,7 @@ from typing import Callable, Mapping, Sequence
 
 import discord
 
-from .. import cards, emoji_pipeline
+from modules.recruitment import cards, emoji_pipeline
 from shared.sheets.recruitment import RecruitmentClanRecord
 
 PAGE_SIZE = 5
@@ -113,7 +113,7 @@ class MemberSearchPagedView(discord.ui.View):
         files: list[discord.File] = []
 
         if not self.rows:
-            from .member_panel import _build_empty_embed
+            from modules.recruitment.views.member_panel import _build_empty_embed
 
             return [_build_empty_embed(self.filters_text)], []
 

--- a/modules/recruitment/views/shared_member.py
+++ b/modules/recruitment/views/shared_member.py
@@ -8,7 +8,7 @@ from typing import Iterable, Sequence
 import discord
 from discord import InteractionResponded
 
-from .. import cards, emoji_pipeline
+from modules.recruitment import cards, emoji_pipeline
 from shared.sheets.recruitment import RecruitmentClanRecord
 
 PAGE_SIZE = 5

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -27,7 +27,7 @@ from config.runtime import (
     get_watchdog_stall_sec,
 )
 from shared import socket_heartbeat as hb
-from .render import (
+from c1c_coreops.render import (
     ChecksheetEmbedData,
     ChecksheetSheetEntry,
     ChecksheetTabEntry,
@@ -46,7 +46,7 @@ from shared.cache import telemetry as cache_telemetry
 from shared.cache.telemetry import get_snapshot as cache_get_snapshot
 from shared.cache.telemetry import humanize_duration as cache_humanize_duration
 from shared.cache.telemetry import list_buckets as cache_list_buckets
-from .help import (
+from c1c_coreops.help import (
     COREOPS_VERSION,
     HelpCommandInfo,
     HelpTier,
@@ -55,7 +55,7 @@ from .help import (
     build_help_detail_embed,
     build_help_overview_embeds,
 )
-from .helpers import help_metadata, tier
+from c1c_coreops.helpers import help_metadata, tier
 from shared.redaction import sanitize_embed, sanitize_log, sanitize_text
 from shared.obs.events import (
     format_refresh_message,
@@ -71,10 +71,10 @@ from shared.sheets.async_core import (
 )
 from shared.sheets.recruitment import get_reports_tab_name
 
-from .config import CoreOpsSettings, load_coreops_settings, normalize_command_text
-from .prefix import detect_admin_bang_command
-from .tags import lifecycle_tag
-from .rbac import (
+from c1c_coreops.config import CoreOpsSettings, load_coreops_settings, normalize_command_text
+from c1c_coreops.prefix import detect_admin_bang_command
+from c1c_coreops.tags import lifecycle_tag
+from c1c_coreops.rbac import (
     admin_only,
     can_view_admin,
     can_view_staff,
@@ -612,7 +612,7 @@ def _admin_roles_configured() -> bool:
     """Return True when admin roles are configured (defaults to True)."""
 
     try:
-        from .rbac import admin_roles_configured  # type: ignore
+        from c1c_coreops.rbac import admin_roles_configured  # type: ignore
     except Exception:
         return True
     try:

--- a/packages/c1c-coreops/src/c1c_coreops/commands/__init__.py
+++ b/packages/c1c-coreops/src/c1c_coreops/commands/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import reload
+from c1c_coreops.commands import reload
 
 __all__ = ["reload"]

--- a/packages/c1c-coreops/src/c1c_coreops/commands/reload.py
+++ b/packages/c1c-coreops/src/c1c_coreops/commands/reload.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 from modules.common import runtime
 from shared import config as cfg
 
-from ..helpers import help_metadata
+from c1c_coreops.helpers import help_metadata
 
 logger = logging.getLogger("c1c.coreops.commands.reload")
 

--- a/packages/c1c-coreops/src/c1c_coreops/render.py
+++ b/packages/c1c-coreops/src/c1c_coreops/render.py
@@ -9,9 +9,9 @@ from typing import Sequence
 
 import discord
 
-from .help import COREOPS_VERSION, build_coreops_footer
+from c1c_coreops.help import COREOPS_VERSION, build_coreops_footer
 from shared.utils import humanize_duration
-from .tags import lifecycle_tag
+from c1c_coreops.tags import lifecycle_tag
 
 def _hms(seconds: float) -> str:
     s = int(max(0, seconds))


### PR DESCRIPTION
## Summary
- replace intra-package relative imports in CoreOps cog, render helpers, and reload command with absolute `c1c_coreops` imports to avoid implicit side effects
- normalize recruitment and onboarding module imports to absolute package paths while keeping public re-exports intact

## Testing
- `python -m compileall modules/onboarding modules/recruitment packages/c1c-coreops/src/c1c_coreops`
[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_69047eb8d12883239ffaf707122b9f49