### PR TITLE
Fix welcome panel targeting and make welcome panel persistent

### DIFF
--- a/docs/ops/Welcome.md
+++ b/docs/ops/Welcome.md
@@ -1,0 +1,6 @@
+# Welcome Panel Operations
+
+- The onboarding panel no longer expires automatically; recruits can reopen the form via **Open questions** whenever needed.
+- If the panel message is missing, react with 🎫 on the welcome post to spawn a fresh panel.
+
+Doc last updated: 2025-10-31 (v0.9.7)

--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -308,7 +308,6 @@ class OnboardingReactionFallbackCog(commands.Cog):
                 member,
                 source="emoji",
                 bot=self.bot,
-                panel_message_id=target_message_id,
             )
         except Exception as exc:
             failure_context = _base_context(member=member, thread=thread)

--- a/modules/onboarding/session_store.py
+++ b/modules/onboarding/session_store.py
@@ -135,6 +135,10 @@ class SessionStore:
         if session._timeout_handle is not None:
             session._timeout_handle.cancel()
 
+        if session._timeout_callback is None:
+            session._timeout_handle = None
+            return
+
         delay = max(1.0, self._timeout)
 
         def _runner() -> None:
@@ -145,6 +149,9 @@ class SessionStore:
     async def _maybe_timeout(self, thread_id: int) -> None:
         session = self._sessions.get(thread_id)
         if not session:
+            return
+        if session._timeout_callback is None:
+            session._timeout_handle = None
             return
         now = time.monotonic()
         if now - session.last_active < self._timeout:

--- a/tests/welcome/test_welcome_panel.py
+++ b/tests/welcome/test_welcome_panel.py
@@ -1,0 +1,142 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from modules.onboarding.controllers import welcome_controller as welcome
+from modules.onboarding.ui import panels
+
+
+class _DummyMessage(SimpleNamespace):
+    pass
+
+
+def test_locate_welcome_message_skips_thread_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        message = _DummyMessage(id=9001, content="hello")
+        fetch_mock = AsyncMock(side_effect=AssertionError("fetch should not be called"))
+
+        class DummyThread:
+            def __init__(self) -> None:
+                self.id = 1234
+                self.starter_message = None
+                self.fetch_message = fetch_mock
+                self.parent = None
+
+            def history(self, **_: object):  # pragma: no cover - signature shim
+                async def _iter():
+                    yield message
+
+                return _iter()
+
+        thread = DummyThread()
+
+        result = await welcome.locate_welcome_message(thread)
+
+        assert result is message
+        fetch_mock.assert_not_awaited()
+
+    asyncio.run(runner())
+
+
+def test_panel_button_launch_sends_modal(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        monkeypatch.setattr(panels.diag, "is_enabled", lambda: False)
+        monkeypatch.setattr(panels.logs, "send_welcome_log", AsyncMock())
+        monkeypatch.setattr(panels.rbac, "is_admin_member", lambda actor: False)
+        monkeypatch.setattr(panels.rbac, "is_recruiter", lambda actor: False)
+
+        controller = MagicMock()
+        controller.diag_target_user_id = MagicMock(return_value=5555)
+        controller.check_interaction = AsyncMock(return_value=(True, None))
+
+        async def _fake_modal_launch(thread_id: int, interaction, *, context=None):
+            await interaction.response.send_modal("sentinel")
+
+        controller._handle_modal_launch = AsyncMock(side_effect=_fake_modal_launch)
+
+        thread_id = 7777
+        view = panels.OpenQuestionsPanelView(controller=controller, thread_id=thread_id)
+
+        response = SimpleNamespace(
+            is_done=MagicMock(return_value=False),
+            send_modal=AsyncMock(),
+        )
+        followup = SimpleNamespace(send=AsyncMock())
+        app_permissions = SimpleNamespace(
+            send_messages=True,
+            send_messages_in_threads=True,
+            embed_links=True,
+            read_message_history=True,
+        )
+        interaction = SimpleNamespace(
+            response=response,
+            followup=followup,
+            user=SimpleNamespace(id=5555, roles=[]),
+            channel=None,
+            channel_id=thread_id,
+            message=_DummyMessage(id=3333),
+            app_permissions=app_permissions,
+        )
+
+        button = next(child for child in view.children if child.custom_id == panels.OPEN_QUESTIONS_CUSTOM_ID)
+        await button.callback(interaction)
+
+        controller._handle_modal_launch.assert_awaited_once()
+        response.send_modal.assert_awaited_once()
+        assert response.send_modal.await_args.args[0] == "sentinel"
+
+    asyncio.run(runner())
+
+
+def test_panel_button_denied_routes_followup(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        logs_mock = AsyncMock()
+        monkeypatch.setattr(panels.diag, "is_enabled", lambda: False)
+        monkeypatch.setattr(panels.logs, "send_welcome_log", logs_mock)
+        monkeypatch.setattr(panels.rbac, "is_admin_member", lambda actor: False)
+        monkeypatch.setattr(panels.rbac, "is_recruiter", lambda actor: False)
+
+        controller = MagicMock()
+        controller.diag_target_user_id = MagicMock(return_value=None)
+        controller.check_interaction = AsyncMock(return_value=(False, "denied"))
+        controller._handle_modal_launch = AsyncMock()
+
+        thread_id = 4242
+        view = panels.OpenQuestionsPanelView(controller=controller, thread_id=thread_id)
+
+        response = SimpleNamespace(
+            is_done=MagicMock(return_value=True),
+            send_modal=AsyncMock(),
+            send_message=AsyncMock(),
+        )
+        followup = SimpleNamespace(send=AsyncMock())
+        app_permissions = SimpleNamespace(
+            send_messages=True,
+            send_messages_in_threads=True,
+            embed_links=True,
+            read_message_history=True,
+        )
+        interaction = SimpleNamespace(
+            response=response,
+            followup=followup,
+            user=SimpleNamespace(id=9999, roles=[]),
+            channel=None,
+            channel_id=thread_id,
+            message=_DummyMessage(id=2222),
+            app_permissions=app_permissions,
+        )
+
+        button = next(child for child in view.children if child.custom_id == panels.OPEN_QUESTIONS_CUSTOM_ID)
+        await button.callback(interaction)
+
+        controller.check_interaction.assert_not_awaited()
+        controller._handle_modal_launch.assert_not_awaited()
+        followup.send.assert_awaited_once()
+        _, followup_kwargs = followup.send.await_args
+        assert followup_kwargs.get("ephemeral") is True
+        assert logs_mock.await_count == 1
+        assert logs_mock.await_args.kwargs.get("result") == "ambiguous_target"
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- stop fetching deleted thread starters when targeting the welcome panel and reuse interaction anchors when available
- drop the manual onboarding timeout logic and gate the panel button with a single-response access check
- document the persistent panel behaviour and add regression tests for panel targeting and button acknowledgements

## Testing
- pytest tests/welcome -q

------
https://chatgpt.com/codex/tasks/task_e_69048ad188008323bb527e2360911018