### PR TITLE
Ensure async sheets helpers avoid blocking client calls

### DIFF
--- a/shared/sheets/async_facade.py
+++ b/shared/sheets/async_facade.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, ParamSpec, TypeVar
 
-from shared.sheets import core as _core_sync
+from shared.sheets import async_core as _core_async
 from shared.sheets import recruitment as _recruitment_sync
 from . import async_adapter as _adapter
 
@@ -65,27 +65,27 @@ async def get_clan_by_tag(*args: Any, **kwargs: Any) -> Any:
 
 # === Core helpers that touch network/files ===
 async def open_by_key(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.open_by_key, *args, **kwargs)
+    return await _core_async.aopen_by_key(*args, **kwargs)
 
 
 async def get_worksheet(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.get_worksheet, *args, **kwargs)
+    return await _core_async.aget_worksheet(*args, **kwargs)
 
 
 async def fetch_records(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.fetch_records, *args, **kwargs)
+    return await _core_async.afetch_records(*args, **kwargs)
 
 
 async def fetch_values(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.fetch_values, *args, **kwargs)
+    return await _core_async.afetch_values(*args, **kwargs)
 
 
 async def sheets_read(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.sheets_read, *args, **kwargs)
+    return await _core_async.asheets_read(*args, **kwargs)
 
 
 async def call_with_backoff(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_core_sync.call_with_backoff, *args, **kwargs)
+    return await _core_async.acall_with_backoff(*args, **kwargs)
 
 
 __all__ = [

--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -146,7 +146,10 @@ async def aopen_by_key(sheet_id: str | None = None, *, timeout: float | None = N
     if resolved in _WorkbookCache:
         return _WorkbookCache[resolved]
 
-    client = get_service_account_client()
+    # ``get_service_account_client`` performs OAuth credential initialisation which
+    # may block while ``gspread`` loads service account data. Run it in the Sheets
+    # executor so the event loop stays responsive on first use.
+    client = await async_adapter.arun(get_service_account_client, timeout=timeout)
     kwargs: dict[str, Any] = {}
     if timeout is not None:
         kwargs["timeout"] = timeout


### PR DESCRIPTION
## Summary
- run service account client construction for async callers through the Sheets adapter executor
- route async facade helpers to the async core wrappers instead of thread-hopping the sync variants
- extend the C-01 guardrail scanner with an AST check that flags gspread/googleapiclient usage inside shared/sheets async defs

## Testing
- python -m compileall shared/sheets scripts/ci/guardrails_suite.py
[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_69048a100da483238852586bf32a2a31