### PR TITLE
Fix async sheets read wrapper to use async core helpers

### DIFF
--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -149,15 +149,14 @@ async def aopen_by_key(sheet_id: str | None = None, *, timeout: float | None = N
     # ``get_service_account_client`` performs OAuth credential initialisation which
     # may block while ``gspread`` loads service account data. Run it in the Sheets
     # executor so the event loop stays responsive on first use.
-    client = await async_adapter.arun(get_service_account_client, timeout=timeout)
-    kwargs: dict[str, Any] = {}
+    run_kwargs: dict[str, Any] = {}
     if timeout is not None:
         run_kwargs["timeout"] = timeout
-    client = await async_adapter.arun(get_service_account_client, **run_kwargs)
-    kwargs: dict[str, Any] = dict(run_kwargs)
+
+    client = await async_adapter.arun(get_service_account_client)
 
     workbook = await _retry_with_backoff_async(
-        async_adapter.aopen_spreadsheet, client, resolved, **kwargs
+        async_adapter.aopen_spreadsheet, client, resolved, **run_kwargs
     )
     _WorkbookCache[resolved] = workbook
     return workbook


### PR DESCRIPTION
## Summary
- add the missing `asheets_read` proxy in `shared.sheets.async_core` and export it
- ensure optional timeouts are only applied to async adapter calls from `aopen_by_key`
- update the facade integration test to stub the async adapter surface now used by the async path

## Testing
- pytest tests/integration/test_sheets_facade_core_wrappers.py::test_core_read_wrapper_uses_async_adapter -q
- python -m compileall shared/sheets scripts/ci/guardrails_suite.py
[meta]
labels: guardrails, infra, codex
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_69048a100da483238852586bf32a2a31