### PR TITLE
Fix welcome watcher startup crash

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import discord
 from discord import RawReactionActionEvent
@@ -34,9 +35,11 @@ def _announce(bot: commands.Bot, message: str) -> None:
     log.info("welcome watcher notice: %s", message)
 
     async def runner() -> None:
+        await bot.wait_until_ready()
         await _send_runtime(message)
 
-    bot.loop.create_task(runner())
+    # discord.py 2.x restricts accessing Client.loop here; schedule via asyncio
+    asyncio.create_task(runner())
 
 
 def _actor_id(actor: discord.abc.User | None) -> int | None:


### PR DESCRIPTION
## Summary
- add asyncio import for welcome watcher bootstrap
- schedule announcement runner with asyncio.create_task after waiting for readiness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904ca3010b88323b8607ca7cecabb6b