### PR TITLE
Instrument welcome panel errors with structured logging

### DIFF
--- a/modules/onboarding/logs.py
+++ b/modules/onboarding/logs.py
@@ -24,6 +24,7 @@ __all__ = [
     "thread_context",
     "send_welcome_log",
     "send_welcome_exception",
+    "log_view_error",
 ]
 
 log = logging.getLogger("c1c.onboarding.logs")
@@ -187,6 +188,15 @@ async def send_welcome_exception(level: str, error: BaseException, **kv: Any) ->
     details["error"] = f"{error.__class__.__name__}: {error}"
     details["trace"] = trace
     await send_welcome_log(level, **details)
+
+
+def log_view_error(extra: Mapping[str, Any] | None, err: BaseException) -> None:
+    payload = dict(extra or {})
+    log.error(
+        "welcome view error",
+        exc_info=(err.__class__, err, err.__traceback__),
+        extra=payload,
+    )
 
 
 def _dedupe_key(payload: Mapping[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary
- add a reusable onboarding log helper for view-level exceptions
- wrap the welcome panel button handler with a fallback interaction notice and re-raise failures
- capture interaction context in OpenQuestionsPanelView.on_error and log structured diagnostics for debugging

## Testing
- python -m compileall modules/onboarding/ui/panels.py modules/onboarding/logs.py

------
https://chatgpt.com/codex/tasks/task_e_6904ce77755083238d88f342650dc965