### PR TITLE
Welcome flow — authorize by thread read access; remove target resolution

### DIFF
--- a/docs/ops/WelcomeFlow.md
+++ b/docs/ops/WelcomeFlow.md
@@ -14,10 +14,9 @@ The welcome questionnaire now runs entirely inside the ticket thread. Recruits (
 - **Greeting phrase:** When a message in the welcome thread contains `"awake by reacting with"` (case-insensitive) the bot reacts 👍 and posts the panel.
 - **🎫 emoji:** When the recruit, a RecruitmentCoordinator, or a GuardianKnight adds 🎫 in the welcome thread the bot posts another panel message. The watcher never edits existing panels—each trigger posts a new one to avoid stale-message errors.
 
-## Eligibility
-- **Recruit:** The thread owner can always launch or resume the modal flow.
-- **Staff:** Members with RecruitmentCoordinator or GuardianKnight roles can start the flow on behalf of the recruit.
-- **Others:** Everyone else receives an ephemeral notice that the panel is restricted, and the watcher logs the blocked attempt.
+### Authorization
+A user may open and complete the onboarding questionnaire if they can read the welcome thread.
+No target-user resolution is required. Recruiter/Admin roles are not needed to kick off or complete the flow.
 
 ## Restart rules
 - Sessions survive restarts thanks to the persistent view ID. If the modal flow is already in progress, pressing the button offers a resume/restart choice. Losing in-memory state is harmless—the recruit can simply start over.

--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -6,8 +6,7 @@ from typing import Any, Dict, Optional
 
 import discord
 
-from c1c_coreops import rbac
-
+from c1c_coreops import rbac  # Retained for compatibility with existing tests/hooks.
 from modules.onboarding import diag, logs
 
 __all__ = [
@@ -290,29 +289,7 @@ class OpenQuestionsPanelView(discord.ui.View):
 
         actor = interaction.user
         actor_id = getattr(actor, "id", None)
-        actor_is_target = (
-            target_user_id is not None
-            and actor_id is not None
-            and int(actor_id) == int(target_user_id)
-        )
-        actor_is_privileged = bool(rbac.is_admin_member(actor) or rbac.is_recruiter(actor))
-        can_use = actor_is_target or actor_is_privileged
-
-        if not can_use:
-            notice = "⚠️ This panel is reserved for the recruit and authorized recruiters."
-            result = "ambiguous_target" if target_user_id is None else "denied_role"
-            extra: dict[str, Any] = {}
-            if result == "denied_role":
-                extra["reason"] = "missing_roles"
-            await logs.send_welcome_log("warn", result=result, **log_context, **extra)
-            try:
-                if interaction.response.is_done():
-                    await interaction.followup.send(notice, ephemeral=True)
-                else:
-                    await interaction.response.send_message(notice, ephemeral=True)
-            except Exception:  # pragma: no cover - defensive logging
-                log.warning("failed to send panel access notice", exc_info=True)
-            return
+        # UI no longer pre-authorizes; controller enforces the permission rule.
 
         if missing:
             await logs.send_welcome_log(

--- a/tests/welcome/test_welcome_panel.py
+++ b/tests/welcome/test_welcome_panel.py
@@ -131,12 +131,10 @@ def test_panel_button_denied_routes_followup(monkeypatch: pytest.MonkeyPatch) ->
         button = next(child for child in view.children if child.custom_id == panels.OPEN_QUESTIONS_CUSTOM_ID)
         await button.callback(interaction)
 
-        controller.check_interaction.assert_not_awaited()
+        controller.check_interaction.assert_awaited_once()
         controller._handle_modal_launch.assert_not_awaited()
-        followup.send.assert_awaited_once()
-        _, followup_kwargs = followup.send.await_args
-        assert followup_kwargs.get("ephemeral") is True
+        followup.send.assert_not_awaited()
         assert logs_mock.await_count == 1
-        assert logs_mock.await_args.kwargs.get("result") == "ambiguous_target"
+        assert logs_mock.await_args.kwargs.get("result") == "clicked"
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- Replace the welcome flow target/role gate with a channel permission check so thread readers can launch the questionnaire.
- Let the panel UI defer authorization to the controller and keep the button logging clean.
- Update docs and tests to describe and exercise the new rule.

## Changes
- modules/onboarding/controllers/welcome_controller.py: simplify `check_interaction` to rely on `permissions_for` and remove role checks.
- modules/onboarding/ui/panels.py: drop the ambiguous-target/privileged gate and keep the rbac shim for existing hooks.
- docs/ops/WelcomeFlow.md: describe the read-access rule and retain the doc footer.
- tests/welcome/test_welcome_panel.py: align expectations with the controller-driven authorization path.

## Risk
- Low. Scope is isolated to the onboarding welcome flow.

## Validation
- pytest tests/welcome/test_welcome_panel.py

------
https://chatgpt.com/codex/tasks/task_e_6904e8d78d908323ae5a5a5bc77c4804