### PR TITLE
Allow onboarding without thread send permission

### DIFF
--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -1034,22 +1034,6 @@ class BaseWelcomeController:
             )
             return False, "no_read"
 
-        if isinstance(subject, discord.Thread) and not perms.send_messages_in_threads:
-            if log_context is not None:
-                await self._log_access(
-                    "warn",
-                    "denied_permission",
-                    thread_id,
-                    interaction,
-                    log_context,
-                    reason="no_thread_send",
-                )
-            await _safe_ephemeral(
-                interaction,
-                "⚠️ I need permission to reply in this thread before opening the onboarding form.",
-            )
-            return False, "no_thread_send"
-
         if actor_id is not None:
             allowed_cache.add(int(actor_id))
         if log_context is not None:


### PR DESCRIPTION
## Summary
- allow onboarding interactions to proceed when the actor only has read access to the thread
- remove the obsolete permission gate that required send_messages_in_threads

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6904ecb15fc88323806e964a9369eeec