### PR TITLE
Handle onboarding interactions missing followup handlers

### DIFF
--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -82,8 +82,12 @@ async def _edit_original_response(
         await interaction.edit_original_response(content=content)
     except Exception as exc:  # pragma: no cover - defensive fallback
         _log_followup_fallback(interaction, action="edit_original", error=exc)
+        followup = getattr(interaction, "followup", None)
+        if followup is None:
+            log.debug("followup handler missing; skipping deferred notice")
+            return
         try:
-            await interaction.followup.send(content, ephemeral=True)
+            await followup.send(content, ephemeral=True)
         except Exception:  # pragma: no cover - final guard
             log.warning("failed to send followup notice", exc_info=True)
 


### PR DESCRIPTION
## Summary
- guard deferred response helpers when discord interactions expose no followup webhook
- avoid raising when modal follow-up sends lack a client/http context and emit diagnostics instead

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6905065b6d788323a6dc5d80ae7b3999