### PR TITLE
chore: simplify logging defaults and env handling

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -24,7 +24,7 @@ Meta: Cache age 42s · Next refresh 02:15 UTC · Actor startup
 
 **Required at startup:** `DISCORD_TOKEN`, `GSPREAD_CREDENTIALS`, `RECRUITMENT_SHEET_ID`
 
-**Optional (warn once when unset):** `ONBOARDING_SHEET_ID`, `ENV_NAME`, `BOT_NAME`, `PUBLIC_BASE_URL`, `RENDER_EXTERNAL_URL`, `LOG_CHANNEL_ID`, `WATCHDOG_CHECK_SEC`, `WATCHDOG_STALL_SEC`, `WATCHDOG_DISCONNECT_GRACE_SEC`
+**Optional:** `ONBOARDING_SHEET_ID`, `ENV_NAME`, `BOT_NAME`, `PUBLIC_BASE_URL`, `RENDER_EXTERNAL_URL`, `LOG_CHANNEL_ID`, `WATCHDOG_CHECK_SEC`, `WATCHDOG_STALL_SEC`, `WATCHDOG_DISCONNECT_GRACE_SEC`
 
 Missing any **Required** key causes the bot to exit with an error at startup. If `LOG_CHANNEL_ID` is empty, Discord channel logging is disabled and a one-time startup warning is emitted.
 
@@ -105,7 +105,7 @@ sync modules remain available for non-async scripts and cache warmers.
 ### Media rendering
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `PUBLIC_BASE_URL` | url | — | External base URL for `/emoji-pad`; falls back to `RENDER_EXTERNAL_URL` when unset. |
+| `PUBLIC_BASE_URL` | url | — | External base URL for `/emoji-pad`; falls back silently to `RENDER_EXTERNAL_URL` when unset. |
 | `RENDER_EXTERNAL_URL` | url | — | Render.com external hostname used when `PUBLIC_BASE_URL` is not provided. |
 | `EMOJI_MAX_BYTES` | int | `2000000` | Maximum emoji payload size accepted by `/emoji-pad`. |
 | `EMOJI_PAD_SIZE` | int | `256` | Square canvas dimension for padded emoji PNGs. |

--- a/docs/ops/Logging.md
+++ b/docs/ops/Logging.md
@@ -66,7 +66,7 @@ Line mode:
 ```
 
 ## Dedupe policy
-- Window: configurable via `LOG_DEDUPE_WINDOW_S` (default 5s). All dedupe is in-memory and process-local.
+- Window: fixed at 5 seconds. All dedupe is in-memory and process-local.
 - Keys:
   - Refresh summaries: `refresh:{scope}:{snapshot_id}` (snapshot ID optional; falls back to a timestamp bucket hash of the bucket list).
   - Welcome summaries: `welcome:{tag}:{recruit_id}` (recruit ID falls back to `0` when unavailable).
@@ -74,9 +74,7 @@ Line mode:
 - Within the window, only the first event is emitted; later duplicates are ignored to keep the Discord channel readable.
 
 ## Configuration knobs
-- `LOG_DEDUPE_WINDOW_S` (float, default `5`): adjusts the shared dedupe horizon for refresh, welcome, and permission sync events.
-- `LOG_REFRESH_RENDER_MODE` (`plain`, `line`, or `table`, default `plain`): toggles between the compact one-line refresh summary and the code-block table layout.
-- `LOG_INCLUDE_NUMERIC_IDS` (`true`/`false`, default `true`): appends the raw numeric ID in parentheses after each label when enabled.
+No runtime environment flags affect logging templates. Numeric snowflake IDs stay hidden, and refresh summaries always use the concise inline layout.
 
 ## Operational rules
 - Do not call Discord `fetch_*` APIs purely for logging; the helpers rely on cached objects and gracefully degrade to `#unknown` placeholders.

--- a/modules/onboarding/logs.py
+++ b/modules/onboarding/logs.py
@@ -10,7 +10,6 @@ import discord
 
 from modules.common import runtime as rt
 from shared import logfmt
-from shared.config import get_log_dedupe_window_s
 from shared.dedupe import EventDeduper
 
 __all__ = [
@@ -30,7 +29,7 @@ __all__ = [
 log = logging.getLogger("c1c.onboarding.logs")
 
 _LOG_METHODS: dict[str, Callable[[str, Any], None]] = {}
-_PANEL_DEDUPER = EventDeduper(window_s=get_log_dedupe_window_s())
+_PANEL_DEDUPER = EventDeduper()
 
 
 def _resolve_logger(level: str) -> Callable[[str, Any], None]:

--- a/modules/ops/permissions_sync.py
+++ b/modules/ops/permissions_sync.py
@@ -20,7 +20,6 @@ from discord.ext import commands
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
 from modules.common import runtime as runtime_helpers
-from shared.config import get_log_dedupe_window_s
 from shared.dedupe import EventDeduper
 from shared.logfmt import LogTemplates
 from shared.permissions.bot_access_profile import (
@@ -35,7 +34,7 @@ __all__ = ["BotPermissionManager", "BotPermissionCog", "setup"]
 
 log = logging.getLogger(__name__)
 
-_PERM_SYNC_DEDUPER = EventDeduper(window_s=get_log_dedupe_window_s())
+_PERM_SYNC_DEDUPER = EventDeduper()
 
 DEFAULT_CONFIG_PATH = Path("config/bot_access_lists.json")
 AUDIT_DIR = Path("AUDIT/diagnostics")

--- a/modules/recruitment/welcome.py
+++ b/modules/recruitment/welcome.py
@@ -24,7 +24,6 @@ from shared.obs.events import (
 from modules.recruitment import emoji_pipeline
 from shared.cache import telemetry as cache_telemetry
 from shared.config import (
-    get_log_dedupe_window_s,
     get_refresh_timezone,
     get_welcome_general_channel_id,
 )
@@ -44,7 +43,7 @@ _DEFAULT_GENERAL_NOTICE = (
     "Be loud, be nerdy, and maybe even helpful. You know the drill, C1C."
 )
 
-_WELCOME_DEDUPER = EventDeduper(window_s=get_log_dedupe_window_s())
+_WELCOME_DEDUPER = EventDeduper()
 
 log = logging.getLogger(__name__)
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -24,9 +24,6 @@ __all__ = [
     "get_allowed_guild_ids",
     "is_guild_allowed",
     "get_log_channel_id",
-    "get_log_dedupe_window_s",
-    "get_log_refresh_render_mode",
-    "get_log_include_numeric_ids",
     "get_notify_channel_id",
     "get_notify_ping_role_id",
     "get_recruiters_thread_id",
@@ -73,22 +70,6 @@ _REQUIRED_ENV = (
     "RECRUITMENT_SHEET_ID",
 )
 
-_OPTIONAL_ENV = (
-    "ONBOARDING_SHEET_ID",
-    "ENV_NAME",
-    "BOT_NAME",
-    "PUBLIC_BASE_URL",
-    "RENDER_EXTERNAL_URL",
-    "LOG_CHANNEL_ID",
-    "LOG_DEDUPE_WINDOW_S",
-    "LOG_REFRESH_RENDER_MODE",
-    "LOG_INCLUDE_NUMERIC_IDS",
-    "WATCHDOG_CHECK_SEC",
-    "WATCHDOG_STALL_SEC",
-    "WATCHDOG_DISCONNECT_GRACE_SEC",
-)
-
-
 def _require_env(name: str) -> str:
     value = os.getenv(name)
     if value is None or str(value).strip() == "":
@@ -96,20 +77,8 @@ def _require_env(name: str) -> str:
     return value
 
 
-def _warn_if_missing(name: str) -> None:
-    if os.getenv(name) in (None, ""):
-        log.warning(
-            "Optional env %s is not set; related features may be disabled.",
-            name,
-        )
-
-
 for _name in _REQUIRED_ENV:
     _require_env(_name)
-
-for _name in _OPTIONAL_ENV:
-    if _name != "LOG_CHANNEL_ID":
-        _warn_if_missing(_name)
 
 _SECRET_VALUE = "set"
 _MISSING_VALUE = "—"
@@ -347,10 +316,6 @@ def _load_config() -> Dict[str, object]:
         "TAG_BADGE_PX": _int_env("TAG_BADGE_PX", 128, min_value=32, max_value=512),
         "TAG_BADGE_BOX": _float_env("TAG_BADGE_BOX", 0.90, min_value=0.2, max_value=0.95),
         "STRICT_EMOJI_PROXY": _env_bool("STRICT_EMOJI_PROXY", True),
-        "LOG_DEDUPE_WINDOW_S": _float_env("LOG_DEDUPE_WINDOW_S", 5.0, min_value=0.0, max_value=60.0),
-        "LOG_REFRESH_RENDER_MODE": (os.getenv("LOG_REFRESH_RENDER_MODE") or "line").strip().lower()
-        or "line",
-        "LOG_INCLUDE_NUMERIC_IDS": _env_bool("LOG_INCLUDE_NUMERIC_IDS", False),
     }
 
     if os.getenv("ENABLE_WELCOME_WATCHER") not in (None, ""):
@@ -366,10 +331,6 @@ def reload_config() -> Dict[str, object]:
 
     for _name in _REQUIRED_ENV:
         _require_env(_name)
-
-    for _name in _OPTIONAL_ENV:
-        if _name != "LOG_CHANNEL_ID":
-            _warn_if_missing(_name)
 
     snapshot = _load_config()
 
@@ -486,36 +447,6 @@ def _optional_id(key: str) -> Optional[int]:
 
 def get_log_channel_id() -> Optional[int]:
     return _optional_id("LOG_CHANNEL_ID")
-
-
-def get_log_dedupe_window_s(default: float = 5.0) -> float:
-    value = _CONFIG.get("LOG_DEDUPE_WINDOW_S")
-    try:
-        return float(value) if value is not None else float(default)
-    except (TypeError, ValueError):
-        return float(default)
-
-
-def get_log_refresh_render_mode(default: str = "plain") -> str:
-    value = _CONFIG.get("LOG_REFRESH_RENDER_MODE")
-    if isinstance(value, str) and value.strip():
-        normalized = value.strip().lower()
-        if normalized in {"line", "table", "plain"}:
-            return normalized
-    return default
-
-
-def get_log_include_numeric_ids() -> bool:
-    value = _CONFIG.get("LOG_INCLUDE_NUMERIC_IDS")
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str) and value.strip():
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off"}:
-            return False
-    return _env_bool("LOG_INCLUDE_NUMERIC_IDS", True)
 
 
 def get_notify_channel_id() -> Optional[int]:

--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -7,11 +7,6 @@ from typing import Mapping, Optional, Sequence
 
 import discord
 
-from shared.config import (
-    get_log_include_numeric_ids,
-    get_log_refresh_render_mode,
-)
-
 __all__ = [
     "LOG_EMOJI",
     "BucketResult",
@@ -39,9 +34,7 @@ LOG_EMOJI = {
 def _append_id(label: str, numeric_id: Optional[int]) -> str:
     if not numeric_id:
         return label
-    if not get_log_include_numeric_ids():
-        return label
-    return f"{label} ({numeric_id})"
+    return label
 
 
 def _clean_name(name: Optional[str], default: str) -> str:
@@ -421,7 +414,4 @@ class LogTemplates:
 
     @staticmethod
     def select_refresh_template(scope: str, buckets: Sequence[BucketResult], total_s: float) -> str:
-        mode = get_log_refresh_render_mode()
-        if mode == "table":
-            return LogTemplates.refresh_table(scope, buckets, total_s)
         return LogTemplates.refresh(scope, buckets, total_s)

--- a/shared/obs/events.py
+++ b/shared/obs/events.py
@@ -6,7 +6,6 @@ import hashlib
 import time
 from typing import Iterable, Sequence, TYPE_CHECKING
 
-from shared.config import get_log_dedupe_window_s
 from shared.dedupe import EventDeduper
 from shared.logfmt import BucketResult, LogTemplates, human_reason
 
@@ -21,7 +20,7 @@ __all__ = [
 ]
 
 
-_REFRESH_DEDUPER = EventDeduper(window_s=get_log_dedupe_window_s())
+_REFRESH_DEDUPER = EventDeduper()
 
 
 def refresh_deduper() -> EventDeduper:


### PR DESCRIPTION
## Summary
- remove unused logging-related environment variables and startup warnings from the config loader
- hardcode the standard dedupe window and inline refresh log formatting so logging no longer depends on env toggles
- update onboarding, permissions, and welcome modules plus operator docs to reflect the fixed logging behaviour and silent PUBLIC_BASE_URL fallback

## Testing
- pytest

[meta]
labels: comp:env, perf, bot:core
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_690513748cf08323900fe982a3fdc7a6