### PR TITLE
Fix welcome panel restart interaction timing

### DIFF
--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -628,9 +628,9 @@ class BaseWelcomeController:
         log_payload.setdefault("custom_id", panels.OPEN_QUESTIONS_CUSTOM_ID)
         log_payload["result"] = "restarted"
 
-        await logs.send_welcome_log("info", **log_payload)
-
         await _safe_ephemeral(interaction, "♻️ Restarting the onboarding form…")
+
+        await logs.send_welcome_log("info", **log_payload)
 
         self._cleanup_session(thread_id)
 

--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -463,9 +463,10 @@ class OpenQuestionsPanelView(discord.ui.View):
 
         restart_context = dict(log_context)
         restart_context["result"] = "restarted"
-        await logs.send_welcome_log("info", **restart_context)
 
         await self._notify_restart(interaction)
+
+        await logs.send_welcome_log("info", **restart_context)
 
         if not isinstance(thread, discord.Thread):
             failure_context = dict(restart_context)

--- a/tests/onboarding/test_open_questions_panel.py
+++ b/tests/onboarding/test_open_questions_panel.py
@@ -1,5 +1,10 @@
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import pytest
+
+from modules.onboarding.ui import panels
 from modules.onboarding.ui.panels import OpenQuestionsPanelView
 
 
@@ -14,5 +19,47 @@ def test_open_questions_button_has_custom_id() -> None:
 
         assert OpenQuestionsPanelView.CUSTOM_ID in button_ids
         assert view.timeout is None
+
+    asyncio.run(runner())
+
+
+def test_restart_from_view_responds_before_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        monkeypatch.setattr(panels.diag, "is_enabled", lambda: False)
+
+        class DummyResponse:
+            def __init__(self) -> None:
+                self.sent_messages: list[str] = []
+
+            def is_done(self) -> bool:
+                return bool(self.sent_messages)
+
+            async def send_message(self, message: str, *, ephemeral: bool = False) -> None:
+                if self.is_done():
+                    raise AssertionError("response already sent")
+                self.sent_messages.append(message)
+
+        response = DummyResponse()
+
+        async def fake_log(level: str, **payload: object) -> None:
+            assert response.is_done()
+
+        log_mock = AsyncMock(side_effect=fake_log)
+        monkeypatch.setattr(panels.logs, "send_welcome_log", log_mock)
+
+        view = OpenQuestionsPanelView()
+        interaction = SimpleNamespace(
+            response=response,
+            channel=None,
+            message=SimpleNamespace(id=1234),
+            user=SimpleNamespace(id=5678, display_name="Recruit"),
+            followup=None,
+        )
+
+        await view._restart_from_view(interaction, {"view": "panel"})
+
+        assert response.is_done()
+        assert response.sent_messages[0] == "♻️ Restarting the onboarding form…"
+        assert log_mock.await_count >= 1
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- send the restart acknowledgement before logging in the welcome panel persistent view so the interaction is acknowledged promptly
- reorder the controller restart fallback to defer to the user before emitting logs
- add a regression test that verifies the restart path responds before logging work begins

## Testing
- pytest tests/onboarding/test_open_questions_panel.py


------
https://chatgpt.com/codex/tasks/task_e_69052adffa808323b28515a2e98946ef