### PR TITLE
Ensure onboarding emoji handlers join threads before posting

### DIFF
--- a/modules/onboarding/thread_membership.py
+++ b/modules/onboarding/thread_membership.py
@@ -1,0 +1,49 @@
+"""Utilities for ensuring the bot has access to target threads."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import discord
+
+__all__ = ["ensure_thread_membership"]
+
+
+def _is_joined(thread: discord.Thread) -> bool:
+    """Return ``True`` when the bot is already a member of ``thread``."""
+
+    member = getattr(thread, "me", None)
+    if member is None:
+        return False
+
+    joined = getattr(member, "joined", None)
+    if joined is not None:
+        return bool(joined)
+
+    # Fallback: Discord may not expose ``joined`` on partial thread members.
+    identifier = getattr(member, "id", None) or getattr(member, "user_id", None)
+    return identifier is not None
+
+
+async def ensure_thread_membership(thread: discord.Thread) -> Tuple[bool, BaseException | None]:
+    """Ensure the bot has joined ``thread``.
+
+    Returns a tuple ``(joined, error)`` where ``joined`` indicates whether the
+    bot is a member after this call and ``error`` is the exception that occurred
+    while attempting to join (if any).
+    """
+
+    if _is_joined(thread):
+        return True, None
+
+    join = getattr(thread, "join", None)
+    if not callable(join):
+        return False, None
+
+    try:
+        await join()
+    except Exception as exc:  # pragma: no cover - exercised via unit tests
+        return False, exc
+
+    return True, None
+

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 from modules.common import feature_flags
 from modules.common import runtime as rt
-from modules.onboarding import logs, thread_scopes
+from modules.onboarding import logs, thread_membership, thread_scopes
 from modules.onboarding.ui import panels
 from shared.config import (
     get_guardian_knight_role_ids,
@@ -150,6 +150,21 @@ class WelcomeWatcher(commands.Cog):
         actor: discord.abc.User | None,
         source: str,
     ) -> None:
+        joined, join_error = await thread_membership.ensure_thread_membership(thread)
+        if not joined:
+            context = self._log_context(
+                thread,
+                actor,
+                source=source,
+                result="thread_join_failed",
+                reason="thread_join",
+            )
+            if join_error is not None:
+                await logs.send_welcome_exception("error", join_error, **context)
+            else:
+                await logs.send_welcome_log("error", **context)
+            return
+
         view = panels.OpenQuestionsPanelView()
         content = "Ready when you are — tap below to open the onboarding questions."
         try:

--- a/tests/onboarding/test_thread_membership.py
+++ b/tests/onboarding/test_thread_membership.py
@@ -1,0 +1,48 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.onboarding import thread_membership
+
+
+def test_skip_join_when_already_member():
+    join_mock = AsyncMock()
+    thread = SimpleNamespace(me=SimpleNamespace(joined=True), join=join_mock)
+
+    joined, error = asyncio.run(thread_membership.ensure_thread_membership(thread))
+
+    assert joined is True
+    assert error is None
+    join_mock.assert_not_called()
+
+
+def test_join_called_when_not_member():
+    join_mock = AsyncMock()
+    thread = SimpleNamespace(me=None, join=join_mock)
+
+    joined, error = asyncio.run(thread_membership.ensure_thread_membership(thread))
+
+    assert joined is True
+    assert error is None
+    join_mock.assert_awaited_once()
+
+
+def test_join_failure_returns_error():
+    exc = RuntimeError("join failed")
+    join_mock = AsyncMock(side_effect=exc)
+    thread = SimpleNamespace(me=None, join=join_mock)
+
+    joined, error = asyncio.run(thread_membership.ensure_thread_membership(thread))
+
+    assert joined is False
+    assert error is exc
+    join_mock.assert_awaited_once()
+
+
+def test_missing_join_returns_false():
+    thread = SimpleNamespace(me=None, join=None)
+
+    joined, error = asyncio.run(thread_membership.ensure_thread_membership(thread))
+
+    assert joined is False
+    assert error is None


### PR DESCRIPTION
## Summary
- add a reusable helper for ensuring the bot has joined onboarding threads
- require successful thread membership before posting welcome panels or launching the fallback flow, logging join failures
- expand reaction fallback coverage and add new tests for the membership helper

## Testing
- `pytest tests/onboarding/test_reaction_fallback.py tests/onboarding/test_thread_membership.py -q`
- `pytest -q` *(fails: welcome panel interaction tests expect deferred responses prior to modal launch)*

------
https://chatgpt.com/codex/tasks/task_e_69053922a3c88323be6375a7fb854e5d