### PR TITLE
Fix welcome modal launch to avoid pre-response and harden logging

### DIFF
--- a/docs/ops/WelcomeFlow.md
+++ b/docs/ops/WelcomeFlow.md
@@ -45,4 +45,8 @@ Gate instrumentation surfaces as single-line console logs:
 ```
 
 ---
-Doc last updated: 2025-10-31 (v0.9.7)
+## Known pitfalls
+
+- **Don't pre-respond before a modal.** `send_modal` must be the first response on the interaction; any prior defer/send forces Discord to reject the modal with `response_is_done: true`.
+
+Doc last updated: 2025-11-02 (v0.9.7)

--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -532,10 +532,6 @@ class OpenQuestionsPanelView(discord.ui.View):
         parent_channel = getattr(thread, "parent", None) if thread is not None else None
 
         extra: dict[str, Any] = {
-            "diag": "welcome_flow",
-            "event": "view_error",
-            "view": self.__class__.__name__,
-            "view_tag": WELCOME_PANEL_TAG,
             "custom_id": getattr(item, "custom_id", None),
             "component_type": item.__class__.__name__ if item is not None else None,
             "message_id": getattr(interaction.message, "id", None)
@@ -545,7 +541,6 @@ class OpenQuestionsPanelView(discord.ui.View):
             "actor": logs.format_actor(interaction.user),
             "actor_id": getattr(interaction.user, "id", None),
             "actor_name": logs.format_actor_handle(interaction.user),
-            "response_is_done": getattr(interaction.response, "is_done", lambda: None)(),
             "app_permissions": perms_text,
             "app_perms_text": perms_text,
             "app_permissions_snapshot": snapshot,
@@ -589,7 +584,13 @@ class OpenQuestionsPanelView(discord.ui.View):
                 extra.setdefault("channel", formatted)
 
         await self._ensure_error_notice(interaction)
-        logs.log_view_error(extra, error)
+        logs.log_view_error(
+            interaction,
+            self,
+            error,
+            tag=WELCOME_PANEL_TAG,
+            extra=extra,
+        )
 
     async def _notify_restart(self, interaction: discord.Interaction) -> None:
         message = "♻️ Restarting the onboarding form…"

--- a/tests/onboarding/test_logs.py
+++ b/tests/onboarding/test_logs.py
@@ -1,6 +1,41 @@
 import logging
+from types import SimpleNamespace
 
 from modules.onboarding import logs
+
+
+class _DummyResponse:
+    def __init__(self, *, done: bool = False) -> None:
+        self._done = done
+
+    def is_done(self) -> bool:
+        return self._done
+
+
+class _DummyUser:
+    def __init__(self) -> None:
+        self.id = 789
+        self.mention = "@Dummy"
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return "Dummy#1234"
+
+
+class _DummyView:
+    pass
+
+
+def _interaction(*, claimed: bool = False) -> SimpleNamespace:
+    interaction = SimpleNamespace()
+    interaction.data = {"custom_id": "welcome.panel.open", "component_type": 2}
+    interaction.message = SimpleNamespace(id=321)
+    interaction.id = 654
+    interaction.user = _DummyUser()
+    interaction.response = _DummyResponse()
+    interaction.app_permissions = SimpleNamespace(value=42)
+    if claimed:
+        interaction._c1c_claimed = True  # type: ignore[attr-defined]
+    return interaction
 
 
 def test_log_view_error_sanitizes_reserved_keys(caplog):
@@ -12,7 +47,7 @@ def test_log_view_error_sanitizes_reserved_keys(caplog):
     err = RuntimeError("boom")
 
     with caplog.at_level(logging.ERROR, logger="c1c.onboarding.logs"):
-        logs.log_view_error(extra, err)
+        logs.log_view_error(_interaction(), _DummyView(), err, tag="panel", extra=extra)
 
     record = caplog.records[-1]
     assert record.custom == "value"
@@ -31,7 +66,7 @@ def test_log_view_error_preserves_existing_alias(caplog):
     err = ValueError("nope")
 
     with caplog.at_level(logging.ERROR, logger="c1c.onboarding.logs"):
-        logs.log_view_error(extra, err)
+        logs.log_view_error(_interaction(claimed=True), _DummyView(), err, tag="panel", extra=extra)
 
     record = caplog.records[-1]
     assert record.context_thread == "<existing>"
@@ -39,3 +74,5 @@ def test_log_view_error_preserves_existing_alias(caplog):
     assert getattr(record, "context_thread_2") == "<456>"
     assert record.error_class == "ValueError"
     assert record.error_message == "nope"
+    # the claimed flag should be available and truthy when set
+    assert getattr(record, "claimed", None) is True


### PR DESCRIPTION
## Summary
- harden welcome view error logging so missing interaction attributes no longer mask exceptions
- guard the welcome modal launch from pre-responses, rehydrate missing question sets, and silently reset out-of-bounds state
- update the welcome flow runbook and tests to cover the new logging behaviour

## Testing
- pytest tests/onboarding/test_logs.py

------
https://chatgpt.com/codex/tasks/task_e_6907974545608323ac40891b84db19df