### PR TITLE
Guard welcome panel interaction claims

### DIFF
--- a/modules/onboarding/logs.py
+++ b/modules/onboarding/logs.py
@@ -286,7 +286,7 @@ def log_view_error(
         "actor_name": _safe(lambda: getattr(getattr(interaction, "user", None), "mention", None)),
         "response_is_done": _response_is_done(),
         "app_permissions": str(getattr(interaction, "app_permissions", None)),
-        "claimed": _safe(lambda: getattr(interaction, "_c1c_claimed", False), False),
+        "claimed": getattr(interaction, "_c1c_claimed", False),
     }
 
     if extra:


### PR DESCRIPTION
## Summary
- guard welcome panel interaction claiming behind a safe helper and call it before launching the modal
- tolerate interactions without the ad-hoc claim flag when logging errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69079ec4e7c08323af4d5c1f297d79da