### PR TITLE
Handle welcome modal fall-forward with retry button

### DIFF
--- a/modules/onboarding/ui/views.py
+++ b/modules/onboarding/ui/views.py
@@ -52,4 +52,78 @@ class NextStepView(discord.ui.View):
                 )
 
 
-__all__ = ["NextStepView"]
+class RetryStartView(discord.ui.View):
+    def __init__(self, controller, thread_id: int, *, timeout: Optional[float] = 300) -> None:
+        super().__init__(timeout=timeout)
+        self.controller = controller
+        self.thread_id = thread_id
+        self.add_item(self.OpenButton(self))
+
+    class OpenButton(discord.ui.Button):
+        def __init__(self, parent: "RetryStartView") -> None:
+            super().__init__(
+                label="Open questions",
+                style=discord.ButtonStyle.primary,
+                custom_id="welcome.panel.start.retry",
+            )
+            self.parent = parent
+
+        async def callback(self, interaction: discord.Interaction) -> None:
+            controller = self.parent.controller
+            thread_id = self.parent.thread_id
+
+            if controller is None or thread_id is None:
+                await _notify_retry_failure(interaction)
+                return
+
+            try:
+                modal = controller.build_modal_stub(thread_id)
+            except Exception:
+                log.warning("failed to build modal stub for retry start", exc_info=True)
+                await _notify_retry_failure(interaction)
+                return
+
+            try:
+                await interaction.response.send_modal(modal)
+            except discord.InteractionResponded:
+                return
+
+            if diag.is_enabled():
+                await diag.log_event(
+                    "info",
+                    "modal_launch_sent_retry",
+                    thread_id=thread_id,
+                    index=getattr(modal, "step_index", getattr(modal, "_c1c_index", 0)),
+                )
+
+
+async def _notify_retry_failure(interaction: discord.Interaction) -> None:
+    response = getattr(interaction, "response", None)
+    if response is None:
+        return
+
+    is_done = getattr(response, "is_done", None)
+    already_done = False
+    if callable(is_done):
+        try:
+            already_done = bool(is_done())
+        except Exception:
+            already_done = False
+    elif isinstance(is_done, bool):
+        already_done = is_done
+
+    if already_done:
+        return
+
+    try:
+        send_message = getattr(response, "send_message")
+        if callable(send_message):
+            await send_message(
+                "Couldn’t open the questions just now. Please press the button again.",
+                ephemeral=True,
+            )
+    except Exception:
+        log.warning("failed to notify user about retry start error", exc_info=True)
+
+
+__all__ = ["NextStepView", "RetryStartView"]


### PR DESCRIPTION
## Summary
- fall forward to a thread-level retry prompt when the welcome panel cannot send its modal
- add a RetryStartView button for launching a fresh modal interaction
- clear tracked retry prompts after the first successful modal submission

## Testing
- python -m compileall modules/onboarding/ui modules/onboarding/controllers/welcome_controller.py

------
https://chatgpt.com/codex/tasks/task_e_6907c20d23588323aa30af12aaec0b7e