### PR TITLE
Implement inline onboarding wizard

### DIFF
--- a/tests/welcome/test_welcome_panel.py
+++ b/tests/welcome/test_welcome_panel.py
@@ -40,29 +40,33 @@ def test_locate_welcome_message_skips_thread_fetch(monkeypatch: pytest.MonkeyPat
     asyncio.run(runner())
 
 
-def test_panel_button_launch_sends_modal(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_panel_button_launch_posts_wizard(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
         monkeypatch.setattr(panels.diag, "is_enabled", lambda: False)
         monkeypatch.setattr(panels.logs, "send_welcome_log", AsyncMock())
         monkeypatch.setattr(panels.rbac, "is_admin_member", lambda actor: False)
         monkeypatch.setattr(panels.rbac, "is_recruiter", lambda actor: False)
 
-        controller = MagicMock()
-        controller.build_modal_stub = MagicMock(return_value="sentinel")
-        controller.get_or_load_questions = AsyncMock(return_value=None)
-        controller._questions = {}
-
         thread_id = 7777
+        controller = SimpleNamespace()
+        question = {"label": "Question", "qid": "qid", "type": "short"}
+
+        async def _load(tid: int) -> None:
+            controller.questions_by_thread[tid] = [question]
+
+        controller.get_or_load_questions = AsyncMock(side_effect=_load)
+        controller.render_step = MagicMock(return_value="Question text")
+        controller.questions_by_thread = {}
+        controller.answers_by_thread = {}
+        controller.has_answer = MagicMock(return_value=False)
+        controller._question_key = lambda q: q.get("qid", "")
+        controller._answer_for = MagicMock(return_value=None)
+
         view = panels.OpenQuestionsPanelView(controller=controller, thread_id=thread_id)
 
         response = SimpleNamespace()
         response.is_done = MagicMock(return_value=False)
-
-        async def _defer(*_, **__):
-            response.is_done.return_value = True
-
-        response.defer = AsyncMock(side_effect=_defer)
-        response.send_modal = AsyncMock()
+        response.send_message = AsyncMock()
         followup = SimpleNamespace(send=AsyncMock())
         app_permissions = SimpleNamespace(
             send_messages=True,
@@ -70,6 +74,7 @@ def test_panel_button_launch_sends_modal(monkeypatch: pytest.MonkeyPatch) -> Non
             embed_links=True,
             read_message_history=True,
         )
+        original_message = SimpleNamespace(edit=AsyncMock())
         interaction = SimpleNamespace(
             response=response,
             followup=followup,
@@ -79,15 +84,20 @@ def test_panel_button_launch_sends_modal(monkeypatch: pytest.MonkeyPatch) -> Non
             channel_id=thread_id,
             message=_DummyMessage(id=3333),
             app_permissions=app_permissions,
+            original_response=AsyncMock(return_value=original_message),
         )
 
         button = next(child for child in view.children if child.custom_id == panels.OPEN_QUESTIONS_CUSTOM_ID)
         await button.callback(interaction)
 
         controller.get_or_load_questions.assert_awaited_once_with(thread_id)
-        controller.build_modal_stub.assert_called_once_with(thread_id)
-        response.defer.assert_not_awaited()
-        response.send_modal.assert_awaited_once_with("sentinel")
+        controller.render_step.assert_called_once_with(thread_id, 0)
+        response.send_message.assert_awaited()
+        args, kwargs = response.send_message.await_args
+        assert kwargs["content"] == "Question text"
+        assert isinstance(kwargs["view"], panels.OnboardWizard)
+        interaction.original_response.assert_awaited_once_with()
+        assert kwargs["view"].message is original_message
 
     asyncio.run(runner())
 
@@ -100,22 +110,22 @@ def test_panel_button_denied_routes_followup(monkeypatch: pytest.MonkeyPatch) ->
         monkeypatch.setattr(panels.rbac, "is_admin_member", lambda actor: False)
         monkeypatch.setattr(panels.rbac, "is_recruiter", lambda actor: False)
 
-        controller = MagicMock()
-        controller.build_modal_stub = MagicMock(return_value="sentinel")
-        controller.get_or_load_questions = AsyncMock(return_value=None)
-        controller._questions = {}
-
         thread_id = 4242
+        controller = SimpleNamespace()
+        controller.get_or_load_questions = AsyncMock(return_value=None)
+        controller.render_step = MagicMock(return_value="Question text")
+        controller.questions_by_thread = {thread_id: [{"label": "Question", "qid": "qid", "type": "short"}]}
+        controller.answers_by_thread = {}
+        controller.has_answer = MagicMock(return_value=False)
+        controller._question_key = lambda question: question.get("qid", "")
+        controller._answer_for = MagicMock(return_value=None)
+
         view = panels.OpenQuestionsPanelView(controller=controller, thread_id=thread_id)
+        retry_mock = AsyncMock()
+        monkeypatch.setattr(view, "_post_retry_start", retry_mock)
 
         response = SimpleNamespace()
-        response.is_done = MagicMock(return_value=False)
-
-        async def _defer(*_, **__):
-            response.is_done.return_value = True
-
-        response.defer = AsyncMock(side_effect=_defer)
-        response.send_modal = AsyncMock()
+        response.is_done = MagicMock(return_value=True)
         response.send_message = AsyncMock()
         followup = SimpleNamespace(send=AsyncMock())
         app_permissions = SimpleNamespace(
@@ -133,15 +143,16 @@ def test_panel_button_denied_routes_followup(monkeypatch: pytest.MonkeyPatch) ->
             channel_id=thread_id,
             message=_DummyMessage(id=2222),
             app_permissions=app_permissions,
+            original_response=AsyncMock(),
         )
 
         button = next(child for child in view.children if child.custom_id == panels.OPEN_QUESTIONS_CUSTOM_ID)
         await button.callback(interaction)
 
-        controller.get_or_load_questions.assert_awaited_once_with(thread_id)
-        controller.build_modal_stub.assert_called_once_with(thread_id)
-        followup.send.assert_not_awaited()
-        response.defer.assert_not_awaited()
-        assert logs_mock.await_count == 0
+        controller.get_or_load_questions.assert_not_awaited()
+        controller.render_step.assert_not_called()
+        response.send_message.assert_not_awaited()
+        retry_mock.assert_awaited_once()
+        interaction.original_response.assert_not_awaited()
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- replace the modal-based welcome question launcher with the inline OnboardWizard view backed by sheet questions
- capture answers through new controller state helpers and reuse the summary embed with recruiter role mentions on completion
- update welcome panel tests to exercise the inline wizard launch and retry handling paths

## Testing
- pytest tests/welcome/test_welcome_panel.py tests/onboarding/test_open_questions_panel.py

------
https://chatgpt.com/codex/tasks/task_e_69086e2df25c83239807a1397840a720