### PR TITLE
feat: route welcome onboarding to inline wizard

### DIFF
--- a/modules/onboarding/ui/views.py
+++ b/modules/onboarding/ui/views.py
@@ -25,9 +25,11 @@ class NextStepView(discord.ui.View):
 
         async def callback(self, interaction: discord.Interaction) -> None:
             try:
-                modal = self.parent.controller.build_modal_stub(self.parent.thread_id)
+                await self.parent.controller.render_inline_step(
+                    interaction, self.parent.thread_id
+                )
             except Exception:
-                log.warning("failed to build modal stub for next step", exc_info=True)
+                log.warning("failed to render inline step for next step", exc_info=True)
                 if not interaction.response.is_done():
                     try:
                         await interaction.response.send_message(
@@ -37,19 +39,6 @@ class NextStepView(discord.ui.View):
                     except Exception:
                         log.warning("failed to notify user about next-step error", exc_info=True)
                 return
-
-            try:
-                await interaction.response.send_modal(modal)
-            except discord.InteractionResponded:
-                return
-
-            if diag.is_enabled():
-                await diag.log_event(
-                    "info",
-                    "modal_launch_sent",
-                    thread_id=self.parent.thread_id,
-                    index=getattr(modal, "step_index", getattr(modal, "_c1c_index", 0)),
-                )
 
 
 class RetryStartView(discord.ui.View):
@@ -77,24 +66,11 @@ class RetryStartView(discord.ui.View):
                 return
 
             try:
-                modal = controller.build_modal_stub(thread_id)
+                await controller.render_inline_step(interaction, thread_id)
             except Exception:
-                log.warning("failed to build modal stub for retry start", exc_info=True)
+                log.warning("failed to render inline step for retry start", exc_info=True)
                 await _notify_retry_failure(interaction)
                 return
-
-            try:
-                await interaction.response.send_modal(modal)
-            except discord.InteractionResponded:
-                return
-
-            if diag.is_enabled():
-                await diag.log_event(
-                    "info",
-                    "modal_launch_sent_retry",
-                    thread_id=thread_id,
-                    index=getattr(modal, "step_index", getattr(modal, "_c1c_index", 0)),
-                )
 
 
 async def _notify_retry_failure(interaction: discord.Interaction) -> None:

--- a/tests/welcome/test_interaction_state.py
+++ b/tests/welcome/test_interaction_state.py
@@ -58,7 +58,7 @@ def test_modal_launch_skips_when_response_done(monkeypatch: pytest.MonkeyPatch, 
 
         response = SimpleNamespace(
             is_done=MagicMock(return_value=True),
-            send_modal=AsyncMock(),
+            send_message=AsyncMock(),
         )
         followup = SimpleNamespace(send=AsyncMock())
         app_perms = SimpleNamespace(
@@ -79,11 +79,11 @@ def test_modal_launch_skips_when_response_done(monkeypatch: pytest.MonkeyPatch, 
 
         await controller._handle_modal_launch(thread_id, interaction)
 
-        assert response.send_modal.await_count == 0
+        assert response.send_message.await_count == 0
 
         events = _read_events(str(log_path))
-        skipped = [event for event in events if event.get("event") == "modal_launch_skipped"]
-        assert skipped, "expected modal_launch_skipped event"
+        skipped = [event for event in events if event.get("event") == "inline_launch_skipped"]
+        assert skipped, "expected inline_launch_skipped event"
         assert skipped[0].get("response_is_done") is True
 
         welcome.store.end(thread_id)


### PR DESCRIPTION
## Summary
- route modal launch points through a new `render_inline_step` helper so welcome onboarding always uses the inline wizard
- replace the wizard text modal fallback with message-based inline capture and keep the existing button flows working
- update the interaction-state diagnostics test to reflect the inline launch path

## Testing
- pytest tests/welcome/test_interaction_state.py

------
https://chatgpt.com/codex/tasks/task_e_6908e9b490d08323b6823912fe6aaed5