### PR TITLE
Use onboarding sheet helpers for onboarding schema validation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ It exists so that contributors update the correct references after each developm
 * [`Config.md`](ops/Config.md) — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
 * [`Logging.md`](ops/Logging.md) — logging templates, dedupe policy, and configuration toggles.
 * [`Welcome.md`](ops/Welcome.md) — persistent welcome panel behaviour, recovery workflow, and operator tips.
+* [`WelcomeFlow.md`](ops/WelcomeFlow.md) — ticket-thread questionnaire flow and modal interaction notes.
 * [`WelcomeDiag.md`](ops/WelcomeDiag.md) — temporary welcome flow diagnostics flag and log locations.
 * [`PermCommandQuickstart.md`](ops/PermCommandQuickstart.md) — quickstart for the `!perm bot` command surface.
 * [`PermissionsSync.md`](ops/PermissionsSync.md) — bot access list administration and channel overwrite sync runbook.
@@ -78,4 +79,4 @@ It exists so that contributors update the correct references after each developm
 ## Cross-References
 * [`docs/contracts/CollaborationContract.md`](contracts/CollaborationContract.md) documents contributor responsibilities and embeds this index under “Documentation Discipline.”
 
-Doc last updated: 2025-10-31 (v0.9.7)
+Doc last updated: 2025-11-04 (v0.9.7)

--- a/docs/contracts/CollaborationContract.md
+++ b/docs/contracts/CollaborationContract.md
@@ -49,7 +49,7 @@ Single source of truth for how we work (me ↔ ChatGPT ↔ Codex), how pull requ
 | Folder             | Purpose                                                                     |
 | ------------------ | --------------------------------------------------------------------------- |
 | `docs/adr/`        | Architectural Decision Records (ADR-XXXX).                                  |
-| `docs/ops/`        | Ops docs: Config schema, CommandMatrix, Runbook, Troubleshooting, Watchers. |
+| `docs/ops/`        | Ops docs: Config schema, CommandMatrix, Runbook, WelcomeFlow, Troubleshooting, Watchers. |
 | `docs/contracts/`  | Long-lived standards (this contract).                                       |
 | `docs/guardrails/` | Guardrail & CI policy specs (e.g., `RepositoryGuardrails.md`).              |
 | `docs/compliance/` | Audit and guardrail reports (e.g., `REPORT_GUARDRAILS.md`).                 |
@@ -331,4 +331,4 @@ Rules:
 
 ---
 
-Doc last updated: 2025-10-30 (v0.9.7)
+Doc last updated: 2025-11-04 (v0.9.7)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -133,7 +133,12 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 - 'FEATURE_TOGGLES_TAB'
 - 'REPORTS_TAB'
 
+### Onboarding
+- `onboarding.questions_tab` (string) — **Existing** sheet tab name containing the onboarding questions with headers:
+  `flow, order, qid, label, type, required, maxlen, validate, help, note, rules`. No fallback. If missing or invalid, validation and flows must fail fast.
+
 ### Onboarding sheet keys
+- 'ONBOARDING_TAB'
 - 'WELCOME_TICKETS_TAB'
 - 'PROMO_TICKETS_TAB'
 - 'CLANLIST_TAB'
@@ -173,11 +178,12 @@ Feature Toggles:
   recruiter_panel,TRUE
   recruitment_welcome,TRUE
   recruitment_reports,TRUE
+  welcome_dialog,TRUE
   placement_target_select,TRUE
   placement_reservations,TRUE
-  welcome_enabled,TRUE
-  enable_welcome_hook,TRUE
-  enable_promo_watcher,TRUE
+  WELCOME_ENABLED,TRUE
+  ENABLE_WELCOME_HOOK,TRUE
+  ENABLE_PROMO_WATCHER,TRUE
   ```
 
 **Behavior**
@@ -204,4 +210,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-10-31 (v0.9.7)
+Doc last updated: 2025-11-04 (v0.9.7)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -115,6 +115,13 @@ tabs.
 5. If any validations fail, double-check Sheet permissions and the Config tab contents
    before escalating.
 
+### Validation (dry-run)
+Staff can validate the onboarding sheet without starting a flow:
+```
+!ops onb:check
+```
+This command reads the **existing** tab defined by `onboarding.questions_tab` and reports success or the first blocking error (no fallbacks).
+
 ### Daily recruiter summary embed
 - The “Summary Open Spots” card now renders as three distinct blocks: General Overview,
   Per Bracket (one line per bracket with totals), and Bracket Details (per-clan rows).
@@ -129,4 +136,4 @@ tabs.
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-10-31 (v0.9.7)
+Doc last updated: 2025-11-03 (v0.9.7)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -681,6 +681,7 @@ class Runtime:
 
         from c1c_coreops import cog as coreops_cog
         from cogs import app_admin
+        from modules.onboarding import ops_check as onboarding_ops_check
         from modules.onboarding import reaction_fallback as onboarding_reaction_fallback
         from modules.onboarding import watcher_welcome as onboarding_welcome
         from modules.onboarding import watcher_promo as onboarding_promo
@@ -813,6 +814,7 @@ class Runtime:
             "modules.placement.reservations", ("placement_reservations",)
         )
 
+        await onboarding_ops_check.setup(self.bot)
         await onboarding_reaction_fallback.setup(self.bot)
         await onboarding_welcome.setup(self.bot)
         await onboarding_promo.setup(self.bot)

--- a/modules/onboarding/ops_check.py
+++ b/modules/onboarding/ops_check.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from discord.ext import commands
+
+from modules.onboarding.schema import REQUIRED_HEADERS, load_welcome_questions
+from shared.config import get_onboarding_questions_tab
+from shared.logs import log
+
+
+class OnboardingCheck(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="onb:check")
+    @commands.has_permissions(administrator=True)
+    async def onb_check(self, ctx: commands.Context):
+        """Validate the onboarding questions tab (sheet-only, strict)."""
+
+        try:
+            tab = get_onboarding_questions_tab() or "<unset>"
+            questions = load_welcome_questions()
+            await ctx.reply(
+                "✅ Onboarding sheet OK — tab: **{}** • questions: **{}** • headers OK: {}".format(
+                    tab, len(questions), ", ".join(sorted(REQUIRED_HEADERS))
+                ),
+                mention_author=False,
+            )
+            log.human(
+                "info",
+                "✅ Onboarding — schema ok",
+                guild=ctx.guild.name if ctx.guild else "-",
+                tab=tab,
+                count=len(questions),
+            )
+        except Exception as exc:  # noqa: BLE001 - report raw error to staff
+            await ctx.reply(
+                "❌ Onboarding sheet invalid:\n`{}`\nFix the sheet or config and try again.".format(
+                    exc
+                ),
+                mention_author=False,
+            )
+            log.human("error", "❌ Onboarding — schema error", details=str(exc))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(OnboardingCheck(bot))

--- a/modules/onboarding/schema.py
+++ b/modules/onboarding/schema.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from shared.config import (
+    get_onboarding_questions_tab,
+    get_onboarding_sheet_id,
+)
+from shared.sheets.core import fetch_records
+
+_ORDER_RE = re.compile(r"^(?P<num>\d+)(?P<tag>[A-Za-z]?)$")
+
+
+@dataclass
+class Question:
+    flow: str
+    order_raw: str
+    order_key: Tuple[int, str]
+    qid: str
+    label: str
+    qtype: str
+    required: bool
+    maxlen: Optional[int]
+    validate: str
+    help: str
+    note: str
+    rules: str
+
+
+REQUIRED_HEADERS = {
+    "flow",
+    "order",
+    "qid",
+    "label",
+    "type",
+    "required",
+    "maxlen",
+    "validate",
+    "help",
+    "note",
+    "rules",
+}
+
+
+def _order_key(value: str) -> Tuple[int, str]:
+    match = _ORDER_RE.match(str(value).strip())
+    if not match:
+        return (10 ** 6, "z")
+    return (int(match.group("num")), (match.group("tag") or "").lower())
+
+
+def load_welcome_questions() -> List[Question]:
+    """Load and validate the *existing* onboarding tab. Strict, no fallback."""
+
+    tab = get_onboarding_questions_tab()
+    if not tab:
+        raise RuntimeError(
+            "missing config value from get_onboarding_questions_tab()"
+        )
+
+    sheet_id = get_onboarding_sheet_id()
+    if not sheet_id:
+        raise RuntimeError(
+            "missing onboarding sheet id from get_onboarding_sheet_id()"
+        )
+
+    rows = fetch_records(sheet_id=sheet_id, worksheet=tab)
+    if not rows:
+        raise RuntimeError(f"tab '{tab}' is empty")
+
+    headers = set(rows[0].keys())
+    missing = REQUIRED_HEADERS - headers
+    if missing:
+        raise RuntimeError(
+            f"tab '{tab}' missing required headers: {sorted(missing)}"
+        )
+
+    questions: List[Question] = []
+    for index, row in enumerate(rows, start=2):
+        flow = str(row.get("flow", "")).strip()
+        if flow.lower() != "welcome":
+            continue
+
+        order_raw = str(row.get("order", "")).strip()
+        qid = str(row.get("qid", "")).strip()
+        label = str(row.get("label", "")).strip()
+        qtype = str(row.get("type", "")).strip()
+
+        question = Question(
+            flow=flow,
+            order_raw=order_raw,
+            order_key=_order_key(order_raw),
+            qid=qid,
+            label=label,
+            qtype=qtype,
+            required=str(row.get("required", "")).strip().upper() == "TRUE",
+            maxlen=int(row["maxlen"]) if str(row.get("maxlen", "")).strip().isdigit() else None,
+            validate=str(row.get("validate", "")).strip(),
+            help=str(row.get("help", "")).strip(),
+            note=str(row.get("note", "")).strip(),
+            rules=str(row.get("rules", "")).strip(),
+        )
+
+        if question.qid == "" or question.label == "" or question.qtype == "":
+            raise RuntimeError(
+                "row {}: qid/label/type required for enabled items (order={!r})".format(
+                    index, question.order_raw
+                )
+            )
+
+        questions.append(question)
+
+    if not questions:
+        raise RuntimeError(f"no 'welcome' questions found in tab '{tab}'")
+
+    questions.sort(key=lambda question: question.order_key)
+    return questions

--- a/shared/config.py
+++ b/shared/config.py
@@ -35,6 +35,7 @@ __all__ = [
     "get_gspread_credentials",
     "get_recruitment_sheet_id",
     "get_onboarding_sheet_id",
+    "get_onboarding_questions_tab",
     "get_admin_role_ids",
     "get_staff_role_ids",
     "get_recruiter_role_ids",
@@ -286,6 +287,9 @@ def _load_config() -> Dict[str, object]:
         "GSPREAD_CREDENTIALS": os.getenv("GSPREAD_CREDENTIALS", ""),
         "RECRUITMENT_SHEET_ID": (os.getenv("RECRUITMENT_SHEET_ID") or "").strip(),
         "ONBOARDING_SHEET_ID": (os.getenv("ONBOARDING_SHEET_ID") or "").strip(),
+        "ONBOARDING_QUESTIONS_TAB": (
+            os.getenv("ONBOARDING_QUESTIONS_TAB") or ""
+        ).strip(),
         "ADMIN_ROLE_IDS": _int_set(os.getenv("ADMIN_ROLE_IDS")),
         "STAFF_ROLE_IDS": _int_set(os.getenv("STAFF_ROLE_IDS")),
         "RECRUITER_ROLE_IDS": _int_set(os.getenv("RECRUITER_ROLE_IDS")),
@@ -500,6 +504,26 @@ def get_recruitment_sheet_id() -> str:
 
 def get_onboarding_sheet_id() -> str:
     return str(_CONFIG.get("ONBOARDING_SHEET_ID", ""))
+
+
+def get_onboarding_questions_tab() -> str:
+    raw = _CONFIG.get("ONBOARDING_QUESTIONS_TAB", "")
+    value = str(raw or "").strip()
+    if value:
+        return value
+
+    try:
+        from shared.sheets import onboarding as onboarding_sheets  # local import to avoid cycles
+    except Exception:
+        return value
+
+    lookup = getattr(onboarding_sheets, "_config_lookup", None)
+    if callable(lookup):
+        resolved = lookup("onboarding.questions_tab", None)
+        if resolved:
+            return str(resolved).strip()
+
+    return value
 
 
 def _role_set(key: str) -> Set[int]:


### PR DESCRIPTION
## Summary
- resolve the onboarding questions tab via concrete config helpers and read rows with `fetch_records`
- add a shared `get_onboarding_questions_tab` accessor and reuse it in the ops check command

## Testing
- python -m compileall modules/onboarding/schema.py modules/onboarding/ops_check.py shared/config.py

------
https://chatgpt.com/codex/tasks/task_e_69090a7fc2b083238bf4d97440cba3de