### PR TITLE
Establish stable logger module & fix imports

### DIFF
--- a/modules/common/logs.py
+++ b/modules/common/logs.py
@@ -1,0 +1,29 @@
+import logging
+
+
+_pylog = logging.getLogger("c1c")
+
+
+class _Log:
+    def human(self, level: str, message: str, **fields):
+        levelno = {
+            "debug": logging.DEBUG,
+            "info": logging.INFO,
+            "warning": logging.WARNING,
+            "error": logging.ERROR,
+            "critical": logging.CRITICAL,
+        }.get(level.lower(), logging.INFO)
+        _pylog.log(levelno, message, extra=fields)
+
+
+log = _Log()
+
+
+def channel_label(guild, channel_id):
+    g = getattr(guild, "name", None) or getattr(guild, "id", "?")
+    return f"#{g}:{channel_id}"
+
+
+def user_label(guild, user_id):
+    g = getattr(guild, "name", None) or getattr(guild, "id", "?")
+    return f"{g}:{user_id}"

--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -24,7 +24,7 @@ from modules.onboarding.ui.summary_embed import build_summary_embed
 from modules.onboarding.ui.views import NextStepView
 from modules.onboarding.ui import RollingCard, panels
 from shared.sheets.onboarding_questions import Question, schema_hash
-from shared.logfmt import channel_label, user_label
+from modules.common.logs import channel_label, user_label
 
 log = logging.getLogger(__name__)
 gate_log = logging.getLogger("c1c.onboarding.gate")
@@ -698,7 +698,7 @@ class BaseWelcomeController:
                     pass
         except Exception:
             try:
-                from shared.logs import log as shared_log
+                from modules.common.logs import log as shared_log
 
                 shared_log.human(
                     "warning",

--- a/modules/onboarding/ops_check.py
+++ b/modules/onboarding/ops_check.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 from modules.onboarding.schema import REQUIRED_HEADERS, load_welcome_questions
 from shared.config import get_onboarding_questions_tab
-from shared.logs import log
+from modules.common.logs import log
 
 
 class OnboardingCheck(commands.Cog):


### PR DESCRIPTION
## Summary
- add a stable `modules.common.logs` helper with `log.human` plus label helpers
- update onboarding commands and controllers to import the stable logger module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6909d642f650832390f39dae73d4f160