### PR TITLE
Add async caching shim for onboarding welcome questions

### DIFF
--- a/modules/onboarding/startup.py
+++ b/modules/onboarding/startup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from modules.common.logs import log
-from modules.onboarding import schema as onb_schema
+from modules.onboarding.schema import get_cached_welcome_questions
 
 _LOG_SAMPLE_LIMIT = 3
 
@@ -18,8 +18,9 @@ async def preload_onboarding_schema(delay_sec: float = 1.5) -> None:
 
     try:
         await asyncio.sleep(max(0.0, float(delay_sec)))
-        count, sample = onb_schema.prime_welcome_cache()
-        preview = ",".join(sample[:_LOG_SAMPLE_LIMIT])
+        questions = await get_cached_welcome_questions(force=True)
+        count = len(questions)
+        preview = ",".join(question.qid for question in questions[:_LOG_SAMPLE_LIMIT])
         if count == 0:
             log.human(
                 "warning", "onb preload: 0 rows for flow=welcome (check sheet)"


### PR DESCRIPTION
## Summary
- add an async `get_cached_welcome_questions` shim that caches the existing loader
- expose a helper to clear the cache for tests or reload flows
- refresh the onboarding preload routine to warm the cached questions via the shim

## Testing
- pytest tests/onboarding -q *(fails: ImportError: cannot import name 'parse_values_list' from 'modules.onboarding.schema')*


------
https://chatgpt.com/codex/tasks/task_e_690a6d1797b083239f7fb348be74f17b