### PR TITLE
Improve onboarding lifecycle boot logging

### DIFF
--- a/docs/ops/Watchers.md
+++ b/docs/ops/Watchers.md
@@ -32,6 +32,7 @@ single structured log._
 - **Welcome watcher** (`welcome_enabled` + `enable_welcome_hook`) — listens for welcome
   thread closures, appends a row to the configured Sheet tab, and logs the result via
   `[welcome_watcher]` messages.
+  Lifecycle logging emits a single humanized line at startup with real context (no placeholders).
 - **Promo watcher** (`welcome_enabled` + `enable_promo_watcher`) — mirrors the welcome flow
   for promo threads, writing to the promo tab and logging as `[promo_watcher]`.
 
@@ -64,4 +65,4 @@ All jobs post `[cache]` summaries to the ops channel via `modules.common.runtime
 - `/healthz` reports watchdog metrics and cache timestamps; `!ops config` surfaces the active watcher toggles.
 - `LOG_CHANNEL_ID` receives lifecycle notices plus watcher (`[welcome_watcher]`, `[promo_watcher]`) and `[cache]` refresh messages.
 
-Doc last updated: 2025-10-26 (v0.9.6)
+Doc last updated: 2025-11-05 (v0.9.7)

--- a/shared/logs.py
+++ b/shared/logs.py
@@ -1,0 +1,58 @@
+"""Shared logging helpers for lifecycle events."""
+
+from __future__ import annotations
+
+from time import monotonic
+from typing import Any
+
+__all__ = ["log_lifecycle"]
+
+
+_lifecycle_dedupe: dict[tuple[str, str], float] = {}
+
+
+def _fmt_kvs(kvs: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in kvs.items():
+        if value in (None, "", "-", False, 0, {}, []):
+            continue
+        parts.append(f"{key}={value}")
+    return " • ".join(parts)
+
+
+def log_lifecycle(logger: Any, scope: str, event: str, **fields: Any) -> None:
+    """Log a human-readable lifecycle line with dedupe and blank-field filtering.
+
+    Parameters
+    ----------
+    logger:
+        Logger-like object exposing ``info``.
+    scope:
+        High-level component scope (e.g. ``"onboarding"``).
+    event:
+        Lifecycle event name (e.g. ``"view_registered"``).
+    **fields:
+        Additional key/value pairs rendered into the log line. Blank or falsey
+        values (``None``, empty strings, ``-``, ``False``, ``0``, empty
+        containers) are omitted automatically.
+
+    The helper enforces a 5-second dedupe window per ``(scope, event)`` pair to
+    avoid noisy repeat lines during startup races.
+    """
+
+    now = monotonic()
+    key = (scope, event)
+    last = _lifecycle_dedupe.get(key, 0.0)
+    if now - last < 5.0:
+        return
+    _lifecycle_dedupe[key] = now
+
+    prefix = "🛈"
+    title = f"{scope.capitalize()} watcher"
+    kv_text = _fmt_kvs(fields)
+    line = f"{prefix} {title} — event={event}" + (f" • {kv_text}" if kv_text else "")
+    try:
+        logger.info(line)
+    except Exception:
+        # Logging should never raise upstream.
+        pass


### PR DESCRIPTION
## Summary
- add a shared lifecycle logging helper that filters blank fields and dedupes repeated events
- switch the onboarding persistent-view registration to emit one contextual lifecycle line via the helper
- document the single-line lifecycle behavior in the watcher ops guide

## Testing
- python -m compileall shared/logs.py modules/onboarding/ui/panels.py

------
https://chatgpt.com/codex/tasks/task_e_690b25ab0d888323b6200f62a0122566