### PR TITLE
Remove remaining welcome panel lifecycle placeholder emitters

### DIFF
--- a/modules/onboarding/diag.py
+++ b/modules/onboarding/diag.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -11,8 +10,6 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import discord
-
-from modules.onboarding import logs
 
 log = logging.getLogger("c1c.onboarding.diag")
 
@@ -74,16 +71,12 @@ def _append_json_line(payload: dict[str, Any]) -> None:
 
 
 async def log_event(level: str, event: str, **fields: Any) -> None:
-    """Emit a diagnostic event to both the shared log channel and JSON sink."""
+    """Emit a diagnostic event to the JSON sink when enabled."""
 
     if not is_enabled():
         return
 
     payload = _prepare_payload(event, fields)
-    try:
-        await logs.send_welcome_log(level, **payload)
-    except Exception:  # pragma: no cover - defensive guard
-        log.warning("failed to emit welcome diag log", exc_info=True)
     _append_json_line(payload)
 
 
@@ -94,16 +87,6 @@ def log_event_sync(level: str, event: str, **fields: Any) -> None:
         return
 
     payload = _prepare_payload(event, fields)
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    if loop and loop.is_running():
-        loop.create_task(logs.send_welcome_log(level, **payload))
-    else:  # pragma: no cover - defensive guard
-        log.info("%s", payload)
-
     _append_json_line(payload)
 
 

--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -402,15 +402,25 @@ class LogTemplates:
             "error": LOG_EMOJI["error"],
         }
         emoji = palette.get(result, LOG_EMOJI["info"])
-        actor_text = actor or "-"
-        thread_text = thread or "#unknown"
-        detail_text = "; ".join(details or []) if details else "-"
-        segments = [f"actor={actor_text}", f"thread={thread_text}"]
-        if parent:
+        actor_text = (actor or "").strip()
+        thread_text = (thread or "#unknown").strip() or "#unknown"
+        cleaned_details = [item for item in (details or []) if item and item != "-"]
+
+        segments: list[str] = []
+        if actor_text and actor_text != "-":
+            segments.append(f"actor={actor_text}")
+        if thread_text and thread_text != "-":
+            segments.append(f"thread={thread_text}")
+        if parent and parent != "-":
             segments.append(f"channel={parent}")
-        segments.append(f"result={result}")
-        segments.append(f"details: {detail_text}")
-        return f"{emoji} Welcome panel — " + " • ".join(segments)
+        if result and result != "-":
+            segments.append(f"result={result}")
+        if cleaned_details:
+            segments.append("details: " + "; ".join(cleaned_details))
+
+        if segments:
+            return f"{emoji} Welcome panel — " + " • ".join(segments)
+        return f"{emoji} Welcome panel"
 
     @staticmethod
     def select_refresh_template(scope: str, buckets: Sequence[BucketResult], total_s: float) -> str:


### PR DESCRIPTION
## Findings
- `shared/logfmt.py:405-423` — legacy welcome panel formatter emitted placeholder segments (`actor=-`, `thread=-`).

## Summary
- Stop welcome-flow diagnostics from relaying lifecycle lines to the log channel, leaving JSON capture intact.
- Refine the welcome panel formatter to drop placeholder segments when actor/thread/result details are missing.

## Verification
```bash
rg -n --hidden -S "\[watcher\|lifecycle\].*Welcome panel" -g '!AUDIT/**' || echo "✅ legacy emitter gone"
✅ legacy emitter gone
rg -n --hidden -S "Welcome panel — actor=-" -g '!AUDIT/**' || echo "✅ no placeholder variant"
✅ no placeholder variant
```

[meta]
labels: observability, comp:onboarding, P2, ready
milestone: Harmonize v1.0
[/meta]


------
https://chatgpt.com/codex/tasks/task_e_690b5aa534e883239a959fc2e9ee61a8