### PR TITLE
Handle onboarding questions tab in config preload

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -135,7 +135,7 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 
 ### Onboarding
 - `onboarding.questions_tab` (string) — **Existing** sheet tab name containing the onboarding questions with headers:
-  `flow, order, qid, label, type, required, maxlen, validate, help, note, rules`. No fallback. If missing or invalid, validation and flows must fail fast.
+  `flow, order, qid, label, type, required, maxlen, validate, help, note, rules`. No fallback. If missing or invalid, validation and flows must fail fast. `ONBOARDING_TAB` remains a legacy alias; populate **only one** value or ensure both entries match exactly to avoid startup failures.
 
 ### Onboarding sheet keys
 - 'ONBOARDING_TAB'
@@ -210,4 +210,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-11-04 (v0.9.7)
+Doc last updated: 2025-11-05 (v0.9.7)

--- a/tests/test_onboarding_tab_config.py
+++ b/tests/test_onboarding_tab_config.py
@@ -1,0 +1,96 @@
+import importlib
+import sys
+
+import pytest
+
+
+_REQUIRED_ENV = {
+    "DISCORD_TOKEN": "token",
+    "GSPREAD_CREDENTIALS": "{}",
+    "RECRUITMENT_SHEET_ID": "sheet",
+}
+
+
+def _load_config(monkeypatch, sheet_config):
+    for key, value in _REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "sheet")
+
+    import shared.sheets.onboarding as onboarding_sheet
+
+    monkeypatch.setattr(
+        onboarding_sheet,
+        "_load_config",
+        lambda force=False: dict(sheet_config),
+    )
+
+    sys.modules.pop("shared.config", None)
+    try:
+        return importlib.import_module("shared.config")
+    except Exception:
+        sys.modules.pop("shared.config", None)
+        raise
+
+
+def test_onboarding_tab_loaded_from_canonical(monkeypatch):
+    cfg = _load_config(monkeypatch, {"onboarding.questions_tab": "Questions"})
+
+    assert cfg.cfg.get("onboarding.questions_tab") == "Questions"
+    assert cfg.cfg.get("ONBOARDING_TAB") == "Questions"
+
+
+def test_onboarding_tab_loaded_from_alias(monkeypatch):
+    cfg = _load_config(monkeypatch, {"onboarding_tab": "Legacy"})
+
+    assert cfg.cfg.get("onboarding.questions_tab") == "Legacy"
+    assert cfg.cfg.get("ONBOARDING_TAB") == "Legacy"
+
+
+def test_onboarding_tab_conflict_raises(monkeypatch):
+    with pytest.raises(ValueError) as excinfo:
+        _load_config(
+            monkeypatch,
+            {"onboarding.questions_tab": "Primary", "onboarding_tab": "Alias"},
+        )
+
+    message = str(excinfo.value)
+    assert "onboarding.questions_tab='Primary'" in message
+    assert "ONBOARDING_TAB='Alias'" in message
+
+
+def test_resolve_onboarding_tab_prefers_canonical():
+    from shared.config import resolve_onboarding_tab
+
+    mapping = {
+        "onboarding.questions_tab": "Canonical",
+        "ONBOARDING_TAB": "Canonical",
+    }
+
+    assert resolve_onboarding_tab(mapping) == "Canonical"
+
+
+def test_resolve_onboarding_tab_missing_key():
+    from shared.config import resolve_onboarding_tab
+
+    with pytest.raises(KeyError) as excinfo:
+        resolve_onboarding_tab({})
+
+    assert "missing config key: onboarding.questions_tab (alias: ONBOARDING_TAB)" in str(
+        excinfo.value
+    )
+
+
+def test_resolve_onboarding_tab_conflict():
+    from shared.config import resolve_onboarding_tab
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_onboarding_tab(
+            {
+                "onboarding.questions_tab": "One",
+                "ONBOARDING_TAB": "Two",
+            }
+        )
+
+    message = str(excinfo.value)
+    assert "onboarding.questions_tab='One'" in message
+    assert "ONBOARDING_TAB='Two'" in message


### PR DESCRIPTION
## Findings
- Runtime config now merges the onboarding questions tab via `shared/config.py::_merge_onboarding_tab`, which runs inside `_load_config()` before the config snapshot is cached.
- Tab resolvers for the other preload buckets live in `shared/sheets/recruitment.py` (`_clans_tab`, `_templates_tab`) and `shared/sheets/onboarding.py` (`_clanlist_tab`).
- `shared.config` loads during import (via `reload_config()`), after which `modules/common/runtime.schedule_startup_preload()` queues `_startup_preload()` so cache warming runs with the merged config.

## Summary
- Merge the onboarding questions tab from the Config sheet into the runtime snapshot, preferring the canonical `onboarding.questions_tab` and flagging conflicts with `ONBOARDING_TAB`.
- Harden `resolve_onboarding_tab` to use the canonical key first, emit consistent missing-key errors, and surface conflicting definitions.
- Document the alias expectations for the onboarding tab and add focused resolver/ingestion tests.

## Testing
- `pytest tests/test_onboarding_tab_config.py`

[meta]
labels: comp:onboarding, data:sheets, robustness, P1, ready
milestone: Harmonize v1.0
[/meta]

------
https://chatgpt.com/codex/tasks/task_e_690b93d281708323a1f7771f402489f7