### PR TITLE
Onboarding Sheet Loader — remove legacy fallbacks and log resolved sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Improved watcher lifecycle logging to correctly emit `schema_load_failed` and preload diagnostics.
 * Adjusted startup refresh summary to remove alias notes and align with other cache buckets.
 * Prepared PR metadata rules for Codex compliance (meta-block instruction re-added).
+* Removed legacy onboarding sheet fallbacks and added startup log for resolved sheet id.
 
 ## v0.9.7 — 2025-11-04 Onboarding Stability & Preload
 - Fixed crash: `TypeError: Command signature requires at least 1 parameter(s)` when initializing `onb` command group.
@@ -272,4 +273,4 @@
 - Sheet tab names moved out of env into each Sheet's **Config** tab.
 
 ---
-Doc last updated: 2025-11-04 (v0.9.7)
+Doc last updated: 2025-11-07 (v0.9.7)

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
@@ -21,16 +22,19 @@ _CLAN_TAGS: List[str] | None = None
 _CLAN_TAG_TS: float = 0.0
 
 
+log = logging.getLogger(__name__)
+
+
 def _sheet_id() -> str:
-    sheet_id = (
-        os.getenv("ONBOARDING_SHEET_ID")
-        or os.getenv("GOOGLE_SHEET_ID")
-        or os.getenv("GSHEET_ID")
-        or ""
-    )
-    sheet_id = sheet_id.strip()
+    """Return the onboarding sheet ID (no legacy fallbacks)."""
+
+    sheet_id = os.getenv("ONBOARDING_SHEET_ID", "").strip()
     if not sheet_id:
         raise RuntimeError("ONBOARDING_SHEET_ID not set")
+
+    tail = sheet_id[-6:] if len(sheet_id) >= 6 else sheet_id
+    redacted = f"…{tail}" if len(sheet_id) > len(tail) else tail
+    log.info("📄 Onboarding sheet resolved • id_tail=%s", redacted)
     return sheet_id
 
 


### PR DESCRIPTION
## Summary
- remove the legacy onboarding sheet ID fallbacks so only `ONBOARDING_SHEET_ID` is accepted
- log the resolved onboarding sheet tail during runtime initialisation
- document the onboarding resolver change in the changelog

## Testing
- not run (not requested)
[meta]
labels: comp:onboarding, fix, logging
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dbfb2054c8323ae4077c1f91b76f1)