### PR TITLE
Sheets: remove all legacy sheet-ID fallbacks (onboarding, recruitment, core, config) + sanity logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Improved watcher lifecycle logging to correctly emit `schema_load_failed` and preload diagnostics.
 * Adjusted startup refresh summary to remove alias notes and align with other cache buckets.
 * Prepared PR metadata rules for Codex compliance (meta-block instruction re-added).
-* Removed legacy onboarding sheet fallbacks and added startup log for resolved sheet id.
+* Removed legacy sheet ID fallbacks across onboarding, recruitment, and shared core helpers; added onboarding resolver telemetry.
 
 ## v0.9.7 — 2025-11-04 Onboarding Stability & Preload
 - Fixed crash: `TypeError: Command signature requires at least 1 parameter(s)` when initializing `onb` command group.

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -26,6 +26,8 @@ Meta: Cache age 42s · Next refresh 02:15 UTC · Actor startup
 
 **Optional:** `ONBOARDING_SHEET_ID`, `ENV_NAME`, `BOT_NAME`, `PUBLIC_BASE_URL`, `RENDER_EXTERNAL_URL`, `LOG_CHANNEL_ID`, `WATCHDOG_CHECK_SEC`, `WATCHDOG_STALL_SEC`, `WATCHDOG_DISCONNECT_GRACE_SEC`
 
+All sheet-facing modules now require their dedicated `*_SHEET_ID` variables; legacy fallbacks such as `GOOGLE_SHEET_ID` / `GSHEET_ID` are ignored.
+
 Missing any **Required** key causes the bot to exit with an error at startup. If `LOG_CHANNEL_ID` is empty, Discord channel logging is disabled and a one-time startup warning is emitted.
 
 ### Core runtime
@@ -51,8 +53,6 @@ Missing any **Required** key causes the bot to exit with an error at startup. If
 | `ONBOARDING_SHEET_ID` | string | — | Google Sheet ID for onboarding trackers. |
 | `REMINDER_SHEET_ID` | string | — | Google Sheet ID for reminders (service-specific). |
 | `MILESTONES_SHEET_ID` | string | — | Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific). |
-| `GOOGLE_SHEET_ID` | string | — | Back-compat sheet ID used when dedicated IDs are unset. |
-| `GSHEET_ID` | string | — | Legacy alias checked when the other IDs are blank. |
 | `RECRUITMENT_CONFIG_TAB` | string | `Config` | Worksheet name containing recruitment config. |
 | `ONBOARDING_CONFIG_TAB` | string | `Config` | Worksheet name containing onboarding config. |
 | `WORKSHEET_NAME` | string | `bot_info` | Fallback for the `clans_tab` worksheet when sheet config is missing. |
@@ -209,4 +209,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-11-06 (v0.9.7)
+Doc last updated: 2025-11-07 (v0.9.7)

--- a/shared/config.py
+++ b/shared/config.py
@@ -278,11 +278,9 @@ def _merge_onboarding_tab(config: Dict[str, object]) -> None:
         log.debug("config: onboarding sheet module unavailable", exc_info=True)
         return
 
-    if not (
-        os.getenv("ONBOARDING_SHEET_ID")
-        or os.getenv("GOOGLE_SHEET_ID")
-        or os.getenv("GSHEET_ID")
-    ):
+    # Only the explicit onboarding sheet id controls merge behaviour. Legacy
+    # fallbacks risk pulling a different sheet's config silently.
+    if not os.getenv("ONBOARDING_SHEET_ID"):
         log.debug("config: onboarding sheet id not configured; skipping tab merge")
         return
 

--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -135,12 +135,11 @@ def _sleep_with_new_loop(delay: float) -> None:
 
 
 def _resolve_sheet_id(sheet_id: str | None) -> str:
-    if sheet_id is None:
-        sheet_id = os.getenv("GOOGLE_SHEET_ID") or os.getenv("GSHEET_ID") or ""
-    sheet_id = sheet_id.strip()
-    if not sheet_id:
-        raise RuntimeError("GOOGLE_SHEET_ID/GSHEET_ID not set")
-    return sheet_id
+    """Resolve ``sheet_id``, requiring callers to provide an explicit value."""
+
+    if sheet_id is None or not str(sheet_id).strip():
+        raise RuntimeError("sheet id not provided")
+    return str(sheet_id).strip()
 
 
 def open_by_key(sheet_id: str | None = None):

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -240,12 +240,7 @@ def _process_clan_sheet(
 
 
 def _sheet_id() -> str:
-    sheet_id = (
-        os.getenv("RECRUITMENT_SHEET_ID")
-        or os.getenv("GOOGLE_SHEET_ID")
-        or os.getenv("GSHEET_ID")
-        or ""
-    ).strip()
+    sheet_id = os.getenv("RECRUITMENT_SHEET_ID", "").strip()
     if not sheet_id:
         raise RuntimeError("RECRUITMENT_SHEET_ID not set")
     return sheet_id

--- a/tests/onboarding/test_onboarding_sheet_id_required.py
+++ b/tests/onboarding/test_onboarding_sheet_id_required.py
@@ -1,0 +1,26 @@
+"""Ensure onboarding sheet ID must be configured explicitly."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.sheets import onboarding
+
+
+def test_sheet_id_requires_explicit_env(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """_sheet_id should raise when ONBOARDING_SHEET_ID is missing."""
+
+    monkeypatch.delenv("ONBOARDING_SHEET_ID", raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        onboarding._sheet_id()
+
+    assert "ONBOARDING_SHEET_ID" in str(excinfo.value)
+
+
+def test_sheet_id_returns_value_when_present(monkeypatch: "pytest.MonkeyPatch") -> None:
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "abc123")
+
+    assert onboarding._sheet_id() == "abc123"
+    # Reset for other tests to avoid residue
+    monkeypatch.delenv("ONBOARDING_SHEET_ID", raising=False)

--- a/tests/recruitment/test_recruitment_sheet_id_required.py
+++ b/tests/recruitment/test_recruitment_sheet_id_required.py
@@ -1,0 +1,23 @@
+"""Recruitment sheet ID resolver requirements."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.sheets import recruitment
+
+
+def test_sheet_id_requires_explicit_env(monkeypatch: "pytest.MonkeyPatch") -> None:
+    monkeypatch.delenv("RECRUITMENT_SHEET_ID", raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        recruitment._sheet_id()
+
+    assert "RECRUITMENT_SHEET_ID" in str(excinfo.value)
+
+
+def test_sheet_id_returns_value(monkeypatch: "pytest.MonkeyPatch") -> None:
+    monkeypatch.setenv("RECRUITMENT_SHEET_ID", "sheet-987654")
+
+    assert recruitment._sheet_id() == "sheet-987654"
+    monkeypatch.delenv("RECRUITMENT_SHEET_ID", raising=False)


### PR DESCRIPTION
## Summary
- remove the remaining GOOGLE_SHEET_ID / GSHEET_ID fallbacks from core sheet helpers and recruitment onboarding integration
- gate the config onboarding tab merge on the explicit ONBOARDING_SHEET_ID only and document the stricter requirement
- add unit coverage for onboarding and recruitment sheet id resolvers while updating changelog guidance

## Testing
- pytest tests/onboarding/test_onboarding_sheet_id_required.py
- pytest tests/recruitment/test_recruitment_sheet_id_required.py
[meta]
labels: comp:onboarding, comp:recruitment, fix, tests, logging
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc7a74e68832390700eda04aa5d78)