### PR TITLE
Ensure onboarding config loads before cache preloads

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ It exists so that contributors update the correct references after each developm
 * [`Architecture.md`](ops/Architecture.md) — detailed system flow, runtime design, and module topology.
 * [`CommandMatrix.md`](ops/CommandMatrix.md) — user/admin command catalogue with permissions, feature gates, and descriptions.
 * [`Config.md`](ops/Config.md) — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
+* [`env.md`](ops/env.md) — minimal environment checklist highlighting required sheet IDs and removed aliases.
 * [`Logging.md`](ops/Logging.md) — logging templates, dedupe policy, and configuration toggles.
 * [`Onboarding-Runbook.md`](ops/Onboarding-Runbook.md) — rolling-card onboarding operations and validation flow notes.
 * [`Welcome.md`](ops/Welcome.md) — persistent welcome panel behaviour, recovery workflow, and operator tips.
@@ -80,4 +81,4 @@ It exists so that contributors update the correct references after each developm
 ## Cross-References
 * [`docs/contracts/CollaborationContract.md`](contracts/CollaborationContract.md) documents contributor responsibilities and embeds this index under “Documentation Discipline.”
 
-Doc last updated: 2025-11-04 (v0.9.7)
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -65,4 +65,4 @@ Here’s your feature-toggle section rewritten to **match that exact spec layout
 ### Verification
 Compliance script must check: structure (S), code (C), docs (D), governance (G) and write `AUDIT/<timestamp>_GUARDRAILS/report.md`.
 
-Doc last updated: 2025-10-30 (v0.9.7)
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/docs/ops/env.md
+++ b/docs/ops/env.md
@@ -1,0 +1,28 @@
+# Environment Variable Quick Reference
+
+This page captures the minimal environment surface needed to run the unified bot.
+It complements [`docs/ops/Config.md`](Config.md) by highlighting the must-have keys
+and the removal of legacy identifiers.
+
+## Required keys
+
+The bot will refuse to start unless all of the following keys are populated:
+
+- `DISCORD_TOKEN`
+- `GSPREAD_CREDENTIALS`
+- `RECRUITMENT_SHEET_ID`
+- `ONBOARDING_SHEET_ID`
+
+All four values must be present in `.env.example` and production deployments. The
+sheet identifiers are distinct: one workbook powers recruitment flows, the other
+serves onboarding config and ticket tabs. Treat them as separate credentials when
+managing access or rotating service accounts.
+
+## Legacy keys removed
+
+Older deployments referenced generic sheet identifiers such as `GOOGLE_SHEET_ID`
+(or the shorter `GSHEET_ID`). These aliases are no longer read anywhere in the
+codebase. Setting them has no effect and may hide misconfigurations. Always use
+the explicit `*_SHEET_ID` variables documented above.
+
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -20,6 +20,8 @@ from discord.ext import commands
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from shared import watchdog as watchdog_loop
+from modules.common.logs import log as human_log
+from shared import config as shared_config
 from shared.config import (
     get_port,
     get_env_name,
@@ -830,6 +832,12 @@ class Runtime:
         await self.load_extensions()
         rehydrate_tiers(self.bot)
         audit_tiers(self.bot, log)
+        try:
+            merged = shared_config.merge_onboarding_config_early()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            human_log.human("warn", "Config preload failed", error=repr(exc))
+        else:
+            log.debug("runtime: onboarding config preload merged %d keys", merged)
         from shared.sheets.cache_scheduler import (
             emit_schedule_log,
             ensure_cache_registration,

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -69,7 +69,11 @@ def _announce(bot: commands.Bot, message: str, *, level: int = logging.INFO) -> 
     log.log(level, "%s", message)
 
     async def runner() -> None:
-        await bot.wait_until_ready()
+        try:
+            await bot.wait_until_ready()
+        except Exception:  # pragma: no cover - defensive guard
+            log.warning("welcome watcher announce skipped: bot not ready")
+            return
         await _send_runtime(message)
 
     # discord.py 2.x restricts accessing Client.loop here; schedule via asyncio

--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -1,0 +1,49 @@
+import importlib
+import logging
+import sys
+import types
+
+
+def test_merge_onboarding_config_early_merges(monkeypatch, caplog):
+    import shared.config as config
+
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("GSPREAD_CREDENTIALS", "{}")
+    monkeypatch.setenv("RECRUITMENT_SHEET_ID", "recruit-sheet")
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "onboard-sheet-XYZ")
+
+    fake_config = {
+        "ONBOARDING_TAB": "WelcomeQuestions",
+        "WELCOME_TICKETS_TAB": "WelcomeTickets",
+        "PROMO_TICKETS_TAB": "PromoTickets",
+    }
+
+    def _read_onboarding_config(sheet_id):
+        assert sheet_id == "onboard-sheet-XYZ"
+        return fake_config
+
+    monkeypatch.setitem(
+        sys.modules,
+        "shared.sheets.onboarding",
+        types.SimpleNamespace(_read_onboarding_config=_read_onboarding_config),
+    )
+
+    original_getenv = config.os.getenv
+
+    def _guarded_getenv(key, default=None):
+        assert key not in {"GOOGLE_SHEET_ID", "GSHEET_ID"}
+        return original_getenv(key, default)
+
+    monkeypatch.setattr(config.os, "getenv", _guarded_getenv)
+
+    importlib.reload(config)
+
+    caplog.set_level(logging.INFO)
+    merged = config.merge_onboarding_config_early()
+
+    assert merged == len(fake_config)
+    assert config.onboarding_config_merge_count() == len(fake_config)
+    assert config.resolve_onboarding_tab(config.cfg) == "WelcomeQuestions"
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("🧩 Config — merged onboarding tab" in message for message in messages)


### PR DESCRIPTION
## Summary
- merge onboarding config values into the runtime before cache scheduling so onboarding questions can resolve their tab
- drop legacy sheet ID fallbacks, tighten onboarding question error logging, and wait for the bot to be ready before watcher announcements
- document the required ONBOARDING_SHEET_ID env key and add a regression test for early onboarding config merges

## Testing
- pytest tests/config/test_merge_onboarding.py

[meta]
labels: comp:onboarding, fix, logging, config
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de56c6d10832381cdb6ccf761c7ed)