### PR TITLE
Improve onboarding watcher readiness and panel refresh logic

### DIFF
--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -1273,8 +1273,9 @@ class OpenQuestionsPanelView(discord.ui.View):
                 label = "Finish" if parent.is_last_step() else "Next"
                 super().__init__(style=discord.ButtonStyle.primary, label=label)
                 self._wizard = parent
-                if not has_answer:
-                    self.disabled = True
+                required = parent._question_required(question)
+                # Disable Next only when required questions lack an answer.
+                self.disabled = required and not has_answer
 
             async def callback(self, interaction: discord.Interaction) -> None:
                 wizard = self._wizard


### PR DESCRIPTION
## Summary
- wait for the Discord client to be ready before registering the welcome panel and runtime announce tasks
- treat members who can post in a ticket thread as eligible for the onboarding flow
- keep the inline wizard bound to its host message so refreshes rebuild controls and keep the Next button disabled until an answer exists

## Testing
- Not run (not requested).

[meta]
labels: comp:onboarding, fix, ui
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e24ed0a308323aadf7d649bdce419)