### PR TITLE
Fix scheduler logging extras to keep jobs running

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -433,7 +433,10 @@ class _RecurringJob:
                 except Exception:
                     log.exception(
                         "recurring job error",
-                        extra={"name": self.name or getattr(job, "__name__", "job"), "tag": self.tag},
+                        extra={
+                            "job_name": self.name or getattr(job, "__name__", "job"),
+                            "tag": self.tag,
+                        },
                     )
                 finally:
                     self.next_run = self._compute_next_run()
@@ -672,7 +675,7 @@ class Runtime:
                 try:
                     result = await callback()
                 except Exception as exc:
-                    log.exception("scheduled task error", extra={"name": name})
+                    log.exception("scheduled task error", extra={"job_name": name})
                     await self.send_log_message(f"❌ {name} failed: {exc}")
                 else:
                     if result:

--- a/tests/shared/test_runtime_scheduler.py
+++ b/tests/shared/test_runtime_scheduler.py
@@ -1,0 +1,45 @@
+import asyncio
+import logging
+import os
+
+import pytest
+
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("GSPREAD_CREDENTIALS", "{}")
+os.environ.setdefault("RECRUITMENT_SHEET_ID", "sheet-id")
+
+
+from modules.common import runtime
+
+
+def test_scheduler_job_exception_does_not_cancel(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def runner() -> None:
+        scheduler = runtime.Scheduler()
+
+        attempt = {"count": 0}
+
+        async def maybe_fail() -> None:
+            attempt["count"] += 1
+            if attempt["count"] == 1:
+                raise RuntimeError("boom")
+
+        def fast_next_run(self, reference=None):
+            now = reference or runtime.datetime.now(runtime.timezone.utc)
+            return now + runtime.timedelta(milliseconds=10)
+
+        monkeypatch.setattr(runtime._RecurringJob, "_compute_next_run", fast_next_run)
+
+        caplog.set_level(logging.ERROR, logger="c1c.runtime")
+
+        scheduler.every(seconds=1, name="test_job", tag="test").do(maybe_fail)
+
+        await asyncio.sleep(0.05)
+        await scheduler.shutdown()
+
+        assert attempt["count"] >= 2
+        assert any("recurring job error" in record.message for record in caplog.records)
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- replace the reserved logging key used by the recurring job supervisor so failures no longer crash the background task
- update schedule-at-times logging to use the same safe field name
- add a regression test that ensures recurring jobs keep running after a raised exception

## Testing
- DISCORD_TOKEN=dummy GSPREAD_CREDENTIALS=dummy RECRUITMENT_SHEET_ID=dummy pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0e3532208323a8a12a84fb29f853)