### PR TITLE
Break circular import for runtime port helper

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -23,7 +23,6 @@ from shared import watchdog as watchdog_loop
 from modules.common.logs import log as human_log
 from shared import config as shared_config
 from shared.config import (
-    get_port,
     get_env_name,
     get_bot_name,
     get_watchdog_check_sec,
@@ -34,6 +33,7 @@ from shared.config import (
     get_refresh_timezone,
     get_strict_emoji_proxy,
 )
+from shared.ports import get_port
 from shared.logging import get_trace_id, set_trace_id, setup_logging
 from shared.obs.events import (
     format_refresh_message,

--- a/shared/config.py
+++ b/shared/config.py
@@ -15,7 +15,6 @@ __all__ = [
     "cfg",
     "reload_config",
     "get_config_snapshot",
-    "get_port",
     "get_env_name",
     "get_bot_name",
     "get_watchdog_check_sec",
@@ -67,6 +66,8 @@ __all__ = [
     "merge_onboarding_config_early",
     "onboarding_config_merge_count",
 ]
+
+# Port helper lives in shared.ports. Import there where needed.
 
 log = logging.getLogger("c1c.config")
 
@@ -485,14 +486,6 @@ def get_config_snapshot() -> Dict[str, object]:
     """Return a shallow copy of the cached config values."""
 
     return dict(_CONFIG)
-
-
-def get_port(default: int = 10000) -> int:
-    try:
-        return int(_CONFIG.get("PORT", default))
-    except (TypeError, ValueError):
-        return default
-
 
 def get_env_name(default: str = "dev") -> str:
     value = _CONFIG.get("ENV_NAME")

--- a/shared/ports.py
+++ b/shared/ports.py
@@ -1,0 +1,11 @@
+import os
+from typing import Optional
+
+
+def get_port(env_var: str = "PORT", fallback: int = 10000) -> int:
+    """Leaf helper to avoid circular imports. Read PORT (Render/Heroku style)."""
+    try:
+        val: Optional[str] = os.getenv(env_var)
+        return int(val) if val else int(fallback)
+    except Exception:
+        return int(fallback)


### PR DESCRIPTION
## Summary
- move the get_port helper into a new shared.ports leaf module to avoid shared.config import cycles
- remove the get_port export from shared.config and update runtime imports to use the leaf helper

## Testing
- pytest -q

[meta]
labels: coreops, runtime, fix, reliability
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1c76da648323a313dfdd69f0397e)