### PR TITLE
feat: add sheet-driven select steps to onboarding wizard

### DIFF
--- a/docs/ops/Onboarding.md
+++ b/docs/ops/Onboarding.md
@@ -50,9 +50,25 @@ _Help comes from the sheet. No invented examples._
 Buttons: `[Answer 💬]  [Skip ⏭️]  [Back ⬅️]  [Next ➡️]  [Cancel ❌]`
 
 ### Boolean
-**Are you interested in participating in Siege?** *(required)*  
+**Are you interested in participating in Siege?** *(required)*
 Buttons: `[✅ Yes]  [❌ No]  [Back ⬅️]  [Next ➡️]  [Cancel ❌]`
 
 > All prompt text, help, validation, and limits are sheet-driven. If a cell is blank, the UI shows nothing (no fallback examples).
 
-Doc last updated: 2025-11-07 (v0.9.7)
+### Single-select
+**Pick the option that matches your stage best.** *(required)*  
+_Values come from the sheet `values` cell; order preserved._  
+🎯 Selected: —  
+Controls: a dropdown with the listed values.  
+Buttons: `[Back ⬅️]  [Next ➡️]  [Cancel ❌]` *(Next disabled until selected)*
+
+### Multi-select
+**Which Hydra difficulties are you currently hitting?** *(optional)*  
+_Values come from the sheet; we do not invent examples._  
+🎯 Selected: —  
+Controls: a dropdown that allows multiple selections (max = number of values).  
+Buttons: `[Skip ⏭️]  [Back ⬅️]  [Next ➡️]  [Cancel ❌]`
+
+> Resume: previously chosen options render pre-selected; users can change and continue later.
+
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/modules/onboarding/sessions.py
+++ b/modules/onboarding/sessions.py
@@ -39,7 +39,10 @@ class Session:
         self.last_updated = utc_now()
 
     def has_answer(self, gid: str) -> bool:
-        return gid in self.answers and self.answers[gid] not in (None, "", "—")
+        return gid in self.answers and self.answers[gid] not in (None, "", "—", [])
+
+    def get_answer(self, gid: str, default=None):
+        return self.answers.get(gid, default)
 
 
 class SessionStore:

--- a/modules/onboarding/ui/render_selects.py
+++ b/modules/onboarding/ui/render_selects.py
@@ -1,0 +1,121 @@
+import discord
+from modules.onboarding.ui.components import SingleSelectView, MultiSelectView
+
+GUIDANCE = "Use the controls below. Don’t type answers as messages—those won’t be read."
+
+def _answer_chip(val):
+    if not val or val == "—":
+        return "—"
+    if isinstance(val, (list, tuple)):
+        joined = ", ".join(val)
+        return joined if len(joined) <= 120 else joined[:120] + "…"
+    return str(val)
+
+def _parse_values(q) -> list[str]:
+    raw = (q.get("values") or "").strip()
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+def build_view(controller, session, q: dict, required: bool, has_answer: bool, optional: bool):
+    values = _parse_values(q)
+    ans = session.get_answer(q["gid"])
+
+    title = f"**{q['label']}** {'(required)' if required else '(optional)'}"
+    help_line = f"_{q.get('help') or ''}_" if q.get('help') else ""
+    chip = f"🎯 Selected: {_answer_chip(ans)}"
+
+    lines = [GUIDANCE, "", title]
+    if help_line:
+        lines.append(help_line)
+    lines += ["", chip, ""]
+    content = "\n".join(lines)
+
+    view = discord.ui.View(timeout=180)
+
+    # Input control
+    if values:
+        if q["type"] == "single-select":
+            def on_pick(interaction: discord.Interaction, value: str):
+                controller._async_spawn(controller._save_select_answer(interaction, session, q, value))
+
+            sv = SingleSelectView(
+                values,
+                preselect=str(ans) if isinstance(ans, str) else None,
+                on_pick=on_pick,
+            )
+            view.add_item(sv.select)
+        else:
+            def on_pick(interaction: discord.Interaction, values_list: list[str]):
+                controller._async_spawn(controller._save_multi_answer(interaction, session, q, values_list))
+
+            mv = MultiSelectView(
+                values,
+                preselect=list(ans) if isinstance(ans, (list, tuple)) else [],
+                on_pick=on_pick,
+            )
+            view.add_item(mv.select)
+    else:
+        # Disabled state if sheet didn't provide options — do not invent choices
+        no_opts_button = discord.ui.Button(
+            label="No options available (sheet 'values' empty)",
+            style=discord.ButtonStyle.secondary,
+            disabled=True,
+            custom_id="q_no_opts",
+        )
+        view.add_item(no_opts_button)
+
+    # Nav
+    back_button = discord.ui.Button(
+        label="Back",
+        style=discord.ButtonStyle.secondary,
+        custom_id="nav_back",
+    )
+
+    async def back_btn(inter, _btn):
+        await inter.response.defer_update()
+        await controller.back(inter, session)
+
+    back_button.callback = back_btn  # type: ignore[assignment]
+    view.add_item(back_button)
+
+    if optional:
+        skip_button = discord.ui.Button(
+            label="Skip",
+            style=discord.ButtonStyle.secondary,
+            custom_id="nav_skip",
+        )
+
+        async def skip_btn(inter, _btn):
+            await inter.response.defer_update()
+            await controller.skip(inter, session, q)
+
+        skip_button.callback = skip_btn  # type: ignore[assignment]
+        view.add_item(skip_button)
+
+    next_button = discord.ui.Button(
+        label="Next",
+        style=discord.ButtonStyle.primary,
+        custom_id="nav_next",
+        disabled=(required and not has_answer),
+    )
+
+    async def next_btn(inter, _btn):
+        await inter.response.defer_update()
+        await controller.next(inter, session)
+
+    next_button.callback = next_btn  # type: ignore[assignment]
+    view.add_item(next_button)
+
+    cancel_button = discord.ui.Button(
+        label="Cancel",
+        style=discord.ButtonStyle.danger,
+        custom_id="nav_cancel",
+    )
+
+    async def cancel_btn(inter, _btn):
+        await inter.response.defer_update()
+        await controller.cancel(inter, session)
+
+    cancel_button.callback = cancel_btn  # type: ignore[assignment]
+    view.add_item(cancel_button)
+
+    return content, view

--- a/tests/onboarding/test_selects_v1.py
+++ b/tests/onboarding/test_selects_v1.py
@@ -1,0 +1,130 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from modules.onboarding.controllers.wizard import WizardController
+from modules.onboarding.sessions import Session, SessionStore
+from modules.onboarding.ui import render_selects as srender
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        yield loop
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def _build_controller(event_loop: asyncio.AbstractEventLoop) -> WizardController:
+    class _Bot:
+        def __init__(self, loop):
+            self.loop = loop
+            self.logger = MagicMock()
+
+    bot = _Bot(event_loop)
+    sessions = SessionStore()
+    renderer = SimpleNamespace(get_question=lambda _: {})
+    controller = WizardController(bot, sessions, renderer)
+    controller.renderer.render = lambda session: ("legacy", discord.ui.View())
+    return controller
+
+
+def _build_interaction(loop: asyncio.AbstractEventLoop):
+    message = MagicMock()
+    message.id = 42
+    message.edit = AsyncMock()
+    channel = SimpleNamespace(
+        id=123,
+        send=AsyncMock(return_value=message),
+        fetch_message=AsyncMock(return_value=message),
+    )
+    response = SimpleNamespace(defer_update=AsyncMock(), send_modal=AsyncMock())
+    followup = SimpleNamespace(send=AsyncMock())
+    client = SimpleNamespace(loop=loop)
+    return SimpleNamespace(
+        client=client,
+        channel=channel,
+        response=response,
+        followup=followup,
+        message=message,
+        user=SimpleNamespace(id=555),
+    )
+
+
+def _flush(loop: asyncio.AbstractEventLoop) -> None:
+    loop.run_until_complete(asyncio.sleep(0))
+
+
+def _build_view(loop, controller, session, question, required, has_answer, optional):
+    async def _inner():
+        return srender.build_view(controller, session, question, required, has_answer, optional)
+
+    return loop.run_until_complete(_inner())
+
+
+def test_single_select_saves_and_gates(event_loop):
+    controller = _build_controller(event_loop)
+    interaction = _build_interaction(event_loop)
+    session = Session(thread_id=interaction.channel.id, applicant_id=interaction.user.id)
+    question = {
+        "gid": "w_stage",
+        "label": "Stage",
+        "type": "single-select",
+        "required": "TRUE",
+        "values": "Beginner, Early Game, Mid Game, Late Game, End Game",
+    }
+    controller.renderer.get_question = lambda idx: question
+
+    event_loop.run_until_complete(controller.sessions.save(session))
+    event_loop.run_until_complete(controller.launch(interaction))
+    _flush(event_loop)
+
+    content, view = _build_view(event_loop, controller, session, question, True, False, False)
+    next_button = next(child for child in view.children if getattr(child, "custom_id", "") == "nav_next")
+    assert next_button.disabled is True
+
+    event_loop.run_until_complete(
+        controller._save_select_answer(interaction, session, question, "Mid Game")
+    )
+    _flush(event_loop)
+
+    assert session.answers["w_stage"] == "Mid Game"
+
+    content, view = _build_view(event_loop, controller, session, question, True, True, False)
+    next_button = next(child for child in view.children if getattr(child, "custom_id", "") == "nav_next")
+    assert next_button.disabled is False
+
+
+def test_multi_select_saves_list_and_resumes(event_loop):
+    controller = _build_controller(event_loop)
+    interaction = _build_interaction(event_loop)
+    session = Session(thread_id=interaction.channel.id, applicant_id=interaction.user.id)
+    question = {
+        "gid": "w_hydra_diff",
+        "label": "Hydra",
+        "type": "multi-select",
+        "required": "FALSE",
+        "values": "Normal, Hard, Brutal, Nightmare",
+    }
+    controller.renderer.get_question = lambda idx: question
+
+    event_loop.run_until_complete(controller.sessions.save(session))
+    event_loop.run_until_complete(controller.launch(interaction))
+    _flush(event_loop)
+
+    event_loop.run_until_complete(
+        controller._save_multi_answer(interaction, session, question, ["Hard", "Brutal"])
+    )
+    _flush(event_loop)
+
+    assert session.answers["w_hydra_diff"] == ["Hard", "Brutal"]
+
+    _, view = _build_view(event_loop, controller, session, question, False, True, True)
+    select = next(child for child in view.children if isinstance(child, discord.ui.Select))
+    assert set(select.default_values) == {"Hard", "Brutal"}


### PR DESCRIPTION
## Summary
- render single-select and multi-select onboarding questions using sheet-provided values
- persist selections with logging, gating, and resume support for both select types
- document the new UI steps and cover storage, gating, and resume with targeted tests

## Testing
- pytest tests/onboarding/test_selects_v1.py
- pytest tests/onboarding/test_inputs_v1.py

[meta]
labels: componboarding, ux, fix
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2033e3ac83239b7b15f4dbd12448)