### PR TITLE
Keep-Alive Regression — Strict Sweep to shared.ports.get_port + Guardrail

### DIFF
--- a/.github/workflows/11-guardrails-suite.yml
+++ b/.github/workflows/11-guardrails-suite.yml
@@ -11,6 +11,10 @@ jobs:
       guardrails_status: ${{ steps.guardrails.outputs.guardrails_status }}
     steps:
       - uses: actions/checkout@v4
+      - name: Forbidden imports check (get_port path)
+        run: |
+          chmod +x scripts/ci/check_forbidden_imports.sh
+          scripts/ci/check_forbidden_imports.sh
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-11-08
+- **Fix:** Restored keep-alive/web server startup by sweeping imports from the deprecated `shared.config` path to `shared.ports.get_port`.
+- **Ops:** Added canonical boot log line `web server listening • port=<n>` to confirm bind.
+- **Guardrails:** New CI check blocks reintroduction of the deprecated import path.
+- **Docs:** Runbook updated with expected boot line & troubleshooting; guardrails doc updated with “Forbidden Imports”.
+
 ### v0.9.7 — 2025-11-07
 - CoreOps: load `modules.coreops.cmd_cfg` as an always-on extension so `!cfg` is available (admin only).
 
@@ -276,4 +282,4 @@
 - Sheet tab names moved out of env into each Sheet's **Config** tab.
 
 ---
-Doc last updated: 2025-11-07 (v0.9.7)
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -24,6 +24,7 @@ Every audit and CI check validates against this document.
 - **C-08 Single-Message Panels:** Interactive panels (like clan panels) update in place; avoid message spam.
 - **C-09 No Legacy Paths:** No imports from removed legacy paths (e.g., top-level `recruitment/`, deprecated shared CoreOps shims, `shared/utils/coreops_*`).
 - **C-10 Config Access:** Runtime config is accessed via the common config accessor (not scattered utility readers).
+- **C-11 Forbidden Ports Import:** Import the runtime port helper from `shared.ports`. Using the old `shared.config` import for `get_port` fails guardrails (`scripts/ci/check_forbidden_imports.sh`, workflow `11-guardrails-suite`).
 
 Ah, yeah — the house style in that doc uses **code-style IDs (C-01, F-01, etc.)**, single-sentence bullets, and tight spacing instead of tables or bold headers.
 Here’s your feature-toggle section rewritten to **match that exact spec layout and tone**:

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -6,6 +6,22 @@ workflows, and post-change validation.
 
 Older GitHub Actions deploy runs may display "skipped by same-file supersession" when a newer queued push touches overlapping files; treat this as expected sequencing.
 
+## Keep-Alive / Web Server — Expected Boot Line
+On successful bind, startup logs:
+
+```
+web server listening • port=<n>
+```
+
+If this line is missing:
+1. Check for import errors near startup (Render logs). An early failure prevents `Runtime.start()` from reaching `start_webserver()`.
+2. Confirm no code imports `get_port` from `shared.config`. The only allowed path is `shared.ports.get_port`.
+3. Verify `/health` responds. If not, the aiohttp site did not start.
+4. After fix, you should see heartbeat/watchdog lines at the configured cadence (`WATCHDOG_*`).
+
+Troubleshooting tip:
+- Run `scripts/ci/check_forbidden_imports.sh` locally to catch the deprecated import.
+
 ## Help overview surfaces
 - `@Bot help` adapts to the caller but always returns four embeds (Overview, Admin / Operational, Staff, User). Sections collapse when the caller cannot run any commands in that slice unless `SHOW_EMPTY_SECTIONS=1` is set, which swaps in a “Coming soon” placeholder for parity checks.
 - Commands are discovered dynamically via `bot.walk_commands()` and filtered through `command.can_run(ctx)` so permission decorators stay authoritative.
@@ -136,4 +152,4 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-11-06 (v0.9.7)
+Doc last updated: 2025-11-08 (v0.9.7)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -529,6 +529,7 @@ class Runtime:
         await self._web_runner.setup()
         self._web_site = web.TCPSite(self._web_runner, host="0.0.0.0", port=port)
         await self._web_site.start()
+        human_log.human("info", f"web server listening • port={port}")
         log.info("web server listening", extra={"port": port})
 
     async def _health_payload(self) -> tuple[dict, bool]:

--- a/scripts/ci/check_forbidden_imports.sh
+++ b/scripts/ci/check_forbidden_imports.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail CI if deprecated get_port import path is used.
+# Exclusions: AUDIT, VCS, envs, node_modules, build caches.
+
+shopt -s globstar nullglob
+
+echo "🔍 Guardrail: scanning for forbidden imports (shared.config → get_port)..."
+
+matches=$(rg -n --hidden --no-ignore \
+  -g '!AUDIT/**' \
+  -g '!**/.git/**' \
+  -g '!**/node_modules/**' \
+  -g '!**/.venv/**' \
+  -g '!**/venv/**' \
+  -g '!**/dist/**' \
+  -g '!**/build/**' \
+  "(from\\s+shared\\.config\\s+import[^\\n]*\\bget_port\\b|shared\\.config\\.get_port)" || true)
+
+if [[ -n "${matches}" ]]; then
+  echo "❌ Forbidden import path detected:"
+  echo "${matches}"
+  echo
+  echo "Use 'from shared.ports import get_port' instead."
+  exit 1
+fi
+
+echo "✅ No forbidden imports found."


### PR DESCRIPTION
## Summary
- add the canonical boot log line after the aiohttp site binds and retain structured logging for the port field
- enforce the shared.ports.get_port import path via a new scripts/ci/check_forbidden_imports.sh guardrail wired into the guardrails workflow
- document the guardrail and boot log expectations in the repository guardrails spec, ops runbook, and changelog

## Testing
- scripts/ci/check_forbidden_imports.sh

[meta]
labels: guardrails, docs, maintenance, comp:shared, comp:coreops, comp:ops, P1, ready, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f734852688323b0a0771033256ce7)