### PR TITLE
Add resilient keepalive route and pinger

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from shared.logfmt import LogTemplates, guild_label, user_label, human_reason
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from modules.common.runtime import Runtime
+from modules.common import keepalive
 from modules.coreops import ready as core_ready
 from c1c_coreops.config import (
     build_command_variants,
@@ -223,6 +224,8 @@ async def on_ready():
         runtime.scheduler.spawn(_daily_summary_loop(), name="cron_daily_summary")
         bot._cron_summary_task = True
         log.info("[cron] summary scheduler started (00:05Z)")
+
+    await keepalive.ensure_started(bot)
 
     runtime.schedule_startup_preload()
 

--- a/docs/ops/keepalive.md
+++ b/docs/ops/keepalive.md
@@ -1,0 +1,32 @@
+# Keep-Alive (Render)
+
+- Route: `GET /keepalive` → `200 ok`
+- URL resolution:
+  1) `KEEPALIVE_URL` (explicit)
+  2) `RENDER_EXTERNAL_URL` + `KEEPALIVE_PATH` (defaults to `/keepalive`)
+- Interval: `KEEPALIVE_INTERVAL` seconds (min 60, default 300)
+
+## Verify
+- Look for logs: `keepalive:task_started`, then periodic `keepalive:ping_ok`.
+
+## Troubleshooting
+- No logs? Ready hook didn’t call `ensure_started()`. Confirm post-ready path.
+- Non-200? Hit the public URL in a browser; route must return 200.
+- Wrong host? Set `KEEPALIVE_URL` explicitly.
+
+## Env / Config
+No hard-coded values. Uses KEEPALIVE_URL | RENDER_EXTERNAL_URL + KEEPALIVE_PATH | local dev fallback.
+
+`KEEPALIVE_INTERVAL` (seconds) optional, defaults 300, never below 60.
+
+## Testing
+Manual: Watch logs for keepalive:task_started, then keepalive:ping_ok every interval.
+
+Render: Confirm service no longer idles; cron logs continue at scheduled times.
+
+Local: Run server; curl http://localhost:PORT/keepalive returns ok.
+
+## Docs
+Added docs/ops/keepalive.md.
+
+No version bump. (Per contract.)

--- a/modules/common/keepalive.py
+++ b/modules/common/keepalive.py
@@ -1,0 +1,123 @@
+"""Keepalive helper for periodic external pings."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+from typing import Optional
+
+import aiohttp
+from discord.ext import commands
+
+__all__ = ["ensure_started", "route_path"]
+
+_TASK: asyncio.Task[None] | None = None
+_URL: str | None = None
+_INTERVAL: int | None = None
+
+
+def route_path() -> str:
+    """Return the configured keepalive route path for the local web app."""
+
+    path = os.getenv("KEEPALIVE_PATH", "/keepalive").strip() or "/keepalive"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+def _resolve_url() -> str:
+    explicit = os.getenv("KEEPALIVE_URL", "").strip()
+    if explicit:
+        return explicit
+
+    base = os.getenv("RENDER_EXTERNAL_URL", "").strip().rstrip("/")
+    path = route_path()
+    if base:
+        return f"{base}{path}"
+
+    port = os.getenv("PORT", "10000").strip() or "10000"
+    return f"http://127.0.0.1:{port}{path}"
+
+
+def _resolve_interval_seconds() -> int:
+    raw = os.getenv("KEEPALIVE_INTERVAL", "300").strip()
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 300
+    return max(60, value)
+
+
+def _get_logger(bot: commands.Bot | None) -> logging.Logger:
+    if bot is not None:
+        logger = getattr(bot, "logger", None)
+        if isinstance(logger, logging.Logger):
+            return logger
+    return logging.getLogger("modules.common.keepalive")
+
+
+async def _runner(bot: commands.Bot, url: str, interval: int) -> None:
+    logger = _get_logger(bot)
+    jitter = max(0, interval // 10)
+    timeout = aiohttp.ClientTimeout(total=10)
+    logger.info("keepalive:task_started • url=%s • interval=%ss", url, interval)
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while True:
+            try:
+                async with session.get(url) as resp:
+                    status = resp.status
+                    if 200 <= status < 300:
+                        logger.info("keepalive:ping_ok • status=%s", status)
+                    else:
+                        logger.warning("keepalive:ping_fail • status=%s", status)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning("keepalive:ping_fail • reason=%s", repr(exc))
+
+            sleep_for = interval
+            if jitter:
+                sleep_for += random.randint(0, jitter)
+            try:
+                await asyncio.sleep(sleep_for)
+            except asyncio.CancelledError:
+                raise
+
+
+async def ensure_started(
+    bot: commands.Bot,
+    *,
+    url: Optional[str] = None,
+    interval: Optional[int] = None,
+) -> None:
+    """Ensure the keepalive runner is active; restart if configuration changed."""
+
+    global _TASK, _URL, _INTERVAL
+
+    resolved_url = url or _resolve_url()
+    resolved_interval = interval or _resolve_interval_seconds()
+
+    task = _TASK
+    if task is not None:
+        if task.done():
+            _TASK = None
+            try:
+                task.result()
+            except Exception:
+                pass
+        elif _URL != resolved_url or _INTERVAL != resolved_interval:
+            task.cancel()
+            try:
+                await task
+            except Exception:
+                pass
+            _TASK = None
+
+    if _TASK is None:
+        loop = asyncio.get_running_loop()
+        _TASK = loop.create_task(_runner(bot, resolved_url, resolved_interval), name="keepalive")
+        _URL = resolved_url
+        _INTERVAL = resolved_interval

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -43,6 +43,7 @@ from shared.obs.events import (
 )
 from c1c_coreops.helpers import audit_tiers, rehydrate_tiers
 from shared.web_routes import mount_emoji_pad
+from . import keepalive
 
 import modules.onboarding as onboarding_pkg
 
@@ -149,10 +150,14 @@ async def create_app(*, runtime: "Runtime | None" = None) -> web.Application:
         status = 200 if healthy else 503
         return web.json_response(payload, status=status)
 
+    async def _keepalive_handler(_: web.Request) -> web.Response:
+        return web.Response(text="ok", status=200)
+
     app.router.add_get("/", root)
     app.router.add_get("/ready", ready)
     app.router.add_get("/health", health)
     app.router.add_get("/healthz", healthz)
+    app.router.add_get(keepalive.route_path(), _keepalive_handler)
 
     return app
 


### PR DESCRIPTION
## Summary
- restore the /keepalive endpoint on the aiohttp app for external pings
- add a resilient keepalive helper that resolves the target URL and runs a jittered background task with logging
- document keepalive configuration and verification steps for operations

## Testing
- not run (not requested)

[meta]
labels: fix, comp:coreops, comp:ops, comp:shared, reliability, robustness, P1, docs
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b4a022288323bbbf2b6ced5d7d3d)