### PR TITLE
Fix sanitize fallback import and include IDs in log labels

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from shared.config import (
     get_config_snapshot,
 )
 from shared.logfmt import LogTemplates, guild_label, user_label, human_reason
+from shared.redaction import sanitize_text
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from modules.common.runtime import Runtime

--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -32,9 +32,13 @@ LOG_EMOJI = {
 
 
 def _append_id(label: str, numeric_id: Optional[int]) -> str:
-    if not numeric_id:
+    if numeric_id is None:
         return label
-    return label
+    try:
+        normalized = int(numeric_id)
+    except (TypeError, ValueError):
+        return label
+    return f"{label} ({normalized})"
 
 
 def _clean_name(name: Optional[str], default: str) -> str:


### PR DESCRIPTION
## Summary
- import the sanitize_text helper in the application entrypoint to keep the ping fallback working
- include numeric identifiers in log labels so channel, user, and guild context is preserved

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b6d49f088323bf3a46ffa8beada1)