### PR TITLE
Update ops docs for current environment requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,24 +53,24 @@ It exists so that contributors update the correct references after each developm
 * [`CollaborationContract.md`](contracts/CollaborationContract.md) — contributor standards, PR review flow, and Codex formatting instructions.
 
 ### `/docs/ops/` — Operational Documentation
-* [`Architecture.md`](ops/Architecture.md) — detailed system flow, runtime design, and module topology.
 * [`CommandMatrix.md`](ops/CommandMatrix.md) — user/admin command catalogue with permissions, feature gates, and descriptions.
 * [`Config.md`](ops/Config.md) — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
-* [`env.md`](ops/env.md) — minimal environment checklist highlighting required sheet IDs and removed aliases.
+* [`env.md`](ops/env.md) — minimal environment checklist highlighting required keys and onboarding fallbacks.
+* [`keepalive.md`](ops/keepalive.md) — watchdog expectations, heartbeat tuning, and stall recovery notes.
 * [`Logging.md`](ops/Logging.md) — logging templates, dedupe policy, and configuration toggles.
+* [`module-toggles.md`](ops/module-toggles.md) — module-level feature toggle reference.
+* [`Onboarding.md`](ops/Onboarding.md) — onboarding sheet schema, cache lifecycle, and escalation playbook.
 * [`Onboarding-Runbook.md`](ops/Onboarding-Runbook.md) — rolling-card onboarding operations and validation flow notes.
-* [`Welcome.md`](ops/Welcome.md) — persistent welcome panel behaviour, recovery workflow, and operator tips.
-* [`WelcomeFlow.md`](ops/WelcomeFlow.md) — ticket-thread questionnaire flow and modal interaction notes.
-* [`WelcomeDiag.md`](ops/WelcomeDiag.md) — temporary welcome flow diagnostics flag and log locations.
 * [`PermCommandQuickstart.md`](ops/PermCommandQuickstart.md) — quickstart for the `!perm bot` command surface.
 * [`PermissionsSync.md`](ops/PermissionsSync.md) — bot access list administration and channel overwrite sync runbook.
 * [`RecruiterPanel.md`](ops/RecruiterPanel.md) — interaction model for the recruiter panel UI and messaging cadence.
 * [`Runbook.md`](ops/Runbook.md) — operator actions for routine tasks and incident handling.
 * [`Troubleshooting.md`](ops/Troubleshooting.md) — quick reference for diagnosing common issues.
 * [`Watchers.md`](ops/Watchers.md) — environment-gated welcome/promo listeners and cache refresh scheduler notes.
+* [`Welcome.md`](ops/Welcome.md) — persistent welcome panel behaviour, recovery workflow, and operator tips.
+* [`WelcomeFlow.md`](ops/WelcomeFlow.md) — ticket-thread questionnaire flow and modal interaction notes.
 * [`commands.md`](ops/commands.md) — supplemental command reference for operational usage.
 * [`development.md`](ops/development.md) — developer setup notes and contribution workflow guidance.
-* [`module-toggles.md`](ops/module-toggles.md) — module-level feature toggle reference.
 
 ## Maintenance Rules
 * Update this index whenever documentation files are added, renamed, or removed.

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -37,7 +37,7 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 # Google Sheet ID for recruitment data.
 RECRUITMENT_SHEET_ID=
 
-# Google Sheet ID for onboarding trackers.
+# Google Sheet ID for onboarding trackers. Required for onboarding features; leave blank only if onboarding is disabled.
 ONBOARDING_SHEET_ID=
 
 # Google Sheet ID for reminders (service-specific).
@@ -45,12 +45,6 @@ REMINDER_SHEET_ID=
 
 # Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific).
 MILESTONES_SHEET_ID=
-
-# Back-compat sheet ID used when dedicated IDs are unset.
-GOOGLE_SHEET_ID=
-
-# Legacy alias checked when the other IDs are blank.
-GSHEET_ID=
 
 # Worksheet name containing recruitment config (default: Config).
 RECRUITMENT_CONFIG_TAB=

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -24,11 +24,13 @@ Meta: Cache age 42s · Next refresh 02:15 UTC · Actor startup
 
 **Required at startup:** `DISCORD_TOKEN`, `GSPREAD_CREDENTIALS`, `RECRUITMENT_SHEET_ID`
 
-**Optional:** `ONBOARDING_SHEET_ID`, `ENV_NAME`, `BOT_NAME`, `PUBLIC_BASE_URL`, `RENDER_EXTERNAL_URL`, `LOG_CHANNEL_ID`, `WATCHDOG_CHECK_SEC`, `WATCHDOG_STALL_SEC`, `WATCHDOG_DISCONNECT_GRACE_SEC`
+**Optional for startup:** `ONBOARDING_SHEET_ID`*, `ENV_NAME`, `BOT_NAME`, `PUBLIC_BASE_URL`, `RENDER_EXTERNAL_URL`, `LOG_CHANNEL_ID`, `WATCHDOG_CHECK_SEC`, `WATCHDOG_STALL_SEC`, `WATCHDOG_DISCONNECT_GRACE_SEC`
 
 All sheet-facing modules now require their dedicated `*_SHEET_ID` variables; legacy fallbacks such as `GOOGLE_SHEET_ID` / `GSHEET_ID` are ignored.
 
 Missing any **Required** key causes the bot to exit with an error at startup. If `LOG_CHANNEL_ID` is empty, Discord channel logging is disabled and a one-time startup warning is emitted.
+
+\* Leaving `ONBOARDING_SHEET_ID` empty allows the process to boot, but onboarding watchers, cache refreshes, and questionnaire-driven commands either skip their work or emit soft errors.
 
 ### Core runtime
 | Key | Type | Default | Notes |

--- a/docs/ops/env.md
+++ b/docs/ops/env.md
@@ -11,18 +11,31 @@ The bot will refuse to start unless all of the following keys are populated:
 - `DISCORD_TOKEN`
 - `GSPREAD_CREDENTIALS`
 - `RECRUITMENT_SHEET_ID`
-- `ONBOARDING_SHEET_ID`
 
-All four values must be present in `.env.example` and production deployments. The
-sheet identifiers are distinct: one workbook powers recruitment flows, the other
-serves onboarding config and ticket tabs. Treat them as separate credentials when
-managing access or rotating service accounts.
+These must exist in `.env.example`, local development shells, and every
+deployment target. `RECRUITMENT_SHEET_ID` points at the primary workbook that
+feeds recruitment commands, digests, and feature toggles.
+
+## Onboarding-dependent keys
+
+`ONBOARDING_SHEET_ID` is optional for startup but required for onboarding
+features. When it is blank, the process still boots, yet the following degrade:
+
+- Onboarding cache warmers raise `missing config key` errors during refresh.
+- Watchers that sync welcome/promo ticket state skip their jobs.
+- Any command that reads onboarding questionnaire data returns fallback copy or
+  soft-errors in logs.
+
+Populate the key to restore the full onboarding flow. Ensure onboarding-only
+deployments use a dedicated service account and sheet permissions where
+possible.
 
 ## Legacy keys removed
 
-Older deployments referenced generic sheet identifiers such as `GOOGLE_SHEET_ID`
-(or the shorter `GSHEET_ID`). These aliases are no longer read anywhere in the
-codebase. Setting them has no effect and may hide misconfigurations. Always use
-the explicit `*_SHEET_ID` variables documented above.
+Older deployments referenced generic sheet identifiers such as
+`GOOGLE_SHEET_ID` (or the shorter `GSHEET_ID`). These aliases are no longer read
+anywhere in the codebase. Setting them has no effect and may hide
+misconfigurations. Always use the explicit `*_SHEET_ID` variables documented
+above.
 
 Doc last updated: 2025-11-08 (v0.9.7)


### PR DESCRIPTION
## Summary
- refresh the ops documentation index so it lists the files that actually exist today
- clarify which environment keys gate startup versus onboarding features in env.md and Config.md
- drop unused sheet ID aliases from the .env template and flag that onboarding IDs are required for those workflows

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131fe1ed8c8323ba9b87a83c248334)