### PR TITLE
Fix goto_if target parsing when spaces are present

### DIFF
--- a/modules/onboarding/rules/parser.py
+++ b/modules/onboarding/rules/parser.py
@@ -304,8 +304,12 @@ def _split_nav_body(body: str) -> tuple[str, str | None]:
     expr = parts[0] if parts else ""
     target = None
     for fragment in parts[1:]:
-        if fragment.lower().startswith("target="):
-            target = fragment[len("target=") :].strip()
+        lowered = fragment.lower()
+        if not lowered.startswith("target"):
+            continue
+        before, sep, after = fragment.partition("=")
+        if sep:
+            target = after.strip()
             break
     return expr, target
 

--- a/tests/onboarding/test_rules.py
+++ b/tests/onboarding/test_rules.py
@@ -39,8 +39,8 @@ def test_navigation_first_match_wins() -> None:
     questions = [
         _question(
             "w_siege",
-            nav_rules='goto_if(value = "yes", target="w_siege_detail")\n'
-            'goto_if(value = "no", target="w_cvc")',
+            nav_rules='goto_if(value = "yes", target = "w_siege_detail")\n'
+            'goto_if(value = "no", target = "w_cvc")',
         ),
         _question("w_siege_detail"),
         _question(


### PR DESCRIPTION
## Summary
- allow the navigation rule parser to accept goto_if target arguments that include whitespace around the equals sign
- extend the navigation tests to cover spaced target assignments to prevent regressions

## Testing
- pytest tests/onboarding/test_rules.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691328f521e48323933fcf2372b0e68c)