### PR TITLE
Implement onboarding rules visibility and tooling

### DIFF
--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -25,6 +25,7 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `!refresh [bucket]` | ✅ | Admin bang alias for single-bucket refresh with the same telemetry. | `!refresh [bucket]` |
 | `!refresh all` | ✅ | Bang alias for the full cache sweep (same cooldown as the `!ops` variant). | `!refresh all` |
 | `!reload [--reboot]` | ✅ | Admin bang alias for config reload plus optional soft reboot. | `!reload [--reboot]` |
+| `!reload onboarding` | ✅ | Reload onboarding questions and log the active schema hash. | `!reload onboarding` |
 | `!ping` | ✅ | Adds a 🏓 reaction so admins can confirm shard responsiveness. | `!ping` |
 | `!perm bot list` | ✅ | Show the current bot allow/deny lists with counts and IDs. | `!perm bot list [--json]` |
 | `!perm bot sync` | ✅ | Bulk apply bot role overwrites with audit logging. | `!perm bot sync [--dry] [--threads on|off] [--include voice|stage] [--limit N]` |

--- a/modules/onboarding/rules/__init__.py
+++ b/modules/onboarding/rules/__init__.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Sequence
 
-from modules.common import feature_flags
 from shared.sheets.onboarding_questions import Question
-
-from . import legacy
 from .evaluator import evaluate_navigation as _evaluate_navigation_v2
 from .evaluator import evaluate_visibility as _evaluate_visibility_v2
 from .parser import (
@@ -25,34 +22,21 @@ from .parser import (
 __all__ = ["evaluate_visibility", "next_index_by_rules", "validate_rules"]
 
 
-def _toggle_enabled() -> bool:
-    try:
-        return feature_flags.is_enabled("onboarding_rules_v2")
-    except Exception:
-        return False
-
-
 def evaluate_visibility(
     questions: Sequence[Question],
     answers: Mapping[str, Any],
 ) -> dict[str, dict[str, Any]]:
-    if _toggle_enabled():
-        return _evaluate_visibility_v2(questions, answers)
-    return legacy.evaluate_visibility(questions, answers)
+    return _evaluate_visibility_v2(questions, answers)
 
 
 def next_index_by_rules(
     current_idx: int, questions: Sequence[Question], answers: Mapping[str, Any]
 ) -> int | None:
-    if _toggle_enabled():
-        return _evaluate_navigation_v2(current_idx, questions, answers)
-    return legacy.next_index_by_rules(current_idx, list(questions), dict(answers))
+    return _evaluate_navigation_v2(current_idx, questions, answers)
 
 
 def validate_rules(questions: Sequence[Question]) -> list[str]:
-    if _toggle_enabled():
-        return _validate_v2(questions)
-    return legacy.validate_rules(questions)
+    return _validate_v2(questions)
 
 
 def _validate_v2(questions: Sequence[Question]) -> list[str]:

--- a/scripts/onboarding_rules_dry_run.py
+++ b/scripts/onboarding_rules_dry_run.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""CLI helper to evaluate onboarding visibility rules locally."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.onboarding import rules
+from shared.sheets import onboarding_questions
+
+
+def _load_answers(spec: str) -> Mapping[str, Any]:
+    if spec.startswith("@"):
+        path = Path(spec[1:])
+        text = path.read_text(encoding="utf-8")
+    else:
+        text = spec
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - user error
+        raise SystemExit(f"Invalid answers payload: {exc}") from exc
+    if not isinstance(data, Mapping):  # pragma: no cover - user error
+        raise SystemExit("Answers payload must be a JSON object")
+    return data
+
+
+def _dump(data: Mapping[str, Any]) -> None:
+    json.dump(data, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "answers",
+        help="JSON object describing answers (prefix with @ to read from file)",
+    )
+    parser.add_argument(
+        "--flow",
+        default="welcome",
+        choices=["welcome", "promo"],
+        help="Question flow to evaluate (default: welcome)",
+    )
+    args = parser.parse_args(argv)
+
+    answers = _load_answers(args.answers)
+    questions = onboarding_questions.get_questions(args.flow)
+    visibility = rules.evaluate_visibility(questions, answers)
+    _dump(visibility)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/shared/sheets/onboarding_questions.py
+++ b/shared/sheets/onboarding_questions.py
@@ -371,6 +371,8 @@ def _hash_payload(questions: Iterable[Question]) -> str:
     for question in questions:
         payload.append(
             {
+                "flow": question.flow,
+                "order": question.order,
                 "qid": question.qid,
                 "label": question.label,
                 "type": question.type,
@@ -379,7 +381,6 @@ def _hash_payload(questions: Iterable[Question]) -> str:
                 "validate": question.validate,
                 "help": question.help,
                 "options": [(option.value, option.label) for option in question.options],
-                "multi_max": question.multi_max,
                 "visibility_rules": question.visibility_rules,
                 "nav_rules": question.nav_rules,
             }

--- a/tests/onboarding/test_rolling_card_session.py
+++ b/tests/onboarding/test_rolling_card_session.py
@@ -47,7 +47,9 @@ class DummyController:
         self.completed.append(thread_id)
 
 
-def _question(order: str, qid: str, label: str, rules: str = "") -> SimpleNamespace:
+def _question(
+    order: str, qid: str, label: str, rules: str = "", nav_rules: str = ""
+) -> SimpleNamespace:
     return SimpleNamespace(
         order=order,
         order_raw=order,
@@ -57,6 +59,7 @@ def _question(order: str, qid: str, label: str, rules: str = "") -> SimpleNamesp
         type="number",
         help="",
         rules=rules,
+        nav_rules=nav_rules,
         maxlen=None,
         validate="",
         required=True,
@@ -72,6 +75,7 @@ def test_rolling_card_session_respects_goto_rules() -> None:
             "importance",
             "How important is CvC to you?",
             rules="if importance <= 2 goto min_commit",
+            nav_rules='goto_if(int(value) <= 2, target="min_commit")',
         ),
         _question("201", "min_cvc", "What’s the minimum CvC points you can commit to?"),
         _question("301", "min_commit", "Next milestone question"),

--- a/tests/onboarding/test_rules_visibility.py
+++ b/tests/onboarding/test_rules_visibility.py
@@ -26,11 +26,6 @@ _TARGET_QIDS = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def _enable_rules_v2(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(rules, "_toggle_enabled", lambda: True)
-
-
 def _question(
     qid: str,
     *,


### PR DESCRIPTION
## Summary
- update the onboarding rules engine to honor the new DSL precedence, emit telemetry, and expose visibility metadata
- persist the canonical visibility map through the welcome controller, adjust navigation, and surface submit errors with the new copy
- add an onboarding reload command, CLI dry-run helper, updated schema hashing, and accompanying docs/tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691338f2f98883239d914239f401dca4)