### PR TITLE
feat: add recruiter reservation command

### DIFF
--- a/docs/adr/ADR-0019-Introduction-of-Clan-SeatReservations.md
+++ b/docs/adr/ADR-0019-Introduction-of-Clan-SeatReservations.md
@@ -19,6 +19,7 @@ We introduce a fully sheet-backed reservation system with:
 * Recruiter-level logs posted to the configured `RECRUITERS_THREAD_ID`.
 * Admins are always permitted to use reservation features (emergency override).
 * All reservation functionality is gated by `FEATURE_RESERVATIONS` (`TRUE`/`FALSE`).
+* Implementation note (PR-RES-02): `!reserve <clantag>` now runs from `modules.placement.reservations`, appends rows to `RESERVATIONS_TAB` with `status=active`, and invokes `recompute_clan_availability` to refresh `AH`/`AF`/`AI` plus the in-memory cache. The command is available inside ticket threads when `FEATURE_RESERVATIONS` is enabled.
 This provides a controlled, predictable, auditable workflow where reservations affect effective availability across the cluster.
 
 ## **Consequences**

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -42,6 +42,7 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `!ops refresh all` | 🧩 | Warm every registered cache bucket and emit a consolidated summary (30 s guild cooldown). | `!ops refresh all` |
 | `!ops reload [--reboot]` | 🧩 | Rebuild the config registry; optionally schedule a soft reboot. | `!ops reload [--reboot]` |
 | `!clanmatch` | 🧩 | Recruiter match workflow (requires recruiter/staff role). [gated: `recruiter_panel`] | `!clanmatch` |
+| `!reserve <clan>` | ✅ | Reserve one clan seat inside a ticket thread and update availability. [gated: `feature_reservations`] | `!reserve <clan>` |
 | `!welcome <clan> [@member] [note]` | ✅ | Post the legacy welcome embed with crest, pings, and general notice routing. [gated: `recruitment_welcome`] | `!welcome <clan> [@member] [note]` |
 
 ## User — general members
@@ -52,6 +53,6 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `!clan <tag>` | 🧩 | Public clan card with crest + 💡 reaction flip between profile and entry criteria. [gated: `clan_profile`] | `!clan <tag>` |
 | `!clansearch` | 🧩 | Member clan search with legacy filters + pager (edits the panel in place). [gated: `member_panel`] | `!clansearch` |
 
-> Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `placement_target_select` and `placement_reservations` remain stub modules that only log when enabled. `onboarding_rules_v2` enables the deterministic onboarding rules DSL (visibility + navigation); disable to fall back to the legacy string parser.
+> Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `feature_reservations` gates the `!reserve` command. `placement_target_select` remains a stub module that only logs when enabled. `onboarding_rules_v2` enables the deterministic onboarding rules DSL (visibility + navigation); disable to fall back to the legacy string parser.
 
-Doc last updated: 2025-11-11 (v0.9.7)
+Doc last updated: 2025-11-13 (v0.9.7)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -144,6 +144,20 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 - Two zero-width divider fields containing `﹘﹘﹘` separate the blocks so desktop and
   mobile layouts both show clear visual boundaries.
 
+## Reserving a clan seat (`!reserve`)
+- Confirm `FEATURE_RESERVATIONS` is enabled in the FeatureToggles worksheet before using the command.
+- Run `!reserve <clan_tag>` inside the recruit’s ticket thread (welcome or promo parent).
+- Follow the prompts:
+  - Mention the recruit or paste their Discord ID.
+  - Provide the reservation end date in `YYYY-MM-DD`.
+  - Add a short reason when no effective seats remain (`AF` = 0).
+- Reply `yes` at the confirmation step to save; `change` lets you re-enter the recruit or date.
+- The bot appends the ledger row in `RESERVATIONS_TAB`, then calls `recompute_clan_availability` to update:
+  - `AH` — active reservations
+  - `AF` — effective open spots (`max(E - AH, 0)`)
+  - `AI` — reservation summary (`"<AH> -> usernames"`)
+- A success message posts in the thread with the refreshed `AH` and `AF` values.
+
 ## Features unexpectedly disabled at startup
 - **Checks:** Confirm the `FEATURE_TOGGLES_TAB` value points to `FeatureToggles`, headers
   match (`feature_name`, `enabled`), and each enabled row uses `TRUE` (case-insensitive).
@@ -152,4 +166,4 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-11-08 (v0.9.7)
+Doc last updated: 2025-11-13 (v0.9.7)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -824,7 +824,8 @@ class Runtime:
             "modules.placement.target_select", ("placement_target_select",)
         )
         await _load_feature_module(
-            "modules.placement.reservations", ("placement_reservations",)
+            "modules.placement.reservations",
+            ("feature_reservations", "placement_reservations"),
         )
 
         await onboarding_ops_check.setup(self.bot)

--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -1,12 +1,530 @@
-"""Stub module for future placement reservation commands."""
+"""Reservation command for holding clan seats inside ticket threads."""
 
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
 import logging
+import re
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Iterable, Optional
 
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import is_admin_member, is_recruiter
+from modules.common import feature_flags
+from modules.recruitment import availability
+from shared.config import get_promo_channel_id, get_welcome_channel_id
+from shared.sheets import recruitment, reservations
 
 log = logging.getLogger(__name__)
 
+PROMPT_TIMEOUT_SECONDS = 300
+ACTIVE_STATUS = "active"
 
-async def setup(_bot) -> None:
-    """Log that the reservations stub has been loaded."""
 
-    log.info("placement.reservations stub loaded (no commands)")
+class ReservationFlowAbort(Exception):
+    """Raised when the interactive flow ends without creating a reservation."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(slots=True)
+class ReservationDetails:
+    """Normalized output from the interactive reservation flow."""
+
+    ticket_user_id: Optional[int]
+    ticket_display: str
+    ticket_username: Optional[str]
+    reserved_until: dt.date
+    notes: str
+
+
+class ReservationConversation:
+    """Interactive prompt that collects reservation metadata from staff."""
+
+    CANCEL_KEYWORDS: Iterable[str] = ("cancel",)
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        *,
+        clan_label: str,
+        manual_open: int,
+        active_reservations: int,
+        wait_for: Callable[..., Awaitable[discord.Message]],
+    ) -> None:
+        self.ctx = ctx
+        self._clan_label = clan_label
+        self._manual_open = manual_open
+        self._active_reservations = active_reservations
+        self._wait_for = wait_for
+        self._author_id = getattr(ctx.author, "id", None)
+        self._channel_id = getattr(ctx.channel, "id", None)
+
+    async def run(self) -> ReservationDetails:
+        """Execute the full conversation flow and return reservation details."""
+
+        user_id, display, username = await self._prompt_user()
+        reserved_until = await self._prompt_date()
+
+        notes = ""
+        if self._effective_available <= 0:
+            notes = await self._prompt_reason()
+
+        while True:
+            action = await self._confirm(display, reserved_until, notes)
+            if action == "yes":
+                return ReservationDetails(
+                    ticket_user_id=user_id,
+                    ticket_display=display,
+                    ticket_username=username,
+                    reserved_until=reserved_until,
+                    notes=notes,
+                )
+            if action == "user":
+                user_id, display, username = await self._prompt_user(reprompt=True)
+                continue
+            if action == "date":
+                reserved_until = await self._prompt_date(reprompt=True)
+                continue
+
+    @property
+    def _effective_available(self) -> int:
+        return max(self._manual_open - self._active_reservations, 0)
+
+    async def _prompt_user(
+        self, *, reprompt: bool = False
+    ) -> tuple[Optional[int], str, Optional[str]]:
+        prompt = (
+            f"Who do you want to reserve a spot for in `{self._clan_label}`?\n"
+            "You can @mention them or paste their Discord ID. Type `cancel` to abort."
+        )
+        if not reprompt:
+            await self.ctx.send(prompt)
+        else:
+            await self.ctx.send(
+                "Please @mention the recruit or paste their Discord ID. Type `cancel` to abort."
+            )
+
+        while True:
+            message = await self._next_message()
+            content = (message.content or "").strip()
+            lowered = content.lower()
+            if lowered in self.CANCEL_KEYWORDS:
+                await self.ctx.send("Reservation cancelled. No changes made.")
+                raise ReservationFlowAbort("cancelled")
+
+            mention = next(iter(getattr(message, "mentions", []) or []), None)
+            if mention is not None:
+                display = getattr(mention, "mention", f"<@{getattr(mention, 'id', '???')}>")
+                ticket_username = _display_name(mention)
+                return getattr(mention, "id", None), display, ticket_username
+
+            match = re.search(r"\d+", content)
+            if match:
+                try:
+                    candidate_id = int(match.group(0))
+                except ValueError:
+                    candidate_id = None
+                if candidate_id is not None:
+                    member = _resolve_member(self.ctx.guild, candidate_id)
+                    if member is not None:
+                        mention_text = getattr(member, "mention", f"<@{candidate_id}>")
+                        return candidate_id, mention_text, _display_name(member)
+                    return candidate_id, f"<@{candidate_id}>", None
+
+            await self.ctx.send(
+                "I didn't catch that. Please @mention the recruit or paste their Discord ID (or type `cancel`)."
+            )
+
+    async def _prompt_date(self, *, reprompt: bool = False) -> dt.date:
+        prompt = (
+            "Until which date do you want to reserve the spot?"
+            " Please use `YYYY-MM-DD` (no time). Type `cancel` to abort."
+        )
+        if not reprompt:
+            await self.ctx.send(prompt)
+        else:
+            await self.ctx.send(
+                "Please provide the reservation end date in `YYYY-MM-DD` (or type `cancel`)."
+            )
+
+        while True:
+            message = await self._next_message()
+            content = (message.content or "").strip()
+            lowered = content.lower()
+            if lowered in self.CANCEL_KEYWORDS:
+                await self.ctx.send("Reservation cancelled. No changes made.")
+                raise ReservationFlowAbort("cancelled")
+            try:
+                parsed = dt.date.fromisoformat(content)
+            except ValueError:
+                parsed = None
+            today = dt.date.today()
+            if parsed is None or parsed < today:
+                await self.ctx.send(
+                    "Please use `YYYY-MM-DD` and make sure the date is today or later."
+                )
+                continue
+            return parsed
+
+    async def _prompt_reason(self) -> str:
+        prompt = (
+            f"Heads up: `{self._clan_label}` currently has 0 effective open spots when existing"
+            " reservations are included. You can still reserve a seat, but please add a short"
+            " reason (or type `cancel` to abort)."
+        )
+        await self.ctx.send(prompt)
+
+        while True:
+            message = await self._next_message()
+            content = (message.content or "").strip()
+            if content.lower() in self.CANCEL_KEYWORDS:
+                await self.ctx.send("Reservation cancelled. No changes made.")
+                raise ReservationFlowAbort("cancelled")
+            if content:
+                return content
+            await self.ctx.send("Please add a short reason (or type `cancel` to abort).")
+
+    async def _confirm(
+        self, display: str, reserved_until: dt.date, notes: str
+    ) -> str:
+        lines = [
+            f"Reserve 1 spot in `{self._clan_label}` for {display} until `{reserved_until.isoformat()}`.",
+        ]
+        if notes:
+            lines.append(f"Reason: {notes}")
+        lines.append("Type `yes` to save, `no` to cancel, or `change` to edit the recruit/date.")
+        await self.ctx.send("\n".join(lines))
+
+        while True:
+            message = await self._next_message()
+            content = (message.content or "").strip().lower()
+            if content in self.CANCEL_KEYWORDS or content in {"no", "n"}:
+                await self.ctx.send("Reservation cancelled. No changes made.")
+                raise ReservationFlowAbort("cancelled")
+            if content in {"yes", "y"}:
+                return "yes"
+            if content in {"change", "c"}:
+                await self.ctx.send("Type `user` to change the recruit or `date` to change the end date.")
+                while True:
+                    followup = await self._next_message()
+                    follow_content = (followup.content or "").strip().lower()
+                    if follow_content in self.CANCEL_KEYWORDS:
+                        await self.ctx.send("Reservation cancelled. No changes made.")
+                        raise ReservationFlowAbort("cancelled")
+                    if "user" in follow_content:
+                        return "user"
+                    if "date" in follow_content:
+                        return "date"
+                    await self.ctx.send("Please type `user` or `date`, or `cancel` to abort.")
+                continue
+            await self.ctx.send("Please reply with `yes`, `no`, or `change` (or type `cancel`).")
+
+    async def _next_message(self) -> discord.Message:
+        if self._wait_for is None:
+            raise ReservationFlowAbort("missing-wait-for")
+
+        try:
+            message = await self._wait_for(
+                "message",
+                timeout=PROMPT_TIMEOUT_SECONDS,
+                check=lambda m: (
+                    getattr(m.author, "id", None) == self._author_id
+                    and getattr(m.channel, "id", None) == self._channel_id
+                ),
+            )
+        except asyncio.TimeoutError:
+            await self.ctx.send(
+                "Reservation timed out. Please run `!reserve` again if you still need it."
+            )
+            raise ReservationFlowAbort("timeout")
+        return message
+
+
+def _display_name(member: object) -> Optional[str]:
+    for attr in ("display_name", "nick", "name"):
+        value = getattr(member, attr, None)
+        if value:
+            text = str(value).strip()
+            if text:
+                return text
+    return None
+
+
+def _resolve_member(guild: object, member_id: int):
+    getter = getattr(guild, "get_member", None)
+    if callable(getter):
+        try:
+            return getter(member_id)
+        except Exception:  # pragma: no cover - defensive guard
+            log.exception(
+                "guild get_member failed",
+                extra={"member_id": member_id},
+            )
+    return None
+
+
+def _normalize_tag(tag: str | None) -> str:
+    text = "" if tag is None else str(tag).strip().upper()
+    return "".join(ch for ch in text if ch.isalnum())
+
+
+def _parse_manual_open(row: list[str]) -> int:
+    if len(row) <= 4:
+        return 0
+    return _to_int(row[4])
+
+
+def _to_int(value: str | None) -> int:
+    if not value:
+        return 0
+    match = re.search(r"-?\d+", str(value))
+    if not match:
+        return 0
+    try:
+        return int(match.group(0))
+    except ValueError:
+        return 0
+
+
+def _ticket_parent_ids() -> set[int]:
+    parents: set[int] = set()
+    for getter in (get_welcome_channel_id, get_promo_channel_id):
+        value = getter()
+        if value is None:
+            continue
+        try:
+            parents.add(int(value))
+        except (TypeError, ValueError):
+            continue
+    return parents
+
+
+def _is_ticket_thread(channel: object) -> bool:
+    if channel is None:
+        return False
+
+    channel_type = getattr(channel, "type", None)
+    thread_types = {
+        getattr(discord.ChannelType, "public_thread", None),
+        getattr(discord.ChannelType, "private_thread", None),
+        getattr(discord.ChannelType, "news_thread", None),
+    }
+    if channel_type not in thread_types:
+        return False
+
+    parent_id = getattr(channel, "parent_id", None)
+    if parent_id is None:
+        return False
+
+    try:
+        parent_value = int(parent_id)
+    except (TypeError, ValueError):
+        return False
+
+    return parent_value in _ticket_parent_ids()
+
+
+def _reservations_enabled() -> bool:
+    for key in ("FEATURE_RESERVATIONS", "feature_reservations", "placement_reservations"):
+        try:
+            if feature_flags.is_enabled(key):
+                return True
+        except Exception:
+            log.exception("feature toggle check failed", extra={"feature": key})
+    return False
+
+
+class ReservationCog(commands.Cog):
+    """Cog hosting the `!reserve` recruiter command."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("staff")
+    @help_metadata(
+        function_group="recruitment",
+        section="recruitment",
+        access_tier="staff",
+    )
+    @commands.command(
+        name="reserve",
+        help="Reserve a clan seat for a recruit until a specific date.",
+        brief="Reserve a clan seat for a recruit.",
+    )
+    async def reserve(self, ctx: commands.Context, clan_tag: str | None = None) -> None:
+        if clan_tag is None or not str(clan_tag).strip():
+            await ctx.reply(
+                "Usage: `!reserve <clantag>` (run inside the recruit's ticket thread).",
+                mention_author=False,
+            )
+            return
+
+        if not _reservations_enabled():
+            await ctx.reply(
+                "Reservations are currently disabled. Please poke an admin if you think this is wrong.",
+                mention_author=False,
+            )
+            return
+
+        if ctx.guild is None:
+            await ctx.reply(
+                "⚠️ `!reserve` can only be used inside a server thread.",
+                mention_author=False,
+            )
+            return
+
+        if not (is_recruiter(ctx) or is_admin_member(ctx)):
+            await ctx.reply(
+                "Only Recruiters (or Admins) can reserve clan spots. If you need a hold, poke the Recruitment Crew.",
+                mention_author=False,
+            )
+            return
+
+        if not _is_ticket_thread(ctx.channel):
+            await ctx.reply(
+                "Please run `!reserve` inside the recruit’s ticket thread so I know who you’re talking about.",
+                mention_author=False,
+            )
+            return
+
+        clan_entry = recruitment.find_clan_row(clan_tag)
+        if clan_entry is None:
+            await ctx.reply(
+                f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
+                mention_author=False,
+            )
+            return
+
+        _, row = clan_entry
+        sheet_tag = row[2] if len(row) > 2 and row[2] else clan_tag
+        manual_open = _parse_manual_open(row)
+
+        try:
+            active_reservations = await reservations.count_active_reservations_for_clan(sheet_tag)
+        except Exception:
+            log.exception(
+                "failed to count active reservations",
+                extra={"clan_tag": _normalize_tag(sheet_tag)},
+            )
+            await ctx.reply(
+                "Something went wrong while checking current reservations. Please try again later or contact an admin.",
+                mention_author=False,
+            )
+            return
+
+        wait_for = getattr(self.bot, "wait_for", None)
+        if wait_for is None:
+            await ctx.reply(
+                "I can't start the reservation flow right now. Please try again later.",
+                mention_author=False,
+            )
+            return
+
+        conversation = ReservationConversation(
+            ctx,
+            clan_label=sheet_tag,
+            manual_open=manual_open,
+            active_reservations=active_reservations,
+            wait_for=wait_for,
+        )
+
+        try:
+            details = await conversation.run()
+        except ReservationFlowAbort:
+            return
+
+        now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+        row_values = [
+            str(getattr(ctx.channel, "id", "")),
+            str(details.ticket_user_id or ""),
+            str(getattr(ctx.author, "id", "")),
+            sheet_tag,
+            details.reserved_until.isoformat(),
+            now.isoformat(),
+            ACTIVE_STATUS,
+            details.notes,
+            details.ticket_username or "",
+        ]
+
+        try:
+            await reservations.append_reservation_row(row_values)
+        except Exception:
+            log.exception(
+                "failed to append reservation row",
+                extra={
+                    "clan_tag": _normalize_tag(sheet_tag),
+                    "thread_id": getattr(ctx.channel, "id", None),
+                },
+            )
+            await ctx.send(
+                "Something went wrong while saving the reservation to the sheet. No changes were made. Please try again or poke an admin."
+            )
+            return
+
+        try:
+            await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)
+        except Exception:
+            log.exception(
+                "failed to recompute clan availability",
+                extra={"clan_tag": _normalize_tag(sheet_tag)},
+            )
+            await ctx.send(
+                "Saved the reservation, but I couldn't refresh clan availability. Please poke an admin to verify the sheet."
+            )
+            return
+
+        fallback_reserved = active_reservations + 1
+        fallback_available = max(manual_open - fallback_reserved, 0)
+
+        updated_row = recruitment.get_clan_by_tag(sheet_tag)
+        if updated_row is not None:
+            ah_value = _safe_cell(updated_row, 33, fallback_reserved)
+            af_value = _safe_cell(updated_row, 31, fallback_available)
+        else:
+            ah_value = str(fallback_reserved)
+            af_value = str(fallback_available)
+
+        await ctx.send(
+            "\n".join(
+                [
+                    f"Reserved 1 spot in `{sheet_tag}` for {details.ticket_display} until `{details.reserved_until.isoformat()}`.",
+                    f"Reserved for this clan: `{ah_value}`. Effective open spots: `{af_value}`.",
+                ]
+            )
+        )
+
+        log.info(
+            "[reserve] reservation created",
+            extra={
+                "clan_tag": _normalize_tag(sheet_tag),
+                "thread_id": getattr(ctx.channel, "id", None),
+                "recruiter_id": getattr(ctx.author, "id", None),
+                "ticket_user_id": details.ticket_user_id,
+                "reserved_until": details.reserved_until.isoformat(),
+                "notes": details.notes,
+            },
+        )
+
+
+def _safe_cell(row: list[str], index: int, fallback: int) -> str:
+    if 0 <= index < len(row):
+        value = row[index]
+        text = str(value).strip()
+        if text:
+            return text
+    return str(fallback)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ReservationCog(bot))
+    log.info("placement.reservations command loaded")
+
+
+__all__ = ["ReservationCog", "setup"]

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -1,0 +1,287 @@
+import asyncio
+from typing import List
+
+import discord
+
+from modules.placement import reservations as reserve_module
+
+
+class FakeMember:
+    def __init__(self, user_id: int, display_name: str = "Recruit") -> None:
+        self.id = user_id
+        self.display_name = display_name
+        self.name = display_name
+        self.mention = f"<@{user_id}>"
+
+
+class FakeGuild:
+    def __init__(self, members: List[FakeMember]) -> None:
+        self._members = {member.id: member for member in members}
+
+    def get_member(self, member_id: int):
+        return self._members.get(member_id)
+
+
+class FakeThread:
+    def __init__(self, thread_id: int, parent_id: int) -> None:
+        self.id = thread_id
+        self.parent_id = parent_id
+        self.type = discord.ChannelType.private_thread
+        self.sent: list[FakeSentMessage] = []
+
+    async def send(self, content: str | None = None, **kwargs):
+        message = FakeSentMessage(content, kwargs)
+        self.sent.append(message)
+        return message
+
+
+class FakeSentMessage:
+    def __init__(self, content: str | None, kwargs: dict) -> None:
+        self.content = content
+        self.kwargs = dict(kwargs)
+
+    async def edit(self, *, content: str | None = None, **kwargs):
+        if content is not None:
+            self.content = content
+        self.kwargs.update(kwargs)
+        return self
+
+
+class FakeMessage:
+    def __init__(self, content: str, author, channel, mentions=None) -> None:
+        self.content = content
+        self.author = author
+        self.channel = channel
+        self.mentions = list(mentions or [])
+
+
+class FakeBot:
+    def __init__(self, messages: List[FakeMessage]) -> None:
+        self._messages = list(messages)
+
+    async def wait_for(self, event_name: str, *, timeout: float, check):
+        while self._messages:
+            message = self._messages.pop(0)
+            if check(message):
+                return message
+        raise asyncio.TimeoutError
+
+
+class FakeContext:
+    def __init__(self, bot: FakeBot, guild: FakeGuild, channel: FakeThread, author) -> None:
+        self.bot = bot
+        self.guild = guild
+        self.channel = channel
+        self.author = author
+        self.replies: list[FakeSentMessage] = []
+
+    async def reply(self, content: str, *, mention_author: bool = False):
+        message = await self.channel.send(content=content)
+        self.replies.append(message)
+        return message
+
+    async def send(self, content: str, **kwargs):
+        return await self.channel.send(content=content, **kwargs)
+
+
+def _enable_feature(monkeypatch, enabled: bool = True) -> None:
+    monkeypatch.setattr(
+        reserve_module.feature_flags,
+        "is_enabled",
+        lambda key: enabled,
+        raising=False,
+    )
+
+
+def _setup_parents(monkeypatch, parent_id: int) -> None:
+    monkeypatch.setattr(reserve_module, "get_welcome_channel_id", lambda: parent_id)
+    monkeypatch.setattr(reserve_module, "get_promo_channel_id", lambda: parent_id)
+
+
+def _setup_permissions(monkeypatch, recruiter: bool, admin: bool = False) -> None:
+    monkeypatch.setattr(reserve_module, "is_recruiter", lambda ctx: recruiter)
+    monkeypatch.setattr(reserve_module, "is_admin_member", lambda ctx: admin)
+
+
+def _make_cog(bot: FakeBot) -> reserve_module.ReservationCog:
+    return reserve_module.ReservationCog(bot)  # type: ignore[arg-type]
+
+
+def test_reserve_success(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=999)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(222, "Recruit One")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=555, parent_id=999)
+
+    mention_message = FakeMessage("reserve user", author=None, channel=thread, mentions=[recruit])
+    date_message = FakeMessage("2025-12-01", author=None, channel=thread)
+    confirm_message = FakeMessage("yes", author=None, channel=thread)
+
+    author = FakeMember(111, "Recruiter")
+    for message in (mention_message, date_message, confirm_message):
+        message.author = author
+
+    bot = FakeBot([mention_message, date_message, confirm_message])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    clan_row = ["", "Clan", "#ABC", "", "3"] + [""] * 40
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row)))
+
+    def fake_updated_row(tag):
+        updated = list(clan_row)
+        while len(updated) <= 33:
+            updated.append("")
+        updated[31] = "1"
+        updated[33] = "2"
+        return updated
+
+    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", fake_updated_row)
+
+    async def fake_count(tag):
+        return 1
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "count_active_reservations_for_clan",
+        fake_count,
+    )
+
+    appended: list[list[str]] = []
+
+    async def fake_append(row_values):
+        appended.append(list(row_values))
+
+    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+
+    recomputed = {}
+
+    async def fake_recompute(clan_tag, *, guild=None, resolver=None):
+        recomputed["tag"] = clan_tag
+
+    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", fake_recompute)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "ABC"))
+
+    assert appended, "reservation row should be appended"
+    saved_row = appended[0]
+    assert saved_row[0] == str(thread.id)
+    assert saved_row[1] == str(recruit.id)
+    assert saved_row[3] == "#ABC"
+    assert saved_row[6] == reserve_module.ACTIVE_STATUS
+    assert saved_row[7] == ""
+    assert recomputed["tag"] == "#ABC"
+    assert thread.sent[-1].content.startswith("Reserved 1 spot in `#ABC`")
+
+
+def test_reserve_requires_reason(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=777)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(333, "Applicant")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=666, parent_id=777)
+
+    author = FakeMember(444, "Recruiter")
+    messages = [
+        FakeMessage("who", author=author, channel=thread, mentions=[recruit]),
+        FakeMessage("2025-11-30", author=author, channel=thread),
+        FakeMessage("Because they confirmed a start date", author=author, channel=thread),
+        FakeMessage("yes", author=author, channel=thread),
+    ]
+
+    bot = FakeBot(messages)
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    clan_row = ["", "Clan", "#DEF", "", "1"] + [""] * 40
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (11, list(clan_row)))
+    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+    async def fake_count(tag):
+        return 1
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "count_active_reservations_for_clan",
+        fake_count,
+    )
+
+    appended: list[list[str]] = []
+
+    async def fake_append(row_values):
+        appended.append(list(row_values))
+
+    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "recompute_clan_availability",
+        lambda *args, **kwargs: asyncio.sleep(0),
+    )
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "DEF"))
+
+    assert appended[0][7] == "Because they confirmed a start date"
+
+
+def test_reserve_feature_disabled(monkeypatch):
+    _enable_feature(monkeypatch, enabled=False)
+    _setup_parents(monkeypatch, parent_id=1001)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(555)
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=777, parent_id=1001)
+    author = FakeMember(556)
+
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "XYZ"))
+
+    assert ctx.replies, "should reply when feature disabled"
+    assert "disabled" in ctx.replies[0].content
+
+
+def test_reserve_permission_denied(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=42)
+    _setup_permissions(monkeypatch, recruiter=False, admin=False)
+
+    recruit = FakeMember(777)
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=888, parent_id=42)
+    author = FakeMember(778)
+
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "JKL"))
+
+    assert ctx.replies, "should reply when user lacks permissions"
+    assert "Only Recruiters" in ctx.replies[0].content
+
+
+def test_reserve_requires_ticket_thread(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=500)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(888)
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=999, parent_id=123)  # parent does not match configured id
+    author = FakeMember(889)
+
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "MNO"))
+
+    assert ctx.replies, "should reply when outside ticket thread"
+    assert "ticket thread" in ctx.replies[0].content


### PR DESCRIPTION
## Summary
- add the `!reserve` interactive flow for recruiters inside ticket threads and persist reservations to the ledger
- recompute clan availability after creating a reservation and load the module when the new feature toggle is enabled
- document the reservation workflow in the command matrix, ops runbook, and ADR, and cover the command with unit tests

## Testing
- pytest tests/placement/test_reserve_command.py

[meta]
labels: enhancement, comp:commands, comp:data-sheets, comp:config, docs, P2, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f2de20c88323abd1d142a54782bc)