### PR TITLE
Add scheduled reservation lifecycle jobs

### DIFF
--- a/docs/adr/ADR-0019-Introduction-of-Clan-SeatReservations.md
+++ b/docs/adr/ADR-0019-Introduction-of-Clan-SeatReservations.md
@@ -14,7 +14,7 @@ We introduce a fully sheet-backed reservation system with:
 * Status values: `active`, `expired`, `released` (future), `cancelled` (optional).
 * Two scheduled tasks:
   * **12:00 UTC reminder job** — warns if a reservation ends today.
-  * **18:00 UTC auto-release job** — expires outdated reservations after a 6-hour grace period.
+  * **18:00 UTC auto-release job** — expires outdated reservations after a 6-hour grace period, flips the ledger status to `expired`, and reruns `recompute_clan_availability` so `AF`/`AH`/`AI` stay in sync.
 * Thread-level user notifications for creation, reminders, expiry.
 * Recruiter-level logs posted to the configured `RECRUITERS_THREAD_ID`.
 * Admins are always permitted to use reservation features (emergency override).
@@ -35,4 +35,4 @@ This provides a controlled, predictable, auditable workflow where reservations a
   * Logging to threads + staff-log channel
 * Future extensions (release/extend/list) can be added without breaking the model.
 
-Doc last updated: 2025-11-13 (v0.9.7)
+Doc last updated: 2025-11-18 (v0.9.7)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -157,6 +157,18 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
   - `AF` — effective open spots (`max(E - AH, 0)`)
   - `AI` — reservation summary (`"<AH> -> usernames"`)
 - A success message posts in the thread with the refreshed `AH` and `AF` values.
+ 
+## Reservation lifecycle (daily jobs)
+- **12:00 UTC — Reminder**
+  - Finds every `active` reservation where `reserved_until == today`.
+  - Posts a reminder in the recruit’s ticket thread and pings Recruiter roles.
+  - Gives Recruiters a six-hour window to extend or intervene before expiry.
+- **18:00 UTC — Auto-release**
+  - Marks `active` reservations with `reserved_until <= today` as `expired` in `RESERVATIONS_TAB`.
+  - Calls `recompute_clan_availability` for each affected clan to refresh `AF`, `AH`, and `AI`.
+  - Posts an expiry notice in the ticket thread (when it still exists) and a summary line in `RECRUITERS_THREAD_ID`.
+
+Both jobs respect the `FEATURE_RESERVATIONS` toggle in the `Feature_Toggles` worksheet. When the flag is disabled they exit without making any changes.
 
 ## Features unexpectedly disabled at startup
 - **Checks:** Confirm the `FEATURE_TOGGLES_TAB` value points to `FeatureToggles`, headers
@@ -166,4 +178,4 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-11-13 (v0.9.7)
+Doc last updated: 2025-11-18 (v0.9.7)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -827,6 +827,10 @@ class Runtime:
             "modules.placement.reservations",
             ("feature_reservations", "placement_reservations"),
         )
+        await _load_feature_module(
+            "modules.placement.reservation_jobs",
+            ("feature_reservations", "placement_reservations"),
+        )
 
         await onboarding_ops_check.setup(self.bot)
         await onboarding_reaction_fallback.setup(self.bot)

--- a/modules/placement/reservation_jobs.py
+++ b/modules/placement/reservation_jobs.py
@@ -1,0 +1,384 @@
+"""Scheduled jobs that maintain clan seat reservations."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from typing import Awaitable, Callable
+
+import discord
+from discord.ext import commands
+
+from modules.common import feature_flags
+from modules.common import runtime as runtime_mod
+from modules.common.logs import log as human_log
+from modules.recruitment import availability
+from shared.config import get_recruiter_role_ids, get_recruiters_thread_id
+from shared.sheets import reservations
+
+log = logging.getLogger(__name__)
+
+_REMINDER_JOB_NAME = "reservations_reminder_daily"
+_AUTORELEASE_JOB_NAME = "reservations_autorelease_daily"
+_FEATURE_KEYS = ("FEATURE_RESERVATIONS", "feature_reservations", "placement_reservations")
+
+_REMINDER_TASK: asyncio.Task | None = None
+_AUTORELEASE_TASK: asyncio.Task | None = None
+
+
+async def reservations_reminder_daily(
+    *,
+    bot: commands.Bot | None = None,
+    today: dt.date | None = None,
+) -> None:
+    """Send reminder messages for reservations that expire today."""
+
+    if not _reservations_enabled():
+        log.debug("reservation reminder skipped (feature disabled)")
+        return
+
+    ledger: reservations.ReservationLedger
+    try:
+        ledger = await reservations.load_reservation_ledger()
+    except Exception:
+        log.exception("failed to load reservations ledger for reminder job")
+        return
+
+    current_date = today or dt.datetime.now(dt.timezone.utc).date()
+    due_rows = [row for row in ledger.rows if row.is_active and row.reserved_until == current_date]
+    if not due_rows:
+        return
+
+    active_bot = bot or _active_bot()
+    if active_bot is None:
+        log.warning("reservation reminder skipped (bot unavailable)")
+        return
+
+    await active_bot.wait_until_ready()
+
+    recruiter_ping = _recruiter_ping()
+    recompute_context: dict[str, discord.Guild | None] = {}
+
+    for row in due_rows:
+        thread = await _resolve_channel(active_bot, row.thread_id)
+        clan_label = _display_tag(row.clan_tag)
+        user_display = _user_display(row)
+        until_display = _format_date(row.reserved_until)
+        normalized_tag = _normalize_tag(row.clan_tag)
+
+        if normalized_tag and normalized_tag not in recompute_context:
+            recompute_context[normalized_tag] = getattr(thread, "guild", None)
+
+        if thread is None:
+            log.warning(
+                "reservation reminder thread missing",
+                extra={"thread_id": row.thread_id, "clan_tag": clan_label},
+            )
+            human_log.human(
+                "warn",
+                "🧭 reservations-reminder — clan=%s • user=%s • until=%s • reason=thread_missing"
+                % (clan_label, user_display, until_display),
+            )
+            continue
+
+        message_lines = [
+            f"Reminder: The reserved spot in `{clan_label}` for {user_display} ends today.",
+            "If you still need this, please extend the reservation with a new date.",
+            "If not, you can ignore this and I’ll release the seat later today.",
+        ]
+        content = "\n".join(message_lines)
+        if recruiter_ping:
+            content = f"{recruiter_ping}\n{content}"
+
+        try:
+            await thread.send(content=content)
+        except Exception:
+            log.warning(
+                "failed to send reservation reminder",
+                exc_info=True,
+                extra={"thread_id": row.thread_id, "clan_tag": clan_label},
+            )
+            human_log.human(
+                "warn",
+                "🧭 reservations-reminder — clan=%s • user=%s • until=%s • result=send_failed"
+                % (clan_label, user_display, until_display),
+            )
+            continue
+
+        human_log.human(
+            "info",
+            "🧭 reservations-reminder — clan=%s • user=%s • until=%s"
+            % (clan_label, user_display, until_display),
+        )
+
+    for clan_tag, guild in recompute_context.items():
+        if not clan_tag:
+            continue
+        try:
+            await availability.recompute_clan_availability(clan_tag, guild=guild)
+        except Exception:
+            log.exception(
+                "failed to recompute availability after reminder",
+                extra={"clan_tag": clan_tag},
+            )
+
+
+async def reservations_autorelease_daily(
+    *,
+    bot: commands.Bot | None = None,
+    today: dt.date | None = None,
+) -> None:
+    """Expire overdue reservations and free seats automatically."""
+
+    if not _reservations_enabled():
+        log.debug("reservation auto-release skipped (feature disabled)")
+        return
+
+    ledger: reservations.ReservationLedger
+    try:
+        ledger = await reservations.load_reservation_ledger()
+    except Exception:
+        log.exception("failed to load reservations ledger for auto-release job")
+        return
+
+    status_column = ledger.status_column()
+    current_date = today or dt.datetime.now(dt.timezone.utc).date()
+    due_rows = [
+        row
+        for row in ledger.rows
+        if row.is_active and row.reserved_until is not None and row.reserved_until <= current_date
+    ]
+    if not due_rows:
+        return
+
+    active_bot = bot or _active_bot()
+    if active_bot is not None:
+        await active_bot.wait_until_ready()
+    else:
+        log.warning("reservation auto-release proceeding without bot context")
+
+    recruiters_thread = None
+    recruiters_thread_id = get_recruiters_thread_id()
+    if active_bot is not None and recruiters_thread_id:
+        recruiters_thread = await _resolve_channel(active_bot, recruiters_thread_id)
+        if recruiters_thread is None:
+            log.warning(
+                "recruiters summary thread missing",
+                extra={"thread_id": recruiters_thread_id},
+            )
+
+    clan_context: dict[str, discord.Guild | None] = {}
+
+    for row in due_rows:
+        clan_label = _display_tag(row.clan_tag)
+        user_display = _user_display(row)
+        until_display = _format_date(row.reserved_until)
+
+        try:
+            await reservations.update_reservation_status(
+                row.row_number,
+                "expired",
+                status_column=status_column,
+            )
+        except Exception:
+            log.exception(
+                "failed to mark reservation expired",
+                extra={"row": row.row_number, "clan_tag": clan_label},
+            )
+            continue
+
+        thread = await _resolve_channel(active_bot, row.thread_id) if active_bot is not None else None
+        guild = getattr(thread, "guild", None)
+        normalized_tag = _normalize_tag(row.clan_tag)
+        if normalized_tag:
+            clan_context.setdefault(normalized_tag, guild)
+
+        if thread is not None:
+            message = (
+                f"The reserved spot in `{clan_label}` for {user_display} has expired and the seat has been released."
+            )
+            try:
+                await thread.send(content=message)
+            except Exception:
+                log.warning(
+                    "failed to post reservation expiry",
+                    exc_info=True,
+                    extra={"thread_id": row.thread_id, "clan_tag": clan_label},
+                )
+        else:
+            log.warning(
+                "reservation expiry thread missing",
+                extra={"thread_id": row.thread_id, "clan_tag": clan_label},
+            )
+
+        summary_line = (
+            f"⚠️ Reservation expired — clan=`{clan_label}` • user=`{user_display}` • until=`{until_display}` • action=auto-release"
+        )
+        if recruiters_thread is not None:
+            try:
+                await recruiters_thread.send(content=summary_line)
+            except Exception:
+                log.warning(
+                    "failed to post reservation expiry summary",
+                    exc_info=True,
+                    extra={"thread_id": recruiters_thread_id},
+                )
+
+        human_log.human(
+            "info",
+            "🧭 reservations-autorelease — clan=%s • user=%s • until=%s • result=expired"
+            % (clan_label, user_display, until_display),
+        )
+
+    for clan_tag, guild in clan_context.items():
+        try:
+            await availability.recompute_clan_availability(clan_tag, guild=guild)
+        except Exception:
+            log.exception(
+                "failed to recompute availability after auto-release",
+                extra={"clan_tag": clan_tag},
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Register the reservation reminder and auto-release jobs."""
+
+    runtime = runtime_mod.get_active_runtime()
+    if runtime is None:
+        log.warning("reservation jobs setup skipped (runtime unavailable)")
+        return
+
+    global _REMINDER_TASK, _AUTORELEASE_TASK
+
+    if _REMINDER_TASK is None or _REMINDER_TASK.done():
+        _REMINDER_TASK = runtime.scheduler.spawn(
+            _daily_loop(12, 0, lambda: reservations_reminder_daily(bot=bot), _REMINDER_JOB_NAME),
+            name=_REMINDER_JOB_NAME,
+        )
+        log.info("[cron] reservation reminder scheduler started (12:00Z)")
+
+    if _AUTORELEASE_TASK is None or _AUTORELEASE_TASK.done():
+        _AUTORELEASE_TASK = runtime.scheduler.spawn(
+            _daily_loop(18, 0, lambda: reservations_autorelease_daily(bot=bot), _AUTORELEASE_JOB_NAME),
+            name=_AUTORELEASE_JOB_NAME,
+        )
+        log.info("[cron] reservation auto-release scheduler started (18:00Z)")
+
+
+def _reservations_enabled() -> bool:
+    for key in _FEATURE_KEYS:
+        try:
+            if feature_flags.is_enabled(key):
+                return True
+        except Exception:
+            log.exception("feature toggle check failed", extra={"feature": key})
+    return False
+
+
+def _active_bot() -> commands.Bot | None:
+    runtime = runtime_mod.get_active_runtime()
+    return runtime.bot if runtime is not None else None
+
+
+def _daily_loop(
+    hour: int,
+    minute: int,
+    job_factory: Callable[[], Awaitable[None]],
+    job_name: str,
+) -> Awaitable[None]:
+    async def runner() -> None:
+        while True:
+            delay = _seconds_until(hour, minute)
+            await asyncio.sleep(delay)
+            try:
+                await job_factory()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("reservation job failed", extra={"job": job_name})
+
+    return runner()
+
+
+def _seconds_until(hour: int, minute: int) -> float:
+    now = dt.datetime.now(dt.timezone.utc)
+    target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if now >= target:
+        target = target + dt.timedelta(days=1)
+    return max(1.0, (target - now).total_seconds())
+
+
+def _recruiter_ping() -> str:
+    role_ids = sorted(get_recruiter_role_ids())
+    return " ".join(f"<@&{role_id}>" for role_id in role_ids if role_id)
+
+
+async def _resolve_channel(
+    bot: commands.Bot | None,
+    channel_id: int | str | None,
+) -> discord.abc.Messageable | None:
+    if bot is None or not channel_id:
+        return None
+    snowflake = _to_int(channel_id)
+    if snowflake is None:
+        return None
+
+    channel = bot.get_channel(snowflake)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(snowflake)
+        except Exception:
+            log.warning(
+                "failed to fetch channel",
+                exc_info=True,
+                extra={"channel_id": snowflake},
+            )
+            return None
+
+    if hasattr(channel, "send"):
+        return channel  # type: ignore[return-value]
+    return None
+
+
+def _display_tag(tag: str | None) -> str:
+    text = str(tag or "").strip()
+    return text or "-"
+
+
+def _normalize_tag(tag: str | None) -> str:
+    text = str(tag or "").strip().upper()
+    return "".join(ch for ch in text if ch.isalnum())
+
+
+def _user_display(row: reservations.ReservationRow) -> str:
+    if row.ticket_user_id:
+        return f"<@{row.ticket_user_id}>"
+    if row.ticket_username:
+        text = row.ticket_username.strip()
+        if text:
+            return text
+    if row.thread_id:
+        return row.thread_id
+    return "the recruit"
+
+
+def _format_date(value: dt.date | None) -> str:
+    return value.isoformat() if value else "-"
+
+
+def _to_int(value: int | str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "reservations_autorelease_daily",
+    "reservations_reminder_daily",
+    "setup",
+]
+

--- a/tests/placement/test_reservation_jobs.py
+++ b/tests/placement/test_reservation_jobs.py
@@ -1,0 +1,150 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+from modules.placement import reservation_jobs
+from shared.sheets import reservations
+
+
+class FakeChannel:
+    def __init__(self, channel_id: int, *, guild: object | None = None) -> None:
+        self.id = channel_id
+        self.guild = guild or SimpleNamespace(id=1234)
+        self.sent: list[str] = []
+
+    async def send(self, *, content: str | None = None, **_: object) -> None:
+        if content is not None:
+            self.sent.append(content)
+
+
+class FakeBot:
+    def __init__(self, channels: dict[int, FakeChannel]) -> None:
+        self._channels = dict(channels)
+
+    async def wait_until_ready(self) -> None:
+        return None
+
+    def get_channel(self, channel_id: int):
+        return self._channels.get(channel_id)
+
+    async def fetch_channel(self, channel_id: int):
+        return self._channels.get(channel_id)
+
+
+def _reservation_row(
+    *,
+    row_number: int,
+    clan_tag: str,
+    reserved_until: dt.date | None,
+    status: str = "active",
+    thread_id: int = 1000,
+    ticket_user_id: int | None = 2000,
+    ticket_username: str = "Recruit One",
+) -> reservations.ReservationRow:
+    return reservations.ReservationRow(
+        row_number=row_number,
+        thread_id=str(thread_id),
+        ticket_user_id=ticket_user_id,
+        recruiter_id=3000,
+        clan_tag=clan_tag,
+        reserved_until=reserved_until,
+        created_at=None,
+        status=status,
+        notes="",
+        ticket_username=ticket_username,
+        raw=[str(thread_id), str(ticket_user_id or ""), "3000", clan_tag, "", "", status, "", ticket_username],
+    )
+
+
+def test_reservations_reminder_daily_posts_message(monkeypatch):
+    today = dt.date(2025, 1, 10)
+    due_row = _reservation_row(row_number=2, clan_tag="#AAA", reserved_until=today, thread_id=5555)
+    future_row = _reservation_row(
+        row_number=3,
+        clan_tag="#BBB",
+        reserved_until=today + dt.timedelta(days=1),
+        thread_id=6666,
+    )
+
+    ledger = reservations.ReservationLedger(rows=[due_row, future_row], header_index={"status": 6})
+
+    async def fake_load():
+        return ledger
+
+    recomputed: list[tuple[str, object | None]] = []
+
+    async def fake_recompute(clan_tag: str, *, guild=None):
+        recomputed.append((clan_tag, guild))
+
+    fake_thread = FakeChannel(5555)
+    bot = FakeBot({5555: fake_thread})
+
+    monkeypatch.setattr(reservation_jobs, "_reservations_enabled", lambda: True)
+    monkeypatch.setattr(reservation_jobs.reservations, "load_reservation_ledger", fake_load)
+    monkeypatch.setattr(reservation_jobs.availability, "recompute_clan_availability", fake_recompute)
+    monkeypatch.setattr(reservation_jobs, "get_recruiter_role_ids", lambda: {42})
+
+    asyncio.run(reservation_jobs.reservations_reminder_daily(bot=bot, today=today))
+
+    assert len(fake_thread.sent) == 1
+    content = fake_thread.sent[0]
+    lines = content.splitlines()
+    assert lines[0] == "<@&42>"
+    assert "reserved spot" in lines[1]
+    assert "extend the reservation" in content
+
+    assert recomputed == [("AAA", fake_thread.guild)]
+
+
+def test_reservations_autorelease_daily_expires_overdue(monkeypatch):
+    today = dt.date(2025, 1, 12)
+    due_row = _reservation_row(row_number=2, clan_tag="#AAA", reserved_until=today, thread_id=7777)
+    future_row = _reservation_row(
+        row_number=3,
+        clan_tag="#AAA",
+        reserved_until=today + dt.timedelta(days=2),
+        thread_id=8888,
+    )
+    inactive_row = _reservation_row(
+        row_number=4,
+        clan_tag="#CCC",
+        reserved_until=today - dt.timedelta(days=1),
+        status="expired",
+        thread_id=9999,
+    )
+
+    ledger = reservations.ReservationLedger(
+        rows=[due_row, future_row, inactive_row],
+        header_index={"status": 6},
+    )
+
+    async def fake_load():
+        return ledger
+
+    updates: list[tuple[int, str, int | None]] = []
+
+    async def fake_update(row_number: int, status: str, *, status_column: int | None = None):
+        updates.append((row_number, status, status_column))
+
+    recomputed: list[str] = []
+
+    async def fake_recompute(clan_tag: str, *, guild=None):
+        recomputed.append(clan_tag)
+
+    summary_thread = FakeChannel(4444)
+    fake_thread = FakeChannel(7777)
+    bot = FakeBot({7777: fake_thread, 4444: summary_thread})
+
+    monkeypatch.setattr(reservation_jobs, "_reservations_enabled", lambda: True)
+    monkeypatch.setattr(reservation_jobs.reservations, "load_reservation_ledger", fake_load)
+    monkeypatch.setattr(reservation_jobs.reservations, "update_reservation_status", fake_update)
+    monkeypatch.setattr(reservation_jobs.availability, "recompute_clan_availability", fake_recompute)
+    monkeypatch.setattr(reservation_jobs, "get_recruiters_thread_id", lambda: 4444)
+
+    asyncio.run(reservation_jobs.reservations_autorelease_daily(bot=bot, today=today))
+
+    assert updates == [(2, "expired", 6)]
+    assert len(fake_thread.sent) == 1
+    assert "expired" in fake_thread.sent[0]
+    assert summary_thread.sent and "auto-release" in summary_thread.sent[0]
+    assert recomputed == ["AAA"]


### PR DESCRIPTION
## Summary
- add daily reminder and auto-release scheduler loops for clan seat reservations
- extend the reservations sheet adapter with ledger helpers and write support
- document the reservation lifecycle and cover the new jobs with unit tests

## Testing
- pytest tests/placement/test_reservation_jobs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691616fedc388323acd1d20f57849430)