### PR TITLE
PR-RES-AUDIT-03 — Reservations recompute diagnostics

### DIFF
--- a/AUDIT/20251113_reservations-availability-wiring.md
+++ b/AUDIT/20251113_reservations-availability-wiring.md
@@ -1,0 +1,49 @@
+# Reservations & Availability Wiring — Audit (2025-11-13)
+
+## Context
+Recruitment staff use the `!reserve` command to hold seats for recruits. The bot stores reservations in the `RESERVATIONS_TAB` worksheet and mirrors clan availability in `CLANS_TAB` (a.k.a. `bot_info`), where columns AF/AH/AI track manual open spots, reserved counts, and reservation summaries.
+
+## Findings — Command implementation
+- **Command handler**: `modules/placement/reservations.py::ReservationCog.reserve`
+  - Prefix command registered via `@commands.command(name="reserve")` with staff-tier help metadata.
+  - Gated by feature toggles (`FEATURE_RESERVATIONS` / aliases) and RBAC checks (`is_recruiter` or `is_admin_member`). Only allowed inside ticket threads whose parent matches `get_welcome_channel_id` / `get_promo_channel_id`.
+  - Accepts `<clantag>` argument; normalized by `_normalize_tag` when validating the sheet lookup.
+- **Clan lookup**: `shared.sheets.recruitment.find_clan_row`
+  - Reads `CLANS_TAB` to retrieve the manual open count (column E) before starting the interactive flow.
+- **Interactive flow**: `ReservationConversation`
+  - Prompts the recruiter for the recruit mention/ID, reservation end date (`YYYY-MM-DD`), and (when effective spots ≤ 0) a reason note.
+  - Uses the pre-fetched manual open value and `reservations.count_active_reservations_for_clan` to show live availability and decide whether a reason is required.
+- **Ledger write**: after confirmation, composes a 9-column row of strings and calls `shared.sheets.reservations.append_reservation_row` to append to `RESERVATIONS_TAB`:
+  1. Ticket thread ID
+  2. Recruit (Discord user ID)
+  3. Recruiter ID
+  4. Clan tag (sheet tag)
+  5. `reserved_until` date (ISO)
+  6. Creation timestamp (`now` UTC, ISO)
+  7. Status = `"active"`
+  8. Free-form notes
+  9. Recruit username snapshot
+- **Post-write refresh**:
+  - Calls `modules.recruitment.availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)`.
+  - Falls back to cached manual values if the recompute helper fails, but still logs and informs staff.
+  - Reloads the clan row via `shared.sheets.recruitment.get_clan_by_tag` to report the updated AF/AH figures back into the ticket thread log message.
+
+## Findings — Availability recompute
+- **Helper location**: `modules/recruitment/availability.py::recompute_clan_availability`
+  - Fetches the clan row (`find_clan_row`) and parses column E (`_parse_manual_open_spots`) as the manual open spot count.
+  - Loads active reservations through `shared.sheets.reservations.get_active_reservations_for_clan` and resolves display names with `resolve_reservation_names` (guild or custom resolver context).
+  - Calculates:
+    - `reservation_count = len(active_reservations)` → written to column AH.
+    - `available_after_reservations = max(manual_open - reservation_count, 0)` → written to column AF.
+    - `reservation_summary = "{count} -> ..."` with resolved usernames → written to column AI.
+  - Preserves the current AG (“inactives”) value while overwriting the AF–AI block in a single `worksheet.update("AF{row}:AI{row}", ...)` call via `async_core.acall_with_backoff`.
+  - Updates in-memory caches with `shared.sheets.recruitment.update_cached_clan_row`, ensuring subsequent lookups see the refreshed AF/AH/AI.
+- **Callers**:
+  - `!reserve` (above) triggers it immediately after appending the ledger row.
+  - Reservation cron jobs (`modules/placement/reservation_jobs.reservations_reminder_daily` and `.reservations_autorelease_daily`) invoke it for each affected clan when reminding or expiring holds.
+
+## Mismatches vs Spec
+- None observed. The live implementation already recalculates AF/AH/AI from column E and active reservations, writes the results back to `CLANS_TAB`, and refreshes caches whenever `!reserve` or the reservation jobs mutate the ledger.
+
+## Non-goals
+No runtime behavior changes were made in this audit. Findings are provided for follow-up work as needed.

--- a/AUDIT/20251113_reservations-cache-and-active-rows.md
+++ b/AUDIT/20251113_reservations-cache-and-active-rows.md
@@ -1,0 +1,37 @@
+## Context
+The reservations flow collects recruiter input through `ReservationCog.reserve` and writes ledger rows via `shared.sheets.reservations.append_reservation_row`. The sheet recently gained a `ticket_username` display column plus a trailing `username_snapshot` field so the ledger can preserve both the recruiter-supplied username and the bot’s normalized snapshot that feeds AF/AH/AI recompute.
+
+## Adapter & cache behavior
+- **Append helper** — `shared/sheets/reservations.py::append_reservation_row` converts the supplied sequence to strings and calls `worksheet.append_row` on `RESERVATIONS_TAB`. It does **not** interact with `cache_service`; no reservation bucket exists, so only the worksheet is updated.
+- **Ledger load** — `shared.sheets.reservations.load_reservation_ledger` refetches the entire sheet on every call by delegating to `_fetch_reservations_matrix` (a direct `async_core.afetch_values` call). Parsed rows are wrapped in `ReservationRow` objects and exposed through `_load_reservations`, so read paths always go back to the sheet.
+
+## Active-row parsing
+- `get_active_reservations_for_clan` normalizes the requested tag, pulls every row from `_load_reservations`, and filters where both `row.is_active` and `row.normalized_clan_tag` match.
+- `ReservationRow.is_active` lowercases the status cell and requires the literal string `"active"`; other lifecycle strings (expired, cancelled, etc.) are ignored.
+- `_build_header_index` resolves headers by alias, so each parsed field comes from the column whose header matches the legacy expectations. The adapter still expects the nine-column order written by the command: `thread_id`, `ticket_user_id`, `recruiter_id`, `clan_tag`, `reserved_until`, `created_at`, `status`, `notes`, `ticket_username`.
+- **Current sheet order** (post username_snapshot rollout) now places `ticket_username` immediately after `ticket_user_id` and appends `username_snapshot` at the end:
+
+  | Index | Header              | Written value today |
+  |-------|---------------------|---------------------|
+  | 0     | Thread ID           | `thread_id`
+  | 1     | Ticket User ID      | `ticket_user_id`
+  | 2     | Ticket Username     | **`recruiter_id` (mismatch)**
+  | 3     | Recruiter ID        | **`clan_tag` (mismatch)**
+  | 4     | Clan Tag            | **`reserved_until` (mismatch)**
+  | 5     | Reserved Until      | **`created_at` (mismatch)**
+  | 6     | Created At          | `status`
+  | 7     | Status              | `notes`
+  | 8     | Notes               | `ticket_username`
+  | 9     | Username Snapshot   | *(blank — bot never writes column 10)*
+
+  Because the adapter has no knowledge of the new column, every field from `recruiter_id` onward is read from the wrong cell when `_parse_reservation_row` runs.
+
+## Root cause hypothesis — “0 reserved, 3 open”
+1. `ReservationCog.reserve` still writes the legacy nine-value payload. The newly inserted `Ticket Username` column shifts subsequent cells one position to the right, so the `Clan Tag` header now points at the ISO `reserved_until` string.
+2. During recompute, `reservations.get_active_reservations_for_clan` parses the row, normalizes `"2025-11-30"` to `"20251130"`, and compares it to the requested clan tag `"ABC"`. The normalized strings do not match, so the fresh reservation is filtered out.
+3. `recompute_clan_availability` therefore sees `reservation_count = 0`, leaving AF/AH/AI unchanged despite the brand-new ledger row.
+
+No cache invalidation is involved — the read helpers always hit the sheet — but the misaligned columns make the freshly appended row invisible to the clan-specific filter until staff manually reorders or copies the row.
+
+## Non-goals
+This PR records the adapter mismatch only. No runtime code has been changed to fix the column order or adjust cache behavior; follow-up work must correct the append logic and/or header parsing.

--- a/AUDIT/20251113_reservations-recompute-not-triggering.md
+++ b/AUDIT/20251113_reservations-recompute-not-triggering.md
@@ -1,0 +1,48 @@
+## Context
+The `!reserve` command (Discord staff-only) is implemented in `modules/placement/reservations.py` and writes rows into the `RESERVATIONS_TAB` worksheet. Immediately after the append it calls `modules.recruitment.availability.recompute_clan_availability` to recalculate the `AF`/`AG`/`AH`/`AI` slice within `CLANS_TAB`. Runtime reports indicate that fresh reservations never change those cells, and the bot produces no availability logs.
+
+## Helper implementation: `recompute_clan_availability`
+- **Location** — `modules/recruitment/availability.py::recompute_clan_availability(clan_tag: str, *, guild=None, resolver=None)`.
+- **Dependencies** — Reads the clan row through `shared.sheets.recruitment.find_clan_row`, fetches reservations via `shared.sheets.reservations.get_active_reservations_for_clan`, resolves names with `reservations.resolve_reservation_names`, then writes back to Sheets using `shared.sheets.async_core.acall_with_backoff`.
+- **Side effects** — Updates `AF{row}:AI{row}` in `CLANS_TAB`, refreshes the in-memory clan cache through `recruitment.update_cached_clan_row`, and emits a `log.debug("recomputed clan availability", extra=...)` entry.
+
+## Command call site and gating
+- **Call path** — `ReservationCog.reserve` lives in `modules/placement/reservations.py`. After collecting inputs and appending the ledger row it executes `await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)` inside a try/except block that only logs on failure.
+- **Feature flag** — `_reservations_enabled()` iterates over `("FEATURE_RESERVATIONS", "feature_reservations", "placement_reservations")` and returns `True` as soon as `modules.common.feature_flags.is_enabled` reports a truthy toggle.
+- **RBAC** — The command returns early unless the invoker satisfies `is_recruiter(ctx)` or `is_admin_member(ctx)`; these checks do not guard the recompute branch once the flow passes validation.
+- **Early exits** — Prior to recompute the only returns come from validation, conversation abort, or append failure. On success the recompute call always executes.
+
+## Runtime flow after appending to the ledger
+```
+append_reservation_row([...])  # writes 9 legacy fields
+recompute_clan_availability(sheet_tag, guild=ctx.guild)
+```
+- The append helper stringifies the payload and calls `worksheet.append_row` directly. There is no cache to invalidate, and subsequent reads go back to the sheet.
+- The recompute call is not conditional beyond the surrounding try/except; no feature flag or RBAC guard is re-checked in that block, and no silent `return` statements intervene.
+- If recompute were to raise, the command would log an exception and post a warning into the ticket thread. Runtime reports never mentioned that warning, implying the call does not throw.
+
+## Logging behavior within recompute
+- The helper only uses `log.debug`, so production log levels (`INFO` by default) will not surface availability recompute lines.
+- No other logger invocations occur before the sheet update completes. If the helper returns normally the only visible log is the final `log.info("[reserve] reservation created", ...)` emitted by the command.
+
+## Sheet update path
+- `recompute_clan_availability` writes `[available_after_reservations, existing_AG, reservation_count, reservation_summary]` to `AF{row}:AI{row}` on the worksheet obtained from `recruitment.get_clans_tab_name()`.
+- The update is wrapped in `async_core.acall_with_backoff`, so gspread/network errors would bubble as exceptions (triggering the command’s warning branch). There is no suppression of failures.
+- Immediately after writing, `recruitment.update_cached_clan_row` mutates the cached clan list so future reads observe the new AF/AH/AI values without another sheet fetch.
+
+## Reservation filtering and why the helper sees zero rows
+- `append_reservation_row` still sends the legacy nine-value payload (`thread_id` through `ticket_username`).
+- The reservations worksheet now includes a tenth column (`Username Snapshot`) immediately after `Ticket Username`.
+- When Sheets inserts the new column, every subsequent field shifts one position to the right, but `_HEADER_ALIASES` still maps `"clan tag"` to index 4.
+- `_parse_reservation_row` therefore reads the ISO reserved-until string (e.g., `2025-11-30`) as the clan tag. `_normalize_tag` strips non-alphanumerics and uppercases, producing `20251130`.
+- `ReservationRow.normalized_clan_tag` returns `20251130`, so `get_active_reservations_for_clan("ABC")` filters the fresh row out. With zero matches, `recompute_clan_availability` calculates `reservation_count = 0` and leaves AF/AH/AI unchanged.
+
+## Feature toggles and runtime state
+- Feature toggles load via `modules/common/feature_flags.py`. Once `FEATURE_RESERVATIONS` is set to `TRUE`, `_reservations_enabled()` returns `True`, the command executes, and the recompute helper is still invoked regardless of toggle state at the moment of append.
+- If the toggle is missing or false, the command stops before prompting the recruiter, so no ledger row is appended in the failing scenario described by ops (confirming the feature flag is not responsible for the mismatch).
+
+## Root cause
+The recompute helper *does* run, but it reads stale clan-tag values because the worksheet header gained an extra column without updating either the append payload or the parser’s header map. As a result, new rows appear under the wrong clan during filtering, so availability math continues to assume zero active reservations. No exceptions are thrown, and the helper’s debug-only logging keeps runtime telemetry silent even though recompute finishes.
+
+## Non-goals
+This audit documents the live behavior only. No code changes were attempted to realign the reservation payload, extend header aliases, or elevate logging levels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.9.7 — 2025-11-13
+- **Audit:** Documented current reservation command flow and AF/AH/AI recompute wiring (`AUDIT/20251113_reservations-availability-wiring.md`).
+- **Audit:** Analyzed reservations cache behavior and header drift causing stale availability counts (`AUDIT/20251113_reservations-cache-and-active-rows.md`).
+- **Audit:** Investigated why recompute stays silent after `!reserve` despite the ledger append, tracing the helper call path, logging, and column drift (`AUDIT/20251113_reservations-recompute-not-triggering.md`).
+
 ### v0.9.7 —2025-11-08
 - **Fix:** Restored keep-alive/web server startup by sweeping imports from the deprecated `shared.config` path to `shared.ports.get_port`.
 - **Ops:** Added canonical boot log line `web server listening • port=<n>` to confirm bind.


### PR DESCRIPTION
## Summary
- Recorded a fresh audit capturing how `recompute_clan_availability` is wired, what the command executes after appending the ledger row, and why no availability logs appear.
- Documented the column-drift root cause that leaves AF/AH/AI unchanged despite active reservations.
- Logged the new audit entry in the changelog for traceability.

## Testing
- Not run (audit-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162a15a15c8323906cbf3305ff5517)