### PR TITLE
Fix welcome close clan tag selection and logging

### DIFF
--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -425,10 +425,10 @@ def load_clan_tags(force: bool = False) -> List[str]:
 
     values = core.fetch_values(_sheet_id(), _clanlist_tab())
     tags: List[str] = []
-    for row in values[1:]:
-        if not row:
+    for row in values:
+        if len(row) < 2:
             continue
-        tag = (row[0] if len(row) > 0 else "").strip().upper()
+        tag = (row[1] if len(row) > 1 else "").strip().upper()
         if tag:
             tags.append(tag)
 
@@ -449,10 +449,10 @@ async def _load_clan_tags_async() -> List[str]:
     tab = _clanlist_tab()
     values = await afetch_values(sheet_id, tab)
     tags: List[str] = []
-    for row in values[1:]:
-        if not row:
+    for row in values:
+        if len(row) < 2:
             continue
-        tag = (row[0] if len(row) > 0 else "").strip().upper()
+        tag = (row[1] if len(row) > 1 else "").strip().upper()
         if tag:
             tags.append(tag)
     return tags

--- a/tests/shared/test_onboarding_clan_tags.py
+++ b/tests/shared/test_onboarding_clan_tags.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import asyncio
+
+import pytest
+
+from shared.sheets import onboarding
+
+
+def _reset_cache() -> None:
+    onboarding._CLAN_TAGS = []
+    onboarding._CLAN_TAG_TS = 0.0
+
+
+def test_load_clan_tags_reads_column_b(monkeypatch) -> None:
+    sample_values = [
+        ["Elders", "C1CE", "Elite End"],
+        ["Island Sacred", "C1C1", "Elite End"],
+        ["", "", ""],
+        ["no placement", "NONE", ""],
+    ]
+
+    def fake_fetch(sheet_id: str, tab: str):  # type: ignore[no-untyped-def]
+        assert sheet_id == "sheet-id"
+        assert tab == "ClanList"
+        return sample_values
+
+    monkeypatch.setattr(onboarding, "_sheet_id", lambda: "sheet-id", raising=False)
+    monkeypatch.setattr(onboarding, "_clanlist_tab", lambda: "ClanList", raising=False)
+    monkeypatch.setattr(onboarding.core, "fetch_values", fake_fetch, raising=True)
+    _reset_cache()
+
+    tags = onboarding.load_clan_tags(force=True)
+
+    assert tags == ["C1CE", "C1C1", "NONE"]
+
+
+def test_load_clan_tags_async_reads_column_b(monkeypatch) -> None:
+    sample_values = [
+        ["Elders", "C1CE"],
+        ["Island Sacred", "C1C1"],
+        ["no placement", "NONE"],
+    ]
+
+    async def fake_afetch(sheet_id: str, tab: str):  # type: ignore[no-untyped-def]
+        assert sheet_id == "sheet-id"
+        assert tab == "ClanList"
+        return sample_values
+
+    async def runner() -> None:
+        monkeypatch.setattr(onboarding, "_sheet_id", lambda: "sheet-id", raising=False)
+        monkeypatch.setattr(onboarding, "_clanlist_tab", lambda: "ClanList", raising=False)
+        monkeypatch.setattr(onboarding, "afetch_values", fake_afetch, raising=True)
+
+        tags = await onboarding._load_clan_tags_async()
+
+        assert tags == ["C1CE", "C1C1", "NONE"]
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- load welcome clan tags directly from CLANLIST column B so the picker mirrors sheet order without hard-coded entries
- enforce tag validation throughout welcome close flow, align success/error logging formats, and route final clan values through tag-aware reconciliation
- extend onboarding tests to cover tag sourcing, manual logging, and invalid text handling plus add coverage for the clan tag sheet helper

## Testing
- `pytest tests/onboarding/test_welcome_reservations.py -q`
- `pytest tests/shared/test_onboarding_clan_tags.py -q`

[meta]
labels: codex,comp:ops,comp:data-sheets,comp:roles,docs,P2
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691867c9687483238702af8edbf99edf)