### PR TITLE
Add reservation management commands and reminder UX updates

### DIFF
--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -169,6 +169,14 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
   - `AF` — effective open spots (`max(E - AH, 0)`)
   - `AI` — reservation summary (`"<AH> -> usernames"`)
 - A success message posts in the thread with the refreshed `AH` and `AF` values.
+- Use the convenience commands below to view or manage the reservation once it exists.
+
+### Reservation management commands
+- `!reservations` *(inside the recruit’s ticket thread)* — lists every active reservation for that recruit, including clan tag, expiry, recruiter, and status. If none exist you’ll receive a quick confirmation.
+- `!reservations <clan_tag>` — recruiter/admin only. Lists all active reservations for that clan, sorted by expiry and showing the ticket code for each hold.
+- `!reserve release` *(inside the recruit’s ticket thread)* — immediately cancels the active reservation, restores the clan’s manual open spot by `+1`, and recomputes availability.
+- `!reserve extend <YYYY-MM-DD>` *(inside the recruit’s ticket thread)* — updates the reservation expiry date without touching manual open spots.
+- `!reserve release` and `!reserve extend` require the ticket thread context so the bot can infer the recruit and reservation row. Both commands log to the ops channel using the `reservation_release` / `reservation_extend` events.
 
 ### Welcome ticket closure sync
 - Closing a welcome ticket now triggers the same reservation + availability helpers used by `!reserve`:
@@ -181,8 +189,8 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 ## Reservation lifecycle (daily jobs)
 - **12:00 UTC — Reminder**
   - Finds every `active` reservation where `reserved_until == today`.
-  - Posts a reminder in the recruit’s ticket thread and pings Recruiter roles.
-  - Gives Recruiters a six-hour window to extend or intervene before expiry.
+  - Posts a reminder in the recruit’s ticket thread, pings Recruiter roles, and includes quick instructions for `!reserve extend <date>` and `!reserve release`.
+  - Gives Recruiters a six-hour window to extend or intervene before expiry. Each reminder logs `reservation_reminder` with the ticket, clan, and expiry date.
 - **18:00 UTC — Auto-release**
   - Marks `active` reservations with `reserved_until <= today` as `expired` in `RESERVATIONS_TAB`.
   - Calls `recompute_clan_availability` for each affected clan to refresh `AF`, `AH`, and `AI`.
@@ -198,4 +206,4 @@ Both jobs respect the `FEATURE_RESERVATIONS` toggle in the `Feature_Toggles` wor
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-11-20 (v0.9.7)
+Doc last updated: 2025-11-30 (v0.9.7)

--- a/shared/sheets/reservations.py
+++ b/shared/sheets/reservations.py
@@ -334,6 +334,26 @@ async def update_reservation_status(
     )
 
 
+async def update_reservation_expiry(row_number: int, reserved_until: dt.date) -> None:
+    """Update the ``reserved_until`` cell for the reservation at ``row_number``."""
+
+    if row_number <= 1:
+        raise ValueError("row_number must reference a data row")
+
+    recruitment.ensure_service_account_credentials()
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    tab_name = recruitment.get_reservations_tab_name()
+    worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
+
+    cell = f"{_column_label(RESERVED_UNTIL_COL)}{row_number}"
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        cell,
+        [[reserved_until.isoformat()]],
+        value_input_option="RAW",
+    )
+
+
 async def _fetch_reservations_matrix() -> List[List[str]]:
     recruitment.ensure_service_account_credentials()
     sheet_id = recruitment.get_recruitment_sheet_id()
@@ -467,4 +487,5 @@ __all__ = [
     "get_active_reservation_names_for_clan",
     "resolve_reservation_names",
     "update_reservation_status",
+    "update_reservation_expiry",
 ]

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -1,9 +1,11 @@
 import asyncio
+import datetime as dt
 from typing import List
 
 import discord
 
 from modules.placement import reservations as reserve_module
+from shared.sheets import reservations as reservations_sheet
 
 
 class FakeMember:
@@ -23,10 +25,21 @@ class FakeGuild:
 
 
 class FakeThread:
-    def __init__(self, thread_id: int, parent_id: int) -> None:
+    def __init__(
+        self,
+        thread_id: int,
+        parent_id: int,
+        *,
+        name: str = "W0000-Test",
+        owner_id: int | None = None,
+        guild: object | None = None,
+    ) -> None:
         self.id = thread_id
         self.parent_id = parent_id
         self.type = discord.ChannelType.private_thread
+        self.name = name
+        self.owner_id = owner_id
+        self.guild = guild
         self.sent: list[FakeSentMessage] = []
 
     async def send(self, content: str | None = None, **kwargs):
@@ -56,8 +69,9 @@ class FakeMessage:
 
 
 class FakeBot:
-    def __init__(self, messages: List[FakeMessage]) -> None:
+    def __init__(self, messages: List[FakeMessage], *, channels: dict[int, FakeThread] | None = None) -> None:
         self._messages = list(messages)
+        self._channels = dict(channels or {})
 
     async def wait_for(self, event_name: str, *, timeout: float, check):
         while self._messages:
@@ -65,6 +79,9 @@ class FakeBot:
             if check(message):
                 return message
         raise asyncio.TimeoutError
+
+    def get_channel(self, channel_id: int):
+        return self._channels.get(channel_id)
 
 
 class FakeContext:
@@ -105,6 +122,42 @@ def _setup_permissions(monkeypatch, recruiter: bool, admin: bool = False) -> Non
 
 def _make_cog(bot: FakeBot) -> reserve_module.ReservationCog:
     return reserve_module.ReservationCog(bot)  # type: ignore[arg-type]
+
+
+def _reservation_row(
+    row_number: int,
+    *,
+    clan_tag: str,
+    reserved_until: dt.date | None = None,
+    status: str = "active",
+    thread_id: int = 555,
+    ticket_user_id: int | None = 222,
+    recruiter_id: int = 111,
+    username_snapshot: str = "Recruit",
+) -> reservations_sheet.ReservationRow:
+    return reservations_sheet.ReservationRow(
+        row_number=row_number,
+        thread_id=str(thread_id),
+        ticket_user_id=ticket_user_id,
+        recruiter_id=recruiter_id,
+        clan_tag=clan_tag,
+        reserved_until=reserved_until,
+        created_at=None,
+        status=status,
+        notes="",
+        username_snapshot=username_snapshot,
+        raw=[
+            str(thread_id),
+            str(ticket_user_id or ""),
+            str(recruiter_id),
+            clan_tag,
+            reserved_until.isoformat() if reserved_until else "",
+            "",
+            status,
+            "",
+            username_snapshot,
+        ],
+    )
 
 
 def test_reserve_success(monkeypatch):
@@ -286,3 +339,372 @@ def test_reserve_requires_ticket_thread(monkeypatch):
 
     assert ctx.replies, "should reply when outside ticket thread"
     assert "ticket thread" in ctx.replies[0].content
+
+
+def test_reservations_thread_no_matches(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=600)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(900, "Recruit Thread")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(
+        thread_id=1000,
+        parent_id=600,
+        name="W0455-Recruit Thread",
+        owner_id=recruit.id,
+    )
+    author = FakeMember(901)
+
+    bot = FakeBot([], channels={thread.id: thread})
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    async def fake_lookup(*_, **__):
+        return []
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_lookup,
+    )
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reservations_command.callback(cog, ctx))
+
+    assert thread.sent and "No active reservations" in thread.sent[0].content
+    assert logs and "result=empty" in logs[0]
+
+
+def test_reservations_thread_lists_matches(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=601)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(910, "Thread User")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(
+        thread_id=1100,
+        parent_id=601,
+        name="W0460-Thread User",
+        owner_id=recruit.id,
+    )
+    author = FakeMember(911)
+
+    rows = [
+        _reservation_row(
+            3,
+            clan_tag="#DEF",
+            reserved_until=dt.date(2025, 11, 20),
+            thread_id=thread.id,
+            ticket_user_id=recruit.id,
+            recruiter_id=author.id,
+            username_snapshot="Thread User",
+        ),
+        _reservation_row(
+            2,
+            clan_tag="#ABC",
+            reserved_until=dt.date(2025, 11, 18),
+            thread_id=thread.id,
+            ticket_user_id=recruit.id,
+            recruiter_id=author.id,
+            username_snapshot="Thread User",
+        ),
+    ]
+
+    async def fake_lookup(*_, **__):
+        return list(rows)
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_lookup,
+    )
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    bot = FakeBot([], channels={thread.id: thread})
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reservations_command.callback(cog, ctx))
+
+    assert thread.sent, "expected reservation listing"
+    content = thread.sent[0].content
+    lines = content.splitlines()
+    assert lines[1].startswith("• `ABC`")
+    assert lines[2].startswith("• `DEF`")
+    assert any("result=ok" in entry for entry in logs)
+
+
+def test_reservations_clan_listing(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_parents(monkeypatch, parent_id=700)
+
+    recruit = FakeMember(920, "User One")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=1200, parent_id=700, name="W0470-Other", owner_id=recruit.id)
+    author = FakeMember(921)
+
+    clan_row = ["", "Clan", "C1CE", ""] + [""] * 10
+
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (5, clan_row))
+
+    rows = [
+        _reservation_row(
+            5,
+            clan_tag="C1CE",
+            reserved_until=dt.date(2025, 11, 21),
+            thread_id=1300,
+            ticket_user_id=recruit.id,
+            username_snapshot="User One",
+        ),
+        _reservation_row(
+            6,
+            clan_tag="C1CE",
+            reserved_until=dt.date(2025, 11, 22),
+            thread_id=1400,
+            ticket_user_id=None,
+            username_snapshot="User Two",
+        ),
+    ]
+
+    async def fake_clan(tag):
+        assert tag == "C1CE"
+        return list(rows)
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "get_active_reservations_for_clan",
+        fake_clan,
+    )
+
+    thread_lookup = {
+        1300: FakeThread(1300, parent_id=700, name="W0471-User One-C1CE", owner_id=recruit.id),
+        1400: FakeThread(1400, parent_id=700, name="W0472-User Two-C1CE", owner_id=None),
+    }
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    bot = FakeBot([], channels=thread_lookup)
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reservations_command.callback(cog, ctx, "C1CE"))
+
+    assert thread.sent, "expected clan reservation listing"
+    content = thread.sent[0].content
+    assert "ticket W0471" in content
+    assert "ticket unknown" not in content.splitlines()[1]
+    assert any("scope=clan" in entry and "result=ok" in entry for entry in logs)
+
+
+def test_reserve_release_success(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=800)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(930, "Release User")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(
+        thread_id=1500,
+        parent_id=800,
+        name="Res-W0480-Release User-C1CE",
+        owner_id=recruit.id,
+    )
+    author = FakeMember(931)
+
+    row = _reservation_row(
+        8,
+        clan_tag="C1CE",
+        reserved_until=dt.date(2025, 11, 23),
+        thread_id=thread.id,
+        ticket_user_id=recruit.id,
+        recruiter_id=author.id,
+        username_snapshot="Release User",
+    )
+
+    async def fake_lookup(*_, **__):
+        return [row]
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_lookup,
+    )
+
+    updated: list[tuple[int, str]] = []
+
+    async def fake_status(row_number: int, status: str):
+        updated.append((row_number, status))
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "update_reservation_status",
+        fake_status,
+    )
+
+    manual_adjustments: list[tuple[str, int]] = []
+
+    async def fake_adjust(tag: str, delta: int):
+        manual_adjustments.append((tag, delta))
+
+    monkeypatch.setattr(reserve_module.availability, "adjust_manual_open_spots", fake_adjust)
+
+    recomputed: list[str] = []
+
+    async def fake_recompute(tag: str, *, guild=None):
+        recomputed.append(tag)
+
+    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", fake_recompute)
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    bot = FakeBot([], channels={thread.id: thread})
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "release"))
+
+    assert updated == [(8, "released")]
+    assert manual_adjustments == [("C1CE", 1)]
+    assert recomputed == ["C1CE"]
+    assert thread.sent and "Released the reserved seat" in thread.sent[-1].content
+    assert any("reservation_release" in entry and "result=ok" in entry for entry in logs)
+
+
+def test_reserve_extend_success(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=801)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(940, "Extend User")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(
+        thread_id=1600,
+        parent_id=801,
+        name="Res-W0485-Extend User-C1CE",
+        owner_id=recruit.id,
+    )
+    author = FakeMember(941)
+
+    row = _reservation_row(
+        10,
+        clan_tag="C1CE",
+        reserved_until=dt.date(2025, 11, 25),
+        thread_id=thread.id,
+        ticket_user_id=recruit.id,
+        recruiter_id=author.id,
+        username_snapshot="Extend User",
+    )
+
+    async def fake_lookup(*_, **__):
+        return [row]
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_lookup,
+    )
+
+    updates: list[tuple[int, dt.date]] = []
+
+    async def fake_expiry(row_number: int, new_date: dt.date):
+        updates.append((row_number, new_date))
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "update_reservation_expiry",
+        fake_expiry,
+    )
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    bot = FakeBot([], channels={thread.id: thread})
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "extend", "2999-01-01"))
+
+    assert updates == [(10, dt.date(2999, 1, 1))]
+    assert thread.sent and "Extended the reservation" in thread.sent[-1].content
+    assert any("reservation_extend" in entry and "result=ok" in entry for entry in logs)
+
+
+def test_reserve_extend_invalid_date(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=802)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    recruit = FakeMember(950, "Extend Fail")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(
+        thread_id=1700,
+        parent_id=802,
+        name="Res-W0488-Extend Fail-C1CE",
+        owner_id=recruit.id,
+    )
+    author = FakeMember(951)
+
+    row = _reservation_row(
+        11,
+        clan_tag="C1CE",
+        reserved_until=dt.date(2025, 11, 30),
+        thread_id=thread.id,
+        ticket_user_id=recruit.id,
+        recruiter_id=author.id,
+        username_snapshot="Extend Fail",
+    )
+
+    async def fake_lookup(*_, **__):
+        return [row]
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_lookup,
+    )
+
+    logs: list[str] = []
+
+    def fake_log(level: str, message: str, **_):
+        logs.append(message)
+
+    monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
+
+    bot = FakeBot([], channels={thread.id: thread})
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "extend", "2020-01-01"))
+
+    assert thread.sent, "expected invalid date message"
+    assert "valid date" in thread.sent[-1].content
+    assert any("invalid_date" in entry for entry in logs)


### PR DESCRIPTION
## Summary
- add `!reservations`, `!reserve release`, and `!reserve extend` flows with humanized logging and sheet updates
- refresh the reservation reminder message with new command guidance and structured ops logging
- document the reservation workflows and extend the placement test suite for the new commands and jobs

## Testing
- pytest tests/placement -q

[meta]
labels: codex,comp:ops,comp:data-sheets,comp:roles,docs,enhancement,P2
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d6aa852083238f0c1eb409603154)