### PR TITLE
Wire onboarding finalize into clan reconcile and improve reserve UX

### DIFF
--- a/docs/ops/Onboarding-Runbook.md
+++ b/docs/ops/Onboarding-Runbook.md
@@ -4,6 +4,7 @@
 The onboarding flow runs as an in-thread wizard message. Each question updates the same message with inline controls:
 
 * `short`, `paragraph`, `number` → click **Enter answer**, type in thread.
+* Forgot to click the button? If a text/number question is waiting, the bot captures answers typed directly into the thread and advances as soon as the input validates.
 * Invalid input shows a ❌ inline hint; valid answers advance automatically.
 * A compact “So far” section lists answered questions as **label → value**.
 
@@ -12,6 +13,8 @@ For `single-select` and `multi-select-N` it shows a dropdown (with max N selecti
 Options come from the sheet (`validate: values: A, B, …` or `note`).
 
 After the final summary is posted, the bot deletes the user's captured answer messages (only those), if cleanup is enabled.
+
+Closing a ticket and picking a clan tag (dropdown or typed) now runs the same reconciliation helpers as `!reserve`: it updates the onboarding sheet row, adjusts manual open spots, recomputes `AF`/`AH`/`AI`, and posts the 🧭 placement log in the ops channel so clan availability stays current.
 
 ### Testing (manual)
 1. Click **Open questions** → view disables with “Launching…”.
@@ -34,4 +37,4 @@ After the final summary is posted, the bot deletes the user's captured answer me
 
 `!ops onb check` — validate the tab, headers, and required columns.
 
-Doc last updated: 2025-11-05 (v0.9.7)
+Doc last updated: 2025-11-17 (v0.9.7)

--- a/docs/ops/Runbook.md
+++ b/docs/ops/Runbook.md
@@ -159,6 +159,7 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
 ## Reserving a clan seat (`!reserve`)
 - Confirm `FEATURE_RESERVATIONS` is enabled in the FeatureToggles worksheet before using the command.
 - Run `!reserve <clan_tag>` inside the recruit’s ticket thread (welcome or promo parent).
+- Optional: `!reserve <clan_tag> @recruit` skips the “Who do you want to reserve a spot for?” prompt. The mention/ID is validated before the date prompt begins.
 - Follow the prompts:
   - Mention the recruit or paste their Discord ID.
   - Provide the reservation end date in `YYYY-MM-DD`.
@@ -191,6 +192,7 @@ This command reads the **existing** tab defined by `ONBOARDING_TAB` and reports 
   - If no reservation existed, the final clan loses one manual open spot (`-1`).
   - Choosing the pseudo tag `NONE` cancels any reservation and restores the reserved clan’s open spot (`+1`).
 - After every adjustment the watcher calls `recompute_clan_availability` so `AF`/`AH`/`AI` stay in sync with the ledger.
+- Finalizing a clan tag also emits the 🧭 placement log (same format as `!reserve`) so ops can audit reconciliations in one channel.
  
 ## Reservation lifecycle (daily jobs)
 - **12:00 UTC — Reminder**
@@ -212,4 +214,4 @@ Both jobs respect the `FEATURE_RESERVATIONS` toggle in the `Feature_Toggles` wor
 - **Remediation:** Fix the Sheet, run `!ops reload` (or the admin bang alias), then
   verify the tab with `!checksheet` before retrying the feature.
 
-Doc last updated: 2025-11-15 (v0.9.7)
+Doc last updated: 2025-11-17 (v0.9.7)

--- a/docs/ops/WelcomeFlow.md
+++ b/docs/ops/WelcomeFlow.md
@@ -6,6 +6,7 @@ The welcome questionnaire now runs entirely inside the ticket thread. Recruits (
 ## Flow steps
 1. **Panel posted** – The watcher listens for the welcome greeting phrase (`"awake by reacting with"`) or the 🎫 emoji. It reacts 👍 to the greeting and posts a fresh message with the persistent **Open questions** button.
 2. **In-thread wizard** – Pressing the button posts the first onboarding question directly in the thread with navigation controls. Each answer is captured inline and retains previously provided values when the wizard is resumed.
+   - For text/number prompts, recruits can also type directly into the thread even if they forget to press **Enter answer**; the watcher treats the message as the answer and advances when validation passes.
 3. **Review & Confirm** – After the final question, the wizard shows a summary in-thread with edit/submit controls so the recruit can revise any section before finalizing.
 4. **Submit** – Confirming posts a single embed in the thread. The embed lists every question and answer (split across multiple embeds if Discord field limits require) and records who submitted along with a UTC timestamp.
 5. **Follow-up** – Coordinators pick up directly in the thread. The session can be resumed or restarted at any time by pressing either **Open questions** or the persistent **Restart** button.
@@ -26,6 +27,7 @@ The welcome questionnaire now runs entirely inside the ticket thread. Recruits (
   - No reservation → consume one manual open spot for the final clan (-1).
   - Final tag `NONE` → status `cancelled`; restore the reserved clan’s manual count (+1) and leave the pseudo clan untouched.
   Availability recompute calls keep AF/AH/AI aligned with the ledger.
+  Every placement emits the 🧭 reservation log entry so ops sees holds/releases and final placements in one channel.
 - **Reservation rename.** Successful `!reserve` runs rename open welcome threads to `Res-W####-username-TAG` so staff can see the hold immediately.
 
 ## Triggers
@@ -67,4 +69,4 @@ Gate instrumentation surfaces as single-line console logs:
 
 - **Always defer first.** Defer the button interaction before posting or editing the wizard message; otherwise Discord returns `response_is_done: true` and the launch fails.
 
-Doc last updated: 2025-11-14 (v0.9.7)
+Doc last updated: 2025-11-17 (v0.9.7)


### PR DESCRIPTION
## Summary
- ensure onboarding ticket closures always update clan availability, emit the 🧭 placement log, and capture thread-typed answers without needing the Enter button
- allow `!reserve` to take an optional recruit mention/ID, add clearer guidance when the extra argument is invalid, and document the new behaviors
- extend the onboarding and reservation test suites to cover the reconcile pipeline, fallback capture paths, and the updated command UX

## Testing
- `pytest tests/onboarding/test_auto_capture.py tests/onboarding/test_welcome_reservations.py tests/placement/test_reserve_command.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0dc305b88323877921750c879393)