### PR TITLE
Tidy onboarding lifecycle logging

### DIFF
--- a/docs/ops/Logging.md
+++ b/docs/ops/Logging.md
@@ -65,6 +65,17 @@ Line mode:
 ❌ Welcome panel — actor=@Recruit • thread=#welcome › ticket-123 • channel=#WELCOME CENTER › welcome • result=error • details:view=panel; source=panel; reason=panel_send
 ```
 
+### Onboarding panel lifecycle logs
+Neutral lifecycle events (open, start, restart) now use the 📘 icon so the feed is quieter, while ✅ still marks a complete run and ⚠️/❌ remain reserved for odd or error conditions. These logs summarize the state change with human labels and omit raw message/thread IDs.
+
+```
+📘 onboarding_panel_open — ticket=W0481-caillean • actor=@Recruit • channel=#WELCOME CENTER › welcome • questions=16
+📘 onboarding_panel_restart — ticket=W0481-caillean • actor=@Recruit • channel=#WELCOME CENTER › welcome • questions=16 • schema=v1
+✅ onboarding_panel_complete — ticket=W0481-caillean • actor=@Recruit • channel=#WELCOME CENTER › welcome • questions=16 • level_detail=Late Game
+```
+
+Only include `reason=` when the emoji is ⚠️ or ❌; keep tickets, actors, and channels readable, and rely on schema short codes (e.g., `v1`) instead of raw hashes. IDs are intentionally hidden—if a one-off investigation needs snowflakes, fall back to the structured console logs.
+
 ## Dedupe policy
 - Window: fixed at 5 seconds. All dedupe is in-memory and process-local.
 - Keys:
@@ -81,4 +92,4 @@ No runtime environment flags affect logging templates. Numeric snowflake IDs sta
 - Continue emitting structured logs (JSON/stdout) for auditability—only the human-facing Discord posts use the templates above.
 ---
 
-Doc last updated: 2025-10-31 (v0.9.7)
+Doc last updated: 2025-11-17 (v0.9.7)

--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -1713,14 +1713,12 @@ class BaseWelcomeController:
         except Exception:
             log.warning("failed to post onboarding summary", exc_info=True)
         else:
-            await logs.send_welcome_log(
-                "info",
-                result="completed",
-                view="inline",
-                source=self._sources.get(thread_id, "unknown"),
-                schema=session.schema_hash if session else None,
-                details=_final_fields(self._questions.get(thread_id, []), dict(answers)),
-                **self._log_fields(thread_id, actor=getattr(interaction, "user", None)),
+            await self._log_panel_completion(
+                thread_id,
+                thread=thread,
+                actor=getattr(interaction, "user", None),
+                session=session,
+                answers=dict(answers),
             )
 
         self.answers_by_thread.pop(thread_id, None)
@@ -1745,6 +1743,33 @@ class BaseWelcomeController:
         if handle:
             context["actor_name"] = handle
         return context
+
+    async def _log_panel_completion(
+        self,
+        thread_id: int,
+        *,
+        thread: discord.Thread | None,
+        actor: discord.abc.User | discord.Member | None,
+        session: SessionData | None,
+        answers: Mapping[str, Any],
+    ) -> None:
+        if self.flow != "welcome":
+            return
+        question_count = len(self._questions.get(thread_id, [])) if hasattr(self, "_questions") else None
+        schema_version = getattr(session, "schema_hash", None)
+        extras: dict[str, Any] | None = None
+        level_detail = _extract_level_detail(answers)
+        if level_detail:
+            extras = {"level_detail": level_detail}
+        await logs.log_onboarding_panel_lifecycle(
+            event="complete",
+            ticket=thread,
+            actor=actor,
+            channel=getattr(thread, "parent", None),
+            questions=question_count,
+            schema_version=schema_version,
+            extras=extras,
+        )
 
     async def _send_panel_with_retry(
         self,
@@ -3131,14 +3156,12 @@ class BaseWelcomeController:
         await thread.send(embed=summary_embed)
         await thread.send("@RecruitmentCoordinator")
 
-        await logs.send_welcome_log(
-            "info",
-            result="completed",
-            view="preview",
-            source=self._sources.get(thread_id, "unknown"),
-            schema=session.schema_hash,
-            details=_final_fields(self._questions[thread_id], session.answers),
-            **self._log_fields(thread_id, actor=interaction.user),
+        await self._log_panel_completion(
+            thread_id,
+            thread=thread,
+            actor=interaction.user,
+            session=session,
+            answers=dict(session.answers),
         )
 
         store.set_preview_message(thread_id, message_id=None, channel_id=None)
@@ -3645,6 +3668,29 @@ def _convert_to_labels(value: Any, mapping: dict[str, str]) -> Any:
     if isinstance(value, str):
         return mapping.get(value, value)
     return value
+
+
+def _extract_level_detail(answers: Mapping[str, Any]) -> str | None:
+    raw = answers.get("w_level_detail") if isinstance(answers, Mapping) else None
+    if isinstance(raw, Mapping):
+        for key in ("label", "value", "text"):
+            candidate = raw.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+    if isinstance(raw, (list, tuple)):
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                return item.strip()
+            if isinstance(item, Mapping):
+                for key in ("label", "value", "text"):
+                    candidate = item.get(key)
+                    if isinstance(candidate, str) and candidate.strip():
+                        return candidate.strip()
+    if raw is not None:
+        text = str(raw).strip()
+        if text:
+            return text
+    return None
 
 
 def _safe_followup(interaction: discord.Interaction, message: str) -> Awaitable[None]:

--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -300,17 +300,13 @@ class OnboardingReactionFallbackCog(commands.Cog):
             restart_context = _base_context(member=member, thread=thread)
             restart_context.update({"trigger": trigger, "result": "restarted"})
             restart_context.update(target_extra)
-            await logs.send_welcome_log("info", **restart_context)
             try:
                 await existing_panel.delete()
             except Exception as exc:
                 await logs.send_welcome_exception("warn", exc, **restart_context)
             panels.mark_panel_inactive_by_message(existing_panel.id)
         else:
-            start_context = _base_context(member=member, thread=thread)
-            start_context.update({"trigger": trigger, "result": "started"})
-            start_context.update(target_extra)
-            await logs.send_welcome_log("info", **start_context)
+            pass
 
         try:
             await start_welcome_dialog(

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -517,44 +517,45 @@ class WelcomeWatcher(commands.Cog):
         actor: discord.abc.User | None,
         source: str,
     ) -> None:
+        parts = parse_welcome_thread_name(getattr(thread, "name", None))
+        ticket_code = getattr(parts, "ticket_code", None)
+        parent_channel = getattr(thread, "parent", None)
+        question_count, schema_version = logs.question_stats("welcome")
+
+        async def _emit(result: str | None = None, reason: str | None = None) -> None:
+            payload: dict[str, object] = {
+                "ticket": ticket_code or thread,
+                "actor": actor,
+                "channel": parent_channel,
+                "questions": question_count,
+                "schema_version": schema_version,
+            }
+            if result is not None:
+                payload["result"] = result
+            if reason is not None:
+                payload["reason"] = reason
+            await logs.log_onboarding_panel_lifecycle(event="open", **payload)
+
         joined, join_error = await thread_membership.ensure_thread_membership(thread)
         if not joined:
-            context = self._log_context(
-                thread,
-                actor,
-                source=source,
-                result="thread_join_failed",
-                reason="thread_join",
-            )
             if join_error is not None:
-                await logs.send_welcome_exception("error", join_error, **context)
-            else:
-                await logs.send_welcome_log("error", **context)
+                log.warning("failed to join welcome thread", exc_info=True)
+            await _emit(result="error", reason="thread_join_failed")
             return
 
         view = panels.OpenQuestionsPanelView()
         content = "Ready when you are — tap below to open the onboarding questions."
         try:
-            message = await thread.send(content, view=view)
-        except Exception as exc:  # pragma: no cover - network
-            await logs.send_welcome_exception(
-                "error",
-                exc,
-                **self._log_context(thread, actor, source=source, result="error", reason="panel_send"),
-            )
+            await thread.send(content, view=view)
+        except Exception:
+            log.exception("failed to post onboarding panel message")
+            await _emit(result="error", reason="panel_send_failed")
             return
 
-        context = self._log_context(
-            thread,
-            actor,
-            source=source,
-            result="posted",
-            message_id=getattr(message, "id", None),
-            details={"view": "panel", "source": source},
-        )
-        if source == "emoji":
-            context["emoji"] = _TICKET_EMOJI
-        await logs.send_welcome_log("info", **context)
+        if ticket_code:
+            await _emit()
+        else:
+            await _emit(result="skipped", reason="ticket_not_parsed")
 
     # ---- listeners ----------------------------------------------------------------
     @commands.Cog.listener()

--- a/modules/onboarding/welcome_flow.py
+++ b/modules/onboarding/welcome_flow.py
@@ -163,17 +163,27 @@ async def start_welcome_dialog(
         )
         return
 
-    await logs.send_welcome_log(
-        "info",
-        **_context(
-            {
-                "result": "started",
-                "schema": schema_version,
-                "questions": len(questions),
-                **context_defaults,
-            }
-        ),
-    )
+    if flow == "welcome":
+        await logs.log_onboarding_panel_lifecycle(
+            event="start",
+            ticket=thread,
+            actor=actor,
+            channel=getattr(thread, "parent", None),
+            questions=len(questions),
+            schema_version=schema_version,
+        )
+    else:
+        await logs.send_welcome_log(
+            "info",
+            **_context(
+                {
+                    "result": "started",
+                    "schema": schema_version,
+                    "questions": len(questions),
+                    **context_defaults,
+                }
+            ),
+        )
 
     controller_bot = bot or _resolve_bot(thread)
     if controller_bot is None:

--- a/tests/onboarding/test_lifecycle_logging.py
+++ b/tests/onboarding/test_lifecycle_logging.py
@@ -1,0 +1,256 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from modules.onboarding import logs, welcome_flow, watcher_welcome
+from modules.onboarding.session_store import store
+from modules.onboarding.ui import panels
+from modules.onboarding.controllers import welcome_controller
+from modules.onboarding import thread_scopes
+from modules.common import feature_flags
+from shared.sheets import onboarding_questions
+
+
+class DummyParent:
+    def __init__(self, name: str = "welcome") -> None:
+        self.name = name
+        self.category = SimpleNamespace(name="WELCOME CENTER")
+
+
+class DummyThread:
+    def __init__(self, name: str = "W0481-caillean") -> None:
+        self.name = name
+        self.id = 4242
+        self.parent = DummyParent()
+
+    async def send(self, *_, **__):
+        return SimpleNamespace(id=999)
+
+
+def test_lifecycle_helper_formats_neutral(monkeypatch, caplog):
+    sent: list[str] = []
+
+    async def fake_send(message: str) -> None:
+        sent.append(message)
+
+    monkeypatch.setattr(logs.rt, "send_log_message", fake_send)
+    caplog.set_level(logging.INFO, logger="c1c.onboarding.logs")
+
+    async def runner() -> None:
+        await logs.log_onboarding_panel_lifecycle(
+            event="open",
+            ticket="W0481-caillean",
+            actor="@Recruit",
+            channel="#WELCOME CENTER › welcome",
+            questions=16,
+            schema_version="abcdef123456",
+        )
+
+    asyncio.run(runner())
+
+    assert sent, "expected log message"
+    assert sent[0].startswith("[watcher|lifecycle] 📘 onboarding_panel_open"), sent[0]
+    assert "schema=vabcdef" in sent[0]
+    assert "message_id" not in sent[0]
+    assert any("📘 onboarding_panel_open" in record.message for record in caplog.records)
+
+
+def test_lifecycle_helper_hides_reason_when_info(monkeypatch):
+    sent: list[str] = []
+
+    async def fake_send(message: str) -> None:
+        sent.append(message)
+
+    monkeypatch.setattr(logs.rt, "send_log_message", fake_send)
+
+    async def runner() -> None:
+        await logs.log_onboarding_panel_lifecycle(
+            event="open",
+            ticket="W0481-caillean",
+            actor="@Recruit",
+            channel="#WELCOME CENTER › welcome",
+            questions=16,
+            schema_version="v1",
+            reason="should_hide",
+        )
+
+    asyncio.run(runner())
+
+    assert sent and "reason=should_hide" not in sent[0]
+
+
+def test_welcome_watcher_logs_open_once(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    async def fake_lifecycle_log(**payload):
+        recorded.append(payload)
+
+    async def ensure_membership(_thread):
+        return True, None
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+    monkeypatch.setattr(logs, "question_stats", lambda flow: (16, "v1"))
+    monkeypatch.setattr(watcher_welcome.thread_membership, "ensure_thread_membership", ensure_membership)
+    monkeypatch.setattr(panels, "OpenQuestionsPanelView", lambda: SimpleNamespace())
+
+    watcher = watcher_welcome.WelcomeWatcher(bot=SimpleNamespace())
+    thread = DummyThread()
+    actor = SimpleNamespace(display_name="Recruit", bot=False)
+
+    async def runner() -> None:
+        await watcher._post_panel(thread, actor=actor, source="phrase")
+
+    asyncio.run(runner())
+
+    assert recorded and recorded[0]["event"] == "open"
+
+
+def test_welcome_watcher_logs_missing_ticket(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    async def fake_lifecycle_log(**payload):
+        recorded.append(payload)
+
+    async def ensure_membership(_thread):
+        return True, None
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+    monkeypatch.setattr(logs, "question_stats", lambda flow: (16, "v1"))
+    monkeypatch.setattr(watcher_welcome.thread_membership, "ensure_thread_membership", ensure_membership)
+    monkeypatch.setattr(panels, "OpenQuestionsPanelView", lambda: SimpleNamespace())
+
+    watcher = watcher_welcome.WelcomeWatcher(bot=SimpleNamespace())
+    thread = DummyThread(name="no-ticket")
+    actor = SimpleNamespace(display_name="Recruit", bot=False)
+
+    async def runner() -> None:
+        await watcher._post_panel(thread, actor=actor, source="phrase")
+
+    asyncio.run(runner())
+
+    assert recorded and recorded[0]["result"] == "skipped"
+    assert recorded[0]["reason"] == "ticket_not_parsed"
+
+
+def test_start_welcome_dialog_logs_once(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    async def fake_lifecycle_log(**payload):
+        recorded.append(payload)
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+    monkeypatch.setattr(thread_scopes, "is_welcome_parent", lambda _thread: True)
+    monkeypatch.setattr(thread_scopes, "is_promo_parent", lambda _thread: False)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda name: True)
+    monkeypatch.setattr(onboarding_questions, "get_questions", lambda flow: [object(), object()])
+    monkeypatch.setattr(onboarding_questions, "schema_hash", lambda flow: "abcdef1234")
+
+    async def fake_locate(_thread):
+        return SimpleNamespace()
+
+    monkeypatch.setattr(welcome_flow, "locate_welcome_message", fake_locate)
+    monkeypatch.setattr(welcome_flow, "extract_target_from_message", lambda _msg: (None, None))
+
+    class DummyController:
+        flow = "welcome"
+
+        def __init__(self, _bot):
+            self._panel_messages = {}
+            self._prefetched_panels = {}
+            self._sources = {}
+
+        async def run(self, *_args, **_kwargs) -> None:
+            return None
+
+    monkeypatch.setattr(welcome_flow, "WelcomeController", DummyController)
+    monkeypatch.setattr(welcome_flow, "PromoController", DummyController)
+    monkeypatch.setattr(panels, "register_panel_message", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(welcome_flow, "_resolve_bot", lambda _thread: SimpleNamespace())
+
+    thread = DummyThread()
+    actor = SimpleNamespace(display_name="Recruit", bot=False)
+
+    async def runner() -> None:
+        await welcome_flow.start_welcome_dialog(thread, actor, source="ticket", bot=SimpleNamespace())
+
+    asyncio.run(runner())
+
+    assert recorded and recorded[0]["event"] == "start"
+
+
+def test_panel_restart_logs_once(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    async def fake_lifecycle_log(**payload):
+        recorded.append(payload)
+
+    async def fake_notify(self, _interaction):
+        return None
+
+    async def fake_start(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+    monkeypatch.setattr(logs, "question_stats", lambda flow: (16, "v1"))
+    monkeypatch.setattr(panels.OpenQuestionsPanelView, "_notify_restart", fake_notify, raising=False)
+    monkeypatch.setattr(welcome_flow, "start_welcome_dialog", fake_start)
+
+    base_thread = type("_RestartThread", (), {})
+    monkeypatch.setattr(panels.discord, "Thread", base_thread)
+
+    class PanelThread(base_thread):
+        def __init__(self):
+            self.id = 123
+            self.name = "W0481-caillean"
+            self.parent = DummyParent()
+
+    async def runner() -> None:
+        thread = PanelThread()
+        interaction = SimpleNamespace(
+            channel=thread,
+            user=SimpleNamespace(display_name="Recruit"),
+            client=SimpleNamespace(),
+            message=SimpleNamespace(id=1),
+        )
+        view = panels.OpenQuestionsPanelView()
+        view.controller = SimpleNamespace(flow="welcome")
+        await view._restart_from_view(interaction, {})
+
+    asyncio.run(runner())
+
+    assert recorded and recorded[0]["event"] == "restart"
+
+
+def test_completion_logging_helper(monkeypatch):
+    recorded: list[dict[str, object]] = []
+
+    async def fake_lifecycle_log(**payload):
+        recorded.append(payload)
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+
+    controller = welcome_controller.WelcomeController(bot=SimpleNamespace())
+    thread_id = 777
+    thread = DummyThread()
+    controller._threads[thread_id] = thread
+    controller._questions[thread_id] = [SimpleNamespace(qid="w_level_detail")]
+    answers = {"w_level_detail": "Late Game"}
+
+    async def runner() -> None:
+        session = store.ensure(thread_id, flow="welcome", schema_hash="schema1")
+        try:
+            await controller._log_panel_completion(
+                thread_id,
+                thread=thread,
+                actor=SimpleNamespace(display_name="Recruit"),
+                session=session,
+                answers=answers,
+            )
+        finally:
+            store._sessions.clear()
+
+    asyncio.run(runner())
+    assert recorded and recorded[0]["event"] == "complete"
+    assert recorded[0]["extras"]["level_detail"] == "Late Game"


### PR DESCRIPTION
## Summary
- add a reusable onboarding panel lifecycle logging helper and route the watcher, flow controller, restart view, and completion paths through it
- remove the noisy ID-heavy lifecycle log emissions and update reaction fallbacks plus docs to describe the new format
- add a focused async-compatible test suite that exercises helper formatting as well as open/start/restart/complete flows

## Testing
- pytest tests/onboarding/test_lifecycle_logging.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b15c9ebcc8323b7de11ea80e7d498)