### PR TITLE
docs: consolidate architecture references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ It exists so that contributors update the correct references after each developm
 ## Folder Map
 
 ### Root docs
-* [`Architecture.md`](Architecture.md) — high-level architecture overview and runtime map.
+* [`Architecture.md`](Architecture.md) — canonical runtime architecture, data flows, and environment map.
 * [`README.md`](README.md) — you are here; master index for the documentation tree.
 
 ### `/docs/adr/` — Architectural Decision Records
@@ -58,6 +58,9 @@ It exists so that contributors update the correct references after each developm
 * [`CollaborationContract.md`](contracts/CollaborationContract.md) — contributor standards, PR review flow, and Codex formatting instructions.
 
 ### `/docs/ops/` — Operational Documentation
+* [`CoreOps.md`](ops/CoreOps.md) — CoreOps responsibilities, scheduler contracts, and cache façade expectations.
+* [`Modules.md`](ops/Modules.md) — module inventory with entry points and links to each deep dive.
+* [`Runbook.md`](ops/Runbook.md) — canonical operator procedures (deploy, health, refresh, and maintenance cadences).
 * [`CommandMatrix.md`](ops/CommandMatrix.md) — user/admin command catalogue with permissions, feature gates, and descriptions.
 * [`Config.md`](ops/Config.md) — environment variables, Config tab mapping, and Sheets schema (including `FEATURE_TOGGLES_TAB`).
 * [`env.md`](ops/env.md) — minimal environment checklist highlighting required keys and onboarding fallbacks.
@@ -69,7 +72,6 @@ It exists so that contributors update the correct references after each developm
 * [`PermCommandQuickstart.md`](ops/PermCommandQuickstart.md) — quickstart for the `!perm bot` command surface.
 * [`PermissionsSync.md`](ops/PermissionsSync.md) — bot access list administration and channel overwrite sync runbook.
 * [`RecruiterPanel.md`](ops/RecruiterPanel.md) — interaction model for the recruiter panel UI and messaging cadence.
-* [`Runbook.md`](ops/Runbook.md) — operator actions for routine tasks and incident handling.
 * [`Troubleshooting.md`](ops/Troubleshooting.md) — quick reference for diagnosing common issues.
 * [`Watchers.md`](ops/Watchers.md) — environment-gated welcome/promo listeners and cache refresh scheduler notes.
 * [`Welcome.md`](ops/Welcome.md) — persistent welcome panel behaviour, recovery workflow, and operator tips.

--- a/docs/adr/ADR-0022-Module-Boundaries.md
+++ b/docs/adr/ADR-0022-Module-Boundaries.md
@@ -66,7 +66,7 @@ layout, watchers/schedules, or feature toggles—then the PR must update:
 - `docs/ops/Module-<Module>.md`
 - `docs/ops/Config.md`
 - `docs/_meta/DocStyle.md` (if formatting changed)
-- `docs/ops/Architecture.md` (if flows changed)
+- `docs/Architecture.md` (if flows changed)
 - `CHANGELOG.md`
 
 New docs may only be created with explicit ADR approval.

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -74,7 +74,7 @@ Every audit and CI check validates against this document.
     • `docs/ops/Module-<Module>.md`  
     • `docs/ops/Config.md`  
     • `docs/_meta/DocStyle.md` (if formatting changed)  
-    • `docs/ops/Architecture.md` (if data flows changed)  
+    • `docs/Architecture.md` (if data flows changed)
     • `CHANGELOG.md`
   No new docs may be created unless an ADR authorises it.
 

--- a/docs/ops/CoreOps.md
+++ b/docs/ops/CoreOps.md
@@ -1,0 +1,57 @@
+# CoreOps Explainer
+
+CoreOps is the runtime spine of this repository. It owns the Discord cog that
+loads first, the scheduler, Sheets adapters, and the structured logging/health
+surfaces that every functional module relies on.
+
+## Responsibilities
+- **Command routing & RBAC.** The CoreOps cog in `packages/c1c-coreops` registers
+  the `!ops` command tree, admin bang shortcuts, and the permission decorators
+  shared by feature modules. Every Discord command passes through CoreOps before
+  reaching the module handler.
+- **Lifecycle hooks.** Startup, reload, refresh, and watchdog events emit
+  `[watcher|lifecycle]` log lines and send status embeds to the ops channel.
+  `!ops reload` rebuilds the config registry and TTL caches; `!ops refresh` calls
+  the cache façade; `!ops reload --reboot` restarts the runtime after reload.
+- **Scheduler.** Handles cache refresh jobs (`clans`, `templates`, `clan_tags`,
+  `welcome_templates`, reservations) plus cron-based reports (daily recruiter
+  update). Scheduler runs inside the CoreOps runtime thread and records telemetry
+  per job.
+- **Sheets façade.** Modules import `shared.sheets.async_facade`. The façade
+  serializes cache calls, routes synchronous helpers through
+  `asyncio.to_thread`, and raises module-friendly exceptions so feature code does
+  not need to understand the lower-level adapters.
+- **Health & logging.** CoreOps configures the aiohttp health server and the JSON
+  logging formatter (`shared.logging.structured.JsonFormatter`). Every HTTP
+  request receives a `trace` id echoed in the response headers.
+
+## Integration points
+- **Modules.** Modules expose cogs in `cogs/` that register their commands. They
+  resolve config, Sheets data, and feature toggles through CoreOps helpers such
+  as `shared.config.registry`, `modules.common.feature_flags`, and the cache API
+  (`refresh_now`, `get_snapshot`). Module docs live in `docs/ops/Modules.md`.
+- **Sheets & config registry.** CoreOps caches sheet tabs using bucket metadata
+  stored in the Config worksheet (`docs/ops/Config.md`). Reloading the registry
+  clears TTL caches and re-reads tab definitions before modules resume work.
+- **Telemetry.** Operational embeds (`!ops health`, `!ops digest`, `!ops checksheet`)
+  read only the public telemetry payloads produced by CoreOps. No module is
+  allowed to import private cache internals.
+
+## Invariants
+- All CoreOps code lives in `packages/c1c-coreops`. CI fails if CoreOps helpers
+  appear elsewhere.
+- Cache access must go through the async façade; direct adapter imports are
+  disallowed.
+- Feature toggles default to disabled when missing or malformed.
+- Watchdog exits should be the only reason the process stops unexpectedly; any
+  other crash must be treated as a regression.
+
+## Module expectations
+- Modules must log via the structured logger and include the active `trace` when
+  they respond to HTTP requests or refresh caches.
+- Long-running handlers must release the event loop by offloading blocking work
+  to `asyncio.to_thread` or background tasks.
+- Modules should record the invoking actor in telemetry when they trigger cache
+  refreshes or reconciliations so `!ops digest` remains auditable.
+
+Doc last updated: 2025-11-17 (v0.9.7)

--- a/docs/ops/Modules.md
+++ b/docs/ops/Modules.md
@@ -1,0 +1,24 @@
+# Modules Overview
+
+This catalog lists the runtime modules that plug into CoreOps. Use it to locate
+entry points, feature toggles, and the deep-dive doc for each surface.
+
+| Module | Role | Primary entry points | Deep-dive references |
+| --- | --- | --- | --- |
+| **CoreOps** | Routing cog, scheduler, cache façade, health/log surfaces. Owns RBAC checks and lifecycle commands. | `!ops …`, `!perm …`, `/health`, `/ready`, watchdog exits. | [`CoreOps.md`](CoreOps.md)
+| **Onboarding** | Thread-first wizard for recruiter questionnaires plus sheet reconciliation. | `!ops onb reload`, `!ops onb check`, `!onb resume`, welcome ticket close handler. | [`Onboarding.md`](Onboarding.md), [`Onboarding-Runbook.md`](Onboarding-Runbook.md)
+| **Welcome** | Persistent welcome panel, template cache, and watcher-controlled ticket creation. | `!welcome`, `!welcome-refresh`, promo/welcome watchers. | [`Welcome.md`](Welcome.md), [`WelcomeFlow.md`](WelcomeFlow.md), [`Welcome_Summary_Spec.md`](Welcome_Summary_Spec.md)
+| **Recruitment** | Clan search panels, recruiter dashboard, emoji rendering helpers, and report embeds. | `!clanmatch`, recruiter panel UI, daily recruiter report cron. | [`RecruiterPanel.md`](RecruiterPanel.md), [`commands.md`](commands.md)
+| **Placement** | Reservations and seat reconciliation when onboarding closes tickets. Shares adapters with recruitment sheets. | `!reserve`, placement watcher hooks, placement summaries in ops channel. | [`Watchers.md`](Watchers.md), [`Welcome_Summary_Spec.md`](Welcome_Summary_Spec.md)
+| **Shared / OBS** | Sheets adapters, cache warming, logging templates, watchdog tuning, and feature toggles. Supports every module. | Scheduler refresh jobs, structured logging pipeline, feature toggle bootstrap. | [`Config.md`](Config.md), [`keepalive.md`](keepalive.md), [`Logging.md`](Logging.md), [`module-toggles.md`](module-toggles.md)
+
+### Module relationships
+- All modules import Sheets data exclusively through the async façade described in
+  [`CoreOps.md`](CoreOps.md) to avoid blocking the event loop.
+- Feature toggles listed in [`module-toggles.md`](module-toggles.md) control each
+  module’s boot sequence. Missing toggles default to disabled.
+- Module-specific docs retain detailed schemas, workflows, and guardrails. This
+  overview intentionally stays short; update the deep-dives for behavioural
+  changes and link them here.
+
+Doc last updated: 2025-11-17 (v0.9.7)


### PR DESCRIPTION
## Summary
- merge the operational architecture narrative into `docs/Architecture.md` so runtime surfaces, data flows, and environment separation live in the canonical file
- drop the redundant `docs/ops/Architecture.md` entry and update the docs index plus guardrails/ADR references to point at the single source of truth

## Testing
- not run (docs-only changes)
[meta]
labels: docs, comp:ops
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9deef64c83238f7c425d207ffe27)