### PR TITLE
Fix guardrails doc/index parity and document TICKET_TOOL_BOT_ID

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,17 +30,17 @@ It exists so that contributors update the correct references after each developm
 * [`ADR-0016`](adr/ADR-0016-import-side-effects.md) — import-time side effects removal.
 * [`ADR-0017`](adr/ADR-0017-Reservations-Placement-Schema.md) — reservations & placement schema.
 * [`ADR-0018`](adr/ADR-0018_DailyRecruiterUpdate.md) — daily recruiter update schedule and sheet-driven report.
-* [`ADR-0019`](ADR-0019-Introduction-of-Clan-SeatReservations.md) — Clan Seet Resevation for Recruiters
-* [`ADR-0020`](ADR-0020-Availability-Derivation.md) — Availability Derivation (E → AF/AH/AI) & Cache Update Strategy
-* [ADR-0021](ADR-0021-availability-recompute-helper.md)	— Reservations Sheet Adapter & Availability Recompute Helper
-* [ADR-0022](ADR-0022-Module-Boundaries.md) — Module Boundaries: Onboarding vs Welcome (and Update Discipline) 
+* [`ADR-0019 — Introduction of Clan Seat Reservations`](adr/ADR-0019-Introduction-of-Clan-SeatReservations.md) — clan seat reservation system rollout for recruiters.
+* [`ADR-0020 — Availability Derivation`](adr/ADR-0020-Availability-Derivation.md) — derivation of availability states from reservation data.
+* [`ADR-0021 — Availability Recompute Helper`](adr/ADR-0021-availability-recompute-helper.md) — reservations sheet adapter and recompute helper.
+* [`ADR-0022 — Module Boundaries`](adr/ADR-0022-Module-Boundaries.md) — onboarding vs welcome module boundaries and update discipline.
 * [`README.md`](adr/README.md) — ADR index and authoring guidelines.
 
 ### `/docs/epic/` — Feature Epics
 * [`README.md`](epic/README.md) — epic index and submission expectations.
 * [`EPIC_WelcomePlacementV2.md`](epic/EPIC_WelcomePlacementV2.md) — welcome & placement v2 thread-first onboarding flow.
 * [`EPIC_DailyRecruiterUpdate.md`](epic/EPIC_DailyRecruiterUpdate.md) — daily recruiter update reporting pipeline.
-* [Clan Seat Reservation System v1](EPIC_WelcomePlacementV2.md)
+* [`EPIC_ClanSeatReservationSystem.md`](epic/EPIC_ClanSeatReservationSystem.md) — Clan Seat Reservation System v1
 
 ### `/docs/_meta/`
 * [`COMMAND_METADATA.md`](_meta/COMMAND_METADATA.md) — canonical command metadata export for Ops and diagnostics.

--- a/docs/contracts/CollaborationContract.md
+++ b/docs/contracts/CollaborationContract.md
@@ -54,6 +54,17 @@ Single source of truth for how we work (me ↔ ChatGPT ↔ Codex), how pull requ
 | `docs/guardrails/` | Guardrail & CI policy specs (e.g., `RepositoryGuardrails.md`).              |
 | `docs/compliance/` | Audit and guardrail reports (e.g., `REPORT_GUARDRAILS.md`).                 |
 
+**Seat reservation architecture references (keep in sync with `docs/README.md`):**
+
+* [`ADR-0019 — Introduction of Clan Seat Reservations`](../adr/ADR-0019-Introduction-of-Clan-SeatReservations.md)
+* [`ADR-0020 — Availability Derivation`](../adr/ADR-0020-Availability-Derivation.md)
+* [`ADR-0021 — Availability Recompute Helper`](../adr/ADR-0021-availability-recompute-helper.md)
+* [`ADR-0022 — Module Boundaries`](../adr/ADR-0022-Module-Boundaries.md)
+
+**Related epic:**
+
+* [`EPIC — Clan Seat Reservation System`](../epic/EPIC_ClanSeatReservationSystem.md)
+
 ### 3.3 ADR template
 Ask for current number if unsure! 
 ```

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -102,7 +102,7 @@ WELCOME_GENERAL_CHANNEL_ID=
 
 # Private welcome ticket channel ID.
 WELCOME_CHANNEL_ID=
-# Ticket Tool bot ID (owner of welcome ticket threads).
+# Discord user ID of the Ticket Tool bot (required when Ticket Tool integration is enabled).
 TICKET_TOOL_BOT_ID=
 
 # Promo ticket channel ID.

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -79,6 +79,7 @@ sync modules remain available for non-async scripts and cache warmers.
 | `RECRUITMENT_INTERACT_CHANNEL` | snowflake | — | Channel where recruiters and clan leads review reservation rosters. |
 | `WELCOME_GENERAL_CHANNEL_ID` | snowflake | — | Public welcome channel ID (optional). |
 | `WELCOME_CHANNEL_ID` | snowflake | — | Private welcome ticket channel ID. |
+| `TICKET_TOOL_BOT_ID` | snowflake | — | Discord user ID of the Ticket Tool bot. Required when Ticket Tool-driven ticket workflows (welcome/onboarding/reservations) are enabled so threads can be associated with the correct bot. |
 | `PROMO_CHANNEL_ID` | snowflake | — | Promo ticket channel ID. |
 | `NOTIFY_CHANNEL_ID` | snowflake | — | Fallback alert channel ID. |
 | `NOTIFY_PING_ROLE_ID` | snowflake | — | Role pinged for urgent alerts. |
@@ -238,4 +239,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-11-15 (v0.9.7)
+Doc last updated: 2025-11-17 (v0.9.7)


### PR DESCRIPTION
## Summary
- document the `TICKET_TOOL_BOT_ID` environment variable in the configuration reference and the env template so guardrails have a consistent SSoT
- link the latest ADRs and Clan Seat Reservation System epic from the docs index and Collaboration Contract to restore documentation parity

## Testing
- Not run (docs-only)

[meta]
labels: docs, guardrails, config, comp:config, comp:ops, maintenance
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb039b7e48323a022ef73371123fd)