### PR TITLE
Add Who We Are role map command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Admins handle the bigger picture:
 - Permissions syncing properly  
 - Onboarding running without stalling  
 Start with:
-- **Ops Runbook:** `docs/Runbook.md`  
-- **Troubleshooting:** `docs/Troubleshooting.md`  
-- **Ops Command Matrix:** `docs/ops/CommandMatrix.md`  
+- **Ops Runbook:** `docs/Runbook.md`
+- **Troubleshooting:** `docs/Troubleshooting.md`
+- **Ops Command Matrix:** `docs/ops/CommandMatrix.md`
 - **Watchers Reference:** `docs/ops/Watchers.md`
-  
+- **Cluster Role Map:** `!whoweare` prints the live "Who We Are" roster straight from the WhoWeAre sheet so cluster leads can see who holds which roles (with snark) in real time.
+
 This is your Swiss-army knife for keeping the bot healthy.
 # 🧭 Behind the Curtain — How It Works
 If you’re curious how the bot thinks, check:
@@ -66,4 +67,4 @@ Each module doc explains what that subsystem does and how it fits into the bigge
   - `docs/contracts/CollaborationContract.md`  
   - ADRs in `docs/adr/`
 
-Doc last updated: 2025-11-17 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -29,6 +29,7 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `!reload onboarding` | ✅ | Reload onboarding questions and log the active schema hash. | `!reload onboarding` |
 | `!ping` | ✅ | Adds a 🏓 reaction so admins can confirm shard responsiveness. | `!ping` |
 | `!servermap refresh` | ✅ | Rebuild the pinned `#server-map` message(s) from the current Discord category/channel structure. | `!servermap refresh` |
+| `!whoweare` | ✅ | Generate the live "Who We Are" role map from the WhoWeAre sheet with snarky blurbs and current role holders. | `!whoweare` |
 | `!perm bot list` | ✅ | Admin-only; show the current bot allow/deny lists with counts, IDs, and optional JSON export. More details: [`PermissionsSync`](../modules/PermissionsSync.md). | `!perm bot list [--json]` |
 | `!perm bot allow <targets…>` | ✅ | Admin-only; add channels/categories to the allow list and clear conflicting deny entries. Targets accept channel mentions or quoted category names. More details: [`PermissionsSync`](../modules/PermissionsSync.md). | `!perm bot allow <targets…>` |
 | `!perm bot deny <targets…>` | ✅ | Admin-only; add channels/categories to the deny list while removing matching allow entries. Use for surgical blocks. More details: [`PermissionsSync`](../modules/PermissionsSync.md). | `!perm bot deny <targets…>` |
@@ -67,4 +68,4 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 
 > Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `feature_reservations` gates the `!reserve` command. `placement_target_select` remains a stub module that only logs when enabled. `onboarding_rules_v2` enables the deterministic onboarding rules DSL (visibility + navigation); disable to fall back to the legacy string parser.
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -145,11 +145,17 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 - 'FEATURE_TOGGLES_TAB'
 - 'REPORTS_TAB'
 - 'RESERVATIONS_TAB'
+- 'ROLEMAP_TAB'
 
 `RESERVATIONS_TAB` defaults to `Reservations` and stores the structured reservation
 ledger used to derive availability. If the key is missing, the adapter falls back
 to the default name so new environments remain inert until the sheet configuration
 is populated.
+
+`ROLEMAP_TAB` defaults to `WhoWeAre` and stores the category/role listings that
+power the `!whoweare` cluster role map command. The worksheet must expose the
+columns `category`, `role_ID`, `role_name`, and `role_description` so the bot
+can group roles, resolve Discord IDs, and surface the sheet's snarky blurbs.
 
 ### Sheet-based Feature Toggles (`Feature_Toggles` tab)
 
@@ -166,6 +172,8 @@ Current keys include (non-exhaustive):
 - `SERVER_MAP` — enables the scheduled refresh and manual `!servermap refresh`
   command; channel routing (`SERVER_MAP_CHANNEL_ID`) and cadence
   (`SERVER_MAP_REFRESH_DAYS`) remain environment-driven.
+- `ClusterRoleMap` — enables the `!whoweare` command that renders the "Who We
+  Are" roster from the configured `ROLEMAP_TAB` worksheet.
 
 If a toggle key is missing in `Feature_Toggles`, its behaviour should default to a
 safe value (usually `FALSE`/disabled) so new environments remain inert until
@@ -256,4 +264,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/modules/ops/__init__.py
+++ b/modules/ops/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "permissions_sync",
     "watchers_permissions",
     "server_map",
+    "cluster_role_map",
 ]

--- a/modules/ops/cluster_role_map.py
+++ b/modules/ops/cluster_role_map.py
@@ -1,0 +1,191 @@
+"""Cluster role map builder backed by the WhoWeAre worksheet."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+import discord
+
+from shared.config import get_recruitment_sheet_id
+from shared.sheets import recruitment
+from shared.sheets.async_core import afetch_records
+
+log = logging.getLogger("c1c.cluster_role_map")
+
+CATEGORY_EMOJIS: Dict[str, str] = {
+    "clusterleadership": "🔥",
+    "clustersupport": "🛡️",
+    "recruitment": "🌱",
+    "communitysupport": "📘",
+    "specialsupporters": "💎",
+}
+
+DEFAULT_DESCRIPTION = "no description set"
+
+
+@dataclass(slots=True)
+class RoleMapRow:
+    """Structured view of a WhoWeAre worksheet row."""
+
+    category: str
+    role_id: int
+    sheet_role_name: str
+    role_description: str
+
+
+@dataclass(slots=True)
+class RoleMapRender:
+    """Rendered output plus summary counts for logging."""
+
+    message: str
+    category_count: int
+    role_count: int
+    unassigned_roles: int
+
+
+class RoleMapLoadError(RuntimeError):
+    """Raised when the WhoWeAre worksheet cannot be read."""
+
+
+def _normalize_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _cell(row: Mapping[str, object], *names: str) -> str:
+    wanted = {name.strip().lower() for name in names if name}
+    for column, value in row.items():
+        column_name = str(column or "").strip().lower()
+        if column_name in wanted:
+            return _normalize_text(value)
+    return ""
+
+
+def parse_role_map_records(rows: Sequence[Mapping[str, object]]) -> List[RoleMapRow]:
+    entries: List[RoleMapRow] = []
+    for row in rows:
+        category = _cell(row, "category")
+        if not category:
+            continue
+        role_id_text = _cell(row, "role_id", "role id")
+        if not role_id_text:
+            continue
+        try:
+            role_id = int(role_id_text)
+        except (TypeError, ValueError):
+            continue
+        sheet_role_name = _cell(row, "role_name", "role name")
+        role_description = _cell(row, "role_description", "role description")
+        entries.append(
+            RoleMapRow(
+                category=category,
+                role_id=role_id,
+                sheet_role_name=sheet_role_name,
+                role_description=role_description,
+            )
+        )
+    return entries
+
+
+async def fetch_role_map_rows(tab_name: str | None = None) -> List[RoleMapRow]:
+    """Return parsed WhoWeAre rows from the configured worksheet."""
+
+    sheet_id = _normalize_text(get_recruitment_sheet_id())
+    if not sheet_id:
+        raise RoleMapLoadError("Recruitment sheet ID is missing")
+
+    rolemap_tab = _normalize_text(tab_name) or recruitment.get_role_map_tab_name()
+    if not rolemap_tab:
+        raise RoleMapLoadError("Role map tab name missing")
+
+    try:
+        records = await afetch_records(sheet_id, rolemap_tab)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pragma: no cover - network/runtime failure
+        log.warning("cluster_role_map: failed to read worksheet", exc_info=True)
+        raise RoleMapLoadError(f"Failed to load worksheet '{rolemap_tab}': {exc}") from exc
+
+    return parse_role_map_records(records)
+
+
+def _category_order(entries: Iterable[RoleMapRow]) -> tuple[List[str], Dict[str, List[RoleMapRow]]]:
+    order: List[str] = []
+    grouped: Dict[str, List[RoleMapRow]] = {}
+    for entry in entries:
+        if entry.category not in grouped:
+            grouped[entry.category] = []
+            order.append(entry.category)
+        grouped[entry.category].append(entry)
+    return order, grouped
+
+
+def _category_emoji(name: str) -> str:
+    normalized = name.strip().lower()
+    return CATEGORY_EMOJIS.get(normalized, "•")
+
+
+def build_role_map_render(guild: discord.Guild | object, entries: Sequence[RoleMapRow]) -> RoleMapRender:
+    """Compose the Discord message for the supplied WhoWeAre rows."""
+
+    order, grouped = _category_order(entries)
+    lines = [
+        "💙 WHO WE ARE — C1C Role Map",
+        "Roles first. Humans optional. Snark mandatory.",
+        "",
+    ]
+
+    role_count = 0
+    unassigned_roles = 0
+
+    get_role = getattr(guild, "get_role", None)
+
+    for category in order:
+        emoji = _category_emoji(category)
+        lines.append(f"{emoji} {category}")
+        lines.append("")
+        for row in grouped.get(category, []):
+            role_count += 1
+            role = get_role(row.role_id) if callable(get_role) else None
+            display_name = ""
+            if role is not None:
+                display_name = _normalize_text(getattr(role, "name", ""))
+                members = list(getattr(role, "members", []) or [])
+            else:
+                members = []
+            if not display_name:
+                display_name = row.sheet_role_name or f"role {row.role_id}"
+            description = row.role_description or DEFAULT_DESCRIPTION
+            lines.append(f"**{display_name}** — {description}")
+            if members:
+                mentions = ", ".join(str(getattr(member, "mention", getattr(member, "name", ""))) for member in members)
+                lines.append(f"• {mentions}")
+            else:
+                lines.append("• (currently unassigned)")
+                unassigned_roles += 1
+            lines.append("")
+
+    if not order:
+        lines.append("(No role entries found.)")
+
+    message = "\n".join(lines).rstrip()
+    return RoleMapRender(
+        message=message,
+        category_count=len(order),
+        role_count=role_count,
+        unassigned_roles=unassigned_roles,
+    )
+
+
+__all__ = [
+    "CATEGORY_EMOJIS",
+    "RoleMapRow",
+    "RoleMapRender",
+    "RoleMapLoadError",
+    "build_role_map_render",
+    "fetch_role_map_rows",
+    "parse_role_map_records",
+]
+

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -358,6 +358,14 @@ def get_reservations_tab_name(default: str = "Reservations") -> str:
     return text or default
 
 
+def get_role_map_tab_name(default: str = "WhoWeAre") -> str:
+    """Return the configured role map worksheet name."""
+
+    value = _config_lookup("rolemap_tab", default) or default
+    text = str(value or "").strip()
+    return text or default
+
+
 def get_reservations_config(force: bool = False) -> ReservationsConfig:
     """Return reservations feature wiring from the Config worksheet."""
 

--- a/tests/cogs/test_app_admin.py
+++ b/tests/cogs/test_app_admin.py
@@ -3,7 +3,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from cogs.app_admin import AppAdmin
-from modules.ops import server_map
+from modules.common import feature_flags
+from modules.ops import cluster_role_map, server_map
+from shared.sheets import recruitment as recruitment_sheet
 
 
 def test_servermap_refresh_command_respects_feature_toggle(monkeypatch):
@@ -61,5 +63,120 @@ def test_servermap_refresh_command_invokes_refresh_when_enabled(monkeypatch):
             "Server map refreshed — messages=2 • chars=1200.",
             mention_author=False,
         )
+
+    asyncio.run(_run())
+
+
+def test_whoweare_command_respects_feature_toggle(monkeypatch):
+    async def _run() -> None:
+        bot = object()
+        cog = AppAdmin(bot)
+        ctx = SimpleNamespace()
+        ctx.guild = SimpleNamespace(name="Guild")
+        ctx.reply = AsyncMock()
+
+        monkeypatch.setattr(feature_flags, "is_enabled", lambda key: False)
+
+        log_messages: list[str] = []
+
+        async def fake_log(message: str) -> None:
+            log_messages.append(message)
+
+        from modules.common import runtime as runtime_helpers
+
+        monkeypatch.setattr(runtime_helpers, "send_log_message", fake_log)
+
+        await cog.whoweare.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "Cluster role map feature is disabled in FeatureToggles.",
+            mention_author=False,
+        )
+        assert log_messages == [
+            "📘 **Cluster role map** — cmd=whoweare • guild=Guild • status=disabled"
+        ]
+
+    asyncio.run(_run())
+
+
+def test_whoweare_command_reports_sheet_errors(monkeypatch):
+    async def _run() -> None:
+        bot = object()
+        cog = AppAdmin(bot)
+        ctx = SimpleNamespace()
+        ctx.guild = SimpleNamespace(name="Guild")
+        ctx.reply = AsyncMock()
+
+        monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+
+        async def raise_error(*_args, **_kwargs):
+            raise cluster_role_map.RoleMapLoadError("sheet offline")
+
+        monkeypatch.setattr(cluster_role_map, "fetch_role_map_rows", raise_error)
+
+        log_messages: list[str] = []
+
+        async def fake_log(message: str) -> None:
+            log_messages.append(message)
+
+        from modules.common import runtime as runtime_helpers
+
+        monkeypatch.setattr(runtime_helpers, "send_log_message", fake_log)
+
+        await cog.whoweare.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "I couldn’t read the role map sheet (`WhoWeAre`). Please check Config and try again.",
+            mention_author=False,
+        )
+        assert log_messages == [
+            "📘 **Cluster role map** — cmd=whoweare • guild=Guild • status=error • reason=sheet offline"
+        ]
+
+    asyncio.run(_run())
+
+
+def test_whoweare_command_posts_rendered_map(monkeypatch):
+    async def _run() -> None:
+        bot = object()
+        cog = AppAdmin(bot)
+        ctx = SimpleNamespace()
+        ctx.guild = SimpleNamespace(name="Guild")
+        ctx.reply = AsyncMock()
+
+        monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+
+        async def fake_fetch(*_args, **_kwargs):
+            return [cluster_role_map.RoleMapRow("Category", 1, "Name", "desc")]
+
+        monkeypatch.setattr(cluster_role_map, "fetch_role_map_rows", fake_fetch)
+
+        render = cluster_role_map.RoleMapRender(
+            message="payload",
+            category_count=1,
+            role_count=1,
+            unassigned_roles=1,
+        )
+
+        monkeypatch.setattr(cluster_role_map, "build_role_map_render", lambda guild, entries: render)
+
+        log_messages: list[str] = []
+
+        async def fake_log(message: str) -> None:
+            log_messages.append(message)
+
+        from modules.common import runtime as runtime_helpers
+
+        monkeypatch.setattr(runtime_helpers, "send_log_message", fake_log)
+
+        await cog.whoweare.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with("payload", mention_author=False)
+        assert log_messages == [
+            "📘 **Cluster role map** — cmd=whoweare • guild=Guild • categories=1 • roles=1 "
+            "• unassigned_roles=1"
+        ]
 
     asyncio.run(_run())

--- a/tests/modules/ops/test_cluster_role_map.py
+++ b/tests/modules/ops/test_cluster_role_map.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from modules.ops import cluster_role_map
+
+
+class DummyMember:
+    def __init__(self, mention: str):
+        self.mention = mention
+
+
+class DummyRole:
+    def __init__(self, role_id: int, name: str, members: list[DummyMember] | None = None):
+        self.id = role_id
+        self.name = name
+        self.members = members or []
+
+
+class DummyGuild:
+    def __init__(self, name: str, roles: list[DummyRole]):
+        self.name = name
+        self._roles = {role.id: role for role in roles}
+
+    def get_role(self, role_id: int):  # pragma: no cover - simple mapping
+        return self._roles.get(role_id)
+
+
+def test_parse_role_map_records_filters_invalid_rows():
+    rows = [
+        {"category": "ClusterLeadership", "role_ID": "123", "role_name": "Lead", "role_description": "Runs it"},
+        {"category": "", "role_ID": "456", "role_name": "Missing"},
+        {"category": "ClusterSupport", "role_ID": "abc", "role_name": "Helper"},
+        {"category": "Recruitment", "role_ID": "789", "role_name": "Recruiter", "role_description": ""},
+    ]
+
+    entries = cluster_role_map.parse_role_map_records(rows)
+
+    assert len(entries) == 2
+    assert entries[0].category == "ClusterLeadership"
+    assert entries[1].category == "Recruitment"
+    assert entries[1].role_description == ""
+
+
+def test_build_role_map_render_renders_categories_and_members():
+    entries = [
+        cluster_role_map.RoleMapRow(
+            category="ClusterLeadership",
+            role_id=1,
+            sheet_role_name="Lead", 
+            role_description="Runs it",
+        ),
+        cluster_role_map.RoleMapRow(
+            category="ClusterSupport",
+            role_id=2,
+            sheet_role_name="Support", 
+            role_description="",
+        ),
+        cluster_role_map.RoleMapRow(
+            category="ClusterSupport",
+            role_id=99,
+            sheet_role_name="Backup", 
+            role_description="Keeps receipts",
+        ),
+    ]
+    guild = DummyGuild(
+        "TestGuild",
+        [
+            DummyRole(1, "Leader", [DummyMember("<@1>")]),
+            DummyRole(2, "Shield", []),
+        ],
+    )
+
+    render = cluster_role_map.build_role_map_render(guild, entries)
+
+    assert "💙 WHO WE ARE" in render.message
+    assert "🔥 ClusterLeadership" in render.message
+    assert "🛡️ ClusterSupport" in render.message
+    assert "**Leader** — Runs it" in render.message
+    assert "<@1>" in render.message
+    assert "**Shield** — no description set" in render.message
+    assert "**Backup** — Keeps receipts" in render.message
+    assert "(currently unassigned)" in render.message
+    assert render.category_count == 2
+    assert render.role_count == 3
+    assert render.unassigned_roles == 2


### PR DESCRIPTION
## Summary
- add the Who We Are command that loads the WhoWeAre sheet, resolves Discord roles, and posts a snarky cluster role map gated by the ClusterRoleMap toggle
- document the ROLEMAP_TAB config key, new command, and README blurb so operators know how the feature is wired
- cover the parsing/render helpers plus the new command with tests

## Testing
- `pytest tests/modules/ops/test_cluster_role_map.py tests/cogs/test_app_admin.py`

[meta]
labels: docs, enhancement, comp:commands, comp:config
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da9d3bccc8323b4d661a34a813efe)