### PR TITLE
Refine server map layout and add blacklist support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ Collaboration Contract and core infra conventions.
 * [`PermCommandQuickstart.md`](ops/PermCommandQuickstart.md) — quickstart for the `!perm bot` command surface.
 * [`modules/ShardTracker.md`](ops/modules/ShardTracker.md) — shard & mercy tracker runbook, channel/thread routing, and mercy math reference.
 * [`.env.example`](../.env.example) — reference environment file for local/testing setups.
-* Automated server map posts keep `#server-map` in sync with live categories. Configuration (`SERVER_MAP_*`) lives in [`ops/Config.md`](ops/Config.md); log formats are in [`ops/Logging.md`](ops/Logging.md).
+* Automated server map posts keep `#server-map` in sync with live categories. Configuration (`SERVER_MAP_*`) lives in [`ops/Config.md`](ops/Config.md); log formats are in [`ops/Logging.md`](ops/Logging.md). The rendered post now starts with an `🧭 Server Map` intro that lists uncategorized channels up top, and staff-only sections can be hidden via the Config blacklists.
 
 ## Module Deep Dives `/docs/modules/` 
 * [`CoreOps.md`](modules/CoreOps.md) — CoreOps responsibilities, scheduler contracts, and cache façade expectations.
@@ -107,4 +107,4 @@ Each module has a **dedicated deep-dive file** describing its scope, flows, data
 ## Cross-References
 * [`docs/contracts/CollaborationContract.md`](contracts/CollaborationContract.md) documents contributor responsibilities and embeds this index under “Documentation Discipline.”
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -140,6 +140,10 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 ### Recruitment runtime state keys
 - `SERVER_MAP_MESSAGE_ID_1`, `SERVER_MAP_MESSAGE_ID_2`, … — message IDs for each segment of the server map post in `SERVER_MAP_CHANNEL_ID`. The scheduler edits these messages in place when the structure changes.
 - `SERVER_MAP_LAST_RUN_AT` — ISO-8601 timestamp recorded after every successful refresh. The daily job reads this value to enforce `SERVER_MAP_REFRESH_DAYS`.
+- `SERVER_MAP_CATEGORY_BLACKLIST` — comma-separated Discord category IDs hidden from the rendered server map.
+- `SERVER_MAP_CHANNEL_BLACKLIST` — comma-separated Discord channel IDs hidden from the server map, even if their parent category is visible.
+
+The `SERVER_MAP` FeatureToggle in the FeatureToggles worksheet still gates the automation. These blacklist keys only hide specific entries; they do not disable scheduling or posting.
 
 ### Recruitment sheet keys
 - 'CLANS_TAB'

--- a/tests/modules/server_map/test_builder.py
+++ b/tests/modules/server_map/test_builder.py
@@ -35,7 +35,7 @@ class StubChannel:
         self.category_id = getattr(category, "id", None)
 
 
-def test_build_map_messages_renders_categories_and_types() -> None:
+def test_build_map_messages_renders_intro_mentions_and_headings() -> None:
     battle = StubCategory("BATTLE CHRONICLES", 1, 10)
     siege = StubChannel("siege", 1, 101, discord.ChannelType.text, battle)
     voice = StubChannel("voice-chat", 2, 102, discord.ChannelType.voice, battle)
@@ -56,13 +56,23 @@ def test_build_map_messages_renders_categories_and_types() -> None:
     messages = server_map.build_map_messages(guild)
 
     expected = (
-        "BATTLE CHRONICLES\n"
-        "🔹 siege\n"
-        "🔹 🎙️ voice-chat\n\n"
-        "GATHERING HALLS\n"
-        "🔹 📁 forum-hq\n\n"
-        "UNCATEGORIZED\n"
-        "🔹 lobby"
+        "# 🧭 Server Map\n"
+        "Tired of wandering the digital wilderness?\n"
+        "Here’s your trusty compass—every channel, category, and secret nook laid out in one sleek guide.\n"
+        "Ready to explore? Let’s go light the path together. ✨\n"
+        "\n"
+        "Channels with a 🔒 icon do need special roles to unlock access.\n"
+        "\n"
+        "🔹 <#104>\n"
+        "\n"
+        "## BATTLE CHRONICLES\n"
+        "\n"
+        "🔹 <#101>\n"
+        "🔹 <#102>\n"
+        "\n"
+        "## GATHERING HALLS\n"
+        "\n"
+        "🔹 <#103>"
     )
     assert messages == [expected]
 
@@ -88,8 +98,58 @@ def test_build_map_messages_splits_when_threshold_hit() -> None:
     messages = server_map.build_map_messages(guild, threshold=40)
 
     assert len(messages) >= 2
-    assert messages[0].startswith("Category 0")
-    assert messages[-1].endswith("channel-2")
+    assert messages[0].startswith("# 🧭 Server Map")
+    assert messages[-1].endswith("🔹 <#202>")
+
+
+def test_build_map_messages_respects_blacklists() -> None:
+    battle = StubCategory("BATTLE CHRONICLES", 1, 10)
+    siege = StubChannel("siege", 1, 101, discord.ChannelType.text, battle)
+    voice = StubChannel("voice-chat", 2, 102, discord.ChannelType.voice, battle)
+    battle.channels.extend([siege, voice])
+
+    halls = StubCategory("GATHERING HALLS", 2, 11)
+    forum = StubChannel("forum-hq", 1, 103, discord.ChannelType.forum, halls)
+    halls.channels.append(forum)
+
+    lobby = StubChannel("lobby", 99, 104, discord.ChannelType.text, None)
+
+    guild = SimpleNamespace(
+        name="C1C",
+        categories=[battle, halls],
+        channels=[battle, halls, siege, voice, forum, lobby],
+    )
+
+    messages = server_map.build_map_messages(
+        guild,
+        category_blacklist={battle.id},
+        channel_blacklist={voice.id, lobby.id},
+    )
+
+    assert len(messages) == 1
+    body = messages[0]
+    assert "## BATTLE CHRONICLES" not in body
+    assert "🔹 <#102>" not in body
+    assert "🔹 <#104>" not in body
+    assert "## GATHERING HALLS" in body
+
+
+def test_build_map_messages_lists_uncategorized_first() -> None:
+    category = StubCategory("AFTER", 1, 10)
+    alpha = StubChannel("alpha", 1, 101, discord.ChannelType.text, category)
+    category.channels.append(alpha)
+    lobby = StubChannel("lobby", 99, 104, discord.ChannelType.text, None)
+
+    guild = SimpleNamespace(
+        name="C1C",
+        categories=[category],
+        channels=[category, alpha, lobby],
+    )
+
+    messages = server_map.build_map_messages(guild)
+    assert len(messages) == 1
+    body = messages[0]
+    assert body.index("🔹 <#104>") < body.index("## AFTER")
 
 
 def test_should_refresh_enforces_interval() -> None:


### PR DESCRIPTION
## Summary
- restyled the server map output with the 🧭 intro, Markdown headings, and clickable channel mentions while preserving the existing split/refresh flow
- added Config-driven category and channel blacklists so sensitive sections can be excluded before rendering
- updated the server map documentation to describe the new formatting expectations and blacklist keys

## Testing
- pytest tests/modules/server_map/test_builder.py

[meta]
labels: enhancement, comp:modules, comp:config, docs, codex, P3
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db3416ab483239252badafed55606)