### PR TITLE
Fix server map blacklist wiring

### DIFF
--- a/tests/modules/server_map/test_builder.py
+++ b/tests/modules/server_map/test_builder.py
@@ -122,8 +122,8 @@ def test_build_map_messages_respects_blacklists() -> None:
 
     messages = server_map.build_map_messages(
         guild,
-        category_blacklist={battle.id},
-        channel_blacklist={voice.id, lobby.id},
+        category_blacklist={str(battle.id)},
+        channel_blacklist={str(voice.id), str(lobby.id)},
     )
 
     assert len(messages) == 1
@@ -132,6 +132,14 @@ def test_build_map_messages_respects_blacklists() -> None:
     assert "🔹 <#102>" not in body
     assert "🔹 <#104>" not in body
     assert "## GATHERING HALLS" in body
+
+
+def test_parse_id_blacklist_trims_entries() -> None:
+    raw = " 101 , 202,  ,303,  "
+
+    result = server_map._parse_id_blacklist(raw)
+
+    assert result == {"101", "202", "303"}
 
 
 def test_build_map_messages_lists_uncategorized_first() -> None:


### PR DESCRIPTION
## Summary
- parse the server map blacklist strings from the Config entries into normalized string sets that tolerate whitespace and legacy values
- filter guild channels once so blacklisted channels never make it into either the uncategorized block or the per-category listings, and skip blacklisted categories entirely
- cover the new parsing path in unit tests to prevent regressions

## Testing
- pytest tests/modules/server_map

[meta]
labels: bug, comp:modules, comp:config, tests, codex, P2
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dce6d1f90832398dd11f4a52bb17f)