### PR TITLE
Fix ShardTracker command registration

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -113,13 +113,16 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        help=(
-            "Shard dashboard with stash counts and mercy chance. Only runs in the Shards & Mercy channel; "
-            "creates your personal thread when needed."
-        ),
         usage="!shards [type]",
     )
-    @commands.group(name="shards", invoke_without_command=True)
+    @commands.group(
+        name="shards",
+        invoke_without_command=True,
+        help=(
+            "Shard dashboard with stash counts and mercy chance. Only runs in the Shards & Mercy "
+            "channel; creates your personal thread when needed."
+        ),
+    )
     async def shards(self, ctx: commands.Context, *, shard_type: str | None = None) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return
@@ -130,10 +133,12 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        help="Set the shard stash count for a specific type (non-negative integers only).",
         usage="!shards set <type> <count>",
     )
-    @shards.command(name="set")
+    @shards.command(
+        name="set",
+        help="Set the shard stash count for a specific type (non-negative integers only).",
+    )
     async def shards_set(self, ctx: commands.Context, shard_type: str, count: int) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return
@@ -144,12 +149,15 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
+        usage="!mercy [type]",
+    )
+    @commands.group(
+        name="mercy",
+        invoke_without_command=True,
         help=(
             "Show mercy counters for all shard types inside your personal thread in the Shards & Mercy channel."
         ),
-        usage="!mercy [type]",
     )
-    @commands.group(name="mercy", invoke_without_command=True)
     async def mercy(self, ctx: commands.Context, *, shard_type: str | None = None) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return
@@ -160,10 +168,12 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        help="Override a mercy counter. Accepts `mythic` to target the primal mythic pity.",
         usage="!mercy set <type> <count>",
     )
-    @mercy.command(name="set")
+    @mercy.command(
+        name="set",
+        help="Override a mercy counter. Accepts `mythic` to target the primal mythic pity.",
+    )
     async def mercy_set(self, ctx: commands.Context, shard_type: str, count: int) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return
@@ -174,12 +184,14 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
+        usage="!lego <type> [after_count]",
+    )
+    @commands.command(
+        name="lego",
         help=(
             "Log a legendary pull for a shard type. Accepts the number of shards you pulled after the LEGO before logging."
         ),
-        usage="!lego <type> [after_count]",
     )
-    @commands.command(name="lego")
     async def log_lego(
         self, ctx: commands.Context, shard_type: str, after_count: int = 0
     ) -> None:
@@ -192,12 +204,16 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        help=(
-            "Log a primal mythic pull. Accepts how many shards you pulled after the mythic before logging."
-        ),
         usage="!mythic primal [after_count]",
     )
-    @commands.group(name="mythic", aliases=["mythical"], invoke_without_command=True)
+    @commands.group(
+        name="mythic",
+        aliases=["mythical"],
+        invoke_without_command=True,
+        help=(
+            "Base command for primal mythic tracking. Run `!mythic primal <after_count>` to log a mythic drop."
+        ),
+    )
     async def mythic(self, ctx: commands.Context) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return
@@ -208,10 +224,12 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        help="Log a primal mythic drop and reset the primal counters (channel + thread restricted).",
         usage="!mythic primal [after_count]",
     )
-    @mythic.command(name="primal")
+    @mythic.command(
+        name="primal",
+        help="Log a primal mythic drop and reset the primal counters (channel + thread restricted).",
+    )
     async def mythic_primal(self, ctx: commands.Context, after_count: int = 0) -> None:
         if not await self._ensure_feature_enabled(ctx):
             return

--- a/tests/community/shard_tracker/conftest.py
+++ b/tests/community/shard_tracker/conftest.py
@@ -4,20 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 import discord
-from c1c_coreops import helpers as helper_mod
-
-
-_ORIGINAL_HELP_METADATA = helper_mod.help_metadata
-
-
-def _patched_help_metadata(*args, **kwargs):
-    kwargs.pop("help", None)
-    return _ORIGINAL_HELP_METADATA(*args, **kwargs)
-
-
-helper_mod.help_metadata = _patched_help_metadata
-
-
 class FakeBot:
     def __init__(self) -> None:
         self._threads: dict[int, FakeThread] = {}
@@ -123,5 +109,3 @@ def fake_discord_env(monkeypatch):
     return env
 
 
-def pytest_unconfigure(config):  # pragma: no cover - test cleanup hook
-    helper_mod.help_metadata = _ORIGINAL_HELP_METADATA


### PR DESCRIPTION
## Summary
- move the ShardTracker help text onto the Discord command decorators so `help_metadata` is only called with supported arguments, allowing the cog to import and register normally
- drop the shard tracker test monkeypatch that previously stripped unsupported decorator kwargs so tests exercise the production wiring

## Testing
- `pytest tests/community/shard_tracker -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dce9421088323b35c3c66e0813596)