### PR TITLE
Add tabbed shard tracker UI and mercy logging modals

### DIFF
--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -59,12 +59,8 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `@Bot ping` | 🧩 | Quick pong reply to confirm the bot is online. | `@Bot ping` |
 | `!clan <tag>` | 🧩 | Public clan card with crest + 💡 reaction flip between profile and entry criteria. [gated: `clan_profile`] | `!clan <tag>` |
 | `!clansearch` | 🧩 | Member clan search with legacy filters + pager (edits the panel in place). [gated: `member_panel`] | `!clansearch` |
-| `!shards [type]` | ✅ | Shard stash + mercy dashboard (only in the Shards & Mercy channel; replies inside your thread). | `!shards [type]` |
+| `!shards [type]` | ✅ | Opens the shard tracker thread (overview + detail tabs). Optional type selects default tab. | `!shards [type]` |
 | `!shards set <type> <count>` | ✅ | Force-set your shard stash count (channel restricted to Shards & Mercy). | `!shards set <type> <count>` |
-| `!mercy [type]` | ✅ | Alias to show your mercy counters inside the shard thread (same channel/thread rules). | `!mercy [type]` |
-| `!mercy set <type> <count>` | ✅ | Override a mercy counter (`mythic` targets the primal mythic pity). | `!mercy set <type> <count>` |
-| `!lego <type> [after_count]` | ✅ | Log a legendary drop and reset that mercy counter (Shards & Mercy channel only). | `!lego <type> [after_count]` |
-| `!mythic primal [after_count]` | ✅ | Log a primal mythic drop; resets both primal counters inside your shard thread. | `!mythic primal [after_count]` |
 
 > Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `feature_reservations` gates the `!reserve` command. `placement_target_select` remains a stub module that only logs when enabled. `onboarding_rules_v2` enables the deterministic onboarding rules DSL (visibility + navigation); disable to fall back to the legacy string parser.
 

--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -22,14 +22,16 @@ from .data import (
     ShardTrackerConfigError,
     ShardTrackerSheetError,
 )
-from .mercy import MERCY_PROFILES, MercyProfile, MercyState, calculate_mercy
+from .mercy import MERCY_CONFIGS, MercyConfig, MercySnapshot, mercy_state
 from .threads import ShardThreadRouter
 from .views import (
+    MythicDisplay,
     ShardDisplay,
     ShardTrackerController,
     ShardTrackerView,
     build_detail_embed,
-    build_summary_embed,
+    build_last_pulls_embed,
+    build_overview_embed,
 )
 from modules.common import runtime
 
@@ -42,8 +44,9 @@ class ShardKind:
     label: str
     stash_field: str
     mercy_field: str
-    mercy_profile: MercyProfile
+    mercy_config: MercyConfig
     timestamp_field: str
+    depth_field: str
 
 
 SHARD_KINDS: Dict[str, ShardKind] = {
@@ -52,33 +55,45 @@ SHARD_KINDS: Dict[str, ShardKind] = {
         label="Ancient",
         stash_field="ancients_owned",
         mercy_field="ancients_since_lego",
-        mercy_profile=MERCY_PROFILES["ancient"],
+        mercy_config=MERCY_CONFIGS["ancient"],
         timestamp_field="last_ancient_lego_iso",
+        depth_field="last_ancient_lego_depth",
     ),
     "void": ShardKind(
         key="void",
         label="Void",
         stash_field="voids_owned",
         mercy_field="voids_since_lego",
-        mercy_profile=MERCY_PROFILES["void"],
+        mercy_config=MERCY_CONFIGS["void"],
         timestamp_field="last_void_lego_iso",
+        depth_field="last_void_lego_depth",
     ),
     "sacred": ShardKind(
         key="sacred",
         label="Sacred",
         stash_field="sacreds_owned",
         mercy_field="sacreds_since_lego",
-        mercy_profile=MERCY_PROFILES["sacred"],
+        mercy_config=MERCY_CONFIGS["sacred"],
         timestamp_field="last_sacred_lego_iso",
+        depth_field="last_sacred_lego_depth",
     ),
     "primal": ShardKind(
         key="primal",
         label="Primal",
         stash_field="primals_owned",
         mercy_field="primals_since_lego",
-        mercy_profile=MERCY_PROFILES["primal"],
+        mercy_config=MERCY_CONFIGS["primal"],
         timestamp_field="last_primal_lego_iso",
+        depth_field="last_primal_lego_depth",
     ),
+}
+
+_BASE_RATES = {
+    "Ancient Legendary": "0.5%",
+    "Void Legendary": "0.5%",
+    "Sacred Legendary": "6%",
+    "Primal Legendary": "1%",
+    "Primal Mythical": "0.5%",
 }
 
 _TYPE_ALIASES = {
@@ -119,7 +134,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         name="shards",
         invoke_without_command=True,
         help=(
-            "Shard dashboard with stash counts and mercy chance. Only runs in the Shards & Mercy "
+            "Shard & Mercy tracker with overview and detail tabs. Only runs in the Shards & Mercy "
             "channel; creates your personal thread when needed."
         ),
     )
@@ -144,105 +159,14 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             return
         await self._handle_stash_set(ctx, shard_type, count)
 
-    @tier("user")
-    @help_metadata(
-        function_group="milestones",
-        section="community",
-        access_tier="user",
-        usage="!mercy [type]",
-    )
-    @commands.group(
-        name="mercy",
-        invoke_without_command=True,
-        help=(
-            "Show mercy counters for all shard types inside your personal thread in the Shards & Mercy channel."
-        ),
-    )
-    async def mercy(self, ctx: commands.Context, *, shard_type: str | None = None) -> None:
-        if not await self._ensure_feature_enabled(ctx):
-            return
-        await self._handle_shards(ctx, shard_type)
-
-    @tier("user")
-    @help_metadata(
-        function_group="milestones",
-        section="community",
-        access_tier="user",
-        usage="!mercy set <type> <count>",
-    )
-    @mercy.command(
-        name="set",
-        help="Override a mercy counter. Accepts `mythic` to target the primal mythic pity.",
-    )
-    async def mercy_set(self, ctx: commands.Context, shard_type: str, count: int) -> None:
-        if not await self._ensure_feature_enabled(ctx):
-            return
-        await self._handle_mercy_set(ctx, shard_type, count)
-
-    @tier("user")
-    @help_metadata(
-        function_group="milestones",
-        section="community",
-        access_tier="user",
-        usage="!lego <type> [after_count]",
-    )
-    @commands.command(
-        name="lego",
-        help=(
-            "Log a legendary pull for a shard type. Accepts the number of shards you pulled after the LEGO before logging."
-        ),
-    )
-    async def log_lego(
-        self, ctx: commands.Context, shard_type: str, after_count: int = 0
-    ) -> None:
-        if not await self._ensure_feature_enabled(ctx):
-            return
-        await self._handle_lego(ctx, shard_type, after_count)
-
-    @tier("user")
-    @help_metadata(
-        function_group="milestones",
-        section="community",
-        access_tier="user",
-        usage="!mythic primal [after_count]",
-    )
-    @commands.group(
-        name="mythic",
-        aliases=["mythical"],
-        invoke_without_command=True,
-        help=(
-            "Base command for primal mythic tracking. Run `!mythic primal <after_count>` to log a mythic drop."
-        ),
-    )
-    async def mythic(self, ctx: commands.Context) -> None:
-        if not await self._ensure_feature_enabled(ctx):
-            return
-        await ctx.reply("Specify the shard type: `!mythic primal <after_count>`.", mention_author=False)
-
-    @tier("user")
-    @help_metadata(
-        function_group="milestones",
-        section="community",
-        access_tier="user",
-        usage="!mythic primal [after_count]",
-    )
-    @mythic.command(
-        name="primal",
-        help="Log a primal mythic drop and reset the primal counters (channel + thread restricted).",
-    )
-    async def mythic_primal(self, ctx: commands.Context, after_count: int = 0) -> None:
-        if not await self._ensure_feature_enabled(ctx):
-            return
-        await self._handle_mythic(ctx, after_count)
-
     # === Button controller ===
 
     async def handle_button_interaction(
         self,
         *,
         interaction: discord.Interaction,
-        shard_key: str,
-        action: str,
+        custom_id: str,
+        active_tab: str,
     ) -> None:
         if not self._feature_enabled():
             await interaction.response.send_message(
@@ -256,9 +180,20 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 "Shard tracker is only available in guild channels.", ephemeral=True
             )
             return
+
+        action = self._parse_custom_id(custom_id)
+        if action is None:
+            await interaction.response.send_message(
+                "Unknown action for shard tracker.", ephemeral=True
+            )
+            return
+
         async with self._user_lock(ctx_author.id):
             try:
                 config = await self.store.get_config()
+                record = await self.store.load_record(
+                    ctx_author.id, ctx_author.display_name or ctx_author.name
+                )
             except ShardTrackerConfigError as exc:
                 await interaction.response.send_message(
                     self._config_error_message(str(exc)),
@@ -266,8 +201,6 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 )
                 await self._notify_admins(str(exc))
                 return
-            try:
-                record = await self.store.load_record(ctx_author.id, ctx_author.display_name or ctx_author.name)
             except ShardTrackerSheetError as exc:
                 await interaction.response.send_message(
                     "Shard tracker sheet misconfigured. Please contact an admin.",
@@ -275,22 +208,56 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 )
                 await self._notify_admins(str(exc))
                 return
-            kind = self._resolve_kind(shard_key)
-            if kind is None:
-                await interaction.response.send_message(
-                    "Unknown shard type for this button.", ephemeral=True
+
+            if action[0] == "tab":
+                new_tab = action[1]
+                embed, view = self._build_panel(
+                    ctx_author, record, interaction.channel, new_tab
                 )
+                await interaction.response.edit_message(embed=embed, view=view)
                 return
-            self._apply_button_action(record, kind, action)
+
+            if action[0] == "log":
+                _, shard_key = action
+                modal = _LegendaryLogModal(
+                    shard_key=shard_key,
+                    controller=self,
+                    owner_id=ctx_author.id,
+                    active_tab=active_tab,
+                )
+                await interaction.response.send_modal(modal)
+                return
+
+            if action[0] == "log_mythic":
+                modal = _MythicLogModal(
+                    controller=self,
+                    owner_id=ctx_author.id,
+                    active_tab=active_tab,
+                )
+                await interaction.response.send_modal(modal)
+                return
+
+            # adjustments
+            action_type, shard_key, delta = action
+            if action_type == "mythic_adjust":
+                self._adjust_mythic_counter(record, delta)
+            else:
+                kind = self._resolve_kind(shard_key)
+                if kind is None:
+                    await interaction.response.send_message(
+                        "Unknown shard type for this button.", ephemeral=True
+                    )
+                    return
+                self._apply_delta(record, kind, delta)
             record.snapshot_name(ctx_author.display_name or ctx_author.name)
             await self.store.save_record(config, record)
-            embed, view = self._build_summary_payload(ctx_author, record, interaction.channel)
+            embed, view = self._build_panel(ctx_author, record, interaction.channel, active_tab)
             await interaction.response.edit_message(embed=embed, view=view)
             await self._log_action(
                 "button",
                 ctx_author,
                 interaction.channel,
-                f"{action} {kind.label}",
+                f"{custom_id}",
             )
 
     # === Internal helpers ===
@@ -337,16 +304,10 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 return
             record.snapshot_name(ctx.author.display_name or ctx.author.name)
             await self.store.save_record(config, record)
-        if shard_type:
-            kind = self._resolve_kind(shard_type)
-            if kind is None:
-                await ctx.reply(self._invalid_type_message(), mention_author=False)
-                return
-            display = self._build_display(record, kind)
-            embed = build_detail_embed(member=ctx.author, display=display)
-            view = None
-        else:
-            embed, view = self._build_summary_payload(ctx.author, record, thread)
+        tab = self._resolve_kind_key(shard_type) if shard_type else "overview"
+        if tab and tab not in SHARD_KINDS:
+            tab = "overview"
+        embed, view = self._build_panel(ctx.author, record, thread, tab)
         await self._send_thread_message(ctx, parent_channel, thread, embed, view)
 
     async def _handle_stash_set(
@@ -372,6 +333,161 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             mention_author=False,
         )
         await self._log_action("stash_set", ctx.author, ctx.channel, f"{kind.label}={count}")
+
+    def _parse_custom_id(
+        self, custom_id: str
+    ) -> tuple[str, str | None, int] | tuple[str, str] | None:
+        if custom_id.startswith("tab:"):
+            return ("tab", custom_id.split(":", 1)[1])
+        if custom_id.endswith("got_legendary"):
+            shard_key = custom_id.split(":", 1)[0]
+            return ("log", shard_key)
+        if custom_id.endswith("got_mythical"):
+            return ("log_mythic", None)
+        parts = custom_id.split(":")
+        if len(parts) == 3 and parts[1] == "add":
+            shard_key, _, delta_raw = parts
+            try:
+                delta = int(delta_raw)
+            except ValueError:
+                return None
+            if shard_key == "primal_mythic":
+                return ("mythic_adjust", shard_key, delta)
+            return ("adjust", shard_key, delta)
+        return None
+
+    def _apply_delta(self, record: ShardRecord, kind: ShardKind, delta: int) -> None:
+        owned = max(0, getattr(record, kind.stash_field, 0))
+        new_owned = max(0, owned + delta)
+        setattr(record, kind.stash_field, new_owned)
+        actual_delta = new_owned - owned
+        if actual_delta < 0:
+            pulled = abs(actual_delta)
+            current_mercy = max(0, getattr(record, kind.mercy_field, 0))
+            setattr(record, kind.mercy_field, current_mercy + pulled)
+            if kind.key == "primal":
+                record.primals_since_mythic = max(0, record.primals_since_mythic) + pulled
+
+    def _adjust_mythic_counter(self, record: ShardRecord, delta: int) -> None:
+        record.primals_since_mythic = max(0, record.primals_since_mythic + delta)
+
+    async def process_legendary_modal(
+        self,
+        *,
+        interaction: discord.Interaction,
+        shard_key: str,
+        total_pulled: int,
+        legend_index: int,
+        active_tab: str,
+    ) -> None:
+        kind = self._resolve_kind(shard_key)
+        if kind is None:
+            await interaction.response.send_message("Unknown shard type.", ephemeral=True)
+            return
+        if legend_index > total_pulled:
+            await interaction.response.send_message(
+                "Legendary shard index cannot exceed total pulled.", ephemeral=True
+            )
+            return
+        async with self._user_lock(interaction.user.id):
+            try:
+                config = await self.store.get_config()
+                record = await self.store.load_record(
+                    interaction.user.id,
+                    interaction.user.display_name or interaction.user.name,
+                )
+            except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+                await interaction.response.send_message(
+                    self._config_error_message(str(exc)), ephemeral=True
+                )
+                await self._notify_admins(str(exc))
+                return
+            self._apply_logged_legendary(record, kind, total_pulled, legend_index)
+            record.snapshot_name(interaction.user.display_name or interaction.user.name)
+            await self.store.save_record(config, record)
+        embed, view = self._build_panel(interaction.user, record, interaction.channel, active_tab)
+        await interaction.response.edit_message(embed=embed, view=view)
+        await self._log_action(
+            "legendary_modal",
+            interaction.user,
+            interaction.channel,
+            f"{kind.label} total={total_pulled} index={legend_index}",
+        )
+
+    async def process_mythic_modal(
+        self,
+        *,
+        interaction: discord.Interaction,
+        total_pulled: int,
+        mythic_index: int,
+        active_tab: str,
+    ) -> None:
+        if mythic_index > total_pulled:
+            await interaction.response.send_message(
+                "Mythical shard index cannot exceed total pulled.", ephemeral=True
+            )
+            return
+        kind = SHARD_KINDS["primal"]
+        async with self._user_lock(interaction.user.id):
+            try:
+                config = await self.store.get_config()
+                record = await self.store.load_record(
+                    interaction.user.id,
+                    interaction.user.display_name or interaction.user.name,
+                )
+            except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+                await interaction.response.send_message(
+                    self._config_error_message(str(exc)), ephemeral=True
+                )
+                await self._notify_admins(str(exc))
+                return
+            self._apply_logged_mythic(record, kind, total_pulled, mythic_index)
+            record.snapshot_name(interaction.user.display_name or interaction.user.name)
+            await self.store.save_record(config, record)
+        embed, view = self._build_panel(interaction.user, record, interaction.channel, active_tab)
+        await interaction.response.edit_message(embed=embed, view=view)
+        await self._log_action(
+            "mythic_modal",
+            interaction.user,
+            interaction.channel,
+            f"Primal total={total_pulled} index={mythic_index}",
+        )
+
+    def _apply_logged_legendary(
+        self, record: ShardRecord, kind: ShardKind, total_pulled: int, legend_index: int
+    ) -> None:
+        total = max(1, total_pulled)
+        index = max(1, legend_index)
+        pre = index
+        post = max(0, total - index)
+        previous = max(0, getattr(record, kind.mercy_field, 0))
+        depth = previous + pre
+        setattr(record, kind.mercy_field, post)
+        setattr(record, kind.depth_field, depth)
+        setattr(record, kind.timestamp_field, self._now_iso())
+        if kind.key == "primal":
+            record.primals_since_mythic = max(0, record.primals_since_mythic) + total
+        owned = max(0, getattr(record, kind.stash_field, 0))
+        setattr(record, kind.stash_field, max(0, owned - total))
+
+    def _apply_logged_mythic(
+        self, record: ShardRecord, kind: ShardKind, total_pulled: int, mythic_index: int
+    ) -> None:
+        total = max(1, total_pulled)
+        index = max(1, mythic_index)
+        pre = index
+        post = max(0, total - index)
+        previous = max(0, record.primals_since_mythic)
+        depth = previous + pre
+        record.primals_since_mythic = post
+        setattr(record, kind.mercy_field, post)
+        timestamp = self._now_iso()
+        record.last_primal_mythic_iso = timestamp
+        record.last_primal_mythic_depth = depth
+        setattr(record, kind.timestamp_field, timestamp)
+        setattr(record, kind.depth_field, depth)
+        owned = max(0, getattr(record, kind.stash_field, 0))
+        setattr(record, kind.stash_field, max(0, owned - total))
 
     async def _handle_mercy_set(
         self, ctx: commands.Context, shard_type: str, count: int
@@ -514,38 +630,64 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 mention_author=False,
             )
 
-    def _build_summary_payload(
+    def _build_panel(
         self,
         member: discord.abc.User,
         record: ShardRecord,
         channel: discord.abc.GuildChannel | discord.Thread | None,
+        active_tab: str,
     ) -> tuple[discord.Embed, ShardTrackerView]:
         displays = [self._build_display(record, kind) for kind in SHARD_KINDS.values()]
-        mythic_state = calculate_mercy(
-            MERCY_PROFILES["primal_mythic"], max(0, record.primals_since_mythic)
-        )
-        embed = build_summary_embed(
-            member=member,
-            displays=displays,
-            mythic_state=mythic_state,
-            channel=channel or member.guild,  # type: ignore[arg-type]
-        )
+        mythic = self._build_mythic_display(record)
+        tab = active_tab if active_tab else "overview"
+
+        if tab == "last_pulls":
+            embed = build_last_pulls_embed(
+                member=member,
+                displays=displays,
+                mythic=mythic,
+                base_rates=_BASE_RATES,
+            )
+        elif tab in SHARD_KINDS:
+            target = next((d for d in displays if d.key == tab), displays[0])
+            embed = build_detail_embed(
+                member=member,
+                display=target,
+                mythic=mythic if tab == "primal" else None,
+            )
+        else:
+            embed = build_overview_embed(member=member, displays=displays, mythic=mythic)
+
         labels = {kind.key: kind.label for kind in SHARD_KINDS.values()}
-        view = ShardTrackerView(owner_id=getattr(member, "id", 0), controller=self, shard_labels=labels)
+        view = ShardTrackerView(
+            owner_id=getattr(member, "id", 0),
+            controller=self,
+            shard_labels=labels,
+            active_tab=tab,
+        )
         return embed, view
 
     def _build_display(self, record: ShardRecord, kind: ShardKind) -> ShardDisplay:
         owned = max(0, getattr(record, kind.stash_field, 0))
         since = max(0, getattr(record, kind.mercy_field, 0))
-        mercy = calculate_mercy(kind.mercy_profile, since)
+        mercy = mercy_state(kind.key, since)
         timestamp = getattr(record, kind.timestamp_field, "")
+        depth = max(0, getattr(record, kind.depth_field, 0))
         return ShardDisplay(
             key=kind.key,
             label=kind.label,
             owned=owned,
-            since=since,
             mercy=mercy,
             last_timestamp=timestamp,
+            last_depth=depth,
+        )
+
+    def _build_mythic_display(self, record: ShardRecord) -> MythicDisplay:
+        state = mercy_state("primal_mythic", max(0, record.primals_since_mythic))
+        return MythicDisplay(
+            mercy=state,
+            last_timestamp=record.last_primal_mythic_iso,
+            last_depth=max(0, record.last_primal_mythic_depth),
         )
 
     def _resolve_kind(self, value: str | None) -> ShardKind | None:
@@ -562,7 +704,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
 
     def _invalid_type_message(self) -> str:
         options = ", ".join(sorted(kind.label.lower() for kind in SHARD_KINDS.values()))
-        return f"Unknown shard type. Choose from: {options}, mythic."
+        return f"Unknown shard type. Choose from: {options}."
 
     def _channel_error_message(self, channel_id: int) -> str:
         return f"Shard & Mercy tracking is only available in <#{channel_id}>."
@@ -621,5 +763,109 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         from datetime import datetime, timezone
 
         return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+class _LegendaryLogModal(discord.ui.Modal):
+    def __init__(
+        self,
+        *,
+        shard_key: str,
+        controller: ShardTracker,
+        owner_id: int,
+        active_tab: str,
+    ) -> None:
+        label = SHARD_KINDS.get(shard_key).label if SHARD_KINDS.get(shard_key) else shard_key.title()
+        super().__init__(title=f"Log Legendary pull — {label} Shards")
+        self.shard_key = shard_key
+        self.controller = controller
+        self.owner_id = owner_id
+        self.active_tab = active_tab
+        self.total_pulled = discord.ui.TextInput(
+            label="Total shards pulled in this session",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 10",
+        )
+        self.legend_index = discord.ui.TextInput(
+            label="On which shard did the Legendary appear?",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 3",
+        )
+        self.add_item(self.total_pulled)
+        self.add_item(self.legend_index)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        if interaction.user.id != self.owner_id:
+            await interaction.response.send_message("Only the tracker owner can log pulls.", ephemeral=True)
+            return
+        try:
+            total = int(str(self.total_pulled.value))
+            index = int(str(self.legend_index.value))
+        except (TypeError, ValueError):
+            await interaction.response.send_message("Please provide numeric values.", ephemeral=True)
+            return
+        if total < 1 or index < 1:
+            await interaction.response.send_message("Values must be at least 1.", ephemeral=True)
+            return
+        await self.controller.process_legendary_modal(
+            interaction=interaction,
+            shard_key=self.shard_key,
+            total_pulled=total,
+            legend_index=index,
+            active_tab=self.active_tab,
+        )
+
+
+class _MythicLogModal(discord.ui.Modal):
+    def __init__(
+        self,
+        *,
+        controller: ShardTracker,
+        owner_id: int,
+        active_tab: str,
+    ) -> None:
+        super().__init__(title="Log Mythical pull — Primal Shards")
+        self.controller = controller
+        self.owner_id = owner_id
+        self.active_tab = active_tab
+        self.total_pulled = discord.ui.TextInput(
+            label="Total primal shards pulled in this session",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 10",
+        )
+        self.mythic_index = discord.ui.TextInput(
+            label="On which shard did the Mythical appear?",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 7",
+        )
+        self.add_item(self.total_pulled)
+        self.add_item(self.mythic_index)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        if interaction.user.id != self.owner_id:
+            await interaction.response.send_message("Only the tracker owner can log pulls.", ephemeral=True)
+            return
+        try:
+            total = int(str(self.total_pulled.value))
+            index = int(str(self.mythic_index.value))
+        except (TypeError, ValueError):
+            await interaction.response.send_message("Please provide numeric values.", ephemeral=True)
+            return
+        if total < 1 or index < 1:
+            await interaction.response.send_message("Values must be at least 1.", ephemeral=True)
+            return
+        await self.controller.process_mythic_modal(
+            interaction=interaction,
+            total_pulled=total,
+            mythic_index=index,
+            active_tab=self.active_tab,
+        )
 
 

--- a/modules/community/shard_tracker/data.py
+++ b/modules/community/shard_tracker/data.py
@@ -33,6 +33,11 @@ EXPECTED_HEADERS: List[str] = [
     "last_sacred_lego_iso",
     "last_primal_lego_iso",
     "last_primal_mythic_iso",
+    "last_ancient_lego_depth",
+    "last_void_lego_depth",
+    "last_sacred_lego_depth",
+    "last_primal_lego_depth",
+    "last_primal_mythic_depth",
     "last_updated_iso",
 ]
 
@@ -64,6 +69,11 @@ class ShardRecord:
     last_sacred_lego_iso: str = ""
     last_primal_lego_iso: str = ""
     last_primal_mythic_iso: str = ""
+    last_ancient_lego_depth: int = 0
+    last_void_lego_depth: int = 0
+    last_sacred_lego_depth: int = 0
+    last_primal_lego_depth: int = 0
+    last_primal_mythic_depth: int = 0
     last_updated_iso: str = ""
 
     def snapshot_name(self, value: str) -> None:
@@ -87,6 +97,11 @@ class ShardRecord:
             "last_sacred_lego_iso": self.last_sacred_lego_iso,
             "last_primal_lego_iso": self.last_primal_lego_iso,
             "last_primal_mythic_iso": self.last_primal_mythic_iso,
+            "last_ancient_lego_depth": str(max(self.last_ancient_lego_depth, 0)),
+            "last_void_lego_depth": str(max(self.last_void_lego_depth, 0)),
+            "last_sacred_lego_depth": str(max(self.last_sacred_lego_depth, 0)),
+            "last_primal_lego_depth": str(max(self.last_primal_lego_depth, 0)),
+            "last_primal_mythic_depth": str(max(self.last_primal_mythic_depth, 0)),
             "last_updated_iso": self.last_updated_iso,
         }
         return [str(mapping.get(name, "")) for name in self.header]
@@ -183,7 +198,7 @@ class ShardSheetStore:
 
     async def save_record(self, config: ShardTrackerConfig, record: ShardRecord) -> None:
         record.last_updated_iso = _now_iso()
-        range_label = f"A{record.row_number}:Q{record.row_number}"
+        range_label = f"A{record.row_number}:V{record.row_number}"
         row = record.to_row()
         worksheet = await async_core.aget_worksheet(config.sheet_id, config.tab_name)
         async with self._sheet_lock:
@@ -240,6 +255,11 @@ class ShardSheetStore:
             last_sacred_lego_iso=cell("last_sacred_lego_iso"),
             last_primal_lego_iso=cell("last_primal_lego_iso"),
             last_primal_mythic_iso=cell("last_primal_mythic_iso"),
+            last_ancient_lego_depth=self._parse_int(cell("last_ancient_lego_depth")),
+            last_void_lego_depth=self._parse_int(cell("last_void_lego_depth")),
+            last_sacred_lego_depth=self._parse_int(cell("last_sacred_lego_depth")),
+            last_primal_lego_depth=self._parse_int(cell("last_primal_lego_depth")),
+            last_primal_mythic_depth=self._parse_int(cell("last_primal_mythic_depth")),
             last_updated_iso=cell("last_updated_iso"),
         )
         record.snapshot_name(username)


### PR DESCRIPTION
## Summary
- replace shard tracker embeds with tabbed overview/detail views and last-pulls info
- update shard mercy math to match Plarium rates and store pull-depth metadata
- add Legendary/Mythical logging modals with stash/mercy adjustments and remove !mercy alias

## Testing
- pytest tests/community/shard_tracker -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e40d20cbc8323839c0237c6bda667)