### PR TITLE
Read server map blacklists from env

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -102,7 +102,9 @@ class AppAdmin(commands.Cog):
             )
             return
 
-        result = await server_map.refresh_server_map(self.bot, force=True, actor="command")
+        result = await server_map.refresh_server_map(
+            self.bot, force=True, actor="command", requested_channel="ctx"
+        )
         if result.status == "ok":
             await ctx.reply(
                 f"Server map refreshed — messages={result.message_count} • chars={result.total_chars}.",

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -84,6 +84,8 @@ sync modules remain available for non-async scripts and cache warmers.
 | `NOTIFY_CHANNEL_ID` | snowflake | — | Fallback alert channel ID. |
 | `NOTIFY_PING_ROLE_ID` | snowflake | — | Role pinged for urgent alerts. |
 | `SERVER_MAP_CHANNEL_ID` | snowflake | — | Discord channel hosting the server map embed when the SERVER_MAP toggle is enabled. |
+| `SERVER_MAP_CATEGORY_BLACKLIST` | csv | — | Comma-separated Discord category IDs hidden from the rendered server map. |
+| `SERVER_MAP_CHANNEL_BLACKLIST` | csv | — | Comma-separated Discord channel IDs hidden from the server map, even when their parent category is visible. |
 | `PANEL_THREAD_MODE` | enum | `same` | `same` posts panels in the invoking channel; `fixed` routes to a dedicated thread. |
 | `PANEL_FIXED_THREAD_ID` | snowflake | — | Thread used when `PANEL_THREAD_MODE=fixed`. |
 | `REPORT_RECRUITERS_DEST_ID` | snowflake | — | Channel or thread receiving the Daily Recruiter Update. |
@@ -140,8 +142,8 @@ Both Google Sheets referenced above must expose a `Config` worksheet with **Key*
 ### Recruitment runtime state keys
 - `SERVER_MAP_MESSAGE_ID_1`, `SERVER_MAP_MESSAGE_ID_2`, … — message IDs for each segment of the server map post in `SERVER_MAP_CHANNEL_ID`. The scheduler edits these messages in place when the structure changes.
 - `SERVER_MAP_LAST_RUN_AT` — ISO-8601 timestamp recorded after every successful refresh. The daily job reads this value to enforce `SERVER_MAP_REFRESH_DAYS`.
-- `SERVER_MAP_CATEGORY_BLACKLIST` — comma-separated Discord category IDs hidden from the rendered server map.
-- `SERVER_MAP_CHANNEL_BLACKLIST` — comma-separated Discord channel IDs hidden from the server map, even if their parent category is visible.
+
+Blacklist keys for server map rendering are environment variables (`SERVER_MAP_CATEGORY_BLACKLIST`, `SERVER_MAP_CHANNEL_BLACKLIST`) rather than sheet config entries.
 
 The `SERVER_MAP` FeatureToggle in the FeatureToggles worksheet still gates the automation. These blacklist keys only hide specific entries; they do not disable scheduling or posting.
 

--- a/docs/ops/Logging.md
+++ b/docs/ops/Logging.md
@@ -47,9 +47,12 @@ hidden, and refresh summaries always use the concise inline layout.
   retryable errors and will raise alerts if the ops channel becomes unavailable.
 
 ## Server map automation
-- `📘 Server map — refreshed • messages=2 • chars=3120` — posted after the bot edits or recreates the pinned map messages.
+- `📘 Server map — cmd=servermap • guild=<guild> • channel_fallback=#server-map • requested_channel=ctx` — emitted at the start of a manual refresh (scheduled runs use `cmd=cron`/`requested_channel=config`).
+- `📘 Server map — config • guild=<guild> • cat_blacklist_raw='123,456' • chan_blacklist_raw='999' • cat_ids=2 • chan_ids=1` — raw config view of the blacklists pulled from the Config worksheet.
+- `📘 Server map — cmd=servermap • guild=<guild> • cleaned_messages=1` — appears when the refresh deletes stale server-map messages before posting the new copy.
+- `📘 Server map — cmd=servermap • guild=<guild> • categories=5 • channels=38 • uncategorized=2 • messages=3 • cat_blacklist_ids=1 • chan_blacklist_ids=2 • target_channel=#server-map` — summary after the map posts.
 - `📘 Server map — skipped • reason=interval_not_elapsed • last_run=2025-11-05T12:34:56Z` — emitted when the scheduled job sees fewer than `SERVER_MAP_REFRESH_DAYS` since the prior run.
 - `📘 Server map — skipped • reason=feature_disabled` — emitted when the `SERVER_MAP` FeatureToggle disables both the scheduler and manual `!servermap refresh` command.
 - `❌ Server map — error • reason=missing_channel_id` — configuration or Discord failures; inspect runtime logs for details before retrying the manual command.
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/docs/ops/Watchers.md
+++ b/docs/ops/Watchers.md
@@ -29,7 +29,7 @@ source of truth covers every automation hook:
 | **Onboarding questions refresh** | `shared.sheets.onboarding` warmers | Weekly | Reloads onboarding question forms to match the latest Config worksheet. | `[cache] bucket=onboarding_questions` (startup + scheduler) with `actor=startup` or `actor=scheduler`. | Requires `ONBOARDING_TAB` and FeatureToggles enabling onboarding modules. |
 | **Cleanup watcher** | `modules.ops.cleanup_watcher` | Every `CLEANUP_AGE_HOURS` hours | Deletes all non-pinned messages in configured panel threads so each run resets the canvas. | Multi-line `🧹 **Cleanup** — …` summary posted to the ops log channel plus Python WARN lines when fetch/delete fails. | `CLEANUP_AGE_HOURS`, `CLEANUP_THREAD_IDS`. |
 | **Daily Recruiter Update** | `modules.recruitment.reporting.daily_recruiter_update.scheduler_daily_recruiter_update` | Once per day at `REPORT_DAILY_POST_TIME` (UTC) | Posts the recruiter digest embed summarizing placements, queues, and cache freshness into `REPORT_RECRUITERS_DEST_ID`. | Structured console logs plus the Discord embed; scheduler start/stop events log via `daily_recruiter_update` helpers. | `REPORT_DAILY_POST_TIME`, `REPORT_RECRUITERS_DEST_ID`, and the `recruitment_reports` feature toggle. |
-| **Server map refresh** | `modules.ops.server_map` | Daily interval check (24 h cadence gated by `SERVER_MAP_REFRESH_DAYS`) | Generates the category/channel overview in `#server-map`, edits existing pinned messages, and pins the first block. | `📘 Server map — refreshed/skipped` logs plus `❌` errors for configuration issues. | FeatureToggles entry `SERVER_MAP` gates both the scheduler and `!servermap refresh`; `SERVER_MAP_CHANNEL_ID` and `SERVER_MAP_REFRESH_DAYS` remain env-driven while runtime state lives in the Recruitment Config tab. |
+| **Server map refresh** | `modules.ops.server_map` | Daily interval check (24 h cadence gated by `SERVER_MAP_REFRESH_DAYS`) | Generates the category/channel overview in `#server-map`, edits existing pinned messages, and pins the first block. | Start logs note `channel_fallback` vs `requested_channel`, followed by config, optional `cleaned_messages`, and summary lines with category/channel counts plus blacklist sizes; `❌` errors still surface configuration issues. | FeatureToggles entry `SERVER_MAP` gates both the scheduler and `!servermap refresh`; `SERVER_MAP_CHANNEL_ID` and `SERVER_MAP_REFRESH_DAYS` remain env-driven while runtime state lives in the Recruitment Config tab. |
 
 ### Cleanup watcher
 - **Environment.** `CLEANUP_AGE_HOURS` defines the fixed interval between runs; `CLEANUP_THREAD_IDS` lists the Discord thread IDs that will be wiped.
@@ -96,4 +96,4 @@ keeps the bot “warm” in two layers:
   scheduler wiring, and watchdog contracts.
 - [`docs/modules/`](../modules) — module owners for the watchers listed here.
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-19 (v0.9.7)

--- a/tests/cogs/test_app_admin.py
+++ b/tests/cogs/test_app_admin.py
@@ -156,7 +156,7 @@ def test_servermap_refresh_command_invokes_refresh_when_enabled(monkeypatch):
 
         await cog.servermap_refresh.callback(cog, ctx)
 
-        refresh.assert_awaited_once()
+        refresh.assert_awaited_once_with(bot, force=True, actor="command", requested_channel="ctx")
         ctx.reply.assert_awaited_once_with(
             "Server map refreshed — messages=2 • chars=1200.",
             mention_author=False,


### PR DESCRIPTION
## Summary
- Read server map category and channel blacklists from environment variables, parse them, and continue logging the configured values before building maps.
- Update server map runtime tests to patch environment-driven blacklists and document the blacklist keys under environment configuration instead of the sheet config section.

## Testing
- pytest tests/modules/server_map

[meta]
labels: bug, comp:modules, comp:config, tests, codex, P2
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e44218528832391d2824369a47ca9)