### PR TITLE
Update shard mercy panel persistence and UI

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -122,6 +122,11 @@ sync modules remain available for non-async scripts and cache warmers.
 | `TAG_BADGE_PX` | int | `128` | Pixel edge length used when generating clan badge attachments. |
 | `TAG_BADGE_BOX` | float | `0.90` | Glyph fill ratio applied during clan badge attachment rendering. |
 | `STRICT_EMOJI_PROXY` | bool | `true` | When truthy (`1`), require padded proxy thumbnails instead of raw CDN URLs. |
+| `SHARD_PANEL_OVERVIEW_EMOJI` | string | `c1c` | Emoji tag or `<:name:id>` value used for the shard overview tab author icon. |
+| `SHARD_EMOJI_ANCIENT` | string | `ancient` | Emoji tag or `<:name:id>` value for the Ancient shard tab/button. |
+| `SHARD_EMOJI_VOID` | string | `void` | Emoji tag or `<:name:id>` value for the Void shard tab/button. |
+| `SHARD_EMOJI_SACRED` | string | `sacred` | Emoji tag or `<:name:id>` value for the Sacred shard tab/button. |
+| `SHARD_EMOJI_PRIMAL` | string | `primal` | Emoji tag or `<:name:id>` value for the Primal shard tab/button. |
 
 > Local development runner (`scripts/dev_run.sh`) now sources `.env` with `set -a; source ./.env`, preserving quoted and space-containing values verbatim.
 >
@@ -272,4 +277,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-11-19 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/ops/modules/ShardTracker.md
+++ b/docs/ops/modules/ShardTracker.md
@@ -12,7 +12,8 @@ users keep a personal, button-driven tracker thread.
 - Enforce channel routing: only the configured Shards & Mercy channel may run
   shard commands, and every user gets a private thread underneath that channel.
 - Surface a mobile-friendly embed with buttons so players can log pulls or add
-  shards without typing commands.
+  shards without typing commands. Panel buttons are persistent and survive
+  bot restarts.
 - Provide modal-based logging for Legendary/Mythical pulls and manual stash
   setters via `!shards set …`.
 - Log lifecycle, warning, and error states through the existing C1C log helper
@@ -75,11 +76,14 @@ there, and replies in the parent channel with a short pointer.
 
 Buttons live on every embed inside the user’s thread:
 
-- **Tab buttons** — Overview, per-shard detail tabs, and a Last Pulls tab.
-- **Stash adjusters** — +/- buttons per shard type to update stash counts; pulls
-  (negative deltas) increment the appropriate mercy counters.
-- **Got Legendary/Mythical** — open modals that record how many shards were
-  pulled, where the drop appeared, and reset counters accordingly.
+- **Tab buttons** — Text-only Overview tab plus emoji-only shard tabs
+  (Ancient/Void/Sacred/Primal) and a text Last Pulls tab.
+- **+ Stash / - Pulls** — open numeric modals on the active shard tab only.
+  + Stash increases stash without touching mercy; - Pulls reduces stash (floored
+  at 0) and increments mercy (Primal increments both legendary and mythical).
+- **Got Legendary** — shard tabs only. Non-Primal resets the legendary mercy to
+  zero; Primal opens a follow-up with Legendary vs Mythical to decide whether to
+  reset only the legendary counter or both mercy tracks.
 
 Only the thread owner may press the buttons; everyone else receives a friendly
 rejection message. Button handlers write through to Sheets immediately and edit
@@ -117,5 +121,5 @@ Automated tests cover:
 - Thread routing unit tests verifying channel restrictions and reusing an
   existing thread before creating a new one.
 
-Doc last updated: 2025-11-18 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)
 

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -34,24 +34,29 @@ class ShardTrackerView(discord.ui.View):
     def __init__(
         self,
         *,
-        owner_id: int,
+        owner_id: int | None,
         controller: "ShardTrackerController",
         active_tab: str,
         shard_labels: Mapping[str, str],
+        shard_emojis: Mapping[str, discord.PartialEmoji | None],
         mythic_controls: bool = True,
     ) -> None:
-        super().__init__(timeout=180)
+        super().__init__(timeout=None)
         self.owner_id = owner_id
         self.active_tab = active_tab
         self._controller = controller
         # Tab buttons
         for tab in ("overview", "ancient", "void", "sacred", "primal", "last_pulls"):
-            label = tab.replace("_", " ").title()
+            label = "Overview" if tab == "overview" else None
+            emoji = shard_emojis.get(tab)
+            if label is None and emoji is None:
+                label = shard_labels.get(tab, tab.replace("_", " ").title())
             style = discord.ButtonStyle.primary if tab == active_tab else discord.ButtonStyle.secondary
             self.add_item(
                 _ShardButton(
                     custom_id=f"tab:{tab}",
                     label=label,
+                    emoji=emoji,
                     style=style,
                     owner_id=owner_id,
                     controller=controller,
@@ -60,52 +65,39 @@ class ShardTrackerView(discord.ui.View):
 
         # Action rows depend on tab
         if active_tab in shard_labels:
-            self._add_stash_buttons(active_tab)
-            self._add_legendary_button(active_tab, shard_labels[active_tab])
-            if active_tab == "primal" and mythic_controls:
-                self._add_primal_mythic_buttons()
+            self._add_primary_buttons()
+            self._add_legendary_button()
 
-    def _add_stash_buttons(self, shard_key: str) -> None:
-        for delta in (-10, -5, -1, 1, 5, 10):
-            label = f"{delta:+d}"
-            self.add_item(
-                _ShardButton(
-                    custom_id=f"{shard_key}:add:{delta}",
-                    label=label,
-                    style=discord.ButtonStyle.secondary,
-                    owner_id=self.owner_id,
-                    controller=self._controller,
-                )
-            )
-
-    def _add_legendary_button(self, shard_key: str, label: str) -> None:
+    def _add_primary_buttons(self) -> None:
         self.add_item(
             _ShardButton(
-                custom_id=f"{shard_key}:got_legendary",
-                label=f"Got Legendary ({label})",
-                style=discord.ButtonStyle.success,
-                owner_id=self.owner_id,
+                custom_id=f"action:stash:{self.active_tab}",
+                label="+ Stash",
+                emoji=None,
+                style=discord.ButtonStyle.primary,
+                owner_id=self.owner_id or 0,
+                controller=self._controller,
+            )
+        )
+        self.add_item(
+            _ShardButton(
+                custom_id=f"action:pulls:{self.active_tab}",
+                label="- Pulls",
+                emoji=None,
+                style=discord.ButtonStyle.secondary,
+                owner_id=self.owner_id or 0,
                 controller=self._controller,
             )
         )
 
-    def _add_primal_mythic_buttons(self) -> None:
-        for delta in (-5, -1, 1, 5):
-            self.add_item(
-                _ShardButton(
-                    custom_id=f"primal_mythic:add:{delta}",
-                    label=f"Mythic {delta:+d}",
-                    style=discord.ButtonStyle.secondary,
-                    owner_id=self.owner_id,
-                    controller=self._controller,
-                )
-            )
+    def _add_legendary_button(self) -> None:
         self.add_item(
             _ShardButton(
-                custom_id="primal:got_mythical",
-                label="Got Mythical",
+                custom_id=f"action:legendary:{self.active_tab}",
+                label="Got Legendary",
+                emoji=None,
                 style=discord.ButtonStyle.success,
-                owner_id=self.owner_id,
+                owner_id=self.owner_id or 0,
                 controller=self._controller,
             )
         )
@@ -117,17 +109,20 @@ class _ShardButton(discord.ui.Button[ShardTrackerView]):
         *,
         custom_id: str,
         label: str,
+        emoji: discord.PartialEmoji | None,
         style: discord.ButtonStyle,
         owner_id: int,
         controller: "ShardTrackerController",
     ) -> None:
-        super().__init__(custom_id=custom_id, label=label, style=style)
+        super().__init__(custom_id=custom_id, label=label, style=style, emoji=emoji)
         self._owner_id = owner_id
         self._controller = controller
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
         user_id = getattr(interaction.user, "id", None)
-        if user_id != self._owner_id:
+        thread_owner = getattr(getattr(interaction.message, "channel", None), "owner_id", None)
+        owner_id = self._owner_id or thread_owner
+        if owner_id and user_id != owner_id:
             await interaction.response.send_message(
                 "Only the owner of this tracker can use these buttons.", ephemeral=True
             )
@@ -135,7 +130,9 @@ class _ShardButton(discord.ui.Button[ShardTrackerView]):
         await self._controller.handle_button_interaction(
             interaction=interaction,
             custom_id=self.custom_id,
-            active_tab=self.view.active_tab if isinstance(self.view, ShardTrackerView) else "overview",
+            active_tab=self.custom_id.split(":")[-1]
+            if self.custom_id.startswith("action:") or self.custom_id.startswith("tab:")
+            else self.view.active_tab if isinstance(self.view, ShardTrackerView) else "overview",
         )
 
 
@@ -155,6 +152,8 @@ def build_overview_embed(
     member: discord.abc.User,
     displays: Sequence[ShardDisplay],
     mythic: MythicDisplay,
+    author_name: str | None = None,
+    author_icon_url: str | None = None,
 ) -> discord.Embed:
     embed = discord.Embed(
         title=f"Shard Overview — {member.display_name or member.name}",
@@ -164,6 +163,8 @@ def build_overview_embed(
             "and the Legendary/Mythical buttons to log pulls."
         ),
     )
+    if author_name:
+        embed.set_author(name=author_name, icon_url=author_icon_url or discord.Embed.Empty)
     for display in displays:
         line = (
             f"Owned: **{max(display.owned, 0):,}** | "
@@ -189,10 +190,14 @@ def build_detail_embed(
     member: discord.abc.User,
     display: ShardDisplay,
     mythic: MythicDisplay | None = None,
+    author_name: str | None = None,
+    author_icon_url: str | None = None,
 ) -> discord.Embed:
     embed = discord.Embed(
         title=f"{display.label} Shards", colour=discord.Color.blurple()
     )
+    if author_name:
+        embed.set_author(name=author_name, icon_url=author_icon_url or discord.Embed.Empty)
     embed.description = _detail_block(display)
     if mythic:
         embed.add_field(name="Primal Mythical", value=_mythic_block(mythic), inline=False)
@@ -205,11 +210,15 @@ def build_last_pulls_embed(
     displays: Sequence[ShardDisplay],
     mythic: MythicDisplay,
     base_rates: Mapping[str, str],
+    author_name: str | None = None,
+    author_icon_url: str | None = None,
 ) -> discord.Embed:
     embed = discord.Embed(
         title=f"Last Pulls & Mercy Info — {member.display_name or member.name}",
         colour=discord.Color.blurple(),
     )
+    if author_name:
+        embed.set_author(name=author_name, icon_url=author_icon_url or discord.Embed.Empty)
     last_lines = []
     for display in displays:
         stamp = human_time(display.last_timestamp) if display.last_timestamp else "Never"
@@ -238,11 +247,10 @@ def build_last_pulls_embed(
 
 def _detail_block(display: ShardDisplay) -> str:
     mercy = display.mercy
-    remaining = max(0, mercy.threshold - mercy.pulls_since)
-    remaining_label = f"{remaining} left" if remaining > 0 else "Maxed"
+    maxed = mercy.pulls_since >= mercy.threshold
     parts = [
         f"Stash: **{max(display.owned, 0):,}**",
-        f"Legendary Mercy: {mercy.pulls_since} / {mercy.threshold} ({remaining_label})",
+        f"Legendary Mercy: {mercy.pulls_since} / {mercy.threshold}" + (" (Maxed)" if maxed else ""),
         f"Legendary Chance: {format_percent(mercy.chance)}",
         _progress_bar(mercy),
     ]
@@ -256,10 +264,9 @@ def _detail_block(display: ShardDisplay) -> str:
 
 def _mythic_block(display: MythicDisplay) -> str:
     mercy = display.mercy
-    remaining = max(0, mercy.threshold - mercy.pulls_since)
-    remaining_label = f"{remaining} left" if remaining > 0 else "Maxed"
+    maxed = mercy.pulls_since >= mercy.threshold
     parts = [
-        f"Mythical Mercy: {mercy.pulls_since} / {mercy.threshold} ({remaining_label})",
+        f"Mythical Mercy: {mercy.pulls_since} / {mercy.threshold}" + (" (Maxed)" if maxed else ""),
         f"Mythical Chance: {format_percent(mercy.chance)}",
         _progress_bar(mercy),
     ]
@@ -284,7 +291,7 @@ def _progress_bar(mercy: MercySnapshot, segments: int = 20) -> str:
         "🟦" * mercy_filled,
         "⬜" * empty,
     ])
-    return f"Progress: [{bar}] {mercy.pulls_since}/{max_pulls}"
+    return f"Progress: [{bar}]"
 
 
 def human_time(iso_value: str) -> str:

--- a/shared/config.py
+++ b/shared/config.py
@@ -56,6 +56,11 @@ __all__ = [
     "get_panel_fixed_thread_id",
     "get_shard_mercy_tab",
     "get_shard_mercy_channel_id",
+    "get_shard_panel_overview_emoji",
+    "get_shard_emoji_ancient",
+    "get_shard_emoji_void",
+    "get_shard_emoji_sacred",
+    "get_shard_emoji_primal",
     "get_public_base_url",
     "get_render_external_url",
     "get_emoji_max_bytes",
@@ -914,6 +919,35 @@ def get_shard_mercy_channel_id() -> int:
         return int(str(value).strip())
     except (TypeError, ValueError):
         return 0
+
+
+def _clean_emoji_value(key: str, default: str) -> str:
+    value = _CONFIG.get(key, default)
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            return text
+    return default
+
+
+def get_shard_panel_overview_emoji(default: str = "c1c") -> str:
+    return _clean_emoji_value("SHARD_PANEL_OVERVIEW_EMOJI", default)
+
+
+def get_shard_emoji_ancient(default: str = "ancient") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_ANCIENT", default)
+
+
+def get_shard_emoji_void(default: str = "void") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_VOID", default)
+
+
+def get_shard_emoji_sacred(default: str = "sacred") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_SACRED", default)
+
+
+def get_shard_emoji_primal(default: str = "primal") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_PRIMAL", default)
 
 
 def get_public_base_url() -> str | None:

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -105,25 +105,25 @@ def test_commands_are_registered():
     asyncio.run(runner())
 
 
-def test_logged_legendary_updates_depth():
+def test_legendary_reset_tracks_depth():
     tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
     record = tracker.store._new_record([], 1, "user")  # type: ignore[arg-type]
     kind = tracker._resolve_kind("ancient")
+    record.ancients_since_lego = 7
 
-    tracker._apply_logged_legendary(record, kind, total_pulled=10, legend_index=4)  # type: ignore[arg-type]
+    tracker._apply_legendary_reset(record, kind)  # type: ignore[arg-type]
 
-    assert record.ancients_since_lego == 6
-    assert record.last_ancient_lego_depth == 4
+    assert record.ancients_since_lego == 0
+    assert record.last_ancient_lego_depth == 7
 
 
 def test_logged_mythic_resets_counters():
     tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
     record = tracker.store._new_record([], 2, "user")  # type: ignore[arg-type]
-    kind = tracker._resolve_kind("primal")
     record.primals_since_mythic = 50
 
-    tracker._apply_logged_mythic(record, kind, total_pulled=15, mythic_index=5)  # type: ignore[arg-type]
+    tracker._apply_primal_mythical(record)  # type: ignore[arg-type]
 
-    assert record.primals_since_mythic == 10
-    assert record.primals_since_lego == 10
-    assert record.last_primal_mythic_depth == 55
+    assert record.primals_since_mythic == 0
+    assert record.primals_since_lego == 0
+    assert record.last_primal_mythic_depth == 50


### PR DESCRIPTION
## Summary
- make the shard tracker view persistent across restarts and use emoji-configured tab and author icons
- update stash/pull/got legendary flows with modal inputs, primal mythic handling, and simplified mercy/progress display
- document the shard panel changes and new emoji configuration keys

## Testing
- python -m pytest tests/community/shard_tracker/test_cog.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e612a45988323859b2c9067a71f52)