### PR TITLE
Fix shard tracker emoji parsing and labels

### DIFF
--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -48,8 +48,9 @@ class ShardTrackerView(discord.ui.View):
         # Tab buttons
         for tab in ("overview", "ancient", "void", "sacred", "primal", "last_pulls"):
             label = "Overview" if tab == "overview" else None
-            emoji = shard_emojis.get(tab)
-            if label is None and emoji is None:
+            emoji = None if tab == "overview" else shard_emojis.get(tab)
+            if tab != "overview" and (not emoji or not getattr(emoji, "id", None)):
+                emoji = None
                 label = shard_labels.get(tab, tab.replace("_", " ").title())
             style = discord.ButtonStyle.primary if tab == active_tab else discord.ButtonStyle.secondary
             self.add_item(


### PR DESCRIPTION
## Summary
- parse shard tracker emoji configuration into valid PartialEmoji objects and log once on invalid values
- ignore invalid or missing shard emojis when building tab buttons so text labels remain and overview stays text-only

## Testing
- python -m compileall modules/community/shard_tracker


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eed148608832394a0721c3888761a)