### PR TITLE
Restore shard tracker champion logging flow

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -267,37 +267,14 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 return
 
             if action_name == "legendary":
-                if tab == "primal":
-                    await interaction.response.send_message(
-                        "What did you pull?",
-                        view=_PrimalDropChoiceView(
-                            controller=self,
-                            owner_id=ctx_author.id,
-                            active_tab=tab,
-                            panel_message=interaction.message,
-                        ),
-                        ephemeral=True,
-                    )
-                    return
-                kind = self._resolve_kind(tab)
-                if kind is None:
-                    await interaction.response.send_message(
-                        "Unknown shard type for this button.", ephemeral=True
-                    )
-                    return
-                self._apply_legendary_reset(record, kind)
-                record.snapshot_name(ctx_author.display_name or ctx_author.name)
-                await self.store.save_record(config, record)
-                embed, view = self._build_panel(
-                    ctx_author, record, interaction.channel, tab
+                modal = _LegendaryModal(
+                    controller=self,
+                    owner_id=ctx_author.id,
+                    shard_key=tab,
+                    active_tab=tab,
                 )
-                await interaction.response.edit_message(embed=embed, view=view)
-                await self._log_action(
-                    "legendary_reset",
-                    ctx_author,
-                    interaction.channel,
-                    f"{kind.label} reset",
-                )
+                await interaction.response.send_modal(modal)
+                return
 
     # === Internal helpers ===
 
@@ -471,6 +448,87 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             f"{kind.label} -{amount}",
         )
 
+    async def process_legendary_modal(
+        self,
+        *,
+        interaction: discord.Interaction,
+        shard_key: str,
+        total_pulls: int,
+        after_champion: int,
+        active_tab: str,
+    ) -> None:
+        kind = self._resolve_kind(shard_key)
+        if kind is None:
+            await interaction.response.send_message("Unknown shard type.", ephemeral=True)
+            return
+        if total_pulls <= 0 or after_champion < 0:
+            await interaction.response.send_message(
+                "Please enter positive numbers.", ephemeral=True
+            )
+            return
+        if after_champion > total_pulls:
+            await interaction.response.send_message(
+                "Pulls after the champion cannot exceed total pulls.",
+                ephemeral=True,
+            )
+            return
+
+        async with self._user_lock(interaction.user.id):
+            try:
+                config = await self.store.get_config()
+                record = await self.store.load_record(
+                    interaction.user.id,
+                    interaction.user.display_name or interaction.user.name,
+                )
+            except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+                await interaction.response.send_message(
+                    self._config_error_message(str(exc)), ephemeral=True
+                )
+                await self._notify_admins(str(exc))
+                return
+
+            self._apply_pull_usage(record, kind, total_pulls)
+
+            current_mercy = max(0, getattr(record, kind.mercy_field, 0))
+            drop_depth = max(0, current_mercy - after_champion)
+            setattr(record, kind.mercy_field, drop_depth)
+
+            if kind.key == "primal":
+                previous_mythic = max(0, record.primals_since_mythic)
+                mythic_depth = max(0, previous_mythic + total_pulls - after_champion)
+                record.primals_since_mythic = mythic_depth
+                record.snapshot_name(interaction.user.display_name or interaction.user.name)
+                await self.store.save_record(config, record)
+
+                await interaction.response.send_message(
+                    "What did you pull?",
+                    view=_PrimalDropChoiceView(
+                        controller=self,
+                        owner_id=getattr(interaction.user, "id", 0),
+                        active_tab=active_tab,
+                        panel_message=interaction.message,
+                        after_champion=after_champion,
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            self._apply_legendary_reset(record, kind)
+            setattr(record, kind.mercy_field, after_champion)
+            record.snapshot_name(interaction.user.display_name or interaction.user.name)
+            await self.store.save_record(config, record)
+
+        embed, view = self._build_panel(
+            interaction.user, record, interaction.channel, active_tab
+        )
+        await interaction.response.edit_message(embed=embed, view=view)
+        await self._log_action(
+            "legendary_reset",
+            interaction.user,
+            interaction.channel,
+            f"{kind.label} drop: pulls={total_pulls}, after={after_champion}",
+        )
+
     async def process_primal_choice(
         self,
         *,
@@ -478,6 +536,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         choice: str,
         active_tab: str,
         panel_message: discord.Message | None,
+        after_champion: int,
     ) -> None:
         if choice not in {"legendary", "mythical"}:
             await interaction.response.send_message(
@@ -498,10 +557,18 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 await self._notify_admins(str(exc))
                 return
 
+            current_mythic_mercy = max(0, record.primals_since_mythic)
+
             if choice == "legendary":
                 self._apply_primal_legendary(record)
+                record.primals_since_lego = max(0, after_champion)
+                record.primals_since_mythic = current_mythic_mercy + max(
+                    0, after_champion
+                )
             else:
                 self._apply_primal_mythical(record)
+                record.primals_since_lego = max(0, after_champion)
+                record.primals_since_mythic = max(0, after_champion)
             record.snapshot_name(interaction.user.display_name or interaction.user.name)
             await self.store.save_record(config, record)
 
@@ -993,6 +1060,66 @@ class _PullsModal(_NumberModal):
         )
 
 
+class _LegendaryModal(discord.ui.Modal):
+    def __init__(
+        self,
+        *,
+        controller: ShardTracker,
+        owner_id: int,
+        shard_key: str,
+        active_tab: str,
+    ) -> None:
+        super().__init__(title="Log champion pull")
+        self.controller = controller
+        self.owner_id = owner_id
+        self.shard_key = shard_key
+        self.active_tab = active_tab
+        self.total_pulls = discord.ui.TextInput(
+            label="How many shards did you pull?",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 10",
+        )
+        self.after_champion = discord.ui.TextInput(
+            label="How many shards after the champion?",
+            min_length=1,
+            max_length=6,
+            required=True,
+            placeholder="e.g., 2",
+        )
+        self.add_item(self.total_pulls)
+        self.add_item(self.after_champion)
+
+    def _parse_field(self, field: discord.ui.TextInput) -> int | None:
+        try:
+            return int(str(field.value))
+        except (TypeError, ValueError):
+            return None
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        if interaction.user.id != self.owner_id:
+            await interaction.response.send_message(
+                "Only the tracker owner can log pulls.", ephemeral=True
+            )
+            return
+        total = self._parse_field(self.total_pulls)
+        after = self._parse_field(self.after_champion)
+        if total is None or after is None:
+            await interaction.response.send_message(
+                "Please provide numeric values.", ephemeral=True
+            )
+            return
+
+        await self.controller.process_legendary_modal(
+            interaction=interaction,
+            shard_key=self.shard_key,
+            total_pulls=total,
+            after_champion=after,
+            active_tab=self.active_tab,
+        )
+
+
 class _PrimalDropChoiceView(discord.ui.View):
     def __init__(
         self,
@@ -1001,12 +1128,14 @@ class _PrimalDropChoiceView(discord.ui.View):
         owner_id: int,
         active_tab: str,
         panel_message: discord.Message | None,
+        after_champion: int,
     ) -> None:
         super().__init__(timeout=120)
         self.controller = controller
         self.owner_id = owner_id
         self.active_tab = active_tab
         self.panel_message = panel_message
+        self.after_champion = after_champion
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
         if interaction.user.id != self.owner_id:
@@ -1025,6 +1154,7 @@ class _PrimalDropChoiceView(discord.ui.View):
             choice="legendary",
             active_tab=self.active_tab,
             panel_message=self.panel_message,
+            after_champion=self.after_champion,
         )
 
     @discord.ui.button(label="Mythical", style=discord.ButtonStyle.success)
@@ -1036,6 +1166,7 @@ class _PrimalDropChoiceView(discord.ui.View):
             choice="mythical",
             active_tab=self.active_tab,
             panel_message=self.panel_message,
+            after_champion=self.after_champion,
         )
 
 

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -92,10 +92,11 @@ class ShardTrackerView(discord.ui.View):
         )
 
     def _add_legendary_button(self) -> None:
+        label = "Got Legendary/Mythical" if self.active_tab == "primal" else "Got Legendary"
         self.add_item(
             _ShardButton(
                 custom_id=f"action:legendary:{self.active_tab}",
-                label="Got Legendary",
+                label=label,
                 emoji=None,
                 style=discord.ButtonStyle.success,
                 owner_id=self.owner_id or 0,


### PR DESCRIPTION
## Summary
- Rewire the "Got Legendary" action to open the two-step champion logging modal and apply the existing stash/mercy updates before saving
- Preserve the Primal follow-up choice with after-champion handling and ensure final counters reflect the selected Legendary or Mythical drop
- Clarify the Primal tab action by renaming its button to "Got Legendary/Mythical"

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0d2ccd5c8323a6765975b9efd8f6)