### PR TITLE
Add separate Primal mercy inputs

### DIFF
--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -68,6 +68,7 @@ class ShardTrackerView(discord.ui.View):
         if active_tab in shard_labels:
             self._add_primary_buttons()
             self._add_legendary_button()
+            self._add_last_pulls_button()
 
     def _add_primary_buttons(self) -> None:
         self.add_item(
@@ -99,6 +100,18 @@ class ShardTrackerView(discord.ui.View):
                 label=label,
                 emoji=None,
                 style=discord.ButtonStyle.success,
+                owner_id=self.owner_id or 0,
+                controller=self._controller,
+            )
+        )
+
+    def _add_last_pulls_button(self) -> None:
+        self.add_item(
+            _ShardButton(
+                custom_id=f"action:last_pulls:{self.active_tab}",
+                label="Last Pulls / Mercy",
+                emoji=None,
+                style=discord.ButtonStyle.secondary,
                 owner_id=self.owner_id or 0,
                 controller=self._controller,
             )

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -127,3 +127,28 @@ def test_logged_mythic_resets_counters():
     assert record.primals_since_mythic == 0
     assert record.primals_since_lego == 0
     assert record.last_primal_mythic_depth == 50
+
+
+def test_manual_mercy_sets_primal_independently():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 3, "user")  # type: ignore[arg-type]
+    kind = tracker._resolve_kind("primal")
+
+    tracker._apply_manual_mercy(  # type: ignore[arg-type]
+        record, kind, legendary_mercy=12, mythical_mercy=7
+    )
+
+    assert record.primals_since_lego == 12
+    assert record.primals_since_mythic == 7
+
+
+def test_manual_mercy_sets_non_primal_counter():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 4, "user")  # type: ignore[arg-type]
+    kind = tracker._resolve_kind("sacred")
+
+    tracker._apply_manual_mercy(  # type: ignore[arg-type]
+        record, kind, legendary_mercy=5, mythical_mercy=None
+    )
+
+    assert record.sacreds_since_lego == 5


### PR DESCRIPTION
## Summary
- add a Last Pulls / Mercy modal that accepts separate Primal legendary and mythical counters
- wire the new modal button into shard tabs so Primal mercy updates no longer mirror each other
- add unit tests covering manual Primal mercy updates alongside non-Primal updates

## Testing
- `pytest tests/community/shard_tracker/test_cog.py tests/community/shard_tracker/test_mercy.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1fdfc5a48323846e2ae94dc8af9f)