### PR TITLE
Ping user when sending shard panel

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -837,7 +837,8 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         if thread is None:
             await ctx.reply("Unable to locate or create your shard thread.", mention_author=False)
             return
-        await thread.send(embed=embed, view=view)
+        content = f"{ctx.author.mention}"
+        await thread.send(content=content, embed=embed, view=view)
         if parent and parent == ctx.channel:
             await ctx.reply(
                 f"📬 Posted in your shard thread: {thread.mention}",


### PR DESCRIPTION
## Summary
- mention the requesting user when posting the initial shard tracker panel to their thread so they receive a notification

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f34f8e38c832396686b07100cbef1)