### PR TITLE
Fix shard tracker view ownership scoping

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -127,22 +127,6 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         self._emoji_tags = self._load_emoji_tags()
         self._tab_emojis = self._load_tab_emojis()
 
-    async def cog_load(self) -> None:
-        labels = {kind.key: kind.label for kind in SHARD_KINDS.values()}
-        for tab in ("ancient", "void", "sacred", "primal"):
-            try:
-                self.bot.add_view(
-                    ShardTrackerView(
-                        owner_id=None,
-                        controller=self,
-                        shard_labels=labels,
-                        shard_emojis=self._tab_emojis,
-                        active_tab=tab,
-                    )
-                )
-            except Exception:  # pragma: no cover - defensive registration
-                log.exception("failed to register persistent shard tracker view", extra={"tab": tab})
-
     # === Commands ===
 
     @tier("user")

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -46,14 +46,15 @@ class ShardTrackerView(discord.ui.View):
     def __init__(
         self,
         *,
-        owner_id: int | None,
+        owner_id: int,
         controller: "ShardTrackerController",
         active_tab: str,
         shard_labels: Mapping[str, str],
         shard_emojis: Mapping[str, discord.PartialEmoji | None],
         mythic_controls: bool = True,
+        timeout: float | None = None,
     ) -> None:
-        super().__init__(timeout=None)
+        super().__init__(timeout=timeout)
         self.owner_id = owner_id
         self.active_tab = active_tab
         self._controller = controller
@@ -94,7 +95,7 @@ class ShardTrackerView(discord.ui.View):
                 label="+ Stash",
                 emoji=None,
                 style=discord.ButtonStyle.primary,
-                owner_id=self.owner_id or 0,
+                owner_id=self.owner_id,
                 controller=self._controller,
             )
         )
@@ -104,7 +105,7 @@ class ShardTrackerView(discord.ui.View):
                 label="- Pulls",
                 emoji=None,
                 style=discord.ButtonStyle.secondary,
-                owner_id=self.owner_id or 0,
+                owner_id=self.owner_id,
                 controller=self._controller,
             )
         )
@@ -117,7 +118,7 @@ class ShardTrackerView(discord.ui.View):
                 label=label,
                 emoji=None,
                 style=discord.ButtonStyle.success,
-                owner_id=self.owner_id or 0,
+                owner_id=self.owner_id,
                 controller=self._controller,
             )
         )
@@ -129,7 +130,7 @@ class ShardTrackerView(discord.ui.View):
                 label="Last Pulls / Mercy",
                 emoji=None,
                 style=discord.ButtonStyle.secondary,
-                owner_id=self.owner_id or 0,
+                owner_id=self.owner_id,
                 controller=self._controller,
             )
         )
@@ -145,15 +146,14 @@ class _ShardButton(discord.ui.Button[ShardTrackerView]):
         style: discord.ButtonStyle,
         owner_id: int,
         controller: "ShardTrackerController",
-    ) -> None:
+        ) -> None:
         super().__init__(custom_id=custom_id, label=label, style=style, emoji=emoji)
         self._owner_id = owner_id
         self._controller = controller
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
         user_id = getattr(interaction.user, "id", None)
-        thread_owner = getattr(getattr(interaction.message, "channel", None), "owner_id", None)
-        owner_id = self._owner_id or thread_owner
+        owner_id = self._owner_id
         if owner_id and user_id != owner_id:
             await interaction.response.send_message(
                 "Only the owner of this tracker can use these buttons.", ephemeral=True


### PR DESCRIPTION
## Summary
- require shard tracker views to be constructed with an explicit owner ID and enforce ownership checks against that stored value
- remove the shared persistent shard tracker view registration so each panel message uses its own view instance

## Testing
- python -m compileall modules/community/shard_tracker


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f674566d0832d8f81682df8a2f917)