### PR TITLE
Document shard tracker updates for v0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v0.9.7 — 2025-11-20
+- **Shard tracker:** Added the `!shards` command, which opens a per-user shard tracker panel in a private thread. Tracks stash, mercy counters, and last pulls for Ancient, Void, Sacred, and Primal shards, including separate Legendary and Mythical paths for Primals.
+- **Shard UI & UX:** Introduced tabbed shard views with per-shard embeds, shard-icon tab buttons, and a two-phase mercy progress bar (green/white toward mercy, orange/black for overflow). Added a common `!help shards` footer to explain how it works.
+- **Primal mercy fix:** Legendary and Mythical mercy counters on Primals are now tracked independently. Logging a Mythical pull no longer resets Legendary mercy; depth and last-pull information is cleaned up and consistent across cards.
+- **Panel ownership & lifetime:** Shard tracker buttons are now bound to the owning user so only they can mutate their data. Views use a long timeout so panels don’t silently expire while the user is AFK; users can always spawn a fresh panel with `!shards`.
+- **Docs:** Updated README and internal docs to cover the shard tracker, mercy behaviour, and new configuration keys.
+
 ### v0.9.7 — 2025-11-18
 - **Server map automation:** Added a scheduler job that rebuilds and pins the `#server-map` post using live guild categories, persists message IDs in the Recruitment Config tab, and respects the new `SERVER_MAP_*` env keys.
 - **Admin tooling:** Introduced `!servermap refresh` so CoreOps can regenerate the map on demand without waiting for the cadence gate.
@@ -319,4 +326,4 @@
 - Sheet tab names moved out of env into each Sheet's **Config** tab.
 
 ---
-Doc last updated: 2025-11-08 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Think of it as the cluster’s quiet little helper: always awake, always watchin
 # 🌟 What the Woadkeeper Does
 ### For normal users
 - `@<Botname> help` — lists everything you can access with a short tip for each item.
-- **Find a clan**  
+- **Find a clan**
   `!clan <tag>` gives you a clean profile card with requirements, crest, and quick notes.
-- **Browse the cluster**  
+- **Browse the cluster**
   Use `!clansearch` to open the interactive search menu.
-- **Check the bot**  
+- **Track your shard mercy**
+  `!shards` opens your personal shard tracker panel in a private thread. It shows stash, mercy counters, last pulls, and base chances for Ancient, Void, Sacred, and Primal shards, including the split Legendary/Mythical path for Primals.
+- **Check the bot**
   `@BotName ping` — answers with 🏓 if all systems are up.
 The bot only shows commands you can actually run; if you need more tools, ask an admin to review your roles.
 ### For staff & recruiters
@@ -67,4 +69,4 @@ Each module doc explains what that subsystem does and how it fits into the bigge
   - `docs/contracts/CollaborationContract.md`  
   - ADRs in `docs/adr/`
 
-Doc last updated: 2025-11-19 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -95,6 +95,13 @@ flowchart TD
 CoreOps code exists **only** in `packages/c1c-coreops`. The `audit-coreops` workflow
 fails CI if any legacy imports, shims, or duplicate symbols live elsewhere.
 
+### Community utilities — shard tracker
+- Entry point: `modules.community.shard_tracker` registered via the `!shards` command.
+- Surface: per-user shard tracker panel posted inside a private thread under the configured Shards & Mercy channel.
+- Coverage: Ancient, Void, Sacred, and Primal shards with independent Legendary and Mythical mercy tracking on Primals.
+- UI: tabbed embeds with shard-emoji buttons, two-phase mercy bar (green/white toward mercy, orange/black for overflow), and a common `!help shards` footer explaining behaviour.
+- Ownership: buttons are locked to the owning user; long-lived views prevent silent expiry so users can keep sessions open or respawn via `!shards` at any time.
+
 ## Configuration & Startup
 Config validation is performed during bot startup (e.g., in `setup()`), not at package import, so libraries remain importable in build pipelines.
 
@@ -189,4 +196,4 @@ off in production until the panels ship._
 - Structured logs emit `[ops]`, `[cron]`, `[lifecycle]`, `[refresh]`, and `[command]` tags with context for quick filtering in Discord (transitioning from `[watcher|lifecycle]` to `[lifecycle]` during the dual-tag release).
 - Failures fall back to stale caches when safe and always raise a structured log to `LOG_CHANNEL_ID`.
 
-Doc last updated: 2025-11-17 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/Runbook.md
+++ b/docs/Runbook.md
@@ -83,6 +83,15 @@ when onboarding, welcome, recruitment, or placement flows misbehave.
      `reservations-autorelease`) around 12:00Z/18:00Z; if those disappear, verify
      the feature toggle and scheduler health.
 
+### Shard tracker (`!shards`)
+1. Shard commands only run in the configured Shards & Mercy channel
+   (`SHARD_MERCY_CHANNEL_ID` env or sheet Config row). If the bot replies with a
+   channel error, confirm the env/config source in the milestones Config tab.
+2. Each user gets a private thread; if the panel fails to open, check the
+   milestones sheet headers and the `shardtracker` feature toggle.
+3. Missing shard icons or blank tab buttons usually mean the shard emoji env
+   vars are unset (`SHARD_PANEL_OVERVIEW_EMOJI`, `SHARD_EMOJI_*`).
+
 ### Watchers & keepalive
 - [`Watchers.md`](Watchers.md) is the canonical source for watcher gating,
   scheduler cadences, watchdog thresholds, and keepalive expectations.
@@ -115,4 +124,4 @@ when onboarding, welcome, recruitment, or placement flows misbehave.
   mitigation tips.
 - [`docs/ops/Watchers.md`](Watchers.md) — watcher gating and scheduler details.
 
-Doc last updated: 2025-11-17 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -16,6 +16,7 @@
 | `n/a` ages in `!digest` | Bot restarted → cache not yet warmed | wait 5 min or run `!ops refresh all` |
 | “No tabs listed in Config” | Missing key in Sheet Config tab | check sheet permissions + tab names |
 | “I can't find a configured welcome for **TAG**. Add it in the sheet.” | Row missing or inactive in `WelcomeTemplates`; confirm `ACTIVE` = `Y`. | Update the sheet then ask an admin to run `!welcome-refresh` |
+| `!shards` replies but no panel appears | Shard tracker channel/thread misconfigured or feature toggle off | Check `SHARD_MERCY_CHANNEL_ID`/Config tab and `shardtracker` toggle; review shard tracker logs in ops channel |
 
 Refer to the automation keys listed in [`Config.md`](ops/Config.md#automation-listeners--cron-jobs)
 when adjusting cadences or toggles.
@@ -56,4 +57,4 @@ when adjusting cadences or toggles.
   opening an incident.
 - Ping #bot-production with the summary before filing a longer report.
 
-Doc last updated: 2025-11-17 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/ops/CommandMatrix.md
+++ b/docs/ops/CommandMatrix.md
@@ -59,9 +59,11 @@ _Module note:_ CoreOps now resides in `packages/c1c-coreops` via `c1c_coreops.*`
 | `@Bot ping` | 🧩 | Quick pong reply to confirm the bot is online. | `@Bot ping` |
 | `!clan <tag>` | 🧩 | Public clan card with crest + 💡 reaction flip between profile and entry criteria. [gated: `clan_profile`] | `!clan <tag>` |
 | `!clansearch` | 🧩 | Member clan search with legacy filters + pager (edits the panel in place). [gated: `member_panel`] | `!clansearch` |
-| `!shards [type]` | ✅ | Opens the shard tracker thread (overview + detail tabs). Optional type selects default tab. | `!shards [type]` |
+| `!shards [type]` | ✅ | Opens your shard tracker in a private thread with overview + shard tabs. Shows stash, mercy, last pulls, and base chances; optional type selects the default tab. | `!shards [type]` |
 | `!shards set <type> <count>` | ✅ | Force-set your shard stash count (channel restricted to Shards & Mercy). | `!shards set <type> <count>` |
+
+Shard tracker buttons are owner-only, use shard-emoji tab selectors, and keep a common `!help shards` footer explaining mercy behaviour.
 
 > Feature toggle note — `recruitment_reports` powers the Daily Recruiter Update (manual + scheduled). `feature_reservations` gates the `!reserve` command. `placement_target_select` remains a stub module that only logs when enabled. `onboarding_rules_v2` enables the deterministic onboarding rules DSL (visibility + navigation); disable to fall back to the legacy string parser.
 
-Doc last updated: 2025-11-19 (v0.9.7)
+Doc last updated: 2025-11-20 (v0.9.7)

--- a/docs/ops/modules/ShardTracker.md
+++ b/docs/ops/modules/ShardTracker.md
@@ -1,21 +1,24 @@
 # Shard & Mercy Tracker Module
 
 Community-focused module that lets members maintain their RAID shard stash and
-legendary mercy counters directly in Discord. Every interaction happens inside
-the dedicated **Shards & Mercy** channel so global chatter stays clean while
-users keep a personal, button-driven tracker thread.
+mercy counters directly in Discord. Every interaction happens inside the
+dedicated **Shards & Mercy** channel so global chatter stays clean while users
+keep a private, button-driven tracker thread.
 
 ## Scope & Responsibilities
 
-- Persist shard stash counts plus mercy counters (`ancient`, `void`, `sacred`,
-  `primal`, and the primal-mythical mercy) per Discord user.
+- Persist shard stash counts, last pulls, and mercy counters (`ancient`,
+  `void`, `sacred`, `primal`) per Discord user, including separate Legendary
+  and Mythical mercy tracks for Primals.
 - Enforce channel routing: only the configured Shards & Mercy channel may run
   shard commands, and every user gets a private thread underneath that channel.
-- Surface a mobile-friendly embed with buttons so players can log pulls or add
-  shards without typing commands. Panel buttons are persistent and survive
-  bot restarts.
+- Surface a mobile-friendly, tabbed embed with shard-icon buttons and a
+  two-phase mercy bar (green/white toward mercy, orange/black when past it) so
+  players can log pulls or add shards without typing commands. Panel buttons are
+  persistent and survive bot restarts.
 - Provide modal-based logging for Legendary/Mythical pulls and manual stash
-  setters via `!shards set …`.
+  setters via `!shards set …` plus a shared `!help shards` footer to explain
+  the controls.
 - Log lifecycle, warning, and error states through the existing C1C log helper
   plus ADMIN_ROLE_IDS pings on hard failures.
 
@@ -74,13 +77,15 @@ runs a command directly in that channel, the bot creates (or reuses) their
 personal thread named `Shards – <Display Name> [user_id]`, posts the embed
 there, and replies in the parent channel with a short pointer.
 
-Buttons live on every embed inside the user’s thread:
+Buttons live on every embed inside the user’s thread and are **locked to the
+thread owner**:
 
 - **Tab buttons** — Text-only Overview tab plus emoji-only shard tabs
   (Ancient/Void/Sacred/Primal) and a text Last Pulls tab.
 - **+ Stash / - Pulls** — open numeric modals on the active shard tab only.
   + Stash increases stash without touching mercy; - Pulls reduces stash (floored
-  at 0) and increments mercy (Primal increments both legendary and mythical).
+  at 0) and increments mercy. Primal pull logging increments Legendary and
+  Mythical mercy separately so Mythical pulls no longer reset Legendary mercy.
 - **Got Legendary** — shard tabs only. Non-Primal resets the legendary mercy to
   zero; Primal opens a follow-up with Legendary vs Mythical to decide whether to
   reset only the legendary counter or both mercy tracks.
@@ -122,4 +127,3 @@ Automated tests cover:
   existing thread before creating a new one.
 
 Doc last updated: 2025-11-20 (v0.9.7)
-


### PR DESCRIPTION
```markdown
Summary:
- Added a 2025-11-20 v0.9.7 changelog entry covering shard tracker additions and mercy fixes.
- Updated README plus ops/module docs (Command Matrix, Runbook, Troubleshooting, Architecture) to describe the shard tracker UI, ownership, and config keys.

Testing:
- Not run (docs-only changes)

[meta]
labels: docs, enhancement, comp:modules, guardrails
milestone: Harmonize v1.0
[/meta]
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f84312c88832d91624bf1d46e5ec1)