### PR TITLE
Improve inline onboarding refresh resiliency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Docs:** Updated README and internal docs to cover the shard tracker, mercy behaviour, and new configuration keys.
 - **Fix:** Hardened onboarding inline reply capture so answers typed into welcome threads bind the respondent automatically, survive session restores, and unblock **Next** when “Input is required.”
 - **Docs:** Clarified the inline reply capture model for onboarding (no Enter Answer button) and reinforced respondent binding behaviour.
+- **Fix:** Refreshed onboarding inline wizard cards even when the cached message cannot be resolved, re-rendering in the thread so saved answers clear the “Input is required” state and enable **Next**.
 
 ### v0.9.7 — 2025-11-18
 - **Server map automation:** Added a scheduler job that rebuilds and pins the `#server-map` post using live guild categories, persists message IDs in the Recruitment Config tab, and respects the new `SERVER_MAP_*` env keys.


### PR DESCRIPTION
```markdown
## Summary
- Resolve onboarding inline wizard refreshes by restoring the thread from session/bot cache before attempting message edits.
- Fall back to re-rendering the inline wizard in-thread when cached inline messages cannot be found so saved answers immediately update the card state.
- Documented the inline wizard refresh fix in the changelog.

## Testing
- python -m compileall modules/onboarding/controllers/welcome_controller.py

Tests:
Not run (reason: compile-only check executed; full suite not requested)
Docs:
Updated: CHANGELOG.md
[meta]
labels: codex, bug, docs, comp:modules, P1
milestone: Harmonize v1.0
[/meta]
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692073a39744832db6e1ed1c0a1f3a78)