### PR TITLE
Sync onboarding wizard navigation with thread capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Fix:** Hardened onboarding inline reply capture so answers typed into welcome threads bind the respondent automatically, survive session restores, and unblock **Next** when “Input is required.”
 - **Docs:** Clarified the inline reply capture model for onboarding (no Enter Answer button) and reinforced respondent binding behaviour.
 - **Fix:** Refreshed onboarding inline wizard cards even when the cached message cannot be resolved, re-rendering in the thread so saved answers clear the “Input is required” state and enable **Next**.
+- **Fix:** Synced onboarding wizard navigation with thread-answer capture so **Next**/**Back** keep the active step aligned instead of looping to earlier questions.
 
 ### v0.9.7 — 2025-11-18
 - **Server map automation:** Added a scheduler job that rebuilds and pins the `#server-map` post using live guild categories, persists message IDs in the Recruitment Config tab, and respects the new `SERVER_MAP_*` env keys.

--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -1772,6 +1772,9 @@ class OpenQuestionsPanelView(discord.ui.View):
                 if callable(resolver):
                     previous = resolver(wizard.thread_id, wizard.step)
                     if previous is not None:
+                        sync_step = getattr(wizard.controller, "_set_current_step_for_thread", None)
+                        if callable(sync_step):
+                            sync_step(wizard.thread_id, previous)
                         wizard.step = previous
                     elif wizard.step > 0:
                         wizard.step -= 1
@@ -1806,6 +1809,9 @@ class OpenQuestionsPanelView(discord.ui.View):
                     )
                     wizard.stop()
                     return
+                sync_step = getattr(wizard.controller, "_set_current_step_for_thread", None)
+                if callable(sync_step):
+                    sync_step(wizard.thread_id, next_index)
                 wizard.step = next_index
                 await wizard.refresh(interaction)
                 wizard._touch()

--- a/tests/onboarding/test_inline_session_sync.py
+++ b/tests/onboarding/test_inline_session_sync.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+
+from modules.onboarding.controllers.welcome_controller import WelcomeController
+from modules.onboarding.session_store import store
+
+
+def _question(qid: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        qid=qid,
+        label=qid,
+        type="short",
+        options=[],
+        required=True,
+        nav_rules="",
+        visibility_rules="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(store, "_schedule_timeout", lambda *_args, **_kwargs: None)
+    try:
+        store._sessions.clear()
+    except Exception:  # pragma: no cover - defensive cleanup
+        for thread_id in list(getattr(store, "_sessions", {}).keys()):
+            store.end(thread_id)
+    yield
+    try:
+        store._sessions.clear()
+    except Exception:  # pragma: no cover - defensive cleanup
+        for thread_id in list(getattr(store, "_sessions", {}).keys()):
+            store.end(thread_id)
+
+
+def test_set_current_step_updates_pending_and_current_index() -> None:
+    bot = SimpleNamespace()
+    controller = WelcomeController(bot)
+    thread_id = 101
+    controller._questions[thread_id] = [_question("q1"), _question("q2")]
+
+    session = store.ensure(thread_id, flow=controller.flow, schema_hash="hash")
+    store.set_pending_step(thread_id, {"kind": "inline", "index": 0})
+    session.current_question_index = 0
+
+    updated = controller._set_current_step_for_thread(thread_id, 1)
+
+    assert updated is session
+    assert session.current_question_index == 1
+    assert session.pending_step == {"kind": "inline", "index": 1}
+
+    inline_index, capture_mode = controller._resolve_inline_index(thread_id, session)
+    assert inline_index == 1
+    assert capture_mode == "pending"
+
+
+def test_set_current_step_rejects_out_of_range() -> None:
+    bot = SimpleNamespace()
+    controller = WelcomeController(bot)
+    thread_id = 202
+    controller._questions[thread_id] = [_question("q1"), _question("q2")]
+
+    session = store.ensure(thread_id, flow=controller.flow, schema_hash="hash")
+    store.set_pending_step(thread_id, {"kind": "inline", "index": 0})
+    session.current_question_index = 0
+
+    updated = controller._set_current_step_for_thread(thread_id, 5)
+
+    assert updated is None
+    assert session.current_question_index == 0
+    assert session.pending_step == {"kind": "inline", "index": 0}


### PR DESCRIPTION
```
## Summary
- keep onboarding session pending step and current question aligned with visible wizard navigation
- update inline navigation callbacks to sync thread capture state with Next/Back actions
- document the onboarding navigation fix in the changelog

## Testing
- pytest tests/onboarding/test_inline_session_sync.py tests/onboarding/test_inline_nav_rules.py

Tests:
Updated: tests/onboarding/test_inline_session_sync.py
Docs:
Updated: CHANGELOG.md
[meta]
labels: codex, bug, comp:modules, P1
milestone: Harmonize v1.0
[/meta]
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69208259a66c832dbb74468a32d559db)