### PR TITLE
Clean up onboarding thread replies after capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Docs:** Clarified the inline reply capture model for onboarding (no Enter Answer button) and reinforced respondent binding behaviour.
 - **Fix:** Refreshed onboarding inline wizard cards even when the cached message cannot be resolved, re-rendering in the thread so saved answers clear the “Input is required” state and enable **Next**.
 - **Fix:** Synced onboarding wizard navigation with thread-answer capture so **Next**/**Back** keep the active step aligned instead of looping to earlier questions.
+- **Change:** Cleaned up onboarding threads by deleting user reply messages after answers are captured so only the wizard card and recruiter summary remain.
 
 ### v0.9.7 — 2025-11-18
 - **Server map automation:** Added a scheduler job that rebuilds and pins the `#server-map` post using live guild categories, persists message IDs in the Recruitment Config tab, and respects the new `SERVER_MAP_*` env keys.

--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -2558,6 +2558,12 @@ class BaseWelcomeController:
         await self._react_to_message(message, "✅")
         await self._refresh_inline_message(thread_id, index=index)
         try:
+            await message.delete()
+        except (discord.Forbidden, discord.NotFound):
+            pass
+        except discord.HTTPException:
+            pass
+        try:
             qkey = self._question_key(question)
         except Exception:
             qkey = "unknown"

--- a/tests/onboarding/test_auto_capture.py
+++ b/tests/onboarding/test_auto_capture.py
@@ -38,6 +38,7 @@ def test_handle_thread_message_captures_answer() -> None:
             content="  Answer  ",
             id=99,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller._react_to_message = AsyncMock()
@@ -50,6 +51,7 @@ def test_handle_thread_message_captures_answer() -> None:
         assert stored.get("w_ign") == "Answer"
         controller._react_to_message.assert_any_call(message, "✅")
         controller._refresh_inline_message.assert_awaited_with(thread_id, index=0)
+        message.delete.assert_awaited()
 
         store.end(thread_id)
 
@@ -84,6 +86,7 @@ def test_handle_thread_message_ignores_other_users() -> None:
             content="Should be ignored",
             id=100,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller._react_to_message = AsyncMock()
@@ -95,6 +98,7 @@ def test_handle_thread_message_ignores_other_users() -> None:
         controller._react_to_message.assert_not_called()
         controller._refresh_inline_message.assert_not_called()
         assert controller.answers_by_thread.get(thread_id) is None
+        message.delete.assert_not_awaited()
 
         store.end(thread_id)
 
@@ -129,6 +133,7 @@ def test_handle_thread_message_requires_bound_respondent() -> None:
             content="Should not capture",
             id=200,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller._react_to_message = AsyncMock()
@@ -144,6 +149,7 @@ def test_handle_thread_message_requires_bound_respondent() -> None:
         refreshed = store.get(thread_id)
         assert refreshed is not None
         assert refreshed.respondent_id == 999
+        message.delete.assert_awaited()
 
         store.end(thread_id)
 
@@ -178,6 +184,7 @@ def test_handle_thread_message_flags_invalid_answer() -> None:
             content="bad",
             id=150,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller.validate_answer = lambda meta, raw: (False, None, "nope")
@@ -190,6 +197,7 @@ def test_handle_thread_message_flags_invalid_answer() -> None:
         controller._react_to_message.assert_called_with(message, "❌")
         controller._refresh_inline_message.assert_not_called()
         assert controller.answers_by_thread.get(thread_id) is None
+        message.delete.assert_not_awaited()
 
         store.end(thread_id)
 
@@ -228,6 +236,7 @@ def test_handle_thread_message_falls_back_to_current_index() -> None:
             content="99",
             id=42,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller._react_to_message = AsyncMock()
@@ -240,6 +249,7 @@ def test_handle_thread_message_falls_back_to_current_index() -> None:
         assert stored.get("w_power") == "99"
         controller._react_to_message.assert_called_with(message, "✅")
         controller._refresh_inline_message.assert_awaited_with(thread_id, index=0)
+        message.delete.assert_awaited()
 
         store.end(thread_id)
 
@@ -278,6 +288,7 @@ def test_handle_thread_message_rehydrates_non_inline_pending() -> None:
             content="AliasName",
             id=314,
             add_reaction=AsyncMock(),
+            delete=AsyncMock(),
         )
 
         controller._react_to_message = AsyncMock()
@@ -294,6 +305,7 @@ def test_handle_thread_message_rehydrates_non_inline_pending() -> None:
         refreshed = store.get(thread_id)
         assert refreshed is not None
         assert refreshed.pending_step == {"kind": "inline", "index": 0}
+        message.delete.assert_awaited()
 
         store.end(thread_id)
 


### PR DESCRIPTION
```markdown
## Summary
- Delete captured onboarding thread reply messages after successful inline save so the wizard card and recruiter summary remain while answers are persisted.
- Add coverage to ensure successful captures delete messages and validation failures leave them intact.
- Note the onboarding thread cleanup in the changelog.

## Testing
- `pytest tests/onboarding/test_auto_capture.py`

Tests:
Updated: tests/onboarding/test_auto_capture.py
Docs:
Updated: CHANGELOG.md

[meta]
labels: codex, comp:modules, enhancement, P2
milestone: Harmonize v1.0
[/meta]
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692093432cf0832da32ccfbfd49abeba)