### PR TITLE
Sanitize Cloudflare HTML in open tickets report send failures

### DIFF
--- a/modules/recruitment/reporting/open_ticket_report.py
+++ b/modules/recruitment/reporting/open_ticket_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Daily report listing currently open Welcome and Move Request tickets."""
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Iterable, Sequence
 
@@ -14,6 +15,7 @@ from modules.common.tickets import TicketThread, fetch_ticket_threads
 from modules.recruitment.reporting.destinations import resolve_report_destination
 
 log = logging.getLogger("c1c.recruitment.reporting.open_tickets")
+_CF_RAY_RE = re.compile(r"Cloudflare Ray ID:\s*<strong[^>]*>([^<]+)<", re.IGNORECASE)
 
 
 def _format_timestamp(value: datetime) -> str:
@@ -115,6 +117,21 @@ def _group_tickets(tickets: Iterable[TicketThread]) -> tuple[list[TicketThread],
     return welcome, move_requests
 
 
+def _summarize_http_error_text(raw_text: object, *, max_chars: int = 220) -> str:
+    text = str(raw_text or "").strip()
+    if not text:
+        return "-"
+
+    match = _CF_RAY_RE.search(text)
+    if match:
+        return f"cloudflare_challenge(ray_id={match.group(1)})"
+
+    compact = " ".join(text.split())
+    if len(compact) <= max_chars:
+        return compact
+    return f"{compact[:max_chars]}…"
+
+
 async def send_currently_open_tickets_report(bot: discord.Client) -> tuple[bool, str]:
     channel, error = await resolve_report_destination(bot)
     if channel is None:
@@ -133,10 +150,11 @@ async def send_currently_open_tickets_report(bot: discord.Client) -> tuple[bool,
         for embed in embeds:
             await channel.send(embeds=[embed])
     except HTTPException as exc:
+        text_summary = _summarize_http_error_text(getattr(exc, "text", None))
         log.warning(
-            "failed to send open tickets report (status=%s text=%r)",
+            "failed to send open tickets report (status=%s text=%s)",
             getattr(exc, "status", "?"),
-            getattr(exc, "text", None),
+            text_summary,
             exc_info=True,
         )
         return False, f"send:{type(exc).__name__}"

--- a/tests/recruitment/test_open_ticket_report.py
+++ b/tests/recruitment/test_open_ticket_report.py
@@ -39,3 +39,15 @@ def test_render_report_handles_empty_sections():
     embed = embeds[0]
     assert isinstance(embed, report.discord.Embed)
     assert any(field.name == "Welcome" for field in embed.fields)
+
+
+def test_summarize_http_error_text_cloudflare_html():
+    html = "<html><span>Cloudflare Ray ID: <strong>abc123</strong></span></html>"
+    assert report._summarize_http_error_text(html) == "cloudflare_challenge(ray_id=abc123)"
+
+
+def test_summarize_http_error_text_truncates_plain_text():
+    text = "x" * 300
+    summarized = report._summarize_http_error_text(text, max_chars=40)
+    assert summarized.endswith("…")
+    assert len(summarized) == 41


### PR DESCRIPTION
### Motivation
- Prevent large or sensitive upstream HTML blobs (e.g. Cloudflare challenge pages) from being dumped into logs when `channel.send(...)` fails. 
- Make failure logs compact and machine-friendly while preserving the key diagnostic (Cloudflare Ray ID) for triage.

### Description
- Added a Cloudflare Ray ID extractor regex `_CF_RAY_RE` and a helper ` _summarize_http_error_text` to produce compact summaries (e.g. `cloudflare_challenge(ray_id=...)`) or truncated plain text. 
- Replaced the raw `exc.text` logging in `send_currently_open_tickets_report` with the summarized text. 
- Added unit tests `test_summarize_http_error_text_cloudflare_html` and `test_summarize_http_error_text_truncates_plain_text` in `tests/recruitment/test_open_ticket_report.py`.

### Testing
- Ran the focused test module with `pytest -q tests/recruitment/test_open_ticket_report.py` and all tests passed (4 tests). 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfd438e688323b58b35be80924d3c)