### PR TITLE
Add fusion publish command, announcement renderer, and sheet write-back helpers

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -1,12 +1,16 @@
-"""Fusion debug commands."""
+"""Fusion debug and publish commands."""
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 
+import discord
 from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion")
@@ -29,7 +33,7 @@ class FusionCog(commands.Cog):
         help="Fusion reminder data commands.",
     )
     async def fusion(self, ctx: commands.Context) -> None:
-        await ctx.reply("Use `!fusion debug`.", mention_author=False)
+        await ctx.reply("Use `!fusion debug` or `!fusion publish`.", mention_author=False)
 
     @tier("user")
     @help_metadata(
@@ -41,14 +45,14 @@ class FusionCog(commands.Cog):
     @fusion.command(name="debug", help="Debug active fusion + first events from sheets cache.")
     async def fusion_debug(self, ctx: commands.Context) -> None:
         try:
-            active = await fusion_sheets.get_active_fusion()
+            active = await fusion_sheets.get_publishable_fusion()
         except Exception as exc:
-            log.exception("fusion debug failed to load active fusion")
+            log.exception("fusion debug failed to load fusion")
             await ctx.reply(f"Fusion config error: {exc}", mention_author=False)
             return
 
         if active is None:
-            await ctx.reply("No published fusion found.", mention_author=False)
+            await ctx.reply("No fusion rows found.", mention_author=False)
             return
 
         try:
@@ -78,3 +82,101 @@ class FusionCog(commands.Cog):
             )
 
         await ctx.reply("\n".join(lines), mention_author=False)
+
+    @tier("admin")
+    @help_metadata(
+        function_group="milestones",
+        section="community",
+        access_tier="admin",
+        usage="!fusion publish",
+    )
+    @fusion.command(name="publish", help="Publish fusion announcement to the configured channel.")
+    @commands.guild_only()
+    @admin_only()
+    async def fusion_publish(self, ctx: commands.Context) -> None:
+        try:
+            target = await fusion_sheets.get_publishable_fusion()
+        except Exception as exc:
+            log.exception("fusion publish failed to load fusion rows")
+            await ctx.reply(f"Could not load fusion data: {exc}", mention_author=False)
+            return
+
+        if target is None:
+            await ctx.reply("No fusion rows exist in the configured fusion sheet tab.", mention_author=False)
+            return
+
+        missing_fields: list[str] = []
+        if target.announcement_channel_id is None:
+            missing_fields.append("announcement_channel_id")
+        if not target.fusion_name:
+            missing_fields.append("fusion_name")
+        if not target.champion:
+            missing_fields.append("champion")
+        if target.start_at_utc is None:
+            missing_fields.append("start_at_utc")
+        if target.end_at_utc is None:
+            missing_fields.append("end_at_utc")
+
+        if missing_fields:
+            await ctx.reply(
+                "Fusion row is missing required fields: " + ", ".join(missing_fields),
+                mention_author=False,
+            )
+            return
+
+        if target.announcement_message_id is not None:
+            await ctx.reply(
+                "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
+                mention_author=False,
+            )
+            return
+
+        channel = self.bot.get_channel(target.announcement_channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(target.announcement_channel_id)
+            except Exception as exc:
+                log.exception(
+                    "fusion publish failed to resolve channel",
+                    extra={"channel_id": target.announcement_channel_id, "fusion_id": target.fusion_id},
+                )
+                await ctx.reply(
+                    f"Configured announcement_channel_id ({target.announcement_channel_id}) could not be resolved: {exc}",
+                    mention_author=False,
+                )
+                return
+
+        if not isinstance(channel, discord.abc.Messageable):
+            await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
+            return
+
+        try:
+            events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            embed = build_fusion_announcement_embed(target, events)
+            announcement_message = await channel.send(embed=embed)
+        except Exception as exc:
+            log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
+            await ctx.reply(f"Failed to publish announcement: {exc}", mention_author=False)
+            return
+
+        set_status_published = target.status.casefold() == "draft"
+        try:
+            await fusion_sheets.update_fusion_publication(
+                target.fusion_id,
+                announcement_message_id=announcement_message.id,
+                published_at=dt.datetime.now(dt.timezone.utc),
+                set_published_status=set_status_published,
+            )
+        except Exception as exc:
+            log.exception("fusion publish metadata write-back failed", extra={"fusion_id": target.fusion_id})
+            await ctx.reply(
+                f"Announcement posted but sheet write-back failed: {exc}. Please update publication columns manually.",
+                mention_author=False,
+            )
+            return
+
+        destination = channel.mention if isinstance(channel, discord.abc.GuildChannel) else "configured channel"
+        await ctx.reply(
+            f"Fusion announcement published to {destination} for **{target.fusion_name}**.",
+            mention_author=False,
+        )

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -1,0 +1,55 @@
+"""Fusion announcement rendering helpers."""
+
+from __future__ import annotations
+
+import discord
+
+from shared.sheets.fusion import FusionEventRow, FusionRow
+
+_FUSION_EMBED_COLOR = discord.Color.blurple()
+
+
+def _format_dt_utc(value) -> str:
+    return value.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _format_event_line(event: FusionEventRow) -> str:
+    points = str(event.points_needed) if event.points_needed is not None else "TBA"
+    bonus_text = f" (+{event.bonus:g} bonus)" if event.bonus is not None and event.bonus > 0 else ""
+    return f"• **{event.event_name}** — {event.reward_amount:g}{bonus_text} | points: {points}"
+
+
+def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
+    """Build the Step 2 fusion publish announcement embed."""
+
+    has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
+    summary_lines = [
+        f"**Champion:** {fusion.champion}",
+        f"**Type:** {fusion.fusion_type or 'Unknown'}",
+        f"**Window:** {_format_dt_utc(fusion.start_at_utc)} → {_format_dt_utc(fusion.end_at_utc)}",
+        f"**Progress Target:** {fusion.needed} needed / {fusion.available} available",
+        f"**Events:** {len(events)} total" + (" • includes bonus rewards" if has_bonus else ""),
+    ]
+
+    event_preview = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))[:5]
+    if event_preview:
+        event_lines = [_format_event_line(event) for event in event_preview]
+    else:
+        event_lines = ["No event rows configured yet."]
+
+    embed = discord.Embed(
+        title=f"Fusion Live: {fusion.fusion_name}",
+        description="\n".join(summary_lines),
+        colour=_FUSION_EMBED_COLOR,
+    )
+    embed.add_field(name="Event Preview (First 5)", value="\n".join(event_lines), inline=False)
+    embed.add_field(
+        name="How to use",
+        value="Fusion reminders and tracking will be posted here.",
+        inline=False,
+    )
+    embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
+    return embed
+
+
+__all__ = ["build_fusion_announcement_embed"]

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -9,7 +9,12 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from shared.config import cfg, get_milestones_sheet_id
-from shared.sheets.async_core import afetch_records
+from shared.sheets.async_core import (
+    acall_with_backoff,
+    afetch_records,
+    afetch_values,
+    aget_worksheet,
+)
 from shared.sheets.cache_service import cache
 
 log = logging.getLogger("c1c.sheets.fusion")
@@ -120,6 +125,15 @@ def _parse_discord_id(value: object) -> int | None:
         return None
     return parsed
 
+def _column_label(index: int) -> str:
+    if index < 0:
+        raise ValueError("column index must be non-negative")
+    value = index + 1
+    label = ""
+    while value > 0:
+        value, remainder = divmod(value - 1, 26)
+        label = chr(65 + remainder) + label
+    return label or "A"
 
 def _parse_iso_utc(value: object) -> dt.datetime:
     raw = str(value or "").strip()
@@ -275,10 +289,90 @@ async def get_fusion_events(fusion_id: str) -> list[FusionEventRow]:
     return filtered
 
 
+async def get_publishable_fusion() -> FusionRow | None:
+    """Return the best fusion row for publish flow selection."""
+
+    fusion_bucket, _ = register_cache_buckets()
+    rows = [row for row in await _cached_rows(fusion_bucket) if isinstance(row, FusionRow)]
+    if not rows:
+        return None
+
+    for status in ("active", "published", "draft"):
+        matches = [row for row in rows if row.status.casefold() == status]
+        if matches:
+            matches.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
+            return matches[0]
+
+    rows.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
+    return rows[0]
+
+
+async def update_fusion_publication(
+    fusion_id: str,
+    *,
+    announcement_message_id: int,
+    published_at: dt.datetime,
+    set_published_status: bool,
+) -> None:
+    """Write publish metadata back to the fusion row in the configured sheet."""
+
+    tab_name = _resolve_tab_name("FUSION_TAB")
+    sheet_id = _sheet_id()
+    matrix = await afetch_values(sheet_id, tab_name)
+    if not matrix:
+        raise RuntimeError("Fusion sheet is empty")
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    row_idx: int | None = None
+    fusion_col = header.index("fusion_id") if "fusion_id" in header else -1
+    if fusion_col < 0:
+        raise RuntimeError("Fusion sheet missing fusion_id column")
+
+    for idx, row in enumerate(matrix[1:], start=2):
+        cell = str(row[fusion_col] if fusion_col < len(row) else "").strip()
+        if cell == fusion_id:
+            row_idx = idx
+            break
+
+    if row_idx is None:
+        raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
+
+    required_cols = ["announcement_message_id", "published_at"]
+    if set_published_status:
+        required_cols.append("status")
+
+    missing = [col for col in required_cols if col not in header]
+    if missing:
+        raise RuntimeError(f"Fusion sheet missing columns: {', '.join(missing)}")
+
+    worksheet = await aget_worksheet(sheet_id, tab_name)
+    updates = {
+        "announcement_message_id": str(announcement_message_id),
+        "published_at": published_at.astimezone(dt.timezone.utc).isoformat(),
+    }
+    if set_published_status:
+        updates["status"] = "published"
+
+    for col_name, value in updates.items():
+        col_index = header.index(col_name)
+        cell = f"{_column_label(col_index)}{row_idx}"
+        await acall_with_backoff(
+            worksheet.update,
+            cell,
+            [[value]],
+            value_input_option="RAW",
+        )
+
+    register_cache_buckets()
+    await cache.refresh_now(_FUSION_BUCKET, actor="fusion_publish")
+
+
 __all__ = [
     "FusionEventRow",
     "FusionRow",
     "get_active_fusion",
+    "get_publishable_fusion",
     "get_fusion_events",
+    "update_fusion_publication",
     "register_cache_buckets",
 ]


### PR DESCRIPTION
### Motivation
- Provide an admin-triggered flow to post Fusion announcements from sheet data into Discord and persist publication metadata back to the sheet.
- Add a reusable embed renderer to produce a consistent announcement format for fusion publications.
- Extend sheet accessors to select a publishable fusion row and write back announcement and publication columns.

### Description
- Add `!fusion publish` admin command in `modules/community/fusion/cog.py` that validates a target fusion row, resolves the announcement channel, sends an embed, and writes publication metadata back to the sheet with error handling and user feedback.
- Update `fusion debug` to use the new selection logic by calling `get_publishable_fusion` and update the help text to mention the new `publish` subcommand.
- Introduce `modules/community/fusion/rendering.py` with `build_fusion_announcement_embed` to construct the announcement `discord.Embed` and helper formatting functions for event previews.
- Extend `shared/sheets/fusion.py` with `get_publishable_fusion`, `update_fusion_publication`, and `_column_label`, and add additional async sheet helpers imports to support reading and writing cells and refreshing the cache.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd09fa9f4083238824e0f0a77f9ea5)