### PR TITLE
Fix lossless Discord snowflake parsing in fusion sheet loader

### DIFF
--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -79,7 +79,9 @@ def _parse_int(value: object) -> int:
     if not text:
         return 0
     try:
-        return int(float(text))
+        if any(ch in text for ch in (".", "e", "E")):
+            return int(float(text))
+        return int(text)
     except ValueError:
         return 0
 
@@ -89,7 +91,9 @@ def _parse_int_optional(value: object) -> int | None:
     if not text:
         return None
     try:
-        return int(float(text))
+        if any(ch in text for ch in (".", "e", "E")):
+            return int(float(text))
+        return int(text)
     except ValueError:
         return None
 
@@ -120,8 +124,15 @@ def _parse_bool(value: object) -> bool:
 
 
 def _parse_discord_id(value: object) -> int | None:
-    parsed = _parse_int_optional(value)
-    if parsed is None or parsed <= 0:
+    # Discord snowflakes must never be parsed via float; float conversion can lose precision.
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+    except ValueError:
+        return None
+    if parsed <= 0:
         return None
     return parsed
 


### PR DESCRIPTION
### Motivation
- Large Discord snowflake IDs from Sheets were being coerced through `float()` which can lose integer precision and caused `!fusion publish` to fail with `404 Unknown Channel`.

### Description
- Update `_parse_discord_id` to strip input and parse with `int(text)` directly, returning `None` for blank/invalid/non-positive values, and add a comment explaining why (no float conversion for snowflakes).  
- Update `_parse_int` and `_parse_int_optional` to prefer `int(text)` and only fall back to `int(float(text))` when the input contains decimal or scientific notation characters (`.`/`e`/`E`) to preserve tolerant numeric parsing for normal numeric fields.  
- The fusion loader continues to use the safe Discord-ID parser for `announcement_channel_id`, `opt_in_role_id`, and `announcement_message_id` so those IDs are now parsed losslessly.  
- Change is limited to `shared/sheets/fusion.py` and does not alter reminder/role or other business logic.

### Testing
- Ran `python -m py_compile shared/sheets/fusion.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd208881208323af74b5c1b7e31534)