### PR TITLE
Refine fusion announcement rendering to be data-driven and grouped by UTC start day

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -2,21 +2,66 @@
 
 from __future__ import annotations
 
+import datetime as dt
+from collections import defaultdict
+
 import discord
 
 from shared.sheets.fusion import FusionEventRow, FusionRow
 
 _FUSION_EMBED_COLOR = discord.Color.blurple()
+_EMBED_FIELD_VALUE_LIMIT = 1024
+_EMBED_MAX_FIELDS = 25
 
 
 def _format_dt_utc(value) -> str:
     return value.strftime("%Y-%m-%d %H:%M UTC")
 
 
+def _format_day_label(value: dt.date) -> str:
+    return f"Starts {value.strftime('%a, %b')} {value.day}"
+
+
 def _format_event_line(event: FusionEventRow) -> str:
-    points = str(event.points_needed) if event.points_needed is not None else "TBA"
-    bonus_text = f" (+{event.bonus:g} bonus)" if event.bonus is not None and event.bonus > 0 else ""
-    return f"• **{event.event_name}** — {event.reward_amount:g}{bonus_text} | points: {points}"
+    has_bonus = event.bonus is not None and event.bonus > 0
+    points_text = (
+        f"{event.points_needed} points" if event.points_needed is not None else "points TBA"
+    )
+    bonus_text = f" (+{event.bonus:g} bonus)" if has_bonus else ""
+    return (
+        f"• {event.event_name} — {points_text} for {event.reward_amount:g} fragments"
+        f"{bonus_text}"
+    )
+
+
+def _chunk_lines(lines: list[str], limit: int) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for line in lines:
+        line_len = len(line)
+        if line_len > limit:
+            if current:
+                chunks.append("\n".join(current))
+                current = []
+                current_len = 0
+            chunks.append(line[:limit])
+            continue
+
+        added_len = line_len if not current else line_len + 1
+        if current and current_len + added_len > limit:
+            chunks.append("\n".join(current))
+            current = [line]
+            current_len = line_len
+            continue
+
+        current.append(line)
+        current_len += added_len
+
+    if current:
+        chunks.append("\n".join(current))
+    return chunks
 
 
 def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
@@ -24,30 +69,36 @@ def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventR
 
     has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
     summary_lines = [
-        f"**Champion:** {fusion.champion}",
-        f"**Type:** {fusion.fusion_type or 'Unknown'}",
-        f"**Window:** {_format_dt_utc(fusion.start_at_utc)} → {_format_dt_utc(fusion.end_at_utc)}",
-        f"**Progress Target:** {fusion.needed} needed / {fusion.available} available",
-        f"**Events:** {len(events)} total" + (" • includes bonus rewards" if has_bonus else ""),
+        f"Type: {fusion.fusion_type}",
+        f"Runs from {_format_dt_utc(fusion.start_at_utc)} → {_format_dt_utc(fusion.end_at_utc)}",
+        f"Target: {fusion.needed} fragments needed / {fusion.available} available",
+        f"Schedule: {len(events)} events/tournaments"
+        + (" • includes bonus rewards" if has_bonus else ""),
     ]
+    if fusion.fusion_structure.strip():
+        summary_lines.insert(1, fusion.fusion_structure.strip())
 
-    event_preview = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))[:5]
-    if event_preview:
-        event_lines = [_format_event_line(event) for event in event_preview]
-    else:
-        event_lines = ["No event rows configured yet."]
+    sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
+    for event in sorted_events:
+        grouped_events[event.start_at_utc.astimezone(dt.timezone.utc).date()].append(event)
 
     embed = discord.Embed(
-        title=f"Fusion Live: {fusion.fusion_name}",
+        title=f"Fusion: {fusion.fusion_name}",
         description="\n".join(summary_lines),
         colour=_FUSION_EMBED_COLOR,
     )
-    embed.add_field(name="Event Preview (First 5)", value="\n".join(event_lines), inline=False)
-    embed.add_field(
-        name="How to use",
-        value="Fusion reminders and tracking will be posted here.",
-        inline=False,
-    )
+
+    for day in sorted(grouped_events):
+        day_lines = [_format_event_line(event) for event in grouped_events[day]]
+        for idx, chunk in enumerate(_chunk_lines(day_lines, _EMBED_FIELD_VALUE_LIMIT)):
+            if len(embed.fields) >= _EMBED_MAX_FIELDS:
+                return embed
+            field_name = _format_day_label(day)
+            if idx > 0:
+                field_name = f"{field_name} (cont.)"
+            embed.add_field(name=field_name, value=chunk, inline=False)
+
     embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
     return embed
 

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -31,6 +31,7 @@ class FusionRow:
     fusion_name: str
     champion: str
     fusion_type: str
+    fusion_structure: str
     reward_type: str
     needed: int
     available: int
@@ -187,6 +188,7 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
                     fusion_name=str(row.get("fusion_name") or "").strip(),
                     champion=str(row.get("champion") or "").strip(),
                     fusion_type=str(row.get("fusion_type") or "").strip(),
+                    fusion_structure=str(row.get("fusion_structure") or "").strip(),
                     reward_type=str(row.get("reward_type") or "").strip(),
                     needed=_parse_int(row.get("needed")),
                     available=_parse_int(row.get("available")),


### PR DESCRIPTION
### Motivation

- Make the Step 2 fusion announcement embed fully data-driven by using the new `fusion_structure` sheet column and remove hardcoded structure text while improving readability. 
- Group events by the UTC calendar day they start so readers can scan a per-day schedule, and ensure rendering stays within Discord embed limits.

### Description

- Added `fusion_structure: str` to `FusionRow` and parse it directly from the fusion sheet (keeps value as a plain stripped string, no fallback synthesis). Files changed: `shared/sheets/fusion.py`.
- Reworked the announcement builder in `modules/community/fusion/rendering.py` to use title `Fusion: {fusion.fusion_name}` and to build the top summary in the requested order, inserting `fusion.fusion_structure` only when non-blank and removing the champion line, preview-only/capped list, and the “How to use” section.
- Render all events (no first-5 cap), sort them, and group them by UTC calendar day using `event.start_at_utc.astimezone(dt.timezone.utc).date()`; day fields are labelled like `Starts Wed, Apr 8`.
- Format event lines per the spec with `points` / `points TBA` and optional `(+{bonus} bonus)` and `for {reward_amount} fragments` phrasing.
- Implement simple chunking to respect Discord limits: `_EMBED_FIELD_VALUE_LIMIT = 1024` characters per field and `_EMBED_MAX_FIELDS = 25`, splitting long day groups into continuation fields labelled `(cont.)` and stopping early if the embed would exceed field count.

### Testing

- Ran `python -m compileall shared/sheets/fusion.py modules/community/fusion/rendering.py` and compilation succeeded.
- Ran `pytest -q` in the repo; the test run reported many failures but they are pre-existing/unrelated to these rendering-only changes and occur across other modules (the failure set is not introduced by this PR).
- Attempted a quick runtime embed smoke-check but the environment is missing required runtime env var `DISCORD_TOKEN`, so a live render smoke-check could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2fc8aad08323af551ce7ba31b23a)