### PR TITLE
Refine fusion publish embeds for readability

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
-from modules.community.fusion.rendering import build_fusion_announcement_embed
+from modules.community.fusion.rendering import build_fusion_announcement_embeds
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion")
@@ -152,8 +152,8 @@ class FusionCog(commands.Cog):
 
         try:
             events = await fusion_sheets.get_fusion_events(target.fusion_id)
-            embed = build_fusion_announcement_embed(target, events)
-            announcement_message = await channel.send(embed=embed)
+            overview_embed, schedule_embed = build_fusion_announcement_embeds(target, events)
+            announcement_message = await channel.send(embeds=[overview_embed, schedule_embed])
         except Exception as exc:
             log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
             await ctx.reply(f"Failed to publish announcement: {exc}", mention_author=False)

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections import defaultdict
+from itertools import chain
 
 import discord
 
@@ -12,6 +13,7 @@ from shared.sheets.fusion import FusionEventRow, FusionRow
 _FUSION_EMBED_COLOR = discord.Color.blurple()
 _EMBED_FIELD_VALUE_LIMIT = 1024
 _EMBED_MAX_FIELDS = 25
+_INVISIBLE_FIELD_NAME = "\u200b"
 
 
 def _format_dt_utc(value) -> str:
@@ -19,7 +21,15 @@ def _format_dt_utc(value) -> str:
 
 
 def _format_day_label(value: dt.date) -> str:
-    return f"Starts {value.strftime('%a, %b')} {value.day}"
+    return value.strftime("%a, %b ") + str(value.day)
+
+
+def _humanize_type(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "Unknown"
+    normalized = text.replace("_", " ").replace("-", " ")
+    return " ".join(token.capitalize() for token in normalized.split())
 
 
 def _format_event_line(event: FusionEventRow) -> str:
@@ -64,43 +74,99 @@ def _chunk_lines(lines: list[str], limit: int) -> list[str]:
     return chunks
 
 
-def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
-    """Build the Step 2 fusion publish announcement embed."""
-
+def _build_overview_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
     has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
+    sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    event_days = [event.start_at_utc.astimezone(dt.timezone.utc).date() for event in sorted_events]
+
     summary_lines = [
-        f"Type: {fusion.fusion_type}",
+        f"Type: {_humanize_type(fusion.fusion_type)}",
         f"Runs from {_format_dt_utc(fusion.start_at_utc)} → {_format_dt_utc(fusion.end_at_utc)}",
-        f"Target: {fusion.needed} fragments needed / {fusion.available} available",
+        f"Target: {fusion.needed:g} fragments needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events/tournaments"
         + (" • includes bonus rewards" if has_bonus else ""),
     ]
     if fusion.fusion_structure.strip():
         summary_lines.insert(1, fusion.fusion_structure.strip())
 
-    sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
-    grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
-    for event in sorted_events:
-        grouped_events[event.start_at_utc.astimezone(dt.timezone.utc).date()].append(event)
+    milestones_lines = [
+        f"First start: {_format_day_label(min(event_days))}" if event_days else "First start: TBA",
+        f"Last start: {_format_day_label(max(event_days))}" if event_days else "Last start: TBA",
+    ]
+    if has_bonus:
+        bonus_events = [event.event_name for event in sorted_events if event.bonus is not None and event.bonus > 0]
+        prefix = "Bonus event" if len(bonus_events) == 1 else "Bonus events"
+        milestones_lines.append(f"{prefix}: {', '.join(bonus_events)}")
 
     embed = discord.Embed(
         title=f"Fusion: {fusion.fusion_name}",
         description="\n".join(summary_lines),
         colour=_FUSION_EMBED_COLOR,
     )
-
-    for day in sorted(grouped_events):
-        day_lines = [_format_event_line(event) for event in grouped_events[day]]
-        for idx, chunk in enumerate(_chunk_lines(day_lines, _EMBED_FIELD_VALUE_LIMIT)):
-            if len(embed.fields) >= _EMBED_MAX_FIELDS:
-                return embed
-            field_name = _format_day_label(day)
-            if idx > 0:
-                field_name = f"{field_name} (cont.)"
-            embed.add_field(name=field_name, value=chunk, inline=False)
-
+    embed.add_field(name="Key Milestones", value="\n".join(milestones_lines), inline=False)
     embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
     return embed
 
 
-__all__ = ["build_fusion_announcement_embed"]
+def _build_schedule_field_chunks(grouped_sections: list[str], limit: int) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for section in grouped_sections:
+        section_len = len(section)
+        added_len = section_len if not current else section_len + 2
+        if current and current_len + added_len > limit:
+            chunks.append("\n\n".join(current))
+            current = [section]
+            current_len = section_len
+            continue
+        if section_len > limit:
+            if current:
+                chunks.append("\n\n".join(current))
+                current = []
+                current_len = 0
+            chunks.extend(_chunk_lines(section.split("\n"), limit))
+            continue
+        current.append(section)
+        current_len += added_len
+    if current:
+        chunks.append("\n\n".join(current))
+    return chunks
+
+
+def _build_schedule_embed(events: list[FusionEventRow]) -> discord.Embed:
+    sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
+    for event in sorted_events:
+        grouped_events[event.start_at_utc.astimezone(dt.timezone.utc).date()].append(event)
+
+    embed = discord.Embed(colour=_FUSION_EMBED_COLOR)
+    if not sorted_events:
+        embed.add_field(name="Schedule", value="No events available.", inline=False)
+        return embed
+
+    sections = [
+        "\n".join(
+            chain(
+                [f"**{_format_day_label(day)}**"],
+                (_format_event_line(event) for event in grouped_events[day]),
+            )
+        )
+        for day in sorted(grouped_events)
+    ]
+    for idx, chunk in enumerate(_build_schedule_field_chunks(sections, _EMBED_FIELD_VALUE_LIMIT)):
+        if len(embed.fields) >= _EMBED_MAX_FIELDS:
+            break
+        embed.add_field(name="Schedule" if idx == 0 else _INVISIBLE_FIELD_NAME, value=chunk, inline=False)
+    return embed
+
+
+def build_fusion_announcement_embeds(
+    fusion: FusionRow, events: list[FusionEventRow]
+) -> tuple[discord.Embed, discord.Embed]:
+    """Build the Step 2 fusion publish announcement embeds."""
+
+    return (_build_overview_embed(fusion, events), _build_schedule_embed(events))
+
+
+__all__ = ["build_fusion_announcement_embeds"]


### PR DESCRIPTION
### Motivation
- Improve readability of fusion announcements in Discord by separating overview and schedule into two embeds and fixing the target/needed display so numeric values from sheets render correctly.

### Description
- Split rendering into two embeds via new `build_fusion_announcement_embeds(...)` and updated the publish flow to send both embeds together with `channel.send(embeds=[overview_embed, schedule_embed])`.
- Overview embed is compact and ordered: title `Fusion: {fusion.fusion_name}`, `Type:` (humanized), optional `fusion_structure`, `Runs from ... → ...`, `Target: {fusion.needed} fragments needed / {fusion.available} available`, `Schedule: {count} events/tournaments` (appends bonus note if any), plus a `Key Milestones` field and `Fusion ID` footer.
- Schedule embed groups events by UTC start day and renders each day as a bold heading with bullet event lines that preserve existing points/bonus wording rules, packs multiple day sections per field up to `_EMBED_FIELD_VALUE_LIMIT` via `_build_schedule_field_chunks`, and falls back to `_chunk_lines` for oversized content.
- Continuation fields use an invisible zero-width name (`_INVISIBLE_FIELD_NAME = "\u200b"`) so only the first schedule field is labeled `Schedule` and no `Schedule (cont.)` labels appear.
- Files changed: `modules/community/fusion/rendering.py` and `modules/community/fusion/cog.py`; no sheet/schema changes were required because `fusion_structure` is already present on `FusionRow`.

### Testing
- Compiled the modified module with `python -m compileall modules/community/fusion` and compilation succeeded.
- Ran unit tests `python -m pytest tests/community/test_leagues_config.py -q` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1ee16cb48323a11fa4610be76d0e)