### PR TITLE
Fix fusion overview needed value and split schedule into multi-field blocks

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -12,6 +12,7 @@ from shared.sheets.fusion import FusionEventRow, FusionRow
 
 _FUSION_EMBED_COLOR = discord.Color.blurple()
 _EMBED_FIELD_VALUE_LIMIT = 1024
+_SCHEDULE_FIELD_TARGET = 700
 _EMBED_MAX_FIELDS = 25
 
 
@@ -152,7 +153,8 @@ def _build_schedule_embed(events: list[FusionEventRow]) -> discord.Embed:
         )
         for day in sorted(grouped_events)
     ]
-    for idx, chunk in enumerate(_build_schedule_field_chunks(sections, _EMBED_FIELD_VALUE_LIMIT)):
+    field_limit = min(_SCHEDULE_FIELD_TARGET, _EMBED_FIELD_VALUE_LIMIT)
+    for idx, chunk in enumerate(_build_schedule_field_chunks(sections, field_limit)):
         if len(embed.fields) >= _EMBED_MAX_FIELDS:
             break
         field_name = "Schedule" if idx == 0 else f"Schedule (Part {idx + 1})"

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -75,6 +75,15 @@ def _normalize(row: Mapping[str, object]) -> dict[str, object]:
     return out
 
 
+def _pick(row: Mapping[str, object], *keys: str) -> object:
+    for key in keys:
+        if key in row:
+            value = row[key]
+            if str(value or "").strip() != "":
+                return value
+    return ""
+
+
 def _parse_int(value: object) -> int:
     text = str(value or "").strip()
     if not text:
@@ -190,8 +199,8 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
                     fusion_type=str(row.get("fusion_type") or "").strip(),
                     fusion_structure=str(row.get("fusion_structure") or "").strip(),
                     reward_type=str(row.get("reward_type") or "").strip(),
-                    needed=_parse_int(row.get("needed")),
-                    available=_parse_int(row.get("available")),
+                    needed=_parse_int(_pick(row, "fusion.needed", "needed")),
+                    available=_parse_int(_pick(row, "fusion.available", "available")),
                     start_at_utc=_parse_iso_utc(row.get("start_at_utc")),
                     end_at_utc=_parse_iso_utc(row.get("end_at_utc")),
                     announcement_channel_id=_parse_discord_id(

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -1,0 +1,73 @@
+import datetime as dt
+
+from modules.community.fusion.rendering import build_fusion_announcement_embeds
+from shared.sheets.fusion import FusionEventRow, FusionRow
+
+
+def _fusion() -> FusionRow:
+    return FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=1,
+        opt_in_role_id=None,
+        announcement_message_id=None,
+        published_at=None,
+        status="draft",
+    )
+
+
+def _event(day: int, idx: int) -> FusionEventRow:
+    start = dt.datetime(2026, 4, day, 9, tzinfo=dt.timezone.utc)
+    return FusionEventRow(
+        fusion_id="f-1",
+        event_id=f"e-{day}-{idx}",
+        event_name=(
+            f"Event {day}-{idx} with deliberately long wording to force schedule chunking across fields"
+        ),
+        event_type="tournament",
+        category="main",
+        start_at_utc=start,
+        end_at_utc=start + dt.timedelta(hours=12),
+        reward_amount=25,
+        bonus=None,
+        reward_type="fragments",
+        points_needed=2000 + idx,
+        is_estimated=False,
+        sort_order=idx,
+    )
+
+
+def test_build_fusion_embeds_target_and_schedule_field_chunks() -> None:
+    events = []
+    for day in range(8, 15):
+        events.extend([_event(day, 1), _event(day, 2)])
+
+    overview, schedule = build_fusion_announcement_embeds(_fusion(), list(reversed(events)))
+
+    assert "Target: 400 fragments needed / 450 available" in (overview.description or "")
+    assert len(schedule.fields) >= 2
+    assert schedule.fields[0].name == "Schedule"
+    assert schedule.fields[1].name == "Schedule (Part 2)"
+
+    day_headers = []
+    for field in schedule.fields:
+        for line in field.value.splitlines():
+            if line.startswith("**") and line.endswith("**"):
+                day_headers.append(line)
+    assert day_headers == [
+        "**Wed, Apr 8**",
+        "**Thu, Apr 9**",
+        "**Fri, Apr 10**",
+        "**Sat, Apr 11**",
+        "**Sun, Apr 12**",
+        "**Mon, Apr 13**",
+        "**Tue, Apr 14**",
+    ]

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -1,0 +1,36 @@
+import asyncio
+import datetime as dt
+
+import pytest
+
+from shared.sheets import fusion
+
+
+def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
+        return [
+            {
+                "fusion_id": "f-1",
+                "fusion_name": "Mavara",
+                "champion": "Mavara",
+                "fusion_type": "traditional",
+                "fusion_structure": "",
+                "reward_type": "fragments",
+                "fusion.needed": "400",
+                "fusion.available": "450",
+                "start_at_utc": "2026-04-08T00:00:00Z",
+                "end_at_utc": "2026-04-22T00:00:00Z",
+                "status": "draft",
+            }
+        ]
+
+    monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+
+    rows = asyncio.run(fusion._load_fusions())
+
+    assert len(rows) == 1
+    assert rows[0].needed == 400
+    assert rows[0].available == 450
+    assert rows[0].start_at_utc == dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc)


### PR DESCRIPTION
### Motivation
- The fusion overview showed incorrect target values when sheets used prefixed headers (e.g. `fusion.needed`) and the schedule rendered as one long text block instead of separate, readable fields.
- The intent is to make the announcement embeds use the real sheet values for `needed`/`available` and split the schedule into multiple embed fields while preserving chronological day-group boundaries.

### Description
- Read prefixed sheet columns first by adding `_pick(...)` and using `needed=_parse_int(_pick(row, "fusion.needed", "needed"))` and `available=_parse_int(_pick(row, "fusion.available", "available"))` in `shared/sheets/fusion.py` so `fusion.needed`/`fusion.available` are honored.
- Add a schedule field target constant `_SCHEDULE_FIELD_TARGET = 700` and apply a `field_limit = min(_SCHEDULE_FIELD_TARGET, _EMBED_FIELD_VALUE_LIMIT)` in `modules/community/fusion/rendering.py` so schedule sections are chunked into multiple embed fields (`Schedule`, `Schedule (Part 2)`, ...).
- Keep Embed 1 layout unchanged (title `Fusion: {fusion.fusion_name}`, compact description lines, single `Key Milestones` field, footer with fusion id) and render Embed 2 as multiple fields where each field contains several full UTC day groups (day header plus that day’s event lines), moving whole day groups between fields to preserve readability.
- Added focused tests: `tests/shared/sheets/test_fusion.py` to verify prefixed `fusion.needed` parsing and `tests/community/test_fusion_rendering.py` to verify overview target and multi-field schedule chunking.
- Files changed: `shared/sheets/fusion.py`, `modules/community/fusion/rendering.py`, `tests/shared/sheets/test_fusion.py`, and `tests/community/test_fusion_rendering.py`.

### Testing
- Ran unit tests: `pytest -q tests/community/test_fusion_rendering.py tests/shared/sheets/test_fusion.py` and both tests passed.
- Performed manual render verification by invoking the rendering helper to count schedule fields (via a short Python invocation of `build_fusion_announcement_embeds(...)`) which produced 4 schedule fields for the Mavara-shaped payload.
- No other automated test failures observed during these runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de38ec0fbc83239ae8b40f2c43e3db)