### PR TITLE
Render fusion announcement as a single sectioned embed

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
-from modules.community.fusion.rendering import build_fusion_announcement_embeds
+from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion")
@@ -152,8 +152,8 @@ class FusionCog(commands.Cog):
 
         try:
             events = await fusion_sheets.get_fusion_events(target.fusion_id)
-            overview_embed, schedule_embed = build_fusion_announcement_embeds(target, events)
-            announcement_message = await channel.send(embeds=[overview_embed, schedule_embed])
+            announcement_embed = build_fusion_announcement_embed(target, events)
+            announcement_message = await channel.send(embed=announcement_embed)
         except Exception as exc:
             log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
             await ctx.reply(f"Failed to publish announcement: {exc}", mention_author=False)

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -12,7 +12,7 @@ from shared.sheets.fusion import FusionEventRow, FusionRow
 
 _FUSION_EMBED_COLOR = discord.Color.blurple()
 _EMBED_FIELD_VALUE_LIMIT = 1024
-_SCHEDULE_FIELD_TARGET = 700
+_SCHEDULE_FIELD_TARGET = 900
 _EMBED_MAX_FIELDS = 25
 
 
@@ -69,14 +69,26 @@ def _chunk_lines(lines: list[str], limit: int) -> list[str]:
     return chunks
 
 
-def _build_overview_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
+def _format_month_day(value: dt.date) -> str:
+    return f"{value.strftime('%b')} {value.day}"
+
+
+def _format_date_range(start: dt.date, end: dt.date) -> str:
+    if start == end:
+        return _format_month_day(start)
+    if start.year == end.year and start.month == end.month:
+        return f"{start.strftime('%b')} {start.day}–{end.day}"
+    return f"{_format_month_day(start)}–{_format_month_day(end)}"
+
+
+def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
     has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     event_days = [event.start_at_utc.astimezone(dt.timezone.utc).date() for event in sorted_events]
 
     summary_lines = [
         f"Type: {_humanize_type(fusion.fusion_type)}",
-        f"Runs: {_format_dt_utc(fusion.start_at_utc)} → {_format_dt_utc(fusion.end_at_utc)}",
+        f"Runs: {_format_dt_utc(fusion.start_at_utc)} -> {_format_dt_utc(fusion.end_at_utc)}",
         f"Target: {fusion.needed:g} fragments needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
     ]
@@ -98,71 +110,60 @@ def _build_overview_embed(fusion: FusionRow, events: list[FusionEventRow]) -> di
         colour=_FUSION_EMBED_COLOR,
     )
     embed.add_field(name="Key Milestones", value="\n".join(milestones_lines), inline=False)
-    embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
-    return embed
-
-
-def _build_schedule_field_chunks(grouped_sections: list[str], limit: int) -> list[str]:
-    chunks: list[str] = []
-    current: list[str] = []
-    current_len = 0
-    for section in grouped_sections:
-        section_len = len(section)
-        added_len = section_len if not current else section_len + 3
-        if current and current_len + added_len > limit:
-            chunks.append("\n\n\n".join(current))
-            current = [section]
-            current_len = section_len
-            continue
-        if section_len > limit:
-            if current:
-                chunks.append("\n\n\n".join(current))
-                current = []
-                current_len = 0
-            chunks.extend(_chunk_lines(section.split("\n"), limit))
-            continue
-        current.append(section)
-        current_len += added_len
-    if current:
-        chunks.append("\n\n\n".join(current))
-    return chunks
-
-
-def _build_schedule_embed(events: list[FusionEventRow]) -> discord.Embed:
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
     for event in sorted_events:
         grouped_events[event.start_at_utc.astimezone(dt.timezone.utc).date()].append(event)
 
-    embed = discord.Embed(title="Schedule", colour=_FUSION_EMBED_COLOR)
     if not sorted_events:
         embed.add_field(name="Schedule", value="No events available.", inline=False)
+        embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
         return embed
 
-    sections = [
-        "\n".join(
-            chain(
-                [f"**{_format_day_label(day)}**"],
-                (_format_event_line(event) for event in grouped_events[day]),
-            )
-        )
-        for day in sorted(grouped_events)
-    ]
     field_limit = min(_SCHEDULE_FIELD_TARGET, _EMBED_FIELD_VALUE_LIMIT)
-    for idx, chunk in enumerate(_build_schedule_field_chunks(sections, field_limit)):
-        if len(embed.fields) >= _EMBED_MAX_FIELDS:
-            break
-        field_name = "Schedule" if idx == 0 else f"Schedule (Part {idx + 1})"
-        embed.add_field(name=field_name, value=chunk, inline=False)
+    current_days: list[dt.date] = []
+    current_sections: list[str] = []
+    current_len = 0
+
+    def flush_current() -> None:
+        nonlocal current_days, current_sections, current_len
+        if not current_days or len(embed.fields) >= _EMBED_MAX_FIELDS:
+            return
+        field_name = _format_date_range(current_days[0], current_days[-1])
+        embed.add_field(name=field_name, value="\n\n".join(current_sections), inline=False)
+        current_days = []
+        current_sections = []
+        current_len = 0
+
+    for day in sorted(grouped_events):
+        section = "\n".join(chain([_format_day_label(day)], (_format_event_line(event) for event in grouped_events[day])))
+        section_len = len(section)
+
+        if section_len > field_limit:
+            flush_current()
+            chunks = _chunk_lines(section.split("\n"), field_limit)
+            for chunk in chunks:
+                if len(embed.fields) >= _EMBED_MAX_FIELDS:
+                    break
+                embed.add_field(name=_format_date_range(day, day), value=chunk, inline=False)
+            continue
+
+        added_len = section_len if not current_sections else section_len + 2
+        if current_sections and current_len + added_len > field_limit:
+            flush_current()
+        current_days.append(day)
+        current_sections.append(section)
+        current_len += added_len if len(current_sections) > 1 else section_len
+
+    flush_current()
+    embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
     return embed
 
 
-def build_fusion_announcement_embeds(
-    fusion: FusionRow, events: list[FusionEventRow]
-) -> tuple[discord.Embed, discord.Embed]:
-    """Build the Step 2 fusion publish announcement embeds."""
+def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
+    """Build the Step 2 fusion publish announcement embed."""
 
-    return (_build_overview_embed(fusion, events), _build_schedule_embed(events))
+    return _build_fusion_embed(fusion, events)
 
 
-__all__ = ["build_fusion_announcement_embeds"]
+__all__ = ["build_fusion_announcement_embed"]

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -1,6 +1,6 @@
 import datetime as dt
 
-from modules.community.fusion.rendering import build_fusion_announcement_embeds
+from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets.fusion import FusionEventRow, FusionRow
 
 
@@ -45,29 +45,30 @@ def _event(day: int, idx: int) -> FusionEventRow:
     )
 
 
-def test_build_fusion_embeds_target_and_schedule_field_chunks() -> None:
+def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
     events = []
     for day in range(8, 15):
         events.extend([_event(day, 1), _event(day, 2)])
 
-    overview, schedule = build_fusion_announcement_embeds(_fusion(), list(reversed(events)))
+    embed = build_fusion_announcement_embed(_fusion(), list(reversed(events)))
 
-    assert "Target: 400 fragments needed / 450 available" in (overview.description or "")
-    assert len(schedule.fields) >= 2
-    assert schedule.fields[0].name == "Schedule"
-    assert schedule.fields[1].name == "Schedule (Part 2)"
+    assert "Target: 400 fragments needed / 450 available" in (embed.description or "")
+    assert embed.fields[0].name == "Key Milestones"
+    assert len(embed.fields) >= 3
+    for field in embed.fields[1:]:
+        assert "Schedule (Part" not in field.name
 
     day_headers = []
-    for field in schedule.fields:
+    for field in embed.fields[1:]:
         for line in field.value.splitlines():
-            if line.startswith("**") and line.endswith("**"):
+            if line and not line.startswith("•"):
                 day_headers.append(line)
     assert day_headers == [
-        "**Wed, Apr 8**",
-        "**Thu, Apr 9**",
-        "**Fri, Apr 10**",
-        "**Sat, Apr 11**",
-        "**Sun, Apr 12**",
-        "**Mon, Apr 13**",
-        "**Tue, Apr 14**",
+        "Wed, Apr 8",
+        "Thu, Apr 9",
+        "Fri, Apr 10",
+        "Sat, Apr 11",
+        "Sun, Apr 12",
+        "Mon, Apr 13",
+        "Tue, Apr 14",
     ]


### PR DESCRIPTION
### Motivation
- The fusion announcement layout must match the screenshot-style single-embed design with visible section cards rather than two embeds or "Schedule (Part N)" labels. 
- Keep the compact overview, visible `Key Milestones`, per-day grouping, short event wording, and the `Fusion ID` footer while avoiding invisible field names and giant schedule walls.

### Description
- Replace the two-embed rendering with a single embed by introducing `build_fusion_announcement_embed` that merges overview and schedule into one embed and preserves the compact overview lines in the description. 
- Keep the `Key Milestones` field visible and unchanged, and render the schedule as additional visible fields grouped by date ranges using new helpers `
_format_date_range` and `
_format_month_day` to produce names like `Apr 8–10`.
- Accumulate full day blocks into each schedule field up to field limits and only split inside a day when necessary using improved chunking logic and an increased field target (`_SCHEDULE_FIELD_TARGET = 900`).
- Update the publish flow to send a single embed (`announcement_message = await channel.send(embed=announcement_embed)`) and update tests to use `build_fusion_announcement_embed` and assert the new field naming/structure.

### Testing
- Ran `pytest -q tests/community/test_fusion_rendering.py`, which passed.
- The test verifies the combined embed contains the compact `Target:` overview, a `Key Milestones` field, date-range schedule fields (no `Schedule (Part N)` labels), and that all day headers are present, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de525da298832392196df4d0758ca7)