### PR TITLE
Show published fusion announcement jump URL and persist announcement channel on publish

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -33,7 +33,39 @@ class FusionCog(commands.Cog):
         help="Fusion reminder data commands.",
     )
     async def fusion(self, ctx: commands.Context) -> None:
-        await ctx.reply("Use `!fusion debug` or `!fusion publish`.", mention_author=False)
+        try:
+            target = await fusion_sheets.get_publishable_fusion()
+        except Exception as exc:
+            log.exception("fusion command failed to load fusion rows")
+            await ctx.reply(f"Could not load fusion data: {exc}", mention_author=False)
+            return
+
+        if target is None:
+            await ctx.reply("No fusion published yet.", mention_author=False)
+            return
+
+        announcement_message_id = target.announcement_message_id
+        announcement_channel_id = target.announcement_channel_id
+        if announcement_message_id is not None and announcement_channel_id is not None:
+            channel = self.bot.get_channel(announcement_channel_id)
+            if channel is None:
+                try:
+                    channel = await self.bot.fetch_channel(announcement_channel_id)
+                except Exception:
+                    channel = None
+
+            if isinstance(channel, discord.abc.Messageable):
+                try:
+                    announcement_message = await channel.fetch_message(announcement_message_id)
+                    await ctx.reply(announcement_message.jump_url, mention_author=False)
+                    return
+                except Exception:
+                    pass
+
+        await ctx.reply(
+            "Fusion is published but the announcement message is unavailable.",
+            mention_author=False,
+        )
 
     @tier("user")
     @help_metadata(
@@ -164,6 +196,7 @@ class FusionCog(commands.Cog):
             await fusion_sheets.update_fusion_publication(
                 target.fusion_id,
                 announcement_message_id=announcement_message.id,
+                announcement_channel_id=channel.id,
                 published_at=dt.datetime.now(dt.timezone.utc),
                 set_published_status=set_status_published,
             )

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -333,6 +333,7 @@ async def update_fusion_publication(
     fusion_id: str,
     *,
     announcement_message_id: int,
+    announcement_channel_id: int | None,
     published_at: dt.datetime,
     set_published_status: bool,
 ) -> None:
@@ -360,6 +361,8 @@ async def update_fusion_publication(
         raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
 
     required_cols = ["announcement_message_id", "published_at"]
+    if announcement_channel_id is not None:
+        required_cols.append("announcement_channel_id")
     if set_published_status:
         required_cols.append("status")
 
@@ -372,6 +375,8 @@ async def update_fusion_publication(
         "announcement_message_id": str(announcement_message_id),
         "published_at": published_at.astimezone(dt.timezone.utc).isoformat(),
     }
+    if announcement_channel_id is not None:
+        updates["announcement_channel_id"] = str(announcement_channel_id)
     if set_published_status:
         updates["status"] = "published"
 

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -1,0 +1,123 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import modules.community.fusion.cog as fusion_cog_module
+from modules.community.fusion.cog import FusionCog
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row(
+    *,
+    announcement_channel_id: int | None = 123,
+    announcement_message_id: int | None = 456,
+    status: str = "published",
+) -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=announcement_channel_id,
+        opt_in_role_id=None,
+        announcement_message_id=announcement_message_id,
+        published_at=None,
+        status=status,
+    )
+
+
+class FakeMessageable(discord.abc.Messageable):
+    def __init__(self, channel_id: int) -> None:
+        self.id = channel_id
+        self.mention = f"<#{channel_id}>"
+        self.fetch_message = AsyncMock()
+        self.send = AsyncMock()
+
+    async def _get_channel(self):
+        return self
+
+
+def test_fusion_command_returns_jump_url(monkeypatch):
+    async def _run() -> None:
+        message = SimpleNamespace(jump_url="https://discord.com/channels/1/123/456")
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(return_value=message)
+        bot = SimpleNamespace(
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row()
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+
+        await cog.fusion.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(message.jump_url, mention_author=False)
+        channel.fetch_message.assert_awaited_once_with(456)
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_handles_missing_announcement_message(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(side_effect=RuntimeError("gone"))
+        bot = SimpleNamespace(
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row()
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+
+        await cog.fusion.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "Fusion is published but the announcement message is unavailable.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_publish_persists_announcement_channel_id(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=999))
+        bot = SimpleNamespace(get_channel=lambda _channel_id: channel, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=None, status="draft")
+
+        update = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
+
+        await cog.fusion_publish.callback(cog, ctx)
+
+        assert update.await_count == 1
+        _, kwargs = update.await_args
+        assert kwargs["announcement_message_id"] == 999
+        assert kwargs["announcement_channel_id"] == 123
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -58,11 +58,7 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
     for field in embed.fields[1:]:
         assert "Schedule (Part" not in field.name
 
-    day_headers = []
-    for field in embed.fields[1:]:
-        for line in field.value.splitlines():
-            if line and not line.startswith("•"):
-                day_headers.append(line)
+    day_headers = [field.name for field in embed.fields[1:]]
     assert day_headers == [
         "Wed, Apr 8",
         "Thu, Apr 9",


### PR DESCRIPTION
### Motivation

- Expose the existing published fusion announcement directly from the `!fusion` command so users can jump to the announcement message. 
- Ensure the announcement channel ID is written back to the sheet during publish so publication metadata is complete.

### Description

- Update `FusionCog.fusion` to call `get_publishable_fusion`, resolve the announcement channel/message, and reply with the announcement `jump_url` when available, with robust channel fetch and error handling. 
- Ensure `fusion publish` writes back `announcement_channel_id` when posting the announcement and include channel resolution checks. 
- Extend `shared.sheets.update_fusion_publication` to accept an optional `announcement_channel_id` parameter and write the column when present, while validating required columns. 
- Add unit tests in `tests/community/test_fusion_cog.py` covering jump URL reply, missing announcement handling, and persistence of `announcement_channel_id`, and simplify `tests/community/test_fusion_rendering.py` header extraction logic.

### Testing

- Ran the added unit tests in `tests/community/test_fusion_cog.py`, all tests passed. 
- Ran the updated rendering test in `tests/community/test_fusion_rendering.py`, and it passed. 
- No automated tests failed related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df445431908323bbc25aafb6155154)