### PR TITLE
Refactor fusion announcement publishing, add helpers, improve error handling and tests

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -20,6 +20,73 @@ class FusionCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
+    async def _resolve_announcement_channel(
+        self, channel_id: int | None
+    ) -> discord.abc.Messageable | None:
+        if channel_id is None:
+            return None
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except Exception:
+                return None
+        if not isinstance(channel, discord.abc.Messageable):
+            return None
+        return channel
+
+    async def _post_fusion_announcement(
+        self,
+        target: fusion_sheets.FusionRow,
+        channel: discord.abc.Messageable,
+    ) -> discord.Message:
+        events = await fusion_sheets.get_fusion_events(target.fusion_id)
+        announcement_embed = build_fusion_announcement_embed(target, events)
+        return await channel.send(embed=announcement_embed)
+
+    async def _persist_fusion_publication(
+        self,
+        target: fusion_sheets.FusionRow,
+        channel_id: int,
+        message_id: int,
+    ) -> None:
+        set_status_published = target.status.casefold() == "draft"
+        await fusion_sheets.update_fusion_publication(
+            target.fusion_id,
+            announcement_message_id=message_id,
+            announcement_channel_id=channel_id,
+            published_at=dt.datetime.now(dt.timezone.utc),
+            set_published_status=set_status_published,
+        )
+
+    async def _publish_fusion_announcement(
+        self,
+        target: fusion_sheets.FusionRow,
+    ) -> discord.Message | None:
+        channel = await self._resolve_announcement_channel(target.announcement_channel_id)
+        if channel is None:
+            return None
+
+        announcement_message = await self._post_fusion_announcement(target, channel)
+        await self._persist_fusion_publication(target, channel.id, announcement_message.id)
+        return announcement_message
+
+    async def _ensure_fusion_announcement(
+        self,
+        target: fusion_sheets.FusionRow,
+    ) -> discord.Message | None:
+        channel = await self._resolve_announcement_channel(target.announcement_channel_id)
+        if channel is None:
+            return None
+
+        if target.announcement_message_id is not None:
+            try:
+                return await channel.fetch_message(target.announcement_message_id)
+            except Exception:
+                pass
+
+        return await self._publish_fusion_announcement(target)
+
     @tier("user")
     @help_metadata(
         function_group="milestones",
@@ -35,37 +102,37 @@ class FusionCog(commands.Cog):
     async def fusion(self, ctx: commands.Context) -> None:
         try:
             target = await fusion_sheets.get_publishable_fusion()
-        except Exception as exc:
+        except Exception:
             log.exception("fusion command failed to load fusion rows")
-            await ctx.reply(f"Could not load fusion data: {exc}", mention_author=False)
+            await ctx.reply("Couldn’t check the fusion right now. Try again in a moment.", mention_author=False)
             return
 
         if target is None:
-            await ctx.reply("No fusion published yet.", mention_author=False)
+            await ctx.reply("No fusion running. Enjoy the peace while it lasts.", mention_author=False)
             return
 
-        announcement_message_id = target.announcement_message_id
-        announcement_channel_id = target.announcement_channel_id
-        if announcement_message_id is not None and announcement_channel_id is not None:
-            channel = self.bot.get_channel(announcement_channel_id)
-            if channel is None:
-                try:
-                    channel = await self.bot.fetch_channel(announcement_channel_id)
-                except Exception:
-                    channel = None
+        try:
+            announcement_message = await self._ensure_fusion_announcement(target)
+        except Exception:
+            log.exception("fusion command failed to resolve announcement", extra={"fusion_id": target.fusion_id})
+            announcement_message = None
 
-            if isinstance(channel, discord.abc.Messageable):
-                try:
-                    announcement_message = await channel.fetch_message(announcement_message_id)
-                    await ctx.reply(announcement_message.jump_url, mention_author=False)
-                    return
-                except Exception:
-                    pass
+        if announcement_message is not None:
+            await ctx.reply(
+                f"🔗 Fusion’s up. Don’t get lost:\n{announcement_message.jump_url}",
+                mention_author=False,
+            )
+            return
 
-        await ctx.reply(
-            "Fusion is published but the announcement message is unavailable.",
-            mention_author=False,
-        )
+        try:
+            events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            emergency_embed = build_fusion_announcement_embed(target, events)
+            await ctx.reply(embed=emergency_embed, mention_author=False)
+            return
+        except Exception:
+            log.exception("fusion command emergency embed fallback failed", extra={"fusion_id": target.fusion_id})
+            await ctx.reply("Couldn’t check the fusion right now. Try again in a moment.", mention_author=False)
+            return
 
     @tier("user")
     @help_metadata(
@@ -156,56 +223,30 @@ class FusionCog(commands.Cog):
             )
             return
 
-        if target.announcement_message_id is not None:
-            await ctx.reply(
-                "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
-                mention_author=False,
-            )
-            return
-
-        channel = self.bot.get_channel(target.announcement_channel_id)
+        channel = await self._resolve_announcement_channel(target.announcement_channel_id)
         if channel is None:
-            try:
-                channel = await self.bot.fetch_channel(target.announcement_channel_id)
-            except Exception as exc:
-                log.exception(
-                    "fusion publish failed to resolve channel",
-                    extra={"channel_id": target.announcement_channel_id, "fusion_id": target.fusion_id},
-                )
-                await ctx.reply(
-                    f"Configured announcement_channel_id ({target.announcement_channel_id}) could not be resolved: {exc}",
-                    mention_author=False,
-                )
-                return
-
-        if not isinstance(channel, discord.abc.Messageable):
             await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
             return
 
+        if target.announcement_message_id is not None:
+            try:
+                await channel.fetch_message(target.announcement_message_id)
+                await ctx.reply(
+                    "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
+                    mention_author=False,
+                )
+                return
+            except Exception:
+                pass
+
         try:
-            events = await fusion_sheets.get_fusion_events(target.fusion_id)
-            announcement_embed = build_fusion_announcement_embed(target, events)
-            announcement_message = await channel.send(embed=announcement_embed)
+            announcement_message = await self._publish_fusion_announcement(target)
+            if announcement_message is None:
+                await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
+                return
         except Exception as exc:
             log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
             await ctx.reply(f"Failed to publish announcement: {exc}", mention_author=False)
-            return
-
-        set_status_published = target.status.casefold() == "draft"
-        try:
-            await fusion_sheets.update_fusion_publication(
-                target.fusion_id,
-                announcement_message_id=announcement_message.id,
-                announcement_channel_id=channel.id,
-                published_at=dt.datetime.now(dt.timezone.utc),
-                set_published_status=set_status_published,
-            )
-        except Exception as exc:
-            log.exception("fusion publish metadata write-back failed", extra={"fusion_id": target.fusion_id})
-            await ctx.reply(
-                f"Announcement posted but sheet write-back failed: {exc}. Please update publication columns manually.",
-                mention_author=False,
-            )
             return
 
         destination = channel.mention if isinstance(channel, discord.abc.GuildChannel) else "configured channel"

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -64,16 +64,113 @@ def test_fusion_command_returns_jump_url(monkeypatch):
 
         await cog.fusion.callback(cog, ctx)
 
-        ctx.reply.assert_awaited_once_with(message.jump_url, mention_author=False)
+        ctx.reply.assert_awaited_once_with(
+            "🔗 Fusion’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/456",
+            mention_author=False,
+        )
         channel.fetch_message.assert_awaited_once_with(456)
+        channel.send.assert_not_awaited()
 
     asyncio.run(_run())
 
 
-def test_fusion_command_handles_missing_announcement_message(monkeypatch):
+def test_fusion_command_handles_no_fusion(monkeypatch):
     async def _run() -> None:
+        bot = SimpleNamespace(get_channel=lambda _channel_id: None, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return None
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+
+        await cog.fusion.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "No fusion running. Enjoy the peace while it lasts.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_recreates_missing_announcement(monkeypatch):
+    async def _run() -> None:
+        message = SimpleNamespace(id=999, jump_url="https://discord.com/channels/1/123/999")
         channel = FakeMessageable(123)
         channel.fetch_message = AsyncMock(side_effect=RuntimeError("gone"))
+        channel.send = AsyncMock(return_value=message)
+        bot = SimpleNamespace(
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row()
+
+        update = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
+
+        await cog.fusion.callback(cog, ctx)
+
+        channel.send.assert_awaited_once()
+        assert update.await_count == 1
+        _, kwargs = update.await_args
+        assert kwargs["announcement_message_id"] == 999
+        assert kwargs["announcement_channel_id"] == 123
+        ctx.reply.assert_awaited_once_with(
+            "🔗 Fusion’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/999",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_recreates_when_message_metadata_is_incomplete(monkeypatch):
+    async def _run() -> None:
+        message = SimpleNamespace(id=1001, jump_url="https://discord.com/channels/1/123/1001")
+        channel = FakeMessageable(123)
+        channel.send = AsyncMock(return_value=message)
+        bot = SimpleNamespace(
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=None)
+
+        update = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
+
+        await cog.fusion.callback(cog, ctx)
+
+        channel.fetch_message.assert_not_awaited()
+        channel.send.assert_awaited_once()
+        assert update.await_count == 1
+        ctx.reply.assert_awaited_once_with(
+            "🔗 Fusion’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/1001",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_does_not_recreate_existing_announcement(monkeypatch):
+    async def _run() -> None:
+        message = SimpleNamespace(jump_url="https://discord.com/channels/1/123/456")
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(return_value=message)
         bot = SimpleNamespace(
             get_channel=lambda _channel_id: channel,
             fetch_channel=AsyncMock(return_value=channel),
@@ -85,11 +182,80 @@ def test_fusion_command_handles_missing_announcement_message(monkeypatch):
             return _fusion_row()
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", AsyncMock())
+
+        await cog.fusion.callback(cog, ctx)
+
+        channel.send.assert_not_awaited()
+        fusion_sheets.update_fusion_publication.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_uses_generic_message_when_data_load_fails(monkeypatch):
+    async def _run() -> None:
+        bot = SimpleNamespace(get_channel=lambda _channel_id: None, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            raise RuntimeError("sheets offline")
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
 
         await cog.fusion.callback(cog, ctx)
 
         ctx.reply.assert_awaited_once_with(
-            "Fusion is published but the announcement message is unavailable.",
+            "Couldn’t check the fusion right now. Try again in a moment.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_falls_back_to_emergency_embed_when_announcement_unavailable(monkeypatch):
+    async def _run() -> None:
+        emergency_embed = object()
+        bot = SimpleNamespace(get_channel=lambda _channel_id: None, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row()
+
+        ensure = AsyncMock(side_effect=RuntimeError("discord outage"))
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(cog, "_ensure_fusion_announcement", ensure)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: emergency_embed)
+
+        await cog.fusion.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            embed=emergency_embed,
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_uses_generic_message_when_emergency_embed_fails(monkeypatch):
+    async def _run() -> None:
+        bot = SimpleNamespace(get_channel=lambda _channel_id: None, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row()
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(cog, "_ensure_fusion_announcement", AsyncMock(return_value=None))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(side_effect=RuntimeError("sheet fail")))
+
+        await cog.fusion.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "Couldn’t check the fusion right now. Try again in a moment.",
             mention_author=False,
         )
 
@@ -119,5 +285,29 @@ def test_fusion_publish_persists_announcement_channel_id(monkeypatch):
         _, kwargs = update.await_args
         assert kwargs["announcement_message_id"] == 999
         assert kwargs["announcement_channel_id"] == 123
+
+    asyncio.run(_run())
+
+
+def test_fusion_publish_blocks_duplicate_when_existing_message_resolves(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(return_value=SimpleNamespace(id=456))
+        bot = SimpleNamespace(get_channel=lambda _channel_id: channel, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="published")
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+
+        await cog.fusion_publish.callback(cog, ctx)
+
+        channel.send.assert_not_awaited()
+        ctx.reply.assert_awaited_once_with(
+            "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
+            mention_author=False,
+        )
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Consolidate channel/message resolution and publishing logic to reduce duplication and make publish flows idempotent.
- Improve robustness and user-facing messages when Discord or sheets data is unavailable or inconsistent.
- Expand unit coverage to validate announcement recreation, persistence, and fallback behaviors.

### Description
- Added helper methods `._resolve_announcement_channel`, `._post_fusion_announcement`, `._persist_fusion_publication`, `._publish_fusion_announcement`, and `._ensure_fusion_announcement` to centralize announcement resolution and publication.
- Refactored the `fusion` and `fusion_publish` flows to use the new helpers, handle missing or stale announcement messages by recreating and persisting them, and provide clearer user replies.
- Replaced raw channel/message lookup code with the helpers and tightened error handling and logging around channel fetches and emergency embed fallbacks.
- Updated `tests/community/test_fusion_cog.py` to add and adapt unit tests that exercise the new behaviors, including recreation, persistence, and fallback scenarios.

### Testing
- Ran the updated unit test file `tests/community/test_fusion_cog.py`, which includes tests such as `test_fusion_command_returns_jump_url`, `test_fusion_command_recreates_missing_announcement`, and `test_fusion_publish_blocks_duplicate_when_existing_message_resolves`.
- All updated and added tests passed locally under the test suite run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df535846b0832399660ffac476f4f2)