### PR TITLE
Normalize fusion event timing and add event-state helpers

### DIFF
--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -241,8 +241,28 @@ async def _load_fusion_events() -> tuple[FusionEventRow, ...]:
                     event_name=str(row.get("event_name") or "").strip(),
                     event_type=str(row.get("event_type") or "").strip(),
                     category=str(row.get("category") or "").strip(),
-                    start_at_utc=_parse_iso_utc(row.get("start_at_utc")),
-                    end_at_utc=_parse_iso_utc(row.get("end_at_utc")),
+                    start_at_utc=_parse_iso_utc(
+                        _pick(
+                            row,
+                            "start_at_utc",
+                            "event_start_at_utc",
+                            "start_time_utc",
+                            "event_start_time_utc",
+                            "start_at",
+                            "start_time",
+                        )
+                    ),
+                    end_at_utc=_parse_iso_utc(
+                        _pick(
+                            row,
+                            "end_at_utc",
+                            "event_end_at_utc",
+                            "end_time_utc",
+                            "event_end_time_utc",
+                            "end_at",
+                            "end_time",
+                        )
+                    ),
                     reward_amount=_parse_float(row.get("reward_amount")),
                     bonus=_parse_float_optional(row.get("bonus")),
                     reward_type=str(row.get("reward_type") or "").strip(),
@@ -309,6 +329,104 @@ async def get_fusion_events(fusion_id: str) -> list[FusionEventRow]:
     ]
     filtered.sort(key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     return filtered
+
+
+def _coerce_utc_now(now: dt.datetime | None) -> dt.datetime:
+    if now is None:
+        return dt.datetime.now(dt.timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=dt.timezone.utc)
+    return now.astimezone(dt.timezone.utc)
+
+
+def _valid_event_timing(
+    event: FusionEventRow,
+    *,
+    for_helper: str,
+) -> tuple[dt.datetime, dt.datetime | None] | None:
+    start_at = getattr(event, "start_at_utc", None)
+    end_at = getattr(event, "end_at_utc", None)
+
+    if not isinstance(start_at, dt.datetime):
+        log.warning(
+            "fusion event skipped due to invalid start_at_utc",
+            extra={
+                "helper": for_helper,
+                "fusion_id": getattr(event, "fusion_id", ""),
+                "event_id": getattr(event, "event_id", ""),
+                "event_name": getattr(event, "event_name", ""),
+                "start_at_utc": start_at,
+            },
+        )
+        return None
+
+    if start_at.tzinfo is None:
+        start_at = start_at.replace(tzinfo=dt.timezone.utc)
+    else:
+        start_at = start_at.astimezone(dt.timezone.utc)
+
+    if end_at is None:
+        return start_at, None
+
+    if not isinstance(end_at, dt.datetime):
+        log.warning(
+            "fusion event skipped due to invalid end_at_utc",
+            extra={
+                "helper": for_helper,
+                "fusion_id": getattr(event, "fusion_id", ""),
+                "event_id": getattr(event, "event_id", ""),
+                "event_name": getattr(event, "event_name", ""),
+                "end_at_utc": end_at,
+            },
+        )
+        return None
+
+    if end_at.tzinfo is None:
+        end_at = end_at.replace(tzinfo=dt.timezone.utc)
+    else:
+        end_at = end_at.astimezone(dt.timezone.utc)
+    return start_at, end_at
+
+
+async def get_upcoming_events(
+    fusion_id: str,
+    now: dt.datetime | None = None,
+) -> list[FusionEventRow]:
+    reference = _coerce_utc_now(now)
+    events = await get_fusion_events(fusion_id)
+
+    future: list[FusionEventRow] = []
+    for event in events:
+        timing = _valid_event_timing(event, for_helper="get_upcoming_events")
+        if timing is None:
+            continue
+        start_at, _ = timing
+        if start_at > reference:
+            future.append(event)
+
+    future.sort(key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    return future
+
+
+async def get_active_events(
+    fusion_id: str,
+    now: dt.datetime | None = None,
+) -> list[FusionEventRow]:
+    reference = _coerce_utc_now(now)
+    events = await get_fusion_events(fusion_id)
+
+    active: list[FusionEventRow] = []
+    for event in events:
+        timing = _valid_event_timing(event, for_helper="get_active_events")
+        if timing is None:
+            continue
+
+        start_at, end_at = timing
+        if start_at <= reference and (end_at is None or reference < end_at):
+            active.append(event)
+
+    active.sort(key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    return active
 
 
 async def get_publishable_fusion() -> FusionRow | None:
@@ -398,8 +516,10 @@ __all__ = [
     "FusionEventRow",
     "FusionRow",
     "get_active_fusion",
+    "get_active_events",
     "get_publishable_fusion",
     "get_fusion_events",
+    "get_upcoming_events",
     "update_fusion_publication",
     "register_cache_buckets",
 ]

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -1,5 +1,7 @@
 import asyncio
 import datetime as dt
+import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -34,3 +36,176 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
     assert rows[0].needed == 400
     assert rows[0].available == 450
     assert rows[0].start_at_utc == dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc)
+
+
+def _event(
+    *,
+    event_id: str,
+    start_at_utc: dt.datetime | object,
+    end_at_utc: dt.datetime | object | None,
+    sort_order: int = 0,
+) -> fusion.FusionEventRow:
+    return fusion.FusionEventRow(
+        fusion_id="f-1",
+        event_id=event_id,
+        event_name=f"Event {event_id}",
+        event_type="tournament",
+        category="",
+        start_at_utc=start_at_utc,  # type: ignore[arg-type]
+        end_at_utc=end_at_utc,  # type: ignore[arg-type]
+        reward_amount=100.0,
+        bonus=None,
+        reward_type="fragments",
+        points_needed=None,
+        is_estimated=False,
+        sort_order=sort_order,
+    )
+
+
+def test_load_fusion_events_accepts_legacy_start_end_column_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
+        return [
+            {
+                "fusion_id": "f-1",
+                "event_id": "e-1",
+                "event_name": "Legacy Column Event",
+                "event_type": "tournament",
+                "category": "arena",
+                "start_time_utc": "2026-04-09T00:00:00Z",
+                "end_time_utc": "2026-04-10T00:00:00Z",
+                "reward_amount": "150",
+                "sort_order": "2",
+            }
+        ]
+
+    monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion Events")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+
+    rows = asyncio.run(fusion._load_fusion_events())
+
+    assert len(rows) == 1
+    assert rows[0].start_at_utc == dt.datetime(2026, 4, 9, tzinfo=dt.timezone.utc)
+    assert rows[0].end_at_utc == dt.datetime(2026, 4, 10, tzinfo=dt.timezone.utc)
+
+
+def test_get_upcoming_events_returns_only_future_events_sorted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    events = [
+        _event(
+            event_id="future-later",
+            start_at_utc=now + dt.timedelta(days=2),
+            end_at_utc=now + dt.timedelta(days=3),
+        ),
+        _event(
+            event_id="past",
+            start_at_utc=now - dt.timedelta(days=2),
+            end_at_utc=now - dt.timedelta(days=1),
+        ),
+        _event(
+            event_id="future-soon",
+            start_at_utc=now + dt.timedelta(hours=1),
+            end_at_utc=now + dt.timedelta(days=1),
+        ),
+    ]
+    monkeypatch.setattr(fusion, "get_fusion_events", AsyncMock(return_value=events))
+
+    result = asyncio.run(fusion.get_upcoming_events("f-1", now=now))
+
+    assert [row.event_id for row in result] == ["future-soon", "future-later"]
+
+
+def test_get_active_events_returns_only_currently_active_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    events = [
+        _event(
+            event_id="active-window",
+            start_at_utc=now - dt.timedelta(hours=2),
+            end_at_utc=now + dt.timedelta(hours=2),
+            sort_order=2,
+        ),
+        _event(
+            event_id="active-open-ended",
+            start_at_utc=now - dt.timedelta(hours=1),
+            end_at_utc=None,
+            sort_order=1,
+        ),
+        _event(
+            event_id="future",
+            start_at_utc=now + dt.timedelta(minutes=1),
+            end_at_utc=now + dt.timedelta(hours=4),
+        ),
+    ]
+    monkeypatch.setattr(fusion, "get_fusion_events", AsyncMock(return_value=events))
+
+    result = asyncio.run(fusion.get_active_events("f-1", now=now))
+
+    assert [row.event_id for row in result] == ["active-window", "active-open-ended"]
+
+
+def test_get_active_events_excludes_ended_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    events = [
+        _event(
+            event_id="ended",
+            start_at_utc=now - dt.timedelta(days=2),
+            end_at_utc=now - dt.timedelta(seconds=1),
+        ),
+        _event(
+            event_id="active",
+            start_at_utc=now - dt.timedelta(days=1),
+            end_at_utc=now + dt.timedelta(days=1),
+        ),
+    ]
+    monkeypatch.setattr(fusion, "get_fusion_events", AsyncMock(return_value=events))
+
+    result = asyncio.run(fusion.get_active_events("f-1", now=now))
+
+    assert [row.event_id for row in result] == ["active"]
+
+
+def test_event_helpers_skip_invalid_timestamps_without_failing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    events = [
+        _event(
+            event_id="invalid-start",
+            start_at_utc="not-a-datetime",
+            end_at_utc=now + dt.timedelta(hours=1),
+        ),
+        _event(
+            event_id="invalid-end",
+            start_at_utc=now - dt.timedelta(hours=1),
+            end_at_utc="not-a-datetime",
+        ),
+        _event(
+            event_id="valid-future",
+            start_at_utc=now + dt.timedelta(hours=1),
+            end_at_utc=now + dt.timedelta(hours=2),
+        ),
+        _event(
+            event_id="valid-active",
+            start_at_utc=now - dt.timedelta(hours=1),
+            end_at_utc=now + dt.timedelta(hours=2),
+        ),
+    ]
+    monkeypatch.setattr(fusion, "get_fusion_events", AsyncMock(return_value=events))
+
+    with caplog.at_level(logging.WARNING, logger="c1c.sheets.fusion"):
+        upcoming = asyncio.run(fusion.get_upcoming_events("f-1", now=now))
+        active = asyncio.run(fusion.get_active_events("f-1", now=now))
+
+    assert [row.event_id for row in upcoming] == ["valid-future"]
+    assert [row.event_id for row in active] == ["valid-active"]
+    assert "invalid start_at_utc" in caplog.text
+    assert "invalid end_at_utc" in caplog.text


### PR DESCRIPTION
### Motivation
- Prepare the fusion event layer for reminder work by normalizing event timestamps and providing small, reusable helpers to query event state without introducing scheduler or reminder logic.
- Ensure downstream code consistently uses `start_at_utc` / `end_at_utc` and is resilient to legacy column names and malformed rows.

### Description
- Normalize ingestion of fusion event timestamps by accepting legacy column names (`event_start_at_utc`, `start_time_utc`, `start_at`, `start_time`, and similar fallbacks for end) and mapping them into `start_at_utc` / `end_at_utc` in the existing `FusionEventRow` model.
- Add `get_upcoming_events(fusion_id, now=None)` which returns future events (by `start_at_utc`) sorted ascending and uses timezone-aware UTC comparisons.
- Add `get_active_events(fusion_id, now=None)` which returns events active at `now` (where `start_at_utc <= now` and `end_at_utc is None or now < end_at_utc`) sorted ascending.
- Add defensive timestamp validation that skips malformed events with clear `WARNING` logs (includes helper name and event identifiers) to prevent a single bad row from failing consumers.
- Reuse the existing sheet/event structures (`FusionEventRow`) and export the new helpers via the module `__all__` for downstream reuse.

### Testing
- Ran `pytest -q tests/shared/sheets/test_fusion.py` which covers legacy column parsing, upcoming filtering, active filtering, ended exclusion, invalid timestamp skipping/logging, and sorted output; tests passed (all green).
- Ran `pytest -q tests/community/test_fusion_rendering.py tests/community/test_fusion_cog.py` to ensure surrounding fusion flows and rendering remained unaffected; tests passed (all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6689c8848323ae8e58a9f23eeec6)