### PR TITLE
Add Fusion Opt In/Out buttons and automatic post-fusion role cleanup

### DIFF
--- a/modules/community/fusion/announcements.py
+++ b/modules/community/fusion/announcements.py
@@ -7,6 +7,7 @@ import datetime as dt
 import discord
 from discord.ext import commands
 
+from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
@@ -38,7 +39,8 @@ async def publish_fusion_announcement(
 
     events = await fusion_sheets.get_fusion_events(target.fusion_id)
     announcement_embed = build_fusion_announcement_embed(target, events)
-    announcement_message = await channel.send(embed=announcement_embed)
+    announcement_view = build_fusion_opt_in_view(target)
+    announcement_message = await channel.send(embed=announcement_embed, view=announcement_view)
 
     set_status_published = target.status.casefold() == "draft"
     await fusion_sheets.update_fusion_publication(

--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -1,0 +1,160 @@
+"""Fusion role opt-in/out button view helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import discord
+from discord.ext import commands
+
+from shared.sheets import fusion as fusion_sheets
+
+log = logging.getLogger("c1c.community.fusion.opt_in")
+
+_FUSION_OPT_IN_CUSTOM_ID = "fusion:opt_in"
+_FUSION_OPT_OUT_CUSTOM_ID = "fusion:opt_out"
+
+
+async def _send_ephemeral(interaction: discord.Interaction, message: str) -> None:
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+        return
+    await interaction.response.send_message(message, ephemeral=True)
+
+
+async def _resolve_member(interaction: discord.Interaction) -> discord.Member | None:
+    if isinstance(interaction.user, discord.Member):
+        return interaction.user
+
+    guild = interaction.guild
+    if guild is None:
+        return None
+
+    member = guild.get_member(interaction.user.id)
+    if member is not None:
+        return member
+
+    try:
+        return await guild.fetch_member(interaction.user.id)
+    except Exception:
+        return None
+
+
+async def _resolve_opt_in_role(interaction: discord.Interaction) -> tuple[discord.Member | None, discord.Role | None]:
+    target = await fusion_sheets.get_publishable_fusion()
+    role_id = target.opt_in_role_id if target is not None else None
+    if role_id is None:
+        await _send_ephemeral(interaction, "No fusion opt-in role is configured.")
+        return None, None
+
+    guild = interaction.guild
+    if guild is None:
+        await _send_ephemeral(interaction, "Fusion role actions only work in a server.")
+        return None, None
+
+    member = await _resolve_member(interaction)
+    if member is None:
+        await _send_ephemeral(interaction, "Couldn’t resolve your member record right now.")
+        return None, None
+
+    role = guild.get_role(role_id)
+    if role is None:
+        log.warning(
+            "fusion opt-in role missing in guild",
+            extra={"guild_id": guild.id, "role_id": role_id},
+        )
+        await _send_ephemeral(interaction, "Fusion role is missing in this server.")
+        return member, None
+
+    return member, role
+
+
+async def _handle_opt_action(interaction: discord.Interaction, *, action: Literal["in", "out"]) -> None:
+    try:
+        member, role = await _resolve_opt_in_role(interaction)
+    except Exception:
+        log.exception("fusion opt button failed to resolve role")
+        await _send_ephemeral(interaction, "Temporary issue. Try again shortly.")
+        return
+
+    if member is None or role is None:
+        return
+
+    has_role = role in member.roles
+
+    if action == "in":
+        if has_role:
+            await _send_ephemeral(interaction, "Already opted in.")
+            return
+        try:
+            await member.add_roles(role, reason="Fusion role opt-in button")
+        except Exception:
+            log.exception(
+                "fusion opt-in add role failed",
+                extra={"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id},
+            )
+            await _send_ephemeral(interaction, "Couldn’t update your fusion role right now.")
+            return
+        await _send_ephemeral(interaction, "Opted in. You’ll get fusion pings.")
+        return
+
+    if not has_role:
+        await _send_ephemeral(interaction, "You’re already opted out.")
+        return
+
+    try:
+        await member.remove_roles(role, reason="Fusion role opt-out button")
+    except Exception:
+        log.exception(
+            "fusion opt-out remove role failed",
+            extra={"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id},
+        )
+        await _send_ephemeral(interaction, "Couldn’t update your fusion role right now.")
+        return
+
+    await _send_ephemeral(interaction, "Opted out. No more fusion pings.")
+
+
+class FusionOptInView(discord.ui.View):
+    """Persistent button view for fusion opt-in role management."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        label="Opt In",
+        style=discord.ButtonStyle.success,
+        custom_id=_FUSION_OPT_IN_CUSTOM_ID,
+    )
+    async def opt_in_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        await _handle_opt_action(interaction, action="in")
+
+    @discord.ui.button(
+        label="Opt Out",
+        style=discord.ButtonStyle.secondary,
+        custom_id=_FUSION_OPT_OUT_CUSTOM_ID,
+    )
+    async def opt_out_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        await _handle_opt_action(interaction, action="out")
+
+
+def build_fusion_opt_in_view(target: fusion_sheets.FusionRow) -> discord.ui.View | None:
+    """Build the reusable fusion button row when the role is configured."""
+
+    if target.opt_in_role_id is None:
+        return None
+    return FusionOptInView()
+
+
+def register_persistent_fusion_views(bot: commands.Bot) -> None:
+    """Register persistent fusion button handlers on startup."""
+
+    bot.add_view(FusionOptInView())
+
+
+__all__ = [
+    "FusionOptInView",
+    "build_fusion_opt_in_view",
+    "register_persistent_fusion_views",
+]

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -10,6 +10,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.fusion.announcements import ensure_fusion_announcement
+from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.reminders")
@@ -117,7 +118,8 @@ async def process_fusion_reminders(
                     jump_url=announcement_message.jump_url,
                 )
                 mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
-                await announcement_message.channel.send(content=mention_content, embed=embed)
+                reminder_view = build_fusion_opt_in_view(target)
+                await announcement_message.channel.send(content=mention_content, embed=embed, view=reminder_view)
                 await fusion_sheets.mark_reminder_sent(
                     target.fusion_id,
                     event_id=event.event_id,

--- a/modules/community/fusion/role_cleanup.py
+++ b/modules/community/fusion/role_cleanup.py
@@ -1,0 +1,115 @@
+"""Fusion opt-in role cleanup for ended fusions."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+import discord
+from discord.ext import commands
+
+from modules.community.fusion.announcements import resolve_announcement_channel
+from shared.sheets import fusion as fusion_sheets
+
+log = logging.getLogger("c1c.community.fusion.role_cleanup")
+
+_ROLE_CLEANUP_EVENT_ID = "__fusion_role_cleanup__"
+_ROLE_CLEANUP_TYPE = "ended"
+
+
+def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
+    if now is None:
+        return dt.datetime.now(dt.timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=dt.timezone.utc)
+    return now.astimezone(dt.timezone.utc)
+
+
+async def _resolve_cleanup_guild(bot: commands.Bot, target: fusion_sheets.FusionRow) -> discord.Guild | None:
+    channel = await resolve_announcement_channel(bot, target.announcement_channel_id)
+    if isinstance(channel, discord.abc.GuildChannel):
+        return channel.guild
+
+    if target.opt_in_role_id is None:
+        return None
+
+    for guild in bot.guilds:
+        if guild.get_role(target.opt_in_role_id) is not None:
+            return guild
+    return None
+
+
+async def process_ended_fusion_role_cleanup(
+    bot: commands.Bot,
+    *,
+    now: dt.datetime | None = None,
+) -> None:
+    reference = _utc_now(now)
+
+    try:
+        ended_fusions = await fusion_sheets.get_ended_fusions(now=reference)
+    except Exception:
+        log.exception("fusion role cleanup failed to load ended fusions")
+        return
+
+    for target in ended_fusions:
+        if target.opt_in_role_id is None:
+            continue
+
+        try:
+            sent_keys = await fusion_sheets.get_sent_reminder_keys(target.fusion_id)
+        except Exception:
+            log.exception(
+                "fusion role cleanup failed to load dedupe state",
+                extra={"fusion_id": target.fusion_id},
+            )
+            continue
+
+        cleanup_key = (_ROLE_CLEANUP_EVENT_ID, _ROLE_CLEANUP_TYPE)
+        if cleanup_key in sent_keys:
+            continue
+
+        try:
+            guild = await _resolve_cleanup_guild(bot, target)
+            if guild is None:
+                log.warning(
+                    "fusion role cleanup skipped; guild unavailable",
+                    extra={"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id},
+                )
+                continue
+
+            role = guild.get_role(target.opt_in_role_id)
+            if role is None:
+                log.warning(
+                    "fusion role cleanup role missing",
+                    extra={"fusion_id": target.fusion_id, "guild_id": guild.id, "role_id": target.opt_in_role_id},
+                )
+            else:
+                for member in list(role.members):
+                    try:
+                        await member.remove_roles(role, reason=f"Fusion ended: {target.fusion_id}")
+                    except Exception:
+                        log.exception(
+                            "fusion role cleanup failed for member",
+                            extra={
+                                "fusion_id": target.fusion_id,
+                                "guild_id": guild.id,
+                                "role_id": role.id,
+                                "user_id": member.id,
+                            },
+                        )
+
+            await fusion_sheets.mark_reminder_sent(
+                target.fusion_id,
+                event_id=_ROLE_CLEANUP_EVENT_ID,
+                reminder_type=_ROLE_CLEANUP_TYPE,
+                sent_at=reference,
+            )
+        except Exception:
+            log.exception(
+                "fusion role cleanup iteration failed",
+                extra={"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id},
+            )
+
+
+__all__ = ["process_ended_fusion_role_cleanup"]

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from modules.community.fusion.reminders import process_fusion_reminders
+from modules.community.fusion.role_cleanup import process_ended_fusion_role_cleanup
 
 if TYPE_CHECKING:
     from modules.common.runtime import Runtime
@@ -17,6 +18,7 @@ def schedule_fusion_jobs(runtime: "Runtime") -> None:
     async def _runner() -> None:
         try:
             await process_fusion_reminders(runtime.bot)
+            await process_ended_fusion_role_cleanup(runtime.bot)
         except Exception:
             log.exception("fusion reminder scheduler tick failed")
 

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -6,6 +6,7 @@ import logging
 
 from discord.ext import commands
 
+from modules.community.fusion.opt_in_view import register_persistent_fusion_views
 from modules.onboarding import watcher_promo, watcher_welcome
 from modules.onboarding.ui import panels
 
@@ -19,6 +20,7 @@ async def on_ready(bot: commands.Bot) -> None:
     # Existing startup wiring …
     # Register onboarding persistent views *after* the bot is ready to avoid race conditions.
     panels.register_views(bot)
+    register_persistent_fusion_views(bot)
 
     # Ensure both onboarding watchers are wired
     await watcher_welcome.setup(bot)

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -535,6 +535,23 @@ async def mark_reminder_sent(
     )
 
 
+
+
+async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:
+    """Return ended fusions that may still need post-end cleanup tasks."""
+
+    reference = _coerce_utc_now(now)
+    fusion_bucket, _ = register_cache_buckets()
+    rows = [row for row in await _cached_rows(fusion_bucket) if isinstance(row, FusionRow)]
+
+    ended = [
+        row
+        for row in rows
+        if row.status.casefold() in {"active", "published"} and row.end_at_utc <= reference
+    ]
+    ended.sort(key=lambda row: (row.end_at_utc, row.fusion_id), reverse=True)
+    return ended
+
 async def get_publishable_fusion() -> FusionRow | None:
     """Return the best fusion row for publish flow selection."""
 
@@ -622,6 +639,7 @@ __all__ = [
     "FusionEventRow",
     "FusionRow",
     "get_active_fusion",
+    "get_ended_fusions",
     "get_active_events",
     "get_valid_event_timing",
     "get_publishable_fusion",

--- a/tests/community/test_fusion_announcements.py
+++ b/tests/community/test_fusion_announcements.py
@@ -1,0 +1,71 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.community.fusion import announcements
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=opt_in_role_id,
+        announcement_message_id=None,
+        published_at=None,
+        status="draft",
+    )
+
+
+class _Channel:
+    def __init__(self) -> None:
+        self.id = 123
+        self.send = AsyncMock(return_value=SimpleNamespace(id=999))
+
+
+def test_publish_announcement_attaches_buttons_when_role_configured(monkeypatch):
+    async def _run() -> None:
+        channel = _Channel()
+        bot = SimpleNamespace(get_channel=lambda _id: channel, fetch_channel=AsyncMock(return_value=channel))
+        target = _fusion_row(opt_in_role_id=777)
+        monkeypatch.setattr(announcements, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(announcements, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(announcements, "build_fusion_opt_in_view", lambda _target: "view")
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", AsyncMock())
+
+        await announcements.publish_fusion_announcement(bot, target)
+
+        _, kwargs = channel.send.await_args
+        assert kwargs["view"] == "view"
+
+    asyncio.run(_run())
+
+
+def test_publish_announcement_omits_buttons_when_role_not_configured(monkeypatch):
+    async def _run() -> None:
+        channel = _Channel()
+        bot = SimpleNamespace(get_channel=lambda _id: channel, fetch_channel=AsyncMock(return_value=channel))
+        target = _fusion_row(opt_in_role_id=None)
+        monkeypatch.setattr(announcements, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(announcements, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(announcements, "build_fusion_opt_in_view", lambda _target: None)
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", AsyncMock())
+
+        await announcements.publish_fusion_announcement(bot, target)
+
+        _, kwargs = channel.send.await_args
+        assert kwargs["view"] is None
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -1,0 +1,165 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.community.fusion import opt_in_view
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=opt_in_role_id,
+        announcement_message_id=456,
+        published_at=dt.datetime(2026, 4, 7, tzinfo=dt.timezone.utc),
+        status="active",
+    )
+
+
+class _Response:
+    def __init__(self) -> None:
+        self.send_message = AsyncMock()
+
+    def is_done(self) -> bool:
+        return False
+
+
+class _Member:
+    def __init__(self, role):
+        self.id = 10
+        self.guild = SimpleNamespace(id=1)
+        self.roles = [] if role is None else [role]
+        self.add_roles = AsyncMock(side_effect=self._add)
+        self.remove_roles = AsyncMock(side_effect=self._remove)
+
+    async def _add(self, role, reason=None):
+        if role not in self.roles:
+            self.roles.append(role)
+
+    async def _remove(self, role, reason=None):
+        self.roles = [r for r in self.roles if r != role]
+
+
+class _Guild:
+    def __init__(self, role, member):
+        self.id = 1
+        self._role = role
+        self._member = member
+
+    def get_role(self, _role_id):
+        return self._role
+
+    def get_member(self, _user_id):
+        return self._member
+
+
+def _interaction(guild, member):
+    return SimpleNamespace(
+        guild=guild,
+        user=member,
+        response=_Response(),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def test_opt_in_click_adds_role(monkeypatch):
+    async def _run() -> None:
+        role = SimpleNamespace(id=777)
+        member = _Member(role=None)
+        guild = _Guild(role=role, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="in")
+
+        member.add_roles.assert_awaited_once_with(role, reason="Fusion role opt-in button")
+
+    asyncio.run(_run())
+
+
+def test_opt_in_click_is_harmless_when_already_opted_in(monkeypatch):
+    async def _run() -> None:
+        role = SimpleNamespace(id=777)
+        member = _Member(role=role)
+        guild = _Guild(role=role, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="in")
+
+        member.add_roles.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_opt_out_click_removes_role(monkeypatch):
+    async def _run() -> None:
+        role = SimpleNamespace(id=777)
+        member = _Member(role=role)
+        guild = _Guild(role=role, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="out")
+
+        member.remove_roles.assert_awaited_once_with(role, reason="Fusion role opt-out button")
+
+    asyncio.run(_run())
+
+
+def test_opt_out_click_is_harmless_when_missing_role(monkeypatch):
+    async def _run() -> None:
+        role = SimpleNamespace(id=777)
+        member = _Member(role=None)
+        guild = _Guild(role=role, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="out")
+
+        member.remove_roles.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_missing_guild_role_is_handled_cleanly(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="in")
+
+        interaction.response.send_message.assert_awaited_once_with("Fusion role is missing in this server.", ephemeral=True)
+
+    asyncio.run(_run())
+
+
+def test_permission_failure_is_handled_cleanly(monkeypatch):
+    async def _run() -> None:
+        role = SimpleNamespace(id=777)
+        member = _Member(role=None)
+        member.add_roles = AsyncMock(side_effect=RuntimeError("forbidden"))
+        guild = _Guild(role=role, member=member)
+        interaction = _interaction(guild, member)
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+
+        await opt_in_view._handle_opt_action(interaction, action="in")
+
+        interaction.response.send_message.assert_awaited_once_with(
+            "Couldn’t update your fusion role right now.", ephemeral=True
+        )
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -48,8 +48,8 @@ class _DummyChannel:
     def __init__(self) -> None:
         self.sent = []
 
-    async def send(self, *, content=None, embed=None):
-        self.sent.append({"content": content, "embed": embed})
+    async def send(self, *, content=None, embed=None, view=None):
+        self.sent.append({"content": content, "embed": embed, "view": view})
 
 
 class _DummyAnnouncementMessage:
@@ -78,12 +78,14 @@ def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
 
     assert len(channel.sent) == 1
     assert channel.sent[0]["content"] is None
+    assert channel.sent[0]["view"] is None
     assert channel.sent[0]["embed"].title == "⚠️ Event e-start is live"
     assert ("f-1", "e-start", "start") in persisted
 
@@ -108,12 +110,14 @@ def test_prestart_reminder_fires_once(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(minutes=1)))
 
     assert len(channel.sent) == 1
     assert channel.sent[0]["content"] == "<@&777>"
+    assert channel.sent[0]["view"] == "view"
     embed = channel.sent[0]["embed"]
     assert embed.title == "⏳ Event e-pre starts soon"
     assert embed.description == "Starts in 6h. Plan accordingly."
@@ -140,11 +144,13 @@ def test_invalid_events_skipped_and_no_role_mention_when_absent(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
 
     assert len(channel.sent) == 1
     assert channel.sent[0]["content"] is None
+    assert channel.sent[0]["view"] is None
 
 
 def test_announcement_self_heals_before_sending(monkeypatch):

--- a/tests/community/test_fusion_role_cleanup.py
+++ b/tests/community/test_fusion_role_cleanup.py
@@ -1,0 +1,142 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.community.fusion import role_cleanup
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row(*, opt_in_role_id: int | None = 777) -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-ended",
+        fusion_name="Old Fusion",
+        champion="Mavara",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 3, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=opt_in_role_id,
+        announcement_message_id=456,
+        published_at=dt.datetime(2026, 3, 31, tzinfo=dt.timezone.utc),
+        status="published",
+    )
+
+
+class _Member:
+    def __init__(self, member_id: int, *, fail: bool = False) -> None:
+        self.id = member_id
+        self._fail = fail
+        self.remove_roles = AsyncMock(side_effect=self._remove_roles)
+
+    async def _remove_roles(self, _role, reason=None):
+        if self._fail:
+            raise RuntimeError("nope")
+
+
+class _Role:
+    def __init__(self, role_id: int, members: list[_Member]) -> None:
+        self.id = role_id
+        self.members = members
+
+
+class _Guild:
+    def __init__(self, role):
+        self.id = 1
+        self._role = role
+
+    def get_role(self, _role_id):
+        return self._role
+
+
+def test_ended_fusion_triggers_role_cleanup(monkeypatch):
+    async def _run() -> None:
+        members = [_Member(1), _Member(2)]
+        role = _Role(777, members)
+        guild = _Guild(role)
+        channel = SimpleNamespace(guild=guild)
+        bot = SimpleNamespace(guilds=[guild])
+
+        monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+        monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(role_cleanup, "_resolve_cleanup_guild", AsyncMock(return_value=guild))
+
+        await role_cleanup.process_ended_fusion_role_cleanup(bot)
+
+        for member in members:
+            member.remove_roles.assert_awaited_once_with(role, reason="Fusion ended: f-ended")
+        fusion_sheets.mark_reminder_sent.assert_awaited_once()
+
+    asyncio.run(_run())
+
+
+def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
+    async def _run() -> None:
+        member = _Member(1)
+        role = _Role(777, [member])
+        guild = _Guild(role)
+        channel = SimpleNamespace(guild=guild)
+        bot = SimpleNamespace(guilds=[guild])
+
+        monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(
+            fusion_sheets,
+            "get_sent_reminder_keys",
+            AsyncMock(return_value={("__fusion_role_cleanup__", "ended")}),
+        )
+        monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
+
+        await role_cleanup.process_ended_fusion_role_cleanup(bot)
+
+        member.remove_roles.assert_not_awaited()
+        fusion_sheets.mark_reminder_sent.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_missing_role_is_handled_safely(monkeypatch):
+    async def _run() -> None:
+        guild = _Guild(role=None)
+        channel = SimpleNamespace(guild=guild)
+        bot = SimpleNamespace(guilds=[guild])
+
+        monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+        monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(role_cleanup, "_resolve_cleanup_guild", AsyncMock(return_value=guild))
+
+        await role_cleanup.process_ended_fusion_role_cleanup(bot)
+
+        fusion_sheets.mark_reminder_sent.assert_awaited_once()
+
+    asyncio.run(_run())
+
+
+def test_partial_member_failure_does_not_abort(monkeypatch):
+    async def _run() -> None:
+        members = [_Member(1, fail=True), _Member(2, fail=False)]
+        role = _Role(777, members)
+        guild = _Guild(role)
+        channel = SimpleNamespace(guild=guild)
+        bot = SimpleNamespace(guilds=[guild])
+
+        monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+        monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
+
+        await role_cleanup.process_ended_fusion_role_cleanup(bot)
+
+        assert members[0].remove_roles.await_count == 1
+        assert members[1].remove_roles.await_count == 1
+        fusion_sheets.mark_reminder_sent.assert_awaited_once()
+
+    asyncio.run(_run())

--- a/tests/coreops/test_ready.py
+++ b/tests/coreops/test_ready.py
@@ -1,0 +1,20 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from modules.coreops import ready
+
+
+def test_on_ready_registers_fusion_persistent_view(monkeypatch):
+    async def _run() -> None:
+        bot = SimpleNamespace(logger=None)
+        monkeypatch.setattr(ready.panels, "register_views", Mock())
+        monkeypatch.setattr(ready, "register_persistent_fusion_views", Mock())
+        monkeypatch.setattr(ready.watcher_welcome, "setup", AsyncMock())
+        monkeypatch.setattr(ready.watcher_promo, "setup", AsyncMock())
+
+        await ready.on_ready(bot)
+
+        ready.register_persistent_fusion_views.assert_called_once_with(bot)
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Provide a low-friction, command-free way for users to self-manage the fusion opt-in role via buttons on the announcement and reminder messages.
- Ensure button interactions survive restarts and that the opt-in role is cleaned up automatically once a fusion ends.

### Description
- Add a reusable persistent view `FusionOptInView` with `Opt In` / `Opt Out` buttons and centralized interaction handling in `modules/community/fusion/opt_in_view.py`, using ephemeral responses and admin-facing logging for failure cases, and a `build_fusion_opt_in_view` helper to attach the view only when `opt_in_role_id` exists.
- Attach the view to announcements in `publish_fusion_announcement` so published and self-healed announcement messages include the buttons when configured, and attach the same view to reminder messages in `modules/community/fusion/reminders.py`.
- Register the persistent view on startup via `register_persistent_fusion_views` wired into `modules/coreops/ready.py` so buttons remain functional across restarts.
- Add automatic ended-fusion cleanup in `modules/community/fusion/role_cleanup.py` that finds ended fusions, removes the opt-in role from members, logs failures per-member, and marks the cleanup as one-shot using the existing durable reminder keys mechanism.
- Add `get_ended_fusions` to `shared/sheets/fusion.py` and run cleanup alongside reminders in the fusion scheduler (`modules/community/fusion/scheduler.py`).
- Add tests covering announcement/button attachment, reminder/button attachment, opt-in/opt-out interaction behavior (idempotency and error handling), ended-fusion cleanup behavior (one-shot dedupe, missing role, partial failures), and startup persistent-view registration.

### Testing
- Ran targeted unit tests for the new and updated fusion flows: `tests/community/test_fusion_announcements.py`, `tests/community/test_fusion_opt_in_view.py`, `tests/community/test_fusion_reminders.py`, `tests/community/test_fusion_role_cleanup.py`, and `tests/coreops/test_ready.py`; all tests passed.
- Ran the same suite plus `tests/community/test_fusion_cog.py` to verify integration with existing publish/self-heal paths; the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9f557f34832388a1d963361292a1)