### PR TITLE
Add champion image support to fusion announcement embeds

### DIFF
--- a/modules/community/fusion/announcements.py
+++ b/modules/community/fusion/announcements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 
 import discord
 from discord.ext import commands
@@ -10,6 +11,8 @@ from discord.ext import commands
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
+
+log = logging.getLogger("c1c.community.fusion.announcements")
 
 
 async def resolve_announcement_channel(
@@ -40,7 +43,20 @@ async def publish_fusion_announcement(
     events = await fusion_sheets.get_fusion_events(target.fusion_id)
     announcement_embed = build_fusion_announcement_embed(target, events)
     announcement_view = build_fusion_opt_in_view(target)
-    announcement_message = await channel.send(embed=announcement_embed, view=announcement_view)
+    try:
+        announcement_message = await channel.send(embed=announcement_embed, view=announcement_view)
+    except discord.HTTPException:
+        image_url = str(getattr(getattr(announcement_embed, "image", None), "url", "") or "").strip()
+        if not image_url:
+            raise
+        log.warning(
+            "fusion announcement send failed with champion image; retrying without image",
+            extra={"fusion_id": target.fusion_id, "champion_image_url": image_url},
+            exc_info=True,
+        )
+        fallback_embed = announcement_embed.copy()
+        fallback_embed.set_image(url=None)
+        announcement_message = await channel.send(embed=fallback_embed, view=announcement_view)
 
     set_status_published = target.status.casefold() == "draft"
     await fusion_sheets.update_fusion_publication(

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from collections import defaultdict
 from itertools import chain
+from urllib.parse import urlparse
 
 import discord
 
@@ -81,6 +82,18 @@ def _format_date_range(start: dt.date, end: dt.date) -> str:
     return f"{_format_month_day(start)}–{_format_month_day(end)}"
 
 
+def _normalize_image_url(value: str) -> str | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if not parsed.netloc:
+        return None
+    return candidate
+
+
 def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
     has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
@@ -109,6 +122,9 @@ def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> disc
         description="\n".join(summary_lines),
         colour=_FUSION_EMBED_COLOR,
     )
+    champion_image_url = _normalize_image_url(fusion.champion_image_url)
+    if champion_image_url:
+        embed.set_image(url=champion_image_url)
     embed.add_field(name="Key Milestones", value="\n".join(milestones_lines), inline=False)
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -35,6 +35,7 @@ class FusionRow:
     fusion_id: str
     fusion_name: str
     champion: str
+    champion_image_url: str
     fusion_type: str
     fusion_structure: str
     reward_type: str
@@ -223,6 +224,7 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
                     fusion_id=str(row.get("fusion_id") or "").strip(),
                     fusion_name=str(row.get("fusion_name") or "").strip(),
                     champion=str(row.get("champion") or "").strip(),
+                    champion_image_url=str(row.get("champion_image_url") or "").strip(),
                     fusion_type=str(row.get("fusion_type") or "").strip(),
                     fusion_structure=str(row.get("fusion_structure") or "").strip(),
                     reward_type=str(row.get("reward_type") or "").strip(),

--- a/tests/community/test_fusion_announcements.py
+++ b/tests/community/test_fusion_announcements.py
@@ -3,6 +3,7 @@ import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import discord
 from modules.community.fusion import announcements
 from shared.sheets import fusion as fusion_sheets
 
@@ -12,6 +13,7 @@ def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",
@@ -67,5 +69,36 @@ def test_publish_announcement_omits_buttons_when_role_not_configured(monkeypatch
 
         _, kwargs = channel.send.await_args
         assert kwargs["view"] is None
+
+    asyncio.run(_run())
+
+
+def test_publish_announcement_retries_without_image_on_http_exception(monkeypatch):
+    async def _run() -> None:
+        channel = _Channel()
+        channel.send = AsyncMock(
+            side_effect=[
+                discord.HTTPException(response=SimpleNamespace(status=400, reason="Bad Request"), message="invalid image"),
+                SimpleNamespace(id=1001),
+            ]
+        )
+        bot = SimpleNamespace(get_channel=lambda _id: channel, fetch_channel=AsyncMock(return_value=channel))
+        target = _fusion_row(opt_in_role_id=777)
+        monkeypatch.setattr(announcements, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(announcements, "build_fusion_opt_in_view", lambda _target: "view")
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", AsyncMock())
+
+        embed = discord.Embed(title="fusion")
+        embed.set_image(url="https://cdn.discordapp.com/champion.png")
+        monkeypatch.setattr(announcements, "build_fusion_announcement_embed", lambda *_args: embed)
+
+        await announcements.publish_fusion_announcement(bot, target)
+
+        assert channel.send.await_count == 2
+        first_call = channel.send.await_args_list[0].kwargs["embed"]
+        second_call = channel.send.await_args_list[1].kwargs["embed"]
+        assert str(first_call.image.url) == "https://cdn.discordapp.com/champion.png"
+        assert not str(second_call.image.url or "").strip()
 
     asyncio.run(_run())

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -19,6 +19,7 @@ def _fusion_row(
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -12,6 +12,7 @@ def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -11,6 +11,7 @@ def _fusion_row(*, opt_in_role_id: int | None = None) -> fusion_sheets.FusionRow
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from dataclasses import replace
 
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets.fusion import FusionEventRow, FusionRow
@@ -9,6 +10,7 @@ def _fusion() -> FusionRow:
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",
@@ -68,3 +70,19 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
         "Mon, Apr 13",
         "Tue, Apr 14",
     ]
+
+
+def test_build_fusion_embed_sets_champion_image_when_url_present() -> None:
+    fusion = replace(_fusion(), champion_image_url="https://cdn.discordapp.com/champion.png")
+
+    embed = build_fusion_announcement_embed(fusion, [])
+
+    assert str(embed.image.url) == "https://cdn.discordapp.com/champion.png"
+
+
+def test_build_fusion_embed_skips_invalid_champion_image_url() -> None:
+    fusion = replace(_fusion(), champion_image_url="notaurl")
+
+    embed = build_fusion_announcement_embed(fusion, [])
+
+    assert not str(embed.image.url or "").strip()

--- a/tests/community/test_fusion_role_cleanup.py
+++ b/tests/community/test_fusion_role_cleanup.py
@@ -12,6 +12,7 @@ def _fusion_row(*, opt_in_role_id: int | None = 777) -> fusion_sheets.FusionRow:
         fusion_id="f-ended",
         fusion_name="Old Fusion",
         champion="Mavara",
+        champion_image_url="",
         fusion_type="traditional",
         fusion_structure="",
         reward_type="fragments",

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -15,6 +15,7 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
                 "fusion_id": "f-1",
                 "fusion_name": "Mavara",
                 "champion": "Mavara",
+                "champion_image_url": "https://cdn.discordapp.com/champion.png",
                 "fusion_type": "traditional",
                 "fusion_structure": "",
                 "reward_type": "fragments",
@@ -35,6 +36,7 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
     assert len(rows) == 1
     assert rows[0].needed == 400
     assert rows[0].available == 450
+    assert rows[0].champion_image_url == "https://cdn.discordapp.com/champion.png"
     assert rows[0].start_at_utc == dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc)
 
 


### PR DESCRIPTION
### Motivation
- Provide Phase 7 fusion support by allowing a fusion-level `champion_image_url` to be rendered as a full announcement embed image. 
- Ensure the image is applied consistently for initial publish and for any self-heal / rebuild flow without hard-coding sheet columns or tab names. 
- Prevent bad or missing URLs from blocking publish/rebuild by failing open and logging failures.

### Description
- Added a `champion_image_url` field to the fusion model and sheet loader so fusion rows carry the image URL from the configured sheet (`shared/sheets/fusion.py`).
- Centralized embed behavior in the announcement builder by validating/normalizing image URLs and calling `embed.set_image(url=...)` when a valid `http/https` URL is present (`modules/community/fusion/rendering.py`).
- Hardened publishing so `publish_fusion_announcement` will catch `discord.HTTPException`, log the failing image, and retry once with a copy of the embed that omits the image to avoid blocking publication (`modules/community/fusion/announcements.py`).
- Updated and added tests and test fixtures to cover sheet parsing, valid/invalid image handling, and the retry-without-image fallback (`tests/shared/sheets/test_fusion.py`, `tests/community/test_fusion_rendering.py`, `tests/community/test_fusion_announcements.py`), and updated affected fusion tests to include the new field in fixtures.

### Testing
- Ran the focused unit test suite: `pytest -q tests/shared/sheets/test_fusion.py tests/community/test_fusion_rendering.py tests/community/test_fusion_announcements.py tests/community/test_fusion_cog.py tests/community/test_fusion_reminders.py tests/community/test_fusion_role_cleanup.py tests/community/test_fusion_opt_in_view.py` and all tests passed (dot-run output showed 100% success).
- New/modified tests exercise: row parsing for `champion_image_url`, embed image inclusion for valid URLs, embed omission for invalid URLs, and the publish retry behavior when Discord rejects an image.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd03835c483239ef076669938b63a)