### PR TITLE
Fusion: announcement auto-refresh with event status tracking

### DIFF
--- a/modules/community/fusion/announcement_refresh.py
+++ b/modules/community/fusion/announcement_refresh.py
@@ -1,0 +1,119 @@
+"""Fusion announcement auto-refresh loop helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import logging
+
+import discord
+from discord.ext import commands
+
+from modules.community.fusion.announcements import ensure_fusion_announcement, resolve_announcement_channel
+from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
+from modules.community.fusion.rendering import build_fusion_announcement_embed
+from shared.sheets import fusion as fusion_sheets
+
+log = logging.getLogger("c1c.community.fusion.announcement_refresh")
+
+
+def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
+    if now is None:
+        return dt.datetime.now(dt.timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=dt.timezone.utc)
+    return now.astimezone(dt.timezone.utc)
+
+
+def _compute_status_hash(
+    events: list[fusion_sheets.FusionEventRow],
+    *,
+    now: dt.datetime,
+) -> str:
+    pairs: list[tuple[str, str]] = []
+    for event in sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id)):
+        timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_announcement_refresh")
+        if timing is None:
+            continue
+        start_at, end_at = timing
+        status = fusion_sheets.derive_event_status(start_at_utc=start_at, end_at_utc=end_at, now=now)
+        pairs.append((event.event_id, status))
+    encoded = "|".join(f"{event_id}:{status}" for event_id, status in pairs).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _needs_refresh(
+    fusion: fusion_sheets.FusionRow,
+    *,
+    now: dt.datetime,
+    status_hash: str,
+) -> bool:
+    last_refresh = fusion.last_announcement_refresh_at
+    if last_refresh is None:
+        return True
+    if last_refresh.date() != now.date():
+        return True
+    return str(fusion.last_announcement_status_hash or "").strip() != status_hash
+
+
+async def _fetch_existing_announcement(
+    bot: commands.Bot,
+    target: fusion_sheets.FusionRow,
+) -> discord.Message | None:
+    if target.announcement_channel_id is None or target.announcement_message_id is None:
+        return None
+    channel = await resolve_announcement_channel(bot, target.announcement_channel_id)
+    if channel is None:
+        return None
+    try:
+        return await channel.fetch_message(target.announcement_message_id)
+    except Exception:
+        return None
+
+
+async def process_fusion_announcement_refreshes(
+    bot: commands.Bot,
+    *,
+    now: dt.datetime | None = None,
+) -> None:
+    reference = _utc_now(now)
+    try:
+        targets = await fusion_sheets.get_published_fusions()
+    except Exception:
+        log.exception("fusion announcement refresh failed to load published fusions")
+        return
+
+    for target in targets:
+        try:
+            events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            status_hash = _compute_status_hash(events, now=reference)
+            if not _needs_refresh(target, now=reference, status_hash=status_hash):
+                continue
+
+            existing_message = await _fetch_existing_announcement(bot, target)
+            if existing_message is None:
+                announcement_message = await ensure_fusion_announcement(bot, target)
+                if announcement_message is None:
+                    log.warning(
+                        "fusion announcement refresh skipped; announcement unavailable",
+                        extra={"fusion_id": target.fusion_id},
+                    )
+                    continue
+            else:
+                announcement_embed = build_fusion_announcement_embed(target, events, now=reference)
+                announcement_view = build_fusion_opt_in_view(target)
+                await existing_message.edit(embed=announcement_embed, view=announcement_view)
+
+            await fusion_sheets.update_fusion_announcement_refresh_state(
+                target.fusion_id,
+                refreshed_at=reference,
+                status_hash=status_hash,
+            )
+        except Exception:
+            log.exception(
+                "fusion announcement refresh failed",
+                extra={"fusion_id": target.fusion_id},
+            )
+
+
+__all__ = ["process_fusion_announcement_refreshes"]

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import discord
 
 from shared.sheets.fusion import FusionEventRow, FusionRow
+from shared.sheets import fusion as fusion_sheets
 
 _FUSION_EMBED_COLOR = discord.Color.blurple()
 _EMBED_FIELD_VALUE_LIMIT = 1024
@@ -33,11 +34,22 @@ def _humanize_type(value: str) -> str:
     return " ".join(token.capitalize() for token in normalized.split())
 
 
-def _format_event_line(event: FusionEventRow) -> str:
+def _status_icon(status: str) -> str:
+    if status == "live":
+        return "🔥"
+    if status == "ended":
+        return "✅"
+    return "⏳"
+
+
+def _format_event_line(event: FusionEventRow, *, status: str) -> str:
     has_bonus = event.bonus is not None and event.bonus > 0
     points_text = f"{event.points_needed} pts" if event.points_needed is not None else "pts TBA"
     bonus_text = f" (+{event.bonus:g} bonus)" if has_bonus else ""
-    return f"{event.event_name} — {points_text} for {event.reward_amount:g} frags{bonus_text}"
+    return (
+        f"{_status_icon(status)} {event.event_name} — "
+        f"{points_text} for {event.reward_amount:g} frags{bonus_text}"
+    )
 
 
 def _chunk_lines(lines: list[str], limit: int) -> list[str]:
@@ -94,7 +106,12 @@ def _normalize_image_url(value: str) -> str | None:
     return candidate
 
 
-def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
+def _build_fusion_embed(
+    fusion: FusionRow,
+    events: list[FusionEventRow],
+    *,
+    now: dt.datetime | None = None,
+) -> discord.Embed:
     has_bonus = any(event.bonus is not None and event.bonus > 0 for event in events)
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     event_days = [event.start_at_utc.astimezone(dt.timezone.utc).date() for event in sorted_events]
@@ -127,6 +144,28 @@ def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> disc
         embed.set_image(url=champion_image_url)
     embed.add_field(name="Key Milestones", value="\n".join(milestones_lines), inline=False)
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
+    status_by_event_id: dict[str, str] = {}
+    for event in sorted_events:
+        timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_embed")
+        if timing is None:
+            status = "upcoming"
+        else:
+            start_at, end_at = timing
+            status = fusion_sheets.derive_event_status(start_at_utc=start_at, end_at_utc=end_at, now=now)
+        status_by_event_id[event.event_id] = status
+
+    if sorted_events:
+        status_lines = [
+            f"- {_status_icon(status_by_event_id[event.event_id])} {event.event_name}"
+            for event in sorted_events
+        ]
+        status_chunks = _chunk_lines(status_lines, _EMBED_FIELD_VALUE_LIMIT)
+        for idx, chunk in enumerate(status_chunks, start=1):
+            name = "Event Status" if idx == 1 else f"Event Status (Part {idx})"
+            if len(embed.fields) >= _EMBED_MAX_FIELDS:
+                break
+            embed.add_field(name=name, value=chunk, inline=False)
+
     grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
     for event in sorted_events:
         grouped_events[event.start_at_utc.astimezone(dt.timezone.utc).date()].append(event)
@@ -141,7 +180,7 @@ def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> disc
         if len(embed.fields) >= _EMBED_MAX_FIELDS:
             break
         lines = [
-            f"• {_format_event_line(event)}"
+            f"• {_format_event_line(event, status=status_by_event_id[event.event_id])}"
             for event in grouped_events[day]
         ]
         embed.add_field(
@@ -153,10 +192,15 @@ def _build_fusion_embed(fusion: FusionRow, events: list[FusionEventRow]) -> disc
     return embed
 
 
-def build_fusion_announcement_embed(fusion: FusionRow, events: list[FusionEventRow]) -> discord.Embed:
+def build_fusion_announcement_embed(
+    fusion: FusionRow,
+    events: list[FusionEventRow],
+    *,
+    now: dt.datetime | None = None,
+) -> discord.Embed:
     """Build the Step 2 fusion publish announcement embed."""
 
-    return _build_fusion_embed(fusion, events)
+    return _build_fusion_embed(fusion, events, now=now)
 
 
 __all__ = ["build_fusion_announcement_embed"]

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from modules.community.fusion.announcement_refresh import process_fusion_announcement_refreshes
 from modules.community.fusion.reminders import process_fusion_reminders
 from modules.community.fusion.role_cleanup import process_ended_fusion_role_cleanup
 
@@ -18,6 +19,7 @@ def schedule_fusion_jobs(runtime: "Runtime") -> None:
     async def _runner() -> None:
         try:
             await process_fusion_reminders(runtime.bot)
+            await process_fusion_announcement_refreshes(runtime.bot)
             await process_ended_fusion_role_cleanup(runtime.bot)
         except Exception:
             log.exception("fusion reminder scheduler tick failed")

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -47,6 +47,8 @@ class FusionRow:
     opt_in_role_id: int | None
     announcement_message_id: int | None
     published_at: dt.datetime | None
+    last_announcement_refresh_at: dt.datetime | None
+    last_announcement_status_hash: str
     status: str
 
 
@@ -240,6 +242,12 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
                         row.get("announcement_message_id")
                     ),
                     published_at=_parse_iso_utc_optional(row.get("published_at")),
+                    last_announcement_refresh_at=_parse_iso_utc_optional(
+                        row.get("last_announcement_refresh_at")
+                    ),
+                    last_announcement_status_hash=str(
+                        row.get("last_announcement_status_hash") or ""
+                    ).strip(),
                     status=str(row.get("status") or "").strip().lower(),
                 )
             )
@@ -345,6 +353,19 @@ async def get_active_fusion() -> FusionRow | None:
         candidates.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
         return candidates[0]
     return None
+
+
+async def get_published_fusions() -> list[FusionRow]:
+    """Return all fusions currently eligible for live announcement maintenance."""
+
+    fusion_bucket, _ = register_cache_buckets()
+    rows = [
+        row
+        for row in await _cached_rows(fusion_bucket)
+        if isinstance(row, FusionRow) and row.status.casefold() in {"active", "published"}
+    ]
+    rows.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
+    return rows
 
 
 async def get_fusion_events(fusion_id: str) -> list[FusionEventRow]:
@@ -466,6 +487,22 @@ def get_valid_event_timing(
     """Validate and coerce fusion event timing into UTC-aware datetimes."""
 
     return _valid_event_timing(event, for_helper=for_helper)
+
+
+def derive_event_status(
+    *,
+    start_at_utc: dt.datetime,
+    end_at_utc: dt.datetime | None,
+    now: dt.datetime | None = None,
+) -> str:
+    """Return canonical event status from normalized UTC timestamps."""
+
+    reference = _coerce_utc_now(now)
+    if reference < start_at_utc:
+        return "upcoming"
+    if end_at_utc is None or reference < end_at_utc:
+        return "live"
+    return "ended"
 
 
 async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
@@ -673,12 +710,66 @@ async def update_fusion_publication(
     await cache.refresh_now(_FUSION_BUCKET, actor="fusion_publish")
 
 
+async def update_fusion_announcement_refresh_state(
+    fusion_id: str,
+    *,
+    refreshed_at: dt.datetime,
+    status_hash: str,
+) -> None:
+    """Persist announcement refresh metadata for scheduler dedupe/restart safety."""
+
+    tab_name = _resolve_tab_name("FUSION_TAB")
+    sheet_id = _sheet_id()
+    matrix = await afetch_values(sheet_id, tab_name)
+    if not matrix:
+        raise RuntimeError("Fusion sheet is empty")
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    row_idx: int | None = None
+    fusion_col = header.index("fusion_id") if "fusion_id" in header else -1
+    if fusion_col < 0:
+        raise RuntimeError("Fusion sheet missing fusion_id column")
+
+    for idx, row in enumerate(matrix[1:], start=2):
+        cell = str(row[fusion_col] if fusion_col < len(row) else "").strip()
+        if cell == fusion_id:
+            row_idx = idx
+            break
+    if row_idx is None:
+        raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
+
+    required_cols = ["last_announcement_refresh_at", "last_announcement_status_hash"]
+    missing = [col for col in required_cols if col not in header]
+    if missing:
+        raise RuntimeError(f"Fusion sheet missing columns: {', '.join(missing)}")
+
+    worksheet = await aget_worksheet(sheet_id, tab_name)
+    updates = {
+        "last_announcement_refresh_at": refreshed_at.astimezone(dt.timezone.utc).isoformat(),
+        "last_announcement_status_hash": str(status_hash or "").strip(),
+    }
+    for col_name, value in updates.items():
+        col_index = header.index(col_name)
+        cell = f"{_column_label(col_index)}{row_idx}"
+        await acall_with_backoff(
+            worksheet.update,
+            cell,
+            [[value]],
+            value_input_option="RAW",
+        )
+
+    register_cache_buckets()
+    await cache.refresh_now(_FUSION_BUCKET, actor="fusion_announcement_refresh")
+
+
 __all__ = [
     "FusionEventRow",
     "FusionRow",
     "get_active_fusion",
     "get_ended_fusions",
+    "get_published_fusions",
     "get_active_events",
+    "derive_event_status",
     "get_valid_event_timing",
     "get_publishable_fusion",
     "get_fusion_events",
@@ -686,5 +777,6 @@ __all__ = [
     "get_upcoming_events",
     "mark_reminder_sent",
     "update_fusion_publication",
+    "update_fusion_announcement_refresh_state",
     "register_cache_buckets",
 ]

--- a/tests/community/test_fusion_announcement_refresh.py
+++ b/tests/community/test_fusion_announcement_refresh.py
@@ -1,0 +1,122 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.community.fusion import announcement_refresh
+from modules.community.fusion.rendering import build_fusion_announcement_embed
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row(
+    *,
+    last_refresh: dt.datetime | None,
+    last_hash: str,
+) -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        champion_image_url="",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=None,
+        announcement_message_id=456,
+        published_at=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        last_announcement_refresh_at=last_refresh,
+        last_announcement_status_hash=last_hash,
+        status="published",
+    )
+
+
+def _event(*, event_id: str, start_at: dt.datetime, end_at: dt.datetime) -> fusion_sheets.FusionEventRow:
+    return fusion_sheets.FusionEventRow(
+        fusion_id="f-1",
+        event_id=event_id,
+        event_name=f"Event {event_id}",
+        event_type="tournament",
+        category="main",
+        start_at_utc=start_at,
+        end_at_utc=end_at,
+        reward_amount=25,
+        bonus=None,
+        reward_type="fragments",
+        points_needed=2000,
+        is_estimated=False,
+        sort_order=1,
+    )
+
+
+def test_build_embed_includes_event_status_section() -> None:
+    now = dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
+    events = [
+        _event(
+            event_id="upcoming",
+            start_at=now + dt.timedelta(hours=1),
+            end_at=now + dt.timedelta(hours=2),
+        ),
+        _event(
+            event_id="live",
+            start_at=now - dt.timedelta(hours=1),
+            end_at=now + dt.timedelta(hours=1),
+        ),
+        _event(
+            event_id="ended",
+            start_at=now - dt.timedelta(hours=3),
+            end_at=now - dt.timedelta(hours=1),
+        ),
+    ]
+    embed = build_fusion_announcement_embed(_fusion_row(last_refresh=None, last_hash=""), events, now=now)
+    status_field = next(field for field in embed.fields if field.name == "Event Status")
+    assert "⏳ Event upcoming" in status_field.value
+    assert "🔥 Event live" in status_field.value
+    assert "✅ Event ended" in status_field.value
+
+
+def test_refresh_skips_when_day_and_status_hash_unchanged(monkeypatch) -> None:
+    async def _run() -> None:
+        now = dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
+        events = [_event(event_id="live", start_at=now - dt.timedelta(hours=1), end_at=now + dt.timedelta(hours=1))]
+        status_hash = announcement_refresh._compute_status_hash(events, now=now)
+        fusion = _fusion_row(last_refresh=now - dt.timedelta(minutes=10), last_hash=status_hash)
+
+        monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
+        monkeypatch.setattr(announcement_refresh, "ensure_fusion_announcement", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
+
+        await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
+
+        announcement_refresh.ensure_fusion_announcement.assert_not_awaited()
+        fusion_sheets.update_fusion_announcement_refresh_state.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_refresh_edits_existing_announcement_and_updates_metadata(monkeypatch) -> None:
+    async def _run() -> None:
+        now = dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
+        events = [_event(event_id="live", start_at=now - dt.timedelta(hours=1), end_at=now + dt.timedelta(hours=1))]
+        fusion = _fusion_row(last_refresh=now - dt.timedelta(days=1), last_hash="")
+        message = SimpleNamespace(edit=AsyncMock())
+        channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+
+        monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
+        monkeypatch.setattr(announcement_refresh, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(announcement_refresh, "ensure_fusion_announcement", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
+
+        await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
+
+        message.edit.assert_awaited_once()
+        fusion_sheets.update_fusion_announcement_refresh_state.assert_awaited_once()
+        announcement_refresh.ensure_fusion_announcement.assert_not_awaited()
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_announcements.py
+++ b/tests/community/test_fusion_announcements.py
@@ -25,6 +25,8 @@ def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
         opt_in_role_id=opt_in_role_id,
         announcement_message_id=None,
         published_at=None,
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status="draft",
     )
 

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -31,6 +31,8 @@ def _fusion_row(
         opt_in_role_id=None,
         announcement_message_id=announcement_message_id,
         published_at=None,
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status=status,
     )
 

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -24,6 +24,8 @@ def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
         opt_in_role_id=opt_in_role_id,
         announcement_message_id=456,
         published_at=dt.datetime(2026, 4, 7, tzinfo=dt.timezone.utc),
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status="active",
     )
 

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -23,6 +23,8 @@ def _fusion_row(*, opt_in_role_id: int | None = None) -> fusion_sheets.FusionRow
         opt_in_role_id=opt_in_role_id,
         announcement_message_id=456,
         published_at=dt.datetime(2026, 4, 7, tzinfo=dt.timezone.utc),
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status="active",
     )
 

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -22,6 +22,8 @@ def _fusion() -> FusionRow:
         opt_in_role_id=None,
         announcement_message_id=None,
         published_at=None,
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status="draft",
     )
 
@@ -56,11 +58,12 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
 
     assert "Target: 400 fragments needed / 450 available" in (embed.description or "")
     assert embed.fields[0].name == "Key Milestones"
-    assert len(embed.fields) >= 3
-    for field in embed.fields[1:]:
+    assert embed.fields[1].name == "Event Status"
+    assert len(embed.fields) >= 4
+    for field in embed.fields[2:]:
         assert "Schedule (Part" not in field.name
 
-    day_headers = [field.name for field in embed.fields[1:]]
+    day_headers = [field.name for field in embed.fields if field.name.startswith(("Wed,", "Thu,", "Fri,", "Sat,", "Sun,", "Mon,", "Tue,"))]
     assert day_headers == [
         "Wed, Apr 8",
         "Thu, Apr 9",

--- a/tests/community/test_fusion_role_cleanup.py
+++ b/tests/community/test_fusion_role_cleanup.py
@@ -24,6 +24,8 @@ def _fusion_row(*, opt_in_role_id: int | None = 777) -> fusion_sheets.FusionRow:
         opt_in_role_id=opt_in_role_id,
         announcement_message_id=456,
         published_at=dt.datetime(2026, 3, 31, tzinfo=dt.timezone.utc),
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
         status="published",
     )
 


### PR DESCRIPTION
### Motivation
- Provide a live, restart-safe fusion announcement that shows each event’s current state (Upcoming / Live / Ended) and keeps itself up to date without reposting. 
- Avoid unnecessary Discord API calls and ensure dedupe across restarts by persisting refresh metadata in the existing sheet-driven model. 

### Description
- Added a scheduler-driven refresh worker `process_fusion_announcement_refreshes` that runs on the existing ~1 minute cadence and only updates when the UTC day changes or the event status hash changes. 
- Introduced deterministic status derivation via `derive_event_status(...)` and a status-hash computed by `_compute_status_hash(...)`, and persisted metadata with `update_fusion_announcement_refresh_state(...)`. 
- Extended the existing announcement embed builder `build_fusion_announcement_embed` to include an `Event Status` section with icons (`⏳` upcoming, `🔥` live, `✅` ended) and made it reusable by publish/self-heal flows to avoid duplicate logic. 
- Hooked the refresh processor into the existing fusion scheduler and reused `ensure_fusion_announcement` self-heal behavior when the announcement message is missing. 
- Files changed: `modules/community/fusion/announcement_refresh.py`, `modules/community/fusion/rendering.py`, `modules/community/fusion/scheduler.py`, `shared/sheets/fusion.py`, plus test updates and additions. 

### Testing
- Ran the fusion test subset with `pytest -q tests/community/test_fusion_rendering.py tests/community/test_fusion_announcement_refresh.py tests/community/test_fusion_announcements.py tests/community/test_fusion_reminders.py tests/community/test_fusion_role_cleanup.py tests/community/test_fusion_cog.py tests/community/test_fusion_opt_in_view.py`, and all tests passed. 
- New unit tests verify event-status rendering and refresh dedupe/edit flows via `tests/community/test_fusion_announcement_refresh.py` and existing rendering/announcement/reminder/cleanup tests were updated to include the new `FusionRow` fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd39d1b748323b169e90f5177f50c)