### PR TITLE
Phase 9: Add private per-event Fusion progress tracking (My Progress button)

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -1,8 +1,10 @@
-"""Fusion role opt-in/out button view helpers."""
+"""Fusion role and personal-progress button view helpers."""
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
+from collections.abc import Sequence
 from typing import Literal
 
 import discord
@@ -14,6 +16,17 @@ log = logging.getLogger("c1c.community.fusion.opt_in")
 
 _FUSION_OPT_IN_CUSTOM_ID = "fusion:opt_in"
 _FUSION_OPT_OUT_CUSTOM_ID = "fusion:opt_out"
+_FUSION_MY_PROGRESS_CUSTOM_ID = "fusion:my_progress"
+_FUSION_PROGRESS_EVENT_CUSTOM_ID = "fusion:progress:event"
+_FUSION_PROGRESS_STATUS_CUSTOM_ID = "fusion:progress:status"
+
+_STATUS_ORDER = ("done", "in_progress", "skipped", "not_started")
+_STATUS_LABELS = {
+    "not_started": "Not Started",
+    "in_progress": "In Progress",
+    "done": "Done",
+    "skipped": "Skipped",
+}
 
 
 async def _send_ephemeral(interaction: discord.Interaction, message: str) -> None:
@@ -116,16 +129,256 @@ async def _handle_opt_action(interaction: discord.Interaction, *, action: Litera
     await _send_ephemeral(interaction, "Opted out. No more fusion pings.")
 
 
-class FusionOptInView(discord.ui.View):
-    """Persistent button view for fusion opt-in role management."""
+def _build_progress_summary_embed(
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: dict[str, str],
+    selected_event_id: str | None = None,
+    last_update: tuple[str, str] | None = None,
+) -> discord.Embed:
+    counts = {status: 0 for status in _STATUS_ORDER}
+    for event in events:
+        status = progress_by_event.get(event.event_id, "not_started")
+        if status not in counts:
+            status = "not_started"
+        counts[status] += 1
 
-    def __init__(self) -> None:
+    embed = discord.Embed(
+        title=f"My Progress — {target.fusion_name}",
+        description="Private tracker for your fusion events.",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Done", value=str(counts["done"]), inline=True)
+    embed.add_field(name="In Progress", value=str(counts["in_progress"]), inline=True)
+    embed.add_field(name="Skipped", value=str(counts["skipped"]), inline=True)
+    embed.add_field(name="Not Started", value=str(counts["not_started"]), inline=True)
+    embed.add_field(name="Total Events", value=str(len(events)), inline=True)
+
+    if selected_event_id:
+        selected = next((event for event in events if event.event_id == selected_event_id), None)
+        if selected is not None:
+            current = progress_by_event.get(selected.event_id, "not_started")
+            embed.add_field(
+                name="Selected Event",
+                value=f"{selected.event_name} — {_STATUS_LABELS.get(current, 'Not Started')}",
+                inline=False,
+            )
+
+    if last_update is not None:
+        event_name, status = last_update
+        embed.add_field(
+            name="Last Update",
+            value=f"{event_name} → {_STATUS_LABELS.get(status, 'Not Started')}",
+            inline=False,
+        )
+
+    return embed
+
+
+class _FusionProgressEventSelect(discord.ui.Select):
+    def __init__(self, events: Sequence[fusion_sheets.FusionEventRow], selected_event_id: str | None) -> None:
+        options: list[discord.SelectOption] = []
+        for event in events[:25]:
+            options.append(
+                discord.SelectOption(
+                    label=event.event_name[:100] or event.event_id[:100],
+                    value=event.event_id,
+                    default=event.event_id == selected_event_id,
+                )
+            )
+        super().__init__(
+            placeholder="Select an event",
+            min_values=1,
+            max_values=1,
+            options=options,
+            custom_id=_FUSION_PROGRESS_EVENT_CUSTOM_ID,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FusionProgressPanelView):
+            return
+        if interaction.user.id != view.user_id:
+            await _send_ephemeral(interaction, "This progress panel belongs to a different user.")
+            return
+
+        selected_event_id = self.values[0] if self.values else ""
+        view.selected_event_id = selected_event_id or None
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
+        )
+
+
+class _FusionProgressStatusSelect(discord.ui.Select):
+    def __init__(self, selected_status: str | None) -> None:
+        options = [
+            discord.SelectOption(label="Not Started", value="not_started", default=selected_status == "not_started"),
+            discord.SelectOption(label="In Progress", value="in_progress", default=selected_status == "in_progress"),
+            discord.SelectOption(label="Done", value="done", default=selected_status == "done"),
+            discord.SelectOption(label="Skipped", value="skipped", default=selected_status == "skipped"),
+        ]
+        super().__init__(
+            placeholder="Set status",
+            min_values=1,
+            max_values=1,
+            options=options,
+            custom_id=_FUSION_PROGRESS_STATUS_CUSTOM_ID,
+            row=1,
+            disabled=selected_status is None,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FusionProgressPanelView):
+            return
+        if interaction.user.id != view.user_id:
+            await _send_ephemeral(interaction, "This progress panel belongs to a different user.")
+            return
+        if not view.selected_event_id:
+            await _send_ephemeral(interaction, "Choose an event first.")
+            return
+
+        status = self.values[0] if self.values else "not_started"
+        event = view.events_by_id.get(view.selected_event_id)
+        if event is None:
+            await _send_ephemeral(interaction, "That event is no longer available. Reopen My Progress.")
+            return
+
+        now = dt.datetime.now(dt.timezone.utc)
+        try:
+            await fusion_sheets.upsert_user_event_progress(
+                view.fusion_id,
+                str(view.user_id),
+                event.event_id,
+                status,
+                now,
+            )
+        except Exception:
+            log.exception(
+                "fusion progress status update failed",
+                extra={"fusion_id": view.fusion_id, "event_id": event.event_id, "user_id": view.user_id},
+            )
+            await _send_ephemeral(interaction, "Couldn’t save progress right now. Try again in a moment.")
+            return
+
+        view.progress_by_event[event.event_id] = status
+        view.last_update = (event.event_name, status)
+        view.refresh_items()
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
+        )
+
+
+class FusionProgressPanelView(discord.ui.View):
+    """Ephemeral progress panel for one user and one fusion."""
+
+    def __init__(
+        self,
+        *,
+        user_id: int,
+        target: fusion_sheets.FusionRow,
+        events: Sequence[fusion_sheets.FusionEventRow],
+        progress_by_event: dict[str, str],
+    ) -> None:
+        super().__init__(timeout=900)
+        self.user_id = int(user_id)
+        self.fusion_id = target.fusion_id
+        self.target = target
+        self.events = list(events)
+        self.events_by_id = {event.event_id: event for event in self.events}
+        self.progress_by_event = dict(progress_by_event)
+        self.selected_event_id = self.events[0].event_id if self.events else None
+        self.last_update: tuple[str, str] | None = None
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        self.clear_items()
+        if not self.events:
+            return
+
+        self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id))
+        selected_status = None
+        if self.selected_event_id:
+            selected_status = self.progress_by_event.get(self.selected_event_id, "not_started")
+        self.add_item(_FusionProgressStatusSelect(selected_status))
+
+    def build_embed(self) -> discord.Embed:
+        return _build_progress_summary_embed(
+            target=self.target,
+            events=self.events,
+            progress_by_event=self.progress_by_event,
+            selected_event_id=self.selected_event_id,
+            last_update=self.last_update,
+        )
+
+
+async def _handle_my_progress(interaction: discord.Interaction) -> None:
+    try:
+        target = await fusion_sheets.get_publishable_fusion()
+    except Exception:
+        log.exception("fusion my-progress failed to resolve active fusion")
+        await _send_ephemeral(interaction, "Couldn’t load fusion progress right now. Try again shortly.")
+        return
+
+    if target is None:
+        await _send_ephemeral(interaction, "No active fusion is available right now.")
+        return
+
+    try:
+        events = await fusion_sheets.get_fusion_events(target.fusion_id)
+    except Exception:
+        log.exception("fusion my-progress failed to load events", extra={"fusion_id": target.fusion_id})
+        await _send_ephemeral(interaction, "Couldn’t load events right now. Try again shortly.")
+        return
+
+    if not events:
+        await _send_ephemeral(interaction, "No fusion events are configured yet.")
+        return
+
+    try:
+        progress_by_event = await fusion_sheets.get_user_event_progress(
+            target.fusion_id,
+            str(interaction.user.id),
+        )
+    except Exception:
+        log.exception(
+            "fusion my-progress failed to load user progress",
+            extra={"fusion_id": target.fusion_id, "user_id": interaction.user.id},
+        )
+        await _send_ephemeral(interaction, "Couldn’t load your saved progress right now.")
+        return
+
+    view = FusionProgressPanelView(
+        user_id=interaction.user.id,
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+    )
+    embed = view.build_embed()
+    if interaction.response.is_done():
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        return
+    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+
+class FusionOptInView(discord.ui.View):
+    """Persistent button view for fusion role management and private progress."""
+
+    def __init__(self, *, include_opt_buttons: bool = True) -> None:
         super().__init__(timeout=None)
+        if not include_opt_buttons:
+            self.remove_item(self.opt_in_button)
+            self.remove_item(self.opt_out_button)
 
     @discord.ui.button(
         label="Opt In",
         style=discord.ButtonStyle.success,
         custom_id=_FUSION_OPT_IN_CUSTOM_ID,
+        row=0,
     )
     async def opt_in_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
         await _handle_opt_action(interaction, action="in")
@@ -134,17 +387,25 @@ class FusionOptInView(discord.ui.View):
         label="Opt Out",
         style=discord.ButtonStyle.secondary,
         custom_id=_FUSION_OPT_OUT_CUSTOM_ID,
+        row=0,
     )
     async def opt_out_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
         await _handle_opt_action(interaction, action="out")
 
+    @discord.ui.button(
+        label="My Progress",
+        style=discord.ButtonStyle.primary,
+        custom_id=_FUSION_MY_PROGRESS_CUSTOM_ID,
+        row=0,
+    )
+    async def my_progress_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        await _handle_my_progress(interaction)
 
-def build_fusion_opt_in_view(target: fusion_sheets.FusionRow) -> discord.ui.View | None:
-    """Build the reusable fusion button row when the role is configured."""
 
-    if target.opt_in_role_id is None:
-        return None
-    return FusionOptInView()
+def build_fusion_opt_in_view(target: fusion_sheets.FusionRow) -> discord.ui.View:
+    """Build the reusable fusion button row for announcement and reminders."""
+
+    return FusionOptInView(include_opt_buttons=target.opt_in_role_id is not None)
 
 
 def register_persistent_fusion_views(bot: commands.Bot) -> None:

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -28,6 +28,13 @@ _FUSION_REMINDER_FUSION_ID_COL_KEY = "FUSION_REMINDER_COL_FUSION_ID"
 _FUSION_REMINDER_EVENT_ID_COL_KEY = "FUSION_REMINDER_COL_EVENT_ID"
 _FUSION_REMINDER_TYPE_COL_KEY = "FUSION_REMINDER_COL_REMINDER_TYPE"
 _FUSION_REMINDER_SENT_AT_COL_KEY = "FUSION_REMINDER_COL_SENT_AT_UTC"
+_FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
+_FUSION_PROGRESS_FUSION_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_FUSION_ID"
+_FUSION_PROGRESS_USER_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_USER_ID"
+_FUSION_PROGRESS_EVENT_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_EVENT_ID"
+_FUSION_PROGRESS_STATUS_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_STATUS"
+_FUSION_PROGRESS_UPDATED_AT_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_UPDATED_AT_UTC"
+_PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "skipped"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +74,15 @@ class FusionEventRow:
     points_needed: int | None
     is_estimated: bool
     sort_order: int
+
+
+@dataclass(frozen=True, slots=True)
+class FusionUserEventProgressRow:
+    fusion_id: str
+    user_id: str
+    event_id: str
+    status: str
+    updated_at: dt.datetime
 
 
 def _resolve_tab_name(key: str) -> str:
@@ -179,6 +195,22 @@ def _resolve_reminder_sheet_schema() -> tuple[str, dict[str, str]]:
         "event_id": _FUSION_REMINDER_EVENT_ID_COL_KEY,
         "reminder_type": _FUSION_REMINDER_TYPE_COL_KEY,
         "sent_at_utc": _FUSION_REMINDER_SENT_AT_COL_KEY,
+    }
+    column_by_field = {
+        field: _require_config_name(config_key)
+        for field, config_key in config_key_by_field.items()
+    }
+    return tab_name, column_by_field
+
+
+def _resolve_progress_sheet_schema() -> tuple[str, dict[str, str]]:
+    tab_name = _resolve_tab_name(_FUSION_PROGRESS_TAB_KEY)
+    config_key_by_field = {
+        "fusion_id": _FUSION_PROGRESS_FUSION_ID_COL_KEY,
+        "user_id": _FUSION_PROGRESS_USER_ID_COL_KEY,
+        "event_id": _FUSION_PROGRESS_EVENT_ID_COL_KEY,
+        "status": _FUSION_PROGRESS_STATUS_COL_KEY,
+        "updated_at_utc": _FUSION_PROGRESS_UPDATED_AT_COL_KEY,
     }
     column_by_field = {
         field: _require_config_name(config_key)
@@ -610,6 +642,133 @@ async def mark_reminder_sent(
     )
 
 
+def _normalize_progress_status(value: object) -> str:
+    status = str(value or "").strip().lower()
+    if status in _PROGRESS_ALLOWED_STATUSES:
+        return status
+    return "not_started"
+
+
+async def get_user_event_progress(fusion_id: str, user_id: str) -> dict[str, str]:
+    """Return per-event progress status for a fusion/user tuple."""
+
+    tab_name, columns = _resolve_progress_sheet_schema()
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return {}
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    required_fields = ("fusion_id", "user_id", "event_id", "status")
+    required_names = [columns[field] for field in required_fields]
+    missing = [name for name in required_names if name.strip().lower() not in header]
+    if missing:
+        raise RuntimeError(
+            "Fusion user progress sheet missing configured columns "
+            f"(tab={tab_name}, missing={', '.join(missing)}, "
+            f"config_keys={_FUSION_PROGRESS_FUSION_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_USER_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_EVENT_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_STATUS_COL_KEY})"
+        )
+
+    fusion_idx = header.index(columns["fusion_id"].strip().lower())
+    user_idx = header.index(columns["user_id"].strip().lower())
+    event_idx = header.index(columns["event_id"].strip().lower())
+    status_idx = header.index(columns["status"].strip().lower())
+    target_fusion = str(fusion_id or "").strip()
+    target_user = str(user_id or "").strip()
+
+    rows: dict[str, str] = {}
+    for row in matrix[1:]:
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_user = str(row[user_idx] if user_idx < len(row) else "").strip()
+        if row_fusion != target_fusion or row_user != target_user:
+            continue
+        event_id = str(row[event_idx] if event_idx < len(row) else "").strip()
+        if not event_id:
+            continue
+        status = _normalize_progress_status(row[status_idx] if status_idx < len(row) else "")
+        rows[event_id] = status
+    return rows
+
+
+async def upsert_user_event_progress(
+    fusion_id: str,
+    user_id: str,
+    event_id: str,
+    status: str,
+    updated_at: dt.datetime,
+) -> None:
+    """Write user progress status for one fusion/user/event tuple."""
+
+    normalized_status = _normalize_progress_status(status)
+    tab_name, columns = _resolve_progress_sheet_schema()
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        raise RuntimeError(
+            "Fusion user progress sheet is empty "
+            f"(tab={tab_name}, key={_FUSION_PROGRESS_TAB_KEY})"
+        )
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    required_fields = ("fusion_id", "user_id", "event_id", "status", "updated_at_utc")
+    required_names = [columns[field] for field in required_fields]
+    missing = [name for name in required_names if name.strip().lower() not in header]
+    if missing:
+        raise RuntimeError(
+            "Fusion user progress sheet missing configured columns for write "
+            f"(tab={tab_name}, missing={', '.join(missing)}, "
+            f"config_keys={_FUSION_PROGRESS_FUSION_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_USER_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_EVENT_ID_COL_KEY},"
+            f"{_FUSION_PROGRESS_STATUS_COL_KEY},"
+            f"{_FUSION_PROGRESS_UPDATED_AT_COL_KEY})"
+        )
+
+    fusion_idx = header.index(columns["fusion_id"].strip().lower())
+    user_idx = header.index(columns["user_id"].strip().lower())
+    event_idx = header.index(columns["event_id"].strip().lower())
+    status_idx = header.index(columns["status"].strip().lower())
+    updated_idx = header.index(columns["updated_at_utc"].strip().lower())
+    target_fusion = str(fusion_id or "").strip()
+    target_user = str(user_id or "").strip()
+    target_event = str(event_id or "").strip()
+    timestamp = updated_at.astimezone(dt.timezone.utc).isoformat()
+
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    for row_idx, row in enumerate(matrix[1:], start=2):
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_user = str(row[user_idx] if user_idx < len(row) else "").strip()
+        row_event = str(row[event_idx] if event_idx < len(row) else "").strip()
+        if (row_fusion, row_user, row_event) != (target_fusion, target_user, target_event):
+            continue
+        await acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(status_idx)}{row_idx}",
+            [[normalized_status]],
+            value_input_option="RAW",
+        )
+        await acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(updated_idx)}{row_idx}",
+            [[timestamp]],
+            value_input_option="RAW",
+        )
+        return
+
+    row_values = [""] * len(header)
+    row_values[fusion_idx] = target_fusion
+    row_values[user_idx] = target_user
+    row_values[event_idx] = target_event
+    row_values[status_idx] = normalized_status
+    row_values[updated_idx] = timestamp
+    await acall_with_backoff(
+        worksheet.append_row,
+        row_values,
+        value_input_option="RAW",
+    )
+
+
 
 
 async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:
@@ -765,6 +924,7 @@ async def update_fusion_announcement_refresh_state(
 __all__ = [
     "FusionEventRow",
     "FusionRow",
+    "FusionUserEventProgressRow",
     "get_active_fusion",
     "get_ended_fusions",
     "get_published_fusions",
@@ -774,8 +934,10 @@ __all__ = [
     "get_publishable_fusion",
     "get_fusion_events",
     "get_sent_reminder_keys",
+    "get_user_event_progress",
     "get_upcoming_events",
     "mark_reminder_sent",
+    "upsert_user_event_progress",
     "update_fusion_publication",
     "update_fusion_announcement_refresh_state",
     "register_cache_buckets",

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -166,3 +166,21 @@ def test_permission_failure_is_handled_cleanly(monkeypatch):
         )
 
     asyncio.run(_run())
+
+
+def test_build_view_keeps_opt_buttons_when_role_configured():
+    view = opt_in_view.build_fusion_opt_in_view(_fusion_row(opt_in_role_id=777))
+
+    custom_ids = [item.custom_id for item in view.children]
+    assert "fusion:opt_in" in custom_ids
+    assert "fusion:opt_out" in custom_ids
+    assert "fusion:my_progress" in custom_ids
+
+
+def test_build_view_keeps_progress_button_without_opt_role():
+    view = opt_in_view.build_fusion_opt_in_view(_fusion_row(opt_in_role_id=None))
+
+    custom_ids = [item.custom_id for item in view.children]
+    assert "fusion:opt_in" not in custom_ids
+    assert "fusion:opt_out" not in custom_ids
+    assert custom_ids == ["fusion:my_progress"]

--- a/tests/shared/sheets/test_fusion_user_event_progress_schema.py
+++ b/tests/shared/sheets/test_fusion_user_event_progress_schema.py
@@ -1,0 +1,153 @@
+import asyncio
+import datetime as dt
+
+import pytest
+
+import shared.config as config_module
+from shared.sheets import fusion as fusion_sheets
+
+
+class _Worksheet:
+    def __init__(self) -> None:
+        self.updated: list[tuple[str, list[list[str]]]] = []
+        self.appended: list[list[str]] = []
+
+    def update(self, cell: str, values: list[list[str]], value_input_option: str = "RAW") -> None:
+        self.updated.append((cell, values))
+
+    def append_row(self, values: list[str], value_input_option: str = "RAW") -> None:
+        self.appended.append(values)
+
+
+def _install_config(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
+    for key, value in mapping.items():
+        monkeypatch.setitem(config_module._CONFIG, key, value)
+
+
+def _install_progress_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_USER_EVENT_PROGRESS_TAB": "Progress Ledger",
+            "FUSION_USER_EVENT_PROGRESS_COL_FUSION_ID": "FusionKey",
+            "FUSION_USER_EVENT_PROGRESS_COL_USER_ID": "UserKey",
+            "FUSION_USER_EVENT_PROGRESS_COL_EVENT_ID": "EventKey",
+            "FUSION_USER_EVENT_PROGRESS_COL_STATUS": "Status",
+            "FUSION_USER_EVENT_PROGRESS_COL_UPDATED_AT_UTC": "UpdatedAt",
+        },
+    )
+
+
+def test_get_user_event_progress_uses_configured_tab_and_columns(monkeypatch: pytest.MonkeyPatch):
+    _install_progress_config(monkeypatch)
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "Progress Ledger"
+        return [
+            ["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"],
+            ["f-1", "42", "e-1", "done", "2026-01-01T00:00:00+00:00"],
+            ["f-1", "42", "e-2", "unknown", "2026-01-01T00:00:00+00:00"],
+            ["f-2", "42", "e-9", "done", "2026-01-01T00:00:00+00:00"],
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    progress = asyncio.run(fusion_sheets.get_user_event_progress("f-1", "42"))
+
+    assert progress == {"e-1": "done", "e-2": "not_started"}
+
+
+def test_upsert_user_event_progress_updates_existing_row(monkeypatch: pytest.MonkeyPatch):
+    _install_progress_config(monkeypatch)
+    worksheet = _Worksheet()
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "Progress Ledger"
+        return [
+            ["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"],
+            ["f-1", "42", "e-1", "not_started", ""],
+        ]
+
+    async def _aget_worksheet(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def _acall_with_backoff(fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion_sheets, "aget_worksheet", _aget_worksheet)
+    monkeypatch.setattr(fusion_sheets, "acall_with_backoff", _acall_with_backoff)
+
+    asyncio.run(
+        fusion_sheets.upsert_user_event_progress(
+            "f-1",
+            "42",
+            "e-1",
+            "done",
+            dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    assert worksheet.updated
+    assert not worksheet.appended
+    assert [cell for cell, _values in worksheet.updated] == ["D2", "E2"]
+
+
+def test_upsert_user_event_progress_appends_when_missing(monkeypatch: pytest.MonkeyPatch):
+    _install_progress_config(monkeypatch)
+    worksheet = _Worksheet()
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "Progress Ledger"
+        return [["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"]]
+
+    async def _aget_worksheet(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def _acall_with_backoff(fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion_sheets, "aget_worksheet", _aget_worksheet)
+    monkeypatch.setattr(fusion_sheets, "acall_with_backoff", _acall_with_backoff)
+
+    asyncio.run(
+        fusion_sheets.upsert_user_event_progress(
+            "f-1",
+            "42",
+            "e-2",
+            "in_progress",
+            dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    assert not worksheet.updated
+    assert worksheet.appended
+    assert worksheet.appended[0][0:4] == ["f-1", "42", "e-2", "in_progress"]
+
+
+def test_get_user_event_progress_requires_configured_column_keys(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delitem(
+        config_module._CONFIG,
+        "FUSION_USER_EVENT_PROGRESS_COL_FUSION_ID",
+        raising=False,
+    )
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_USER_EVENT_PROGRESS_TAB": "Progress Ledger",
+            "FUSION_USER_EVENT_PROGRESS_COL_USER_ID": "UserKey",
+            "FUSION_USER_EVENT_PROGRESS_COL_EVENT_ID": "EventKey",
+            "FUSION_USER_EVENT_PROGRESS_COL_STATUS": "Status",
+            "FUSION_USER_EVENT_PROGRESS_COL_UPDATED_AT_UTC": "UpdatedAt",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="FUSION_USER_EVENT_PROGRESS_COL_FUSION_ID"):
+        asyncio.run(fusion_sheets.get_user_event_progress("f-1", "42"))


### PR DESCRIPTION
### Motivation
- Implement Phase 9 to allow users to privately track their fusion progress per event through an ephemeral UI reachable from announcements/reminders without requiring commands.
- Keep the announcement as the single public surface while storing user progress in a restart-safe, sheet-backed store driven entirely by existing config-driven sheet patterns.

### Description
- Added a config-driven persisted user-progress table and helpers in `shared/sheets/fusion.py` including `get_user_event_progress(fusion_id, user_id)` and `upsert_user_event_progress(fusion_id, user_id, event_id, status, updated_at)` and a `FusionUserEventProgressRow` dataclass, with schema keys resolved from config (`FUSION_USER_EVENT_PROGRESS_TAB`, `FUSION_USER_EVENT_PROGRESS_COL_*`).
- Implemented status normalization and allowed statuses set to `not_started`, `in_progress`, `done`, and `skipped`, and ensured upserts overwrite the single logical row per `(fusion_id, user_id, event_id)` and append when missing.
- Extended the persistent fusion view in `modules/community/fusion/opt_in_view.py` to expose a `My Progress` button (persistent custom id `fusion:my_progress`) while preserving existing `Opt In`/`Opt Out` behavior, and added an ephemeral two-step UI (event selector + status selector) with a private summary embed and deterministic custom IDs for components.
- Kept changes surgical and config-driven (no hard-coded sheet tab names or column headers), and did not modify intents, OAuth scopes, announcement/reminder delivery logic, or opt-in/out semantics.

### Testing
- Ran targeted unit tests: `tests/shared/sheets/test_fusion_user_event_progress_schema.py`, `tests/shared/sheets/test_fusion_reminder_schema.py`, `tests/community/test_fusion_opt_in_view.py`, and `tests/community/test_fusion_reminders.py`, and all tests passed (pytest completed successfully, with only an unrelated `asyncio_mode` config warning).
- New tests cover config-driven progress schema lookup, read semantics, upsert (update vs append) semantics, normalization to `not_started`, and view composition for both role-configured and role-absent cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd721978483238cef7863b48c3f69)