### PR TITLE
Scheduler/job dedupe, bot-readiness guards for fusion jobs, and clearer fusion sheet errors

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -773,6 +773,17 @@ class Scheduler:
 
     def spawn(self, coro: Awaitable, *, name: Optional[str] = None) -> asyncio.Task:
         if name is not None:
+            for existing in self._tasks:
+                if existing.done():
+                    continue
+                if existing.get_name() == name:
+                    try:
+                        coro.close()
+                    except Exception:
+                        pass
+                    log.debug("scheduler spawn skipped duplicate task", extra={"task_name": name})
+                    return existing
+        if name is not None:
             task = asyncio.create_task(coro, name=name)
         else:
             task = asyncio.create_task(coro)
@@ -795,6 +806,11 @@ class Scheduler:
         name: str | None = None,
         component: str | None = None,
     ) -> _RecurringJob:
+        if name is not None:
+            for existing in self._jobs:
+                if existing.name == name:
+                    log.debug("scheduler registration skipped duplicate job", extra={"job_name": name})
+                    return existing
         total_seconds = float(hours) * 3600.0 + float(minutes) * 60.0 + float(seconds)
         if total_seconds <= 0:
             total_seconds = 60.0
@@ -1426,6 +1442,10 @@ class Runtime:
                     retry_delay_sec,
                     detail,
                 )
+                try:
+                    await self.bot.http.close()
+                except Exception:
+                    log.debug("failed to close discord http client after login failure", exc_info=True)
                 await _sleep_with_shutdown_poll(self.bot, retry_delay_sec)
                 retry_delay_sec = min(
                     _DISCORD_LOGIN_RETRY_CAP_SEC,

--- a/modules/community/fusion/announcement_refresh.py
+++ b/modules/community/fusion/announcement_refresh.py
@@ -76,6 +76,13 @@ async def process_fusion_announcement_refreshes(
     *,
     now: dt.datetime | None = None,
 ) -> None:
+    is_closed = getattr(bot, "is_closed", None)
+    is_ready = getattr(bot, "is_ready", None)
+    if callable(is_closed) and is_closed():
+        return
+    if callable(is_ready) and not is_ready():
+        return
+
     reference = _utc_now(now)
     try:
         targets = await fusion_sheets.get_published_fusions()

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -60,6 +60,13 @@ async def process_fusion_reminders(
     *,
     now: dt.datetime | None = None,
 ) -> None:
+    is_closed = getattr(bot, "is_closed", None)
+    is_ready = getattr(bot, "is_ready", None)
+    if callable(is_closed) and is_closed():
+        return
+    if callable(is_ready) and not is_ready():
+        return
+
     reference = _utc_now(now)
     lookback = dt.timedelta(minutes=_LOOKBACK_MINUTES)
 

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from typing import TYPE_CHECKING
 
@@ -11,12 +12,34 @@ if TYPE_CHECKING:
     from modules.common.runtime import Runtime
 
 log = logging.getLogger("c1c.community.fusion.scheduler")
+_NOT_READY_LOG_INTERVAL_SEC = 300.0
+_last_not_ready_log_at: dt.datetime | None = None
+
+
+def _should_log_not_ready(now: dt.datetime) -> bool:
+    global _last_not_ready_log_at
+    if _last_not_ready_log_at is None:
+        _last_not_ready_log_at = now
+        return True
+    if (now - _last_not_ready_log_at).total_seconds() >= _NOT_READY_LOG_INTERVAL_SEC:
+        _last_not_ready_log_at = now
+        return True
+    return False
 
 
 def schedule_fusion_jobs(runtime: "Runtime") -> None:
+    if any(getattr(job, "name", None) == "fusion_reminders" for job in runtime.scheduler.jobs):
+        log.info("fusion scheduler already registered; skipping duplicate job")
+        return
+
     job = runtime.scheduler.every(minutes=1.0, tag="fusion", name="fusion_reminders")
 
     async def _runner() -> None:
+        if runtime.bot.is_closed() or not runtime.bot.is_ready():
+            now = dt.datetime.now(dt.timezone.utc)
+            if _should_log_not_ready(now):
+                log.info("fusion scheduler paused; bot not ready")
+            return
         try:
             await process_fusion_reminders(runtime.bot)
             await process_fusion_announcement_refreshes(runtime.bot)

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -203,6 +203,21 @@ def _resolve_reminder_sheet_schema() -> tuple[str, dict[str, str]]:
     return tab_name, column_by_field
 
 
+def _reminder_schema_debug() -> dict[str, str]:
+    keys = (
+        _FUSION_REMINDER_TAB_KEY,
+        _FUSION_REMINDER_FUSION_ID_COL_KEY,
+        _FUSION_REMINDER_EVENT_ID_COL_KEY,
+        _FUSION_REMINDER_TYPE_COL_KEY,
+        _FUSION_REMINDER_SENT_AT_COL_KEY,
+    )
+    debug: dict[str, str] = {}
+    for key in keys:
+        value = cfg.get(key)
+        debug[key] = str(value if value is not None else "").strip()
+    return debug
+
+
 def _resolve_progress_sheet_schema() -> tuple[str, dict[str, str]]:
     tab_name = _resolve_tab_name(_FUSION_PROGRESS_TAB_KEY)
     config_key_by_field = {
@@ -540,7 +555,14 @@ def derive_event_status(
 async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
     """Return durable reminder keys previously sent for ``fusion_id``."""
 
-    tab_name, columns = _resolve_reminder_sheet_schema()
+    try:
+        tab_name, columns = _resolve_reminder_sheet_schema()
+    except Exception as exc:
+        debug_config = _reminder_schema_debug()
+        raise RuntimeError(
+            "Fusion reminder durable dedupe config invalid "
+            f"(config={debug_config})"
+        ) from exc
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return set()
@@ -550,9 +572,11 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
     required_names = [columns[field] for field in required_fields]
     missing = [name for name in required_names if name.strip().lower() not in header]
     if missing:
+        available = [str(cell or "").strip() for cell in matrix[0]]
         raise RuntimeError(
             "Fusion reminder sheet missing configured columns for durable dedupe "
             f"(tab={tab_name}, missing={', '.join(missing)}, "
+            f"available={available}, "
             f"config_keys={_FUSION_REMINDER_FUSION_ID_COL_KEY},"
             f"{_FUSION_REMINDER_EVENT_ID_COL_KEY},{_FUSION_REMINDER_TYPE_COL_KEY})"
         )
@@ -583,7 +607,14 @@ async def mark_reminder_sent(
 ) -> None:
     """Persist a sent reminder marker with a durable fusion/event/type key."""
 
-    tab_name, columns = _resolve_reminder_sheet_schema()
+    try:
+        tab_name, columns = _resolve_reminder_sheet_schema()
+    except Exception as exc:
+        debug_config = _reminder_schema_debug()
+        raise RuntimeError(
+            "Fusion reminder durable dedupe config invalid for write "
+            f"(config={debug_config})"
+        ) from exc
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         raise RuntimeError(
@@ -596,9 +627,11 @@ async def mark_reminder_sent(
     required_names = [columns[field] for field in required_fields]
     missing = [name for name in required_names if name.strip().lower() not in header]
     if missing:
+        available = [str(cell or "").strip() for cell in matrix[0]]
         raise RuntimeError(
             "Fusion reminder sheet missing configured columns for write "
             f"(tab={tab_name}, missing={', '.join(missing)}, "
+            f"available={available}, "
             f"config_keys={_FUSION_REMINDER_FUSION_ID_COL_KEY},"
             f"{_FUSION_REMINDER_EVENT_ID_COL_KEY},"
             f"{_FUSION_REMINDER_TYPE_COL_KEY},"

--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from modules.community.fusion import scheduler as fusion_scheduler
+
+
+class _FakeJob:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self._runner = None
+
+    def do(self, runner):
+        self._runner = runner
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.jobs = []
+
+    def every(self, **kwargs):
+        job = _FakeJob(name=kwargs.get("name", ""))
+        self.jobs.append(job)
+        return job
+
+
+def test_schedule_fusion_jobs_is_idempotent() -> None:
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+
+    fusion_scheduler.schedule_fusion_jobs(runtime)
+    fusion_scheduler.schedule_fusion_jobs(runtime)
+
+    assert len(runtime.scheduler.jobs) == 1
+    assert runtime.scheduler.jobs[0].name == "fusion_reminders"

--- a/tests/shared/test_runtime_scheduler.py
+++ b/tests/shared/test_runtime_scheduler.py
@@ -43,3 +43,33 @@ def test_scheduler_job_exception_does_not_cancel(
         assert any("recurring job error" in record.getMessage() for record in caplog.records)
 
     asyncio.run(runner())
+
+
+def test_scheduler_every_dedupes_by_job_name() -> None:
+    scheduler = runtime.Scheduler()
+    try:
+        first = scheduler.every(seconds=30, name="dupe_job", tag="test")
+        second = scheduler.every(seconds=45, name="dupe_job", tag="test")
+        assert first is second
+    finally:
+        asyncio.run(scheduler.shutdown())
+
+
+def test_scheduler_spawn_dedupes_active_named_task() -> None:
+    async def runner() -> None:
+        scheduler = runtime.Scheduler()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def worker() -> None:
+            started.set()
+            await release.wait()
+
+        task1 = scheduler.spawn(worker(), name="dupe_task")
+        await started.wait()
+        task2 = scheduler.spawn(worker(), name="dupe_task")
+        assert task1 is task2
+        release.set()
+        await scheduler.shutdown()
+
+    asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Prevent duplicate background work by ensuring named tasks and recurring jobs are not registered or spawned multiple times.
- Avoid running fusion reminder/announcement logic when the bot is not ready or already closed and reduce log spam when paused.
- Provide clearer diagnostics when fusion reminder sheet configuration is invalid or missing columns.

### Description
- In `modules/common/runtime.py` `Scheduler.spawn` now returns an existing active named task instead of creating a duplicate and logs the skip, and `Scheduler.every` returns an existing job when a job with the same `name` is already registered.
- Added a best-effort close of `bot.http` after a Discord login `HTTPException` retry to free resources during restart attempts.
- In `modules/community/fusion/announcement_refresh.py` and `modules/community/fusion/reminders.py` both processors now bail early if `bot.is_closed()` or not `bot.is_ready()` to avoid running while the client is unavailable.
- In `modules/community/fusion/scheduler.py` the fusion scheduler registration is made idempotent by checking existing `runtime.scheduler.jobs`, and the runner skips work while the bot is not ready with a rate-limited informational log via `_should_log_not_ready`.
- In `shared/sheets/fusion.py` introduced `_reminder_schema_debug` and wrapped `_resolve_reminder_sheet_schema` calls to raise descriptive `RuntimeError`s including config and available header values when schema/config resolution fails or configured columns are missing for both read and write paths.
- Added tests: `tests/community/test_fusion_scheduler.py` to verify idempotent registration and extended `tests/shared/test_runtime_scheduler.py` with tests for job/name deduping and spawn dedupe behaviour.

### Testing
- Ran unit tests for the scheduler dedupe behavior: `tests/shared/test_runtime_scheduler.py::test_scheduler_every_dedupes_by_job_name` and `tests/shared/test_runtime_scheduler.py::test_scheduler_spawn_dedupes_active_named_task`, which passed.
- Ran `tests/community/test_fusion_scheduler.py::test_schedule_fusion_jobs_is_idempotent`, which passed.
- Existing scheduler-related tests remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfde8489348323bead78ae9c60428b)