### PR TITLE
Fix startup login retry lifecycle to avoid closed Discord session reuse

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -361,6 +361,14 @@ async def _sleep_with_shutdown_poll(bot: commands.Bot, delay_sec: int) -> None:
         remaining -= step
 
 
+def _is_bot_http_session_closed(bot: commands.Bot) -> bool:
+    http = getattr(bot, "http", None)
+    if http is None:
+        return False
+    session = getattr(http, "_HTTPClient__session", None)
+    return bool(getattr(session, "closed", False))
+
+
 def _parse_times(parts: Iterable[str]) -> list[dt_time]:
     times: list[dt_time] = []
     for raw in parts:
@@ -1427,7 +1435,14 @@ class Runtime:
             log.exception("failed to schedule fusion reminders")
 
         retry_delay_sec = _DISCORD_LOGIN_RETRY_INITIAL_SEC
+        startup_attempt = 1
         while not self.bot.is_closed():
+            log.info("startup attempt %s begin", startup_attempt)
+            if _is_bot_http_session_closed(self.bot):
+                raise RuntimeError(
+                    "startup retry refused: bot HTTP session is already closed; "
+                    "cannot retry on disposed client"
+                )
             try:
                 await self.bot.start(token)
                 return
@@ -1438,18 +1453,30 @@ class Runtime:
                 if not should_retry:
                     raise
                 log.warning(
-                    "Discord login rate-limited; retrying in %ss (%s)",
+                    "startup attempt %s rate-limited, backing off %ss (%s)",
+                    startup_attempt,
                     retry_delay_sec,
                     detail,
                 )
-                try:
-                    await self.bot.http.close()
-                except Exception:
-                    log.debug("failed to close discord http client after login failure", exc_info=True)
+                log.info(
+                    "startup attempt %s disposed: no-op (retaining active bot/client)",
+                    startup_attempt,
+                )
                 await _sleep_with_shutdown_poll(self.bot, retry_delay_sec)
+                if self.bot.is_closed():
+                    log.info(
+                        "startup attempt %s aborted: bot closed during backoff",
+                        startup_attempt,
+                    )
+                    return
                 retry_delay_sec = min(
                     _DISCORD_LOGIN_RETRY_CAP_SEC,
                     retry_delay_sec * 2,
+                )
+                startup_attempt += 1
+                log.info(
+                    "startup attempt %s rebuilding bot/client: skipped (existing client retained)",
+                    startup_attempt,
                 )
 
     async def close(self) -> None:

--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -1,4 +1,7 @@
+import asyncio
+import logging
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from modules.community.fusion import scheduler as fusion_scheduler
 
@@ -30,3 +33,32 @@ def test_schedule_fusion_jobs_is_idempotent() -> None:
 
     assert len(runtime.scheduler.jobs) == 1
     assert runtime.scheduler.jobs[0].name == "fusion_reminders"
+
+
+def test_fusion_scheduler_pauses_when_bot_not_ready(
+    monkeypatch,
+    caplog,
+) -> None:
+    runtime = SimpleNamespace(
+        bot=SimpleNamespace(is_closed=lambda: False, is_ready=lambda: False),
+        scheduler=_FakeScheduler(),
+    )
+    reminders = AsyncMock()
+    refresh = AsyncMock()
+    cleanup = AsyncMock()
+    monkeypatch.setattr(fusion_scheduler, "process_fusion_reminders", reminders)
+    monkeypatch.setattr(fusion_scheduler, "process_fusion_announcement_refreshes", refresh)
+    monkeypatch.setattr(fusion_scheduler, "process_ended_fusion_role_cleanup", cleanup)
+    monkeypatch.setattr(fusion_scheduler, "_last_not_ready_log_at", None)
+
+    fusion_scheduler.schedule_fusion_jobs(runtime)
+    runner = runtime.scheduler.jobs[0]._runner
+    assert runner is not None
+
+    caplog.set_level(logging.INFO, logger="c1c.community.fusion.scheduler")
+    asyncio.run(runner())
+
+    reminders.assert_not_awaited()
+    refresh.assert_not_awaited()
+    cleanup.assert_not_awaited()
+    assert "fusion scheduler paused; bot not ready" in caplog.text

--- a/tests/shared/test_runtime_startup_retry.py
+++ b/tests/shared/test_runtime_startup_retry.py
@@ -1,0 +1,112 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from modules.common import runtime
+
+
+class _RetryableLoginError(Exception):
+    status = 429
+    text = "cloudflare 1015"
+
+
+class _FakeBot:
+    def __init__(self, outcomes: list[object], *, session_closed: bool = False) -> None:
+        self._outcomes = list(outcomes)
+        self._closed = False
+        self.start_calls = 0
+        self.http = SimpleNamespace(
+            _HTTPClient__session=SimpleNamespace(closed=session_closed)
+        )
+
+    def is_closed(self) -> bool:
+        return self._closed
+
+    async def start(self, _token: str) -> None:
+        self.start_calls += 1
+        if not self._outcomes:
+            return
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return None
+
+
+def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime.discord, "HTTPException", _RetryableLoginError)
+    monkeypatch.setattr(
+        runtime,
+        "_is_startup_rate_limited",
+        lambda _exc: (True, "cloudflare_rate_limited(ray_id=test)"),
+    )
+    monkeypatch.setattr(runtime.Runtime, "start_webserver", AsyncMock())
+    monkeypatch.setattr(runtime.Runtime, "load_extensions", AsyncMock())
+    monkeypatch.setattr(runtime, "rehydrate_tiers", lambda _bot: None)
+    monkeypatch.setattr(runtime, "audit_tiers", lambda _bot, _logger: None)
+    monkeypatch.setattr(
+        runtime.shared_config, "merge_onboarding_config_early", lambda: 0
+    )
+    monkeypatch.setattr(
+        "shared.sheets.cache_scheduler.ensure_cache_registration", lambda: None
+    )
+    monkeypatch.setattr(
+        "shared.sheets.cache_scheduler.preload_on_startup", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        "shared.sheets.cache_scheduler.register_refresh_job",
+        lambda rt, bucket, interval, cadence_label: (
+            SimpleNamespace(bucket=bucket, cadence_label=cadence_label),
+            rt.scheduler.every(seconds=60, name=f"cache_{bucket}"),
+        ),
+    )
+    monkeypatch.setattr(
+        "shared.sheets.cache_scheduler.emit_schedule_log", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        "modules.ops.server_map.schedule_server_map_job", lambda _runtime: None
+    )
+    monkeypatch.setattr(
+        "modules.community.leagues.schedule_leagues_jobs", lambda _runtime: None
+    )
+    monkeypatch.setattr(
+        "modules.community.fusion.scheduler.schedule_fusion_jobs", lambda _runtime: None
+    )
+
+
+def test_runtime_startup_retry_keeps_live_client_for_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def runner() -> None:
+        _patch_runtime_startup(monkeypatch)
+        sleep_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr(runtime, "_sleep_with_shutdown_poll", sleep_mock)
+
+        bot = _FakeBot(outcomes=[_RetryableLoginError(), None], session_closed=False)
+        rt = runtime.Runtime(bot=bot)
+
+        await rt.start("token")
+
+        assert bot.start_calls == 2
+        assert sleep_mock.await_count == 1
+        sleep_args = sleep_mock.await_args.args
+        assert sleep_args[0] is bot
+        assert sleep_args[1] == runtime._DISCORD_LOGIN_RETRY_INITIAL_SEC
+
+    asyncio.run(runner())
+
+
+def test_runtime_startup_retry_refuses_dead_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def runner() -> None:
+        _patch_runtime_startup(monkeypatch)
+        bot = _FakeBot(outcomes=[None], session_closed=True)
+        rt = runtime.Runtime(bot=bot)
+
+        with pytest.raises(RuntimeError, match="session is already closed"):
+            await rt.start("token")
+        assert bot.start_calls == 0
+
+    asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- A startup retry path closed the Discord `http`/aiohttp session after a rate-limited login and then retried on the same `bot` instance, causing `RuntimeError: Session is closed` when discord.py attempted a subsequent login.  
- The intent is to preserve backoff/retry behavior while ensuring no retry uses an already-closed HTTP session and to keep the fusion scheduler readiness gating and scheduler idempotency intact.

### Description
- Add `_is_bot_http_session_closed(bot)` helper to detect a closed aiohttp session on the discord client.  
- In `Runtime.start()` add per-attempt lifecycle logs (`startup attempt N begin`, `rate-limited/backoff`, `disposed`, `rebuilding`) and a pre-attempt guard that raises `RuntimeError` if the bot HTTP session is already closed.  
- Remove the code path that explicitly closed `self.bot.http` during the retry and make disposal a no-op for the retry path so retries use the live client; ensure the backoff loop remains and aborts if the bot closes during backoff.  
- Add unit tests in `tests/shared/test_runtime_startup_retry.py` to validate: retry uses a live client without reusing a closed session, backoff is preserved, and startup refuses to retry on a pre-closed session.  
- Extend `tests/community/test_fusion_scheduler.py` to verify the fusion scheduler pauses while the bot is not ready and does not execute fusion operations in that state.

### Testing
- Ran `pytest -q tests/shared/test_runtime_startup_retry.py tests/community/test_fusion_scheduler.py tests/shared/test_runtime_scheduler.py`, and all tests passed.  
- Added assertions that the retry backoff helper `._sleep_with_shutdown_poll` was called and that the dead-session guard raises as expected.  

[meta]
labels: bug, robustness, comp:scheduler, tests, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe74990e48323badf1b83b0770d2e)