### PR TITLE
Add bot rebuild/dispose behavior for startup retries and update runtime tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ bot = commands.Bot(
 )
 bot.remove_command("help")
 
-runtime = Runtime(bot)
+runtime: Runtime
 _shutdown_lock: asyncio.Lock | None = None
 _shutdown_started = False
 
@@ -452,6 +452,46 @@ async def on_command_error(ctx: commands.Context, error: Exception):
 
 BOT_VERSION = os.getenv("BOT_VERSION", "dev")
 _STARTED_MONO = time.monotonic()
+
+
+_RUNTIME_EVENT_NAMES = (
+    "on_ready",
+    "on_connect",
+    "on_resumed",
+    "on_error",
+    "on_socket_response",
+    "on_socket_raw_receive",
+    "on_disconnect",
+    "on_guild_join",
+    "on_message",
+    "on_command_error",
+)
+
+
+def _clone_bot_for_retry() -> commands.Bot:
+    cloned = commands.Bot(
+        command_prefix=commands.when_mentioned_or(BANG_PREFIX),
+        intents=INTENTS,
+    )
+    cloned.remove_command("help")
+    for event_name in _RUNTIME_EVENT_NAMES:
+        handler = getattr(bot, event_name, None)
+        if handler is None:
+            continue
+        setattr(cloned, event_name, handler)
+    return cloned
+
+
+def _set_active_bot_for_runtime(rebuilt_bot: commands.Bot) -> None:
+    global bot
+    bot = rebuilt_bot
+
+
+runtime = Runtime(
+    bot,
+    bot_factory=_clone_bot_for_retry,
+    bot_rebuild_hook=_set_active_bot_for_runtime,
+)
 
 
 def uptime_seconds() -> float:

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -361,11 +361,19 @@ async def _sleep_with_shutdown_poll(bot: commands.Bot, delay_sec: int) -> None:
         remaining -= step
 
 
-def _is_bot_http_session_closed(bot: commands.Bot) -> bool:
+async def _sleep_startup_retry_backoff(delay_sec: int) -> None:
+    await asyncio.sleep(max(0, int(delay_sec)))
+
+
+def _bot_http_session(bot: commands.Bot) -> Any | None:
     http = getattr(bot, "http", None)
     if http is None:
-        return False
-    session = getattr(http, "_HTTPClient__session", None)
+        return None
+    return getattr(http, "_HTTPClient__session", None)
+
+
+def _is_bot_http_session_closed(bot: commands.Bot) -> bool:
+    session = _bot_http_session(bot)
     return bool(getattr(session, "closed", False))
 
 
@@ -857,8 +865,16 @@ class Scheduler:
 class Runtime:
     """Container object that wires the bot, health server, and scheduler."""
 
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        bot_factory: Callable[[], commands.Bot] | None = None,
+        bot_rebuild_hook: Callable[[commands.Bot], None] | None = None,
+    ) -> None:
         self.bot = bot
+        self._bot_factory = bot_factory
+        self._bot_rebuild_hook = bot_rebuild_hook
         self.scheduler = Scheduler()
         self._web_app: Optional[web.Application] = None
         self._web_runner: Optional[web.AppRunner] = None
@@ -866,6 +882,25 @@ class Runtime:
         self._watchdog_task: Optional[asyncio.Task] = None
         self._watchdog_params: Optional[tuple[int, int, int]] = None
         set_active_runtime(self)
+
+    def _build_bot_for_attempt(self, startup_attempt: int) -> commands.Bot:
+        if startup_attempt <= 1:
+            return self.bot
+        if self._bot_factory is None:
+            raise RuntimeError(
+                "startup retry requested a new bot/client but no bot_factory is configured"
+            )
+        new_bot = self._bot_factory()
+        self.bot = new_bot
+        if self._bot_rebuild_hook is not None:
+            self._bot_rebuild_hook(new_bot)
+        return new_bot
+
+    async def _dispose_bot_for_attempt(self, bot: commands.Bot) -> None:
+        try:
+            await bot.close()
+        except Exception:
+            log.exception("failed to dispose startup attempt bot/client")
 
     async def start_webserver(self, *, port: Optional[int] = None) -> None:
         if self._web_site is not None:
@@ -1436,15 +1471,17 @@ class Runtime:
 
         retry_delay_sec = _DISCORD_LOGIN_RETRY_INITIAL_SEC
         startup_attempt = 1
-        while not self.bot.is_closed():
+        attempt_bot = self._build_bot_for_attempt(startup_attempt)
+        log.info("startup attempt %s created new bot/client", startup_attempt)
+        while not attempt_bot.is_closed():
             log.info("startup attempt %s begin", startup_attempt)
-            if _is_bot_http_session_closed(self.bot):
+            if _is_bot_http_session_closed(attempt_bot):
                 raise RuntimeError(
                     "startup retry refused: bot HTTP session is already closed; "
                     "cannot retry on disposed client"
                 )
             try:
-                await self.bot.start(token)
+                await attempt_bot.start(token)
                 return
             except asyncio.CancelledError:
                 raise
@@ -1458,24 +1495,18 @@ class Runtime:
                     retry_delay_sec,
                     detail,
                 )
-                log.info(
-                    "startup attempt %s disposed: no-op (retaining active bot/client)",
-                    startup_attempt,
-                )
-                await _sleep_with_shutdown_poll(self.bot, retry_delay_sec)
-                if self.bot.is_closed():
-                    log.info(
-                        "startup attempt %s aborted: bot closed during backoff",
-                        startup_attempt,
-                    )
-                    return
+                log.info("startup attempt %s disposing failed bot/client", startup_attempt)
+                await self._dispose_bot_for_attempt(attempt_bot)
+                log.info("startup attempt %s disposed", startup_attempt)
+                await _sleep_startup_retry_backoff(retry_delay_sec)
                 retry_delay_sec = min(
                     _DISCORD_LOGIN_RETRY_CAP_SEC,
                     retry_delay_sec * 2,
                 )
                 startup_attempt += 1
+                attempt_bot = self._build_bot_for_attempt(startup_attempt)
                 log.info(
-                    "startup attempt %s rebuilding bot/client: skipped (existing client retained)",
+                    "startup attempt %s created new bot/client for retry",
                     startup_attempt,
                 )
 

--- a/tests/shared/test_runtime_startup_retry.py
+++ b/tests/shared/test_runtime_startup_retry.py
@@ -13,13 +13,13 @@ class _RetryableLoginError(Exception):
 
 
 class _FakeBot:
-    def __init__(self, outcomes: list[object], *, session_closed: bool = False) -> None:
+    def __init__(self, outcomes: list[object], *, label: str) -> None:
         self._outcomes = list(outcomes)
         self._closed = False
         self.start_calls = 0
-        self.http = SimpleNamespace(
-            _HTTPClient__session=SimpleNamespace(closed=session_closed)
-        )
+        self.close_calls = 0
+        self.label = label
+        self.http = SimpleNamespace(_HTTPClient__session=None)
 
     def is_closed(self) -> bool:
         return self._closed
@@ -32,6 +32,10 @@ class _FakeBot:
         if isinstance(outcome, BaseException):
             raise outcome
         return None
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self._closed = True
 
 
 def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -75,38 +79,55 @@ def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_runtime_startup_retry_keeps_live_client_for_retries(
+def test_runtime_startup_retry_rebuilds_bot_per_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def runner() -> None:
         _patch_runtime_startup(monkeypatch)
         sleep_mock = AsyncMock(return_value=None)
-        monkeypatch.setattr(runtime, "_sleep_with_shutdown_poll", sleep_mock)
+        monkeypatch.setattr(runtime, "_sleep_startup_retry_backoff", sleep_mock)
 
-        bot = _FakeBot(outcomes=[_RetryableLoginError(), None], session_closed=False)
-        rt = runtime.Runtime(bot=bot)
+        bot_attempt_1 = _FakeBot([_RetryableLoginError()], label="attempt-1")
+        bot_attempt_2 = _FakeBot([_RetryableLoginError()], label="attempt-2")
+        bot_attempt_3 = _FakeBot([None], label="attempt-3")
+        built = [bot_attempt_2, bot_attempt_3]
+        rebuilt: list[_FakeBot] = []
+
+        rt = runtime.Runtime(
+            bot=bot_attempt_1,
+            bot_factory=lambda: built.pop(0),
+            bot_rebuild_hook=lambda new_bot: rebuilt.append(new_bot),  # type: ignore[arg-type]
+        )
 
         await rt.start("token")
 
-        assert bot.start_calls == 2
-        assert sleep_mock.await_count == 1
-        sleep_args = sleep_mock.await_args.args
-        assert sleep_args[0] is bot
-        assert sleep_args[1] == runtime._DISCORD_LOGIN_RETRY_INITIAL_SEC
+        assert bot_attempt_1.start_calls == 1
+        assert bot_attempt_2.start_calls == 1
+        assert bot_attempt_3.start_calls == 1
+        assert bot_attempt_1.close_calls == 1
+        assert bot_attempt_2.close_calls == 1
+        assert bot_attempt_3.close_calls == 0
+        assert rebuilt == [bot_attempt_2, bot_attempt_3]
+        assert rt.bot is bot_attempt_3
+        assert sleep_mock.await_count == 2
 
     asyncio.run(runner())
 
 
-def test_runtime_startup_retry_refuses_dead_client(
+def test_runtime_startup_retry_requires_factory_for_rebuild(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def runner() -> None:
         _patch_runtime_startup(monkeypatch)
-        bot = _FakeBot(outcomes=[None], session_closed=True)
+        monkeypatch.setattr(
+            runtime, "_sleep_startup_retry_backoff", AsyncMock(return_value=None)
+        )
+        bot = _FakeBot([_RetryableLoginError()], label="attempt-1")
         rt = runtime.Runtime(bot=bot)
 
-        with pytest.raises(RuntimeError, match="session is already closed"):
+        with pytest.raises(RuntimeError, match="no bot_factory is configured"):
             await rt.start("token")
-        assert bot.start_calls == 0
+        assert bot.start_calls == 1
+        assert bot.close_calls == 1
 
     asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Improve robustness of bot startup retries by allowing creation of fresh `commands.Bot` instances for each retry attempt when rate-limited.
- Ensure failed or rate-limited bot clients are properly disposed to avoid reusing closed HTTP sessions.
- Provide a way for the application to update the active global `bot` reference when a new client is created during retries.

### Description
- Add `bot_factory` and `bot_rebuild_hook` parameters to `Runtime.__init__` and implement `_build_bot_for_attempt` and `_dispose_bot_for_attempt` to create and clean up attempt-specific bots. 
- Change startup loop in `Runtime.start` to use a per-attempt bot (`attempt_bot`), call `.start()` on it, and on retry dispose the failed bot and create a new one with `bot_factory`.
- Extract HTTP session access into `_bot_http_session` and update session-closed checks to use it, and add a simple `_sleep_startup_retry_backoff` helper to separate backoff waiting from shutdown polling.
- Add cloning helpers in `app.py` (`_clone_bot_for_retry`, `_set_active_bot_for_runtime`) and wire `Runtime` construction to pass `bot_factory` and `bot_rebuild_hook`, keeping the global `bot` in sync when rebuilt.

### Testing
- Updated and ran `tests/shared/test_runtime_startup_retry.py` which exercises rebuild/dispose behavior and factory requirement; the test suite assertions all passed. 
- Unit tests assert that multiple attempt bots are built and closed as expected and that a missing `bot_factory` raises the expected `RuntimeError` when a rebuild is required. 
- No other automated tests were modified or reported failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff2a2479c8323bd4e89b5a2d3a9fe)