### PR TITLE
Fail fast on Cloudflare Discord startup rate limits

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -397,6 +397,8 @@ def _is_retryable_discord_start_failure(exc: BaseException) -> tuple[bool, str]:
     if isinstance(exc, discord.HTTPException):
         should_retry, detail = _is_startup_rate_limited(exc)
         if should_retry:
+            if detail.startswith("cloudflare_rate_limited"):
+                return False, detail
             return True, detail
         status = getattr(exc, "status", None)
         if status is not None and int(status) >= 500:


### PR DESCRIPTION
### Motivation
- Cloudflare login/1015-style blocks should not trigger in-process retries because immediate retries do not resolve the block and waste retry attempts and backoff cycles, so the startup should fail fast and let an operator restart after cooldown.

### Description
- In `modules/common/runtime.py` updated `_is_retryable_discord_start_failure` so that when a `discord.HTTPException` is classified with a `detail` starting with `cloudflare_rate_limited` it now returns `False, detail` (non-retryable) while preserving existing retry behavior for timeouts, `OSError`, connection/gateway issues, and HTTP 5xx responses.

### Testing
- Compiled the modified file with `python -m py_compile modules/common/runtime.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b8ce52f083239ea2166f4715af10)