### PR TITLE
Handle ready lifecycle failures per step in on_ready

### DIFF
--- a/app.py
+++ b/app.py
@@ -258,12 +258,20 @@ async def on_ready():
 
     try:
         await core_ready.on_ready(bot)
+    except Exception:
+        log.exception("READY FAILURE: core_ready.on_ready")
+        await _shutdown("ready_lifecycle_failure:core_ready")
+        return
+
+    try:
         await runtime.register_ready_schedulers()
+    except Exception:
+        log.exception("READY FAILURE: runtime.register_ready_schedulers")
+
+    try:
         await ensure_scheduler_started(bot)
     except Exception:
-        log.exception("ready lifecycle failed; requesting shutdown")
-        await _shutdown("ready_lifecycle_failure")
-        return
+        log.exception("READY FAILURE: ensure_scheduler_started")
 
     try:
         started, interval, stall, grace = runtime.watchdog(delay_sec=5.0)


### PR DESCRIPTION
### Motivation
- The previous single `try/except` around the ready lifecycle caused the bot to shut down on any step failure and did not identify which ready step failed, preventing the bot from staying online and making diagnosis harder.

### Description
- Replaced the combined ready lifecycle `try/except` in `on_ready()` with three step-specific `try/except` blocks for `core_ready.on_ready(bot)`, `runtime.register_ready_schedulers()`, and `ensure_scheduler_started(bot)`.
- Preserved the original shutdown behavior only for failures in `core_ready.on_ready(bot)` and added a shutdown call with reason `ready_lifecycle_failure:core_ready` for that case.
- Added explicit step-level log messages `READY FAILURE: core_ready.on_ready`, `READY FAILURE: runtime.register_ready_schedulers`, and `READY FAILURE: ensure_scheduler_started` and ensured the last two exception handlers do not call shutdown.
- Did not change any other logic, names, scheduler code, runtime code, or logging formats.

### Testing
- Ran `python -m py_compile app.py` and it succeeded with no syntax errors.
- Verified the modified `on_ready()` compiles and that the new log messages are present in the changed code block during review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d269eb9c8323a2f9343452640b17)