### PR TITLE
Add step-scoped failure guards in core_ready.on_ready

### DIFF
--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -51,5 +51,4 @@ async def on_ready(bot: commands.Bot) -> None:
             logger = log
         logger.info("on_ready: onboarding views registered (post-ready)")
     except Exception:
-        log.exception("CORE_READY FAILURE: logger.info")
-        return
+        pass

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -19,12 +19,30 @@ async def on_ready(bot: commands.Bot) -> None:
 
     # Existing startup wiring …
     # Register onboarding persistent views *after* the bot is ready to avoid race conditions.
-    panels.register_views(bot)
-    register_persistent_fusion_views(bot)
+    try:
+        panels.register_views(bot)
+    except Exception:
+        log.exception("CORE_READY FAILURE: panels.register_views")
+        return
+
+    try:
+        register_persistent_fusion_views(bot)
+    except Exception:
+        log.exception("CORE_READY FAILURE: register_persistent_fusion_views")
+        return
 
     # Ensure both onboarding watchers are wired
-    await watcher_welcome.setup(bot)
-    await watcher_promo.setup(bot)
+    try:
+        await watcher_welcome.setup(bot)
+    except Exception:
+        log.exception("CORE_READY FAILURE: watcher_welcome.setup")
+        return
+
+    try:
+        await watcher_promo.setup(bot)
+    except Exception:
+        log.exception("CORE_READY FAILURE: watcher_promo.setup")
+        return
 
     # Guard against bots without a .logger attribute; fall back to module logger.
     try:
@@ -33,5 +51,5 @@ async def on_ready(bot: commands.Bot) -> None:
             logger = log
         logger.info("on_ready: onboarding views registered (post-ready)")
     except Exception:
-        # Never let logging break startup
-        pass
+        log.exception("CORE_READY FAILURE: logger.info")
+        return


### PR DESCRIPTION
### Motivation
- Isolate and surface the exact failing substep inside `core_ready.on_ready()` so startup crashes can be diagnosed without taking the bot offline. 
- Keep existing startup order and behavior while ensuring the bot remains online on the first failing substep.

### Description
- Wrapped `panels.register_views(bot)` in its own `try/except` that logs `CORE_READY FAILURE: panels.register_views` and returns early on error. 
- Wrapped `register_persistent_fusion_views(bot)` in its own `try/except` that logs `CORE_READY FAILURE: register_persistent_fusion_views` and returns early on error. 
- Wrapped `await watcher_welcome.setup(bot)` and `await watcher_promo.setup(bot)` each in their own `try/except` blocks that log `CORE_READY FAILURE: watcher_welcome.setup` and `CORE_READY FAILURE: watcher_promo.setup` respectively and return early on error. 
- Preserved the logger fallback and wrapped the final `logger.info(...)` in a `try/except` that logs `CORE_READY FAILURE: logger.info` and returns early on error. 
- No other files were changed and execution order/behavior outside `on_ready` was not altered.

### Testing
- Verified the change by inspecting the diff with `git diff -- modules/coreops/ready.py` which showed the guarded blocks and exact `CORE_READY FAILURE: <step_name>` messages (succeeded). 
- Verified workspace status with `git status --short` (succeeded). 
- Committed the change with `git add` + `git commit` (succeeded). 
- No unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d510c33c83238571908d6c3b780b)