### PR TITLE
Fix fusion reminder dedupe schema and improve announcement refresh diagnostics

### DIFF
--- a/modules/community/fusion/announcement_refresh.py
+++ b/modules/community/fusion/announcement_refresh.py
@@ -9,7 +9,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from modules.community.fusion.announcements import ensure_fusion_announcement, resolve_announcement_channel
+from modules.community.fusion.announcements import resolve_announcement_channel
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
@@ -68,6 +68,14 @@ async def _fetch_existing_announcement(
     try:
         return await channel.fetch_message(target.announcement_message_id)
     except Exception:
+        log.exception(
+            "fusion announcement refresh failed to fetch existing announcement message",
+            extra={
+                "fusion_id": target.fusion_id,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+        )
         return None
 
 
@@ -92,30 +100,57 @@ async def process_fusion_announcement_refreshes(
 
     for target in targets:
         try:
-            events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            try:
+                events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            except Exception:
+                log.exception(
+                    "fusion announcement refresh failed to load events",
+                    extra={"fusion_id": target.fusion_id},
+                )
+                continue
             status_hash = _compute_status_hash(events, now=reference)
             if not _needs_refresh(target, now=reference, status_hash=status_hash):
                 continue
 
             existing_message = await _fetch_existing_announcement(bot, target)
             if existing_message is None:
-                announcement_message = await ensure_fusion_announcement(bot, target)
-                if announcement_message is None:
-                    log.warning(
-                        "fusion announcement refresh skipped; announcement unavailable",
-                        extra={"fusion_id": target.fusion_id},
-                    )
-                    continue
-            else:
+                log.warning(
+                    "fusion announcement refresh skipped; existing announcement missing",
+                    extra={
+                        "fusion_id": target.fusion_id,
+                        "announcement_channel_id": target.announcement_channel_id,
+                        "announcement_message_id": target.announcement_message_id,
+                    },
+                )
+                continue
+
+            try:
                 announcement_embed = build_fusion_announcement_embed(target, events, now=reference)
                 announcement_view = build_fusion_opt_in_view(target)
                 await existing_message.edit(embed=announcement_embed, view=announcement_view)
+            except Exception:
+                log.exception(
+                    "fusion announcement refresh failed to edit existing announcement",
+                    extra={
+                        "fusion_id": target.fusion_id,
+                        "announcement_channel_id": target.announcement_channel_id,
+                        "announcement_message_id": target.announcement_message_id,
+                    },
+                )
+                continue
 
-            await fusion_sheets.update_fusion_announcement_refresh_state(
-                target.fusion_id,
-                refreshed_at=reference,
-                status_hash=status_hash,
-            )
+            try:
+                await fusion_sheets.update_fusion_announcement_refresh_state(
+                    target.fusion_id,
+                    refreshed_at=reference,
+                    status_hash=status_hash,
+                )
+            except Exception:
+                log.exception(
+                    "fusion announcement refresh failed to persist refresh state",
+                    extra={"fusion_id": target.fusion_id, "status_hash": status_hash},
+                )
+                continue
         except Exception:
             log.exception(
                 "fusion announcement refresh failed",

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -81,11 +81,13 @@ async def process_fusion_reminders(
 
     try:
         sent_keys = await fusion_sheets.get_sent_reminder_keys(target.fusion_id)
-    except Exception:
+    except Exception as exc:
         log.exception(
             "fusion reminder failed to load durable dedupe state; continuing fail-open "
             "(config keys: FUSION_REMINDER_TAB, FUSION_REMINDER_COL_FUSION_ID, "
-            "FUSION_REMINDER_COL_EVENT_ID, FUSION_REMINDER_COL_REMINDER_TYPE)",
+            "FUSION_REMINDER_COL_EVENT_ID, FUSION_REMINDER_COL_REMINDER_TYPE, "
+            "details=%s)",
+            exc,
             extra={"fusion_id": target.fusion_id},
         )
         sent_keys = set()

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -188,14 +188,18 @@ def _require_config_name(key: str) -> str:
     raise RuntimeError(f"{key} missing in milestones Config tab")
 
 
-def _resolve_reminder_sheet_schema() -> tuple[str, dict[str, str]]:
+def _resolve_reminder_sheet_schema(
+    *,
+    include_sent_at: bool,
+) -> tuple[str, dict[str, str]]:
     tab_name = _resolve_tab_name(_FUSION_REMINDER_TAB_KEY)
     config_key_by_field = {
         "fusion_id": _FUSION_REMINDER_FUSION_ID_COL_KEY,
         "event_id": _FUSION_REMINDER_EVENT_ID_COL_KEY,
         "reminder_type": _FUSION_REMINDER_TYPE_COL_KEY,
-        "sent_at_utc": _FUSION_REMINDER_SENT_AT_COL_KEY,
     }
+    if include_sent_at:
+        config_key_by_field["sent_at_utc"] = _FUSION_REMINDER_SENT_AT_COL_KEY
     column_by_field = {
         field: _require_config_name(config_key)
         for field, config_key in config_key_by_field.items()
@@ -556,7 +560,7 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
     """Return durable reminder keys previously sent for ``fusion_id``."""
 
     try:
-        tab_name, columns = _resolve_reminder_sheet_schema()
+        tab_name, columns = _resolve_reminder_sheet_schema(include_sent_at=False)
     except Exception as exc:
         debug_config = _reminder_schema_debug()
         raise RuntimeError(
@@ -608,7 +612,7 @@ async def mark_reminder_sent(
     """Persist a sent reminder marker with a durable fusion/event/type key."""
 
     try:
-        tab_name, columns = _resolve_reminder_sheet_schema()
+        tab_name, columns = _resolve_reminder_sheet_schema(include_sent_at=True)
     except Exception as exc:
         debug_config = _reminder_schema_debug()
         raise RuntimeError(

--- a/tests/community/test_fusion_announcement_refresh.py
+++ b/tests/community/test_fusion_announcement_refresh.py
@@ -88,12 +88,10 @@ def test_refresh_skips_when_day_and_status_hash_unchanged(monkeypatch) -> None:
 
         monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
         monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
-        monkeypatch.setattr(announcement_refresh, "ensure_fusion_announcement", AsyncMock())
         monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
 
         await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
 
-        announcement_refresh.ensure_fusion_announcement.assert_not_awaited()
         fusion_sheets.update_fusion_announcement_refresh_state.assert_not_awaited()
 
     asyncio.run(_run())
@@ -110,13 +108,30 @@ def test_refresh_edits_existing_announcement_and_updates_metadata(monkeypatch) -
         monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
         monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
         monkeypatch.setattr(announcement_refresh, "resolve_announcement_channel", AsyncMock(return_value=channel))
-        monkeypatch.setattr(announcement_refresh, "ensure_fusion_announcement", AsyncMock())
         monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
 
         await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
 
         message.edit.assert_awaited_once()
         fusion_sheets.update_fusion_announcement_refresh_state.assert_awaited_once()
-        announcement_refresh.ensure_fusion_announcement.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_refresh_skips_when_existing_announcement_is_missing(monkeypatch) -> None:
+    async def _run() -> None:
+        now = dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
+        events = [_event(event_id="live", start_at=now - dt.timedelta(hours=1), end_at=now + dt.timedelta(hours=1))]
+        fusion = _fusion_row(last_refresh=now - dt.timedelta(days=1), last_hash="")
+        channel = SimpleNamespace(fetch_message=AsyncMock(side_effect=RuntimeError("missing")))
+
+        monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
+        monkeypatch.setattr(announcement_refresh, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
+
+        await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
+
+        fusion_sheets.update_fusion_announcement_refresh_state.assert_not_awaited()
 
     asyncio.run(_run())

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -115,3 +115,35 @@ def test_get_sent_reminder_keys_requires_configured_column_keys(monkeypatch: pyt
 
     with pytest.raises(RuntimeError, match="FUSION_REMINDER_COL_FUSION_ID"):
         asyncio.run(fusion_sheets.get_sent_reminder_keys("f-1"))
+
+
+def test_get_sent_reminder_keys_does_not_require_sent_at_column_key(monkeypatch: pytest.MonkeyPatch):
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_REMINDER_TAB": "Reminder Ledger",
+            "FUSION_REMINDER_COL_FUSION_ID": "FusionKey",
+            "FUSION_REMINDER_COL_EVENT_ID": "EventKey",
+            "FUSION_REMINDER_COL_REMINDER_TYPE": "ReminderKey",
+        },
+    )
+    monkeypatch.delitem(
+        config_module._CONFIG,
+        "FUSION_REMINDER_COL_SENT_AT_UTC",
+        raising=False,
+    )
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "Reminder Ledger"
+        return [
+            ["FusionKey", "EventKey", "ReminderKey"],
+            ["f-1", "e-1", "start"],
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    sent = asyncio.run(fusion_sheets.get_sent_reminder_keys("f-1"))
+
+    assert sent == {("e-1", "start")}


### PR DESCRIPTION
### Motivation
- Durable reminder dedupe reads were failing when the write-only `sent_at` column key was missing, causing silent fail-open behavior; the announcement refresh loop also obscured the real failing call and could attempt non-edit recovery.

### Description
- Split reminder schema resolution into read vs write paths so `get_sent_reminder_keys()` only requires `fusion_id`, `event_id`, and `reminder_type` while `mark_reminder_sent()` still requires `sent_at` (`shared/sheets/fusion.py`).
- Include the caught exception in the reminder fail-open log to surface the real schema/config error (`modules/community/fusion/reminders.py`).
- Add targeted try/except logging around event loading, existing message fetch, message edit, and refresh-state persistence in the announcement refresh loop, and preserve edit-only behavior by skipping when the existing announcement is missing (`modules/community/fusion/announcement_refresh.py`).
- Add unit tests for the adjusted reminder read behavior and for skipping refresh when the existing announcement cannot be fetched (`tests/shared/sheets/test_fusion_reminder_schema.py`, `tests/community/test_fusion_announcement_refresh.py`).
- Changed files: `shared/sheets/fusion.py`, `modules/community/fusion/reminders.py`, `modules/community/fusion/announcement_refresh.py`, `tests/shared/sheets/test_fusion_reminder_schema.py`, `tests/community/test_fusion_announcement_refresh.py`.

### Testing
- Ran `pytest -q tests/shared/sheets/test_fusion_reminder_schema.py tests/community/test_fusion_announcement_refresh.py` and both test modules passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d7cf71c48323a29355c6414373e4)