### PR TITLE
Refactor fusion reminder and announcement refresh persistence to header-driven sheet schema

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -84,9 +84,8 @@ async def process_fusion_reminders(
     except Exception as exc:
         log.exception(
             "fusion reminder failed to load durable dedupe state; continuing fail-open "
-            "(config keys: FUSION_REMINDER_TAB, FUSION_REMINDER_COL_FUSION_ID, "
-            "FUSION_REMINDER_COL_EVENT_ID, FUSION_REMINDER_COL_REMINDER_TYPE, "
-            "details=%s)",
+            "(requires tab from FUSION_REMINDER_TAB with headers fusion_id, event_id, "
+            "reminder_type; details=%s)",
             exc,
             extra={"fusion_id": target.fusion_id},
         )

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -24,10 +24,6 @@ _CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))
 _FUSION_BUCKET = "fusion"
 _FUSION_EVENTS_BUCKET = "fusion_events"
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
-_FUSION_REMINDER_FUSION_ID_COL_KEY = "FUSION_REMINDER_COL_FUSION_ID"
-_FUSION_REMINDER_EVENT_ID_COL_KEY = "FUSION_REMINDER_COL_EVENT_ID"
-_FUSION_REMINDER_TYPE_COL_KEY = "FUSION_REMINDER_COL_REMINDER_TYPE"
-_FUSION_REMINDER_SENT_AT_COL_KEY = "FUSION_REMINDER_COL_SENT_AT_UTC"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
 _FUSION_PROGRESS_FUSION_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_FUSION_ID"
 _FUSION_PROGRESS_USER_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_USER_ID"
@@ -35,6 +31,12 @@ _FUSION_PROGRESS_EVENT_ID_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_EVENT_ID"
 _FUSION_PROGRESS_STATUS_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_STATUS"
 _FUSION_PROGRESS_UPDATED_AT_COL_KEY = "FUSION_USER_EVENT_PROGRESS_COL_UPDATED_AT_UTC"
 _PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "skipped"}
+_FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
+    "fusion_id": ("fusion_id",),
+    "event_id": ("event_id",),
+    "reminder_type": ("reminder_type",),
+    "sent_at_utc": ("sent_at_utc",),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -191,30 +193,16 @@ def _require_config_name(key: str) -> str:
 def _resolve_reminder_sheet_schema(
     *,
     include_sent_at: bool,
-) -> tuple[str, dict[str, str]]:
+) -> tuple[str, tuple[str, ...]]:
     tab_name = _resolve_tab_name(_FUSION_REMINDER_TAB_KEY)
-    config_key_by_field = {
-        "fusion_id": _FUSION_REMINDER_FUSION_ID_COL_KEY,
-        "event_id": _FUSION_REMINDER_EVENT_ID_COL_KEY,
-        "reminder_type": _FUSION_REMINDER_TYPE_COL_KEY,
-    }
+    required_fields: list[str] = ["fusion_id", "event_id", "reminder_type"]
     if include_sent_at:
-        config_key_by_field["sent_at_utc"] = _FUSION_REMINDER_SENT_AT_COL_KEY
-    column_by_field = {
-        field: _require_config_name(config_key)
-        for field, config_key in config_key_by_field.items()
-    }
-    return tab_name, column_by_field
+        required_fields.append("sent_at_utc")
+    return tab_name, tuple(required_fields)
 
 
 def _reminder_schema_debug() -> dict[str, str]:
-    keys = (
-        _FUSION_REMINDER_TAB_KEY,
-        _FUSION_REMINDER_FUSION_ID_COL_KEY,
-        _FUSION_REMINDER_EVENT_ID_COL_KEY,
-        _FUSION_REMINDER_TYPE_COL_KEY,
-        _FUSION_REMINDER_SENT_AT_COL_KEY,
-    )
+    keys = (_FUSION_REMINDER_TAB_KEY,)
     debug: dict[str, str] = {}
     for key in keys:
         value = cfg.get(key)
@@ -263,6 +251,70 @@ def _sheet_id() -> str:
     if not sheet_id:
         raise RuntimeError("MILESTONES_SHEET_ID not set")
     return sheet_id
+
+
+def _resolve_header_index(
+    *,
+    tab_name: str,
+    header: list[str],
+    field: str,
+    aliases_by_field: Mapping[str, tuple[str, ...]] | None = None,
+) -> int:
+    alias_source = aliases_by_field or _FUSION_REMINDER_COLUMN_ALIASES
+    aliases = alias_source.get(field, (field,))
+    normalized_aliases = [alias.strip().lower() for alias in aliases if alias.strip()]
+    for alias in normalized_aliases:
+        if alias in header:
+            return header.index(alias)
+
+    available = [cell.strip() for cell in header]
+    log.error(
+        "fusion reminder schema mismatch; missing required header",
+        extra={
+            "tab": tab_name,
+            "field": field,
+            "expected_headers": list(aliases),
+            "available_headers": available,
+        },
+    )
+    raise RuntimeError(
+        "Fusion reminder sheet missing required header "
+        f"(tab={tab_name}, field={field}, "
+        f"expected={list(aliases)}, available={available})"
+    )
+
+
+async def _load_fusion_sheet_matrix(tab_name: str) -> tuple[str, list[list[object]], list[str]]:
+    sheet_id = _sheet_id()
+    matrix = await afetch_values(sheet_id, tab_name)
+    if not matrix:
+        raise RuntimeError(f"Fusion sheet is empty (tab={tab_name})")
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    return sheet_id, matrix, header
+
+
+def _resolve_fusion_row_index(*, fusion_id: str, header: list[str], matrix: list[list[object]], tab_name: str) -> int:
+    if "fusion_id" not in header:
+        log.error("fusion sheet schema mismatch; missing fusion_id header", extra={"tab": tab_name})
+        raise RuntimeError("Fusion sheet missing fusion_id column")
+
+    fusion_col = header.index("fusion_id")
+    for idx, row in enumerate(matrix[1:], start=2):
+        cell = str(row[fusion_col] if fusion_col < len(row) else "").strip()
+        if cell == fusion_id:
+            return idx
+
+    raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
+
+
+def _require_fusion_headers(*, tab_name: str, header: list[str], required: tuple[str, ...]) -> None:
+    missing = [col for col in required if col not in header]
+    if missing:
+        log.error(
+            "fusion sheet schema mismatch; missing required headers",
+            extra={"tab": tab_name, "missing_headers": missing, "available_headers": header},
+        )
+        raise RuntimeError(f"Fusion sheet missing columns: {', '.join(missing)}")
 
 
 async def _load_fusions() -> tuple[FusionRow, ...]:
@@ -560,7 +612,7 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
     """Return durable reminder keys previously sent for ``fusion_id``."""
 
     try:
-        tab_name, columns = _resolve_reminder_sheet_schema(include_sent_at=False)
+        tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
     except Exception as exc:
         debug_config = _reminder_schema_debug()
         raise RuntimeError(
@@ -572,22 +624,13 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
         return set()
 
     header = [str(cell or "").strip().lower() for cell in matrix[0]]
-    required_fields = ("fusion_id", "event_id", "reminder_type")
-    required_names = [columns[field] for field in required_fields]
-    missing = [name for name in required_names if name.strip().lower() not in header]
-    if missing:
-        available = [str(cell or "").strip() for cell in matrix[0]]
-        raise RuntimeError(
-            "Fusion reminder sheet missing configured columns for durable dedupe "
-            f"(tab={tab_name}, missing={', '.join(missing)}, "
-            f"available={available}, "
-            f"config_keys={_FUSION_REMINDER_FUSION_ID_COL_KEY},"
-            f"{_FUSION_REMINDER_EVENT_ID_COL_KEY},{_FUSION_REMINDER_TYPE_COL_KEY})"
-        )
-
-    fusion_idx = header.index(columns["fusion_id"].strip().lower())
-    event_idx = header.index(columns["event_id"].strip().lower())
-    reminder_idx = header.index(columns["reminder_type"].strip().lower())
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    event_idx = index_by_field["event_id"]
+    reminder_idx = index_by_field["reminder_type"]
     target = str(fusion_id or "").strip()
 
     keys: set[tuple[str, str]] = set()
@@ -612,7 +655,7 @@ async def mark_reminder_sent(
     """Persist a sent reminder marker with a durable fusion/event/type key."""
 
     try:
-        tab_name, columns = _resolve_reminder_sheet_schema(include_sent_at=True)
+        tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
     except Exception as exc:
         debug_config = _reminder_schema_debug()
         raise RuntimeError(
@@ -627,25 +670,14 @@ async def mark_reminder_sent(
         )
 
     header = [str(cell or "").strip().lower() for cell in matrix[0]]
-    required_fields = ("fusion_id", "event_id", "reminder_type", "sent_at_utc")
-    required_names = [columns[field] for field in required_fields]
-    missing = [name for name in required_names if name.strip().lower() not in header]
-    if missing:
-        available = [str(cell or "").strip() for cell in matrix[0]]
-        raise RuntimeError(
-            "Fusion reminder sheet missing configured columns for write "
-            f"(tab={tab_name}, missing={', '.join(missing)}, "
-            f"available={available}, "
-            f"config_keys={_FUSION_REMINDER_FUSION_ID_COL_KEY},"
-            f"{_FUSION_REMINDER_EVENT_ID_COL_KEY},"
-            f"{_FUSION_REMINDER_TYPE_COL_KEY},"
-            f"{_FUSION_REMINDER_SENT_AT_COL_KEY})"
-        )
-
-    fusion_idx = header.index(columns["fusion_id"].strip().lower())
-    event_idx = header.index(columns["event_id"].strip().lower())
-    reminder_idx = header.index(columns["reminder_type"].strip().lower())
-    sent_at_idx = header.index(columns["sent_at_utc"].strip().lower())
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    event_idx = index_by_field["event_id"]
+    reminder_idx = index_by_field["reminder_type"]
+    sent_at_idx = index_by_field["sent_at_utc"]
     target_fusion = str(fusion_id or "").strip()
     target_event = str(event_id or "").strip()
     target_type = str(reminder_type or "").strip()
@@ -852,25 +884,13 @@ async def update_fusion_publication(
     """Write publish metadata back to the fusion row in the configured sheet."""
 
     tab_name = _resolve_tab_name("FUSION_TAB")
-    sheet_id = _sheet_id()
-    matrix = await afetch_values(sheet_id, tab_name)
-    if not matrix:
-        raise RuntimeError("Fusion sheet is empty")
-
-    header = [str(cell or "").strip().lower() for cell in matrix[0]]
-    row_idx: int | None = None
-    fusion_col = header.index("fusion_id") if "fusion_id" in header else -1
-    if fusion_col < 0:
-        raise RuntimeError("Fusion sheet missing fusion_id column")
-
-    for idx, row in enumerate(matrix[1:], start=2):
-        cell = str(row[fusion_col] if fusion_col < len(row) else "").strip()
-        if cell == fusion_id:
-            row_idx = idx
-            break
-
-    if row_idx is None:
-        raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
+    sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
+    row_idx = _resolve_fusion_row_index(
+        fusion_id=fusion_id,
+        header=header,
+        matrix=matrix,
+        tab_name=tab_name,
+    )
 
     required_cols = ["announcement_message_id", "published_at"]
     if announcement_channel_id is not None:
@@ -878,9 +898,7 @@ async def update_fusion_publication(
     if set_published_status:
         required_cols.append("status")
 
-    missing = [col for col in required_cols if col not in header]
-    if missing:
-        raise RuntimeError(f"Fusion sheet missing columns: {', '.join(missing)}")
+    _require_fusion_headers(tab_name=tab_name, header=header, required=tuple(required_cols))
 
     worksheet = await aget_worksheet(sheet_id, tab_name)
     updates = {
@@ -915,29 +933,18 @@ async def update_fusion_announcement_refresh_state(
     """Persist announcement refresh metadata for scheduler dedupe/restart safety."""
 
     tab_name = _resolve_tab_name("FUSION_TAB")
-    sheet_id = _sheet_id()
-    matrix = await afetch_values(sheet_id, tab_name)
-    if not matrix:
-        raise RuntimeError("Fusion sheet is empty")
-
-    header = [str(cell or "").strip().lower() for cell in matrix[0]]
-    row_idx: int | None = None
-    fusion_col = header.index("fusion_id") if "fusion_id" in header else -1
-    if fusion_col < 0:
-        raise RuntimeError("Fusion sheet missing fusion_id column")
-
-    for idx, row in enumerate(matrix[1:], start=2):
-        cell = str(row[fusion_col] if fusion_col < len(row) else "").strip()
-        if cell == fusion_id:
-            row_idx = idx
-            break
-    if row_idx is None:
-        raise RuntimeError(f"Fusion row not found for fusion_id={fusion_id}")
-
-    required_cols = ["last_announcement_refresh_at", "last_announcement_status_hash"]
-    missing = [col for col in required_cols if col not in header]
-    if missing:
-        raise RuntimeError(f"Fusion sheet missing columns: {', '.join(missing)}")
+    sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
+    row_idx = _resolve_fusion_row_index(
+        fusion_id=fusion_id,
+        header=header,
+        matrix=matrix,
+        tab_name=tab_name,
+    )
+    _require_fusion_headers(
+        tab_name=tab_name,
+        header=header,
+        required=("last_announcement_refresh_at", "last_announcement_status_hash"),
+    )
 
     worksheet = await aget_worksheet(sheet_id, tab_name)
     updates = {

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -29,10 +29,6 @@ def test_get_sent_reminder_keys_uses_configured_tab_and_columns(monkeypatch: pyt
         monkeypatch,
         {
             "FUSION_REMINDER_TAB": "Reminder Ledger",
-            "FUSION_REMINDER_COL_FUSION_ID": "FusionKey",
-            "FUSION_REMINDER_COL_EVENT_ID": "EventKey",
-            "FUSION_REMINDER_COL_REMINDER_TYPE": "ReminderKey",
-            "FUSION_REMINDER_COL_SENT_AT_UTC": "SentAt",
         },
     )
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
@@ -40,7 +36,7 @@ def test_get_sent_reminder_keys_uses_configured_tab_and_columns(monkeypatch: pyt
         assert sheet_id == "sheet-1"
         assert tab_name == "Reminder Ledger"
         return [
-            ["FusionKey", "EventKey", "ReminderKey", "SentAt"],
+            ["fusion_id", "event_id", "reminder_type", "sent_at_utc"],
             ["f-1", "e-1", "start", "2026-01-01T00:00:00+00:00"],
             ["f-2", "e-2", "start", "2026-01-01T00:00:00+00:00"],
         ]
@@ -57,10 +53,6 @@ def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeyp
         monkeypatch,
         {
             "FUSION_REMINDER_TAB": "Reminder Ledger",
-            "FUSION_REMINDER_COL_FUSION_ID": "FusionKey",
-            "FUSION_REMINDER_COL_EVENT_ID": "EventKey",
-            "FUSION_REMINDER_COL_REMINDER_TYPE": "ReminderKey",
-            "FUSION_REMINDER_COL_SENT_AT_UTC": "SentAt",
         },
     )
     worksheet = _Worksheet()
@@ -69,7 +61,7 @@ def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeyp
         assert sheet_id == "sheet-1"
         assert tab_name == "Reminder Ledger"
         return [
-            ["FusionKey", "EventKey", "ReminderKey", "SentAt"],
+            ["fusion_id", "event_id", "reminder_type", "sent_at_utc"],
             ["f-1", "e-1", "start", ""],
         ]
 
@@ -97,40 +89,32 @@ def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeyp
     assert worksheet.updated[0][0] == "D2"
 
 
-def test_get_sent_reminder_keys_requires_configured_column_keys(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delitem(
-        config_module._CONFIG,
-        "FUSION_REMINDER_COL_FUSION_ID",
-        raising=False,
-    )
+def test_get_sent_reminder_keys_requires_required_headers(monkeypatch: pytest.MonkeyPatch):
     _install_config(
         monkeypatch,
         {
             "FUSION_REMINDER_TAB": "Reminder Ledger",
-            "FUSION_REMINDER_COL_EVENT_ID": "EventKey",
-            "FUSION_REMINDER_COL_REMINDER_TYPE": "ReminderKey",
-            "FUSION_REMINDER_COL_SENT_AT_UTC": "SentAt",
         },
     )
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
-    with pytest.raises(RuntimeError, match="FUSION_REMINDER_COL_FUSION_ID"):
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "Reminder Ledger"
+        return [["event_id", "reminder_type", "sent_at_utc"], ["e-1", "start", ""]]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    with pytest.raises(RuntimeError, match="missing required header"):
         asyncio.run(fusion_sheets.get_sent_reminder_keys("f-1"))
 
 
-def test_get_sent_reminder_keys_does_not_require_sent_at_column_key(monkeypatch: pytest.MonkeyPatch):
+def test_get_sent_reminder_keys_does_not_require_sent_at_header(monkeypatch: pytest.MonkeyPatch):
     _install_config(
         monkeypatch,
         {
             "FUSION_REMINDER_TAB": "Reminder Ledger",
-            "FUSION_REMINDER_COL_FUSION_ID": "FusionKey",
-            "FUSION_REMINDER_COL_EVENT_ID": "EventKey",
-            "FUSION_REMINDER_COL_REMINDER_TYPE": "ReminderKey",
         },
-    )
-    monkeypatch.delitem(
-        config_module._CONFIG,
-        "FUSION_REMINDER_COL_SENT_AT_UTC",
-        raising=False,
     )
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
@@ -138,7 +122,7 @@ def test_get_sent_reminder_keys_does_not_require_sent_at_column_key(monkeypatch:
         assert sheet_id == "sheet-1"
         assert tab_name == "Reminder Ledger"
         return [
-            ["FusionKey", "EventKey", "ReminderKey"],
+            ["fusion_id", "event_id", "reminder_type"],
             ["f-1", "e-1", "start"],
         ]
 


### PR DESCRIPTION
### Motivation
- The fusion reminder code introduced an ad-hoc requirement that every reminder column be declared in Config, which diverges from the bot's established sheet/config pattern of a config-driven tab name and header-driven schema validation.
- The change re-aligns fusion reminder durability and announcement-refresh persistence with the rest of the codebase by removing per-column Config requirements and using in-sheet headers for schema mapping and validation.
- The goal is a surgical refactor that preserves existing runtime flows while adding clearer schema mismatch logging and making persistence restart-safe.

### Description
- Reworked reminder persistence to use a config-driven tab name from `FUSION_REMINDER_TAB` and to validate required headers (`fusion_id`, `event_id`, `reminder_type`) in-sheet, with `sent_at_utc` required for write operations instead of requiring per-column Config keys. (changed `shared/sheets/fusion.py`).
- Added header-resolution and shared fusion-row helpers (`_resolve_header_index`, `_load_fusion_sheet_matrix`, `_resolve_fusion_row_index`, `_require_fusion_headers`) and used them to unify the fusion row update/refresh logic used by `update_fusion_publication` and `update_fusion_announcement_refresh_state` (changed `shared/sheets/fusion.py`).
- Replaced reminder-specific Config-key error messaging with accurate guidance pointing to `FUSION_REMINDER_TAB` and the required headers, and kept reminder logic otherwise unchanged (changed `modules/community/fusion/reminders.py`).
- Tests: updated reminder-schema tests to assert header-driven behavior instead of per-column Config keys (changed `tests/shared/sheets/test_fusion_reminder_schema.py`).

A) Required Config changes
- None beyond ensuring `FUSION_REMINDER_TAB` remains populated with the reminder tab name (no new Config keys introduced).

B) Required sheet changes
- No new tabs required; the existing reminder ledger tab must include headers: `fusion_id`, `event_id`, `reminder_type`, and `sent_at_utc` (the `sent_at_utc` header is required for writes; read/dedupe requires the first three).

### Testing
- Ran `pytest -q tests/shared/sheets/test_fusion_reminder_schema.py tests/shared/sheets/test_fusion_user_event_progress_schema.py tests/community/test_fusion_reminders.py tests/community/test_fusion_announcement_refresh.py` and all tests passed.
- The modified reminder-schema tests were updated and exercised the new header-driven behavior and passed.
- No changes were made to startup/runtime (`on_ready`) flows per the requirements; existing fusion runtime tests passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e108232e3883239945508d44aab34b)