### PR TITLE
Make watcher_welcome.setup idempotent to avoid duplicate-cog exception

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -3280,8 +3280,18 @@ class WelcomeTicketWatcher(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(WelcomeWatcher(bot))
-    await bot.add_cog(WelcomeTicketWatcher(bot))
+    existing_welcome_watcher = bot.get_cog("WelcomeWatcher")
+    if existing_welcome_watcher is None:
+        await bot.add_cog(WelcomeWatcher(bot))
+    elif not isinstance(existing_welcome_watcher, WelcomeWatcher):
+        raise RuntimeError("cog name collision for WelcomeWatcher")
+
+    existing_ticket_watcher = bot.get_cog("WelcomeTicketWatcher")
+    if existing_ticket_watcher is None:
+        await bot.add_cog(WelcomeTicketWatcher(bot))
+    elif not isinstance(existing_ticket_watcher, WelcomeTicketWatcher):
+        raise RuntimeError("cog name collision for WelcomeTicketWatcher")
+
     _ensure_reminder_job(bot)
     from modules.onboarding.idle_watcher import ensure_idle_watcher
 

--- a/tests/onboarding/test_watcher_sheet_logging.py
+++ b/tests/onboarding/test_watcher_sheet_logging.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 from modules.onboarding import watcher_promo
 from modules.onboarding import watcher_welcome
 from modules.onboarding.watcher_promo import PromoTicketWatcher
-from modules.onboarding.watcher_welcome import TicketContext, WelcomeTicketWatcher
+from modules.onboarding.watcher_welcome import (
+    TicketContext,
+    WelcomeTicketWatcher,
+    WelcomeWatcher,
+)
 
 
 def test_welcome_ticket_logs_sheets(monkeypatch):
@@ -216,6 +220,34 @@ def test_welcome_reminder_sheet_touch_logs(monkeypatch, caplog):
         "sheet_update=ok" in record.message and "phase=reminder_24h" in record.message
         for record in caplog.records
     )
+
+
+def test_setup_is_idempotent_when_watchers_already_registered(monkeypatch):
+    class DummyBot:
+        def __init__(self):
+            self._cogs = {}
+            self.added = []
+
+        def get_cog(self, name):
+            return self._cogs.get(name)
+
+        async def add_cog(self, cog):
+            name = cog.__class__.__name__
+            self._cogs[name] = cog
+            self.added.append(name)
+
+    bot = DummyBot()
+    bot._cogs["WelcomeWatcher"] = WelcomeWatcher(bot)
+    bot._cogs["WelcomeTicketWatcher"] = WelcomeTicketWatcher(bot)
+
+    monkeypatch.setattr(watcher_welcome, "_ensure_reminder_job", lambda _bot: None)
+    ensure_idle = AsyncMock()
+    monkeypatch.setattr("modules.onboarding.idle_watcher.ensure_idle_watcher", ensure_idle)
+
+    asyncio.run(watcher_welcome.setup(bot))
+
+    assert bot.added == []
+    ensure_idle.assert_awaited_once_with(bot)
 
 
 def test_welcome_reminder_sheet_touch_logs_failure(monkeypatch, caplog):


### PR DESCRIPTION
### Motivation
- The ready/boot path was raising `CORE_READY FAILURE: watcher_welcome.setup` after the watcher already reported enabled because `setup` unconditionally called `bot.add_cog(...)` a second time, causing a duplicate-cog registration error on subsequent ready runs.  
- The intent of the change is to prevent that post-success exception by making `watcher_welcome.setup` safe to call multiple times without changing watcher behavior or touching startup/core_ready code.  

### Description
- `modules/onboarding/watcher_welcome.py`: changed `async def setup(bot)` to check `bot.get_cog("WelcomeWatcher")` and `bot.get_cog("WelcomeTicketWatcher")` before calling `add_cog`, adding explicit `RuntimeError` on cog-name/type collisions instead of silently ignoring other collisions.  
- Preserved existing behavior by still calling `_ensure_reminder_job(bot)` and awaiting `ensure_idle_watcher(bot)` exactly as before.  
- `tests/onboarding/test_watcher_sheet_logging.py`: added a regression test `test_setup_is_idempotent_when_watchers_already_registered` that verifies `setup` does not re-add already-registered cogs and that `ensure_idle_watcher` is awaited.  
- Files changed: `modules/onboarding/watcher_welcome.py`, `tests/onboarding/test_watcher_sheet_logging.py`.

### Testing
- Ran targeted pytest for the modified/related tests with `pytest -q tests/onboarding/test_watcher_sheet_logging.py -k "setup_is_idempotent_when_watchers_already_registered or welcome_ticket_logs_sheets"` and the tests passed.  
- The test run produced only unrelated pytest config warnings and no failures.  
- The change keeps runtime scheduling and idle-watcher wiring behavior unchanged and retains explicit error signaling for real cog collisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10d506bf88323ad687e0b1ac167e0)