### PR TITLE
Improve fusion announcement embed: status summary, legend, and ended icon

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime as dt
 from collections import defaultdict
-from itertools import chain
 from urllib.parse import urlparse
 
 import discord
@@ -38,7 +37,7 @@ def _status_icon(status: str) -> str:
     if status == "live":
         return "🔥"
     if status == "ended":
-        return "✅"
+        return "🏁"
     return "⏳"
 
 
@@ -119,6 +118,7 @@ def _build_fusion_embed(
     summary_lines = [
         f"Type: {_humanize_type(fusion.fusion_type)}",
         f"Runs: {_format_dt_utc(fusion.start_at_utc)} -> {_format_dt_utc(fusion.end_at_utc)}",
+        "",
         f"Target: {fusion.needed:g} fragments needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
     ]
@@ -154,17 +154,15 @@ def _build_fusion_embed(
             status = fusion_sheets.derive_event_status(start_at_utc=start_at, end_at_utc=end_at, now=now)
         status_by_event_id[event.event_id] = status
 
-    if sorted_events:
-        status_lines = [
-            f"- {_status_icon(status_by_event_id[event.event_id])} {event.event_name}"
-            for event in sorted_events
-        ]
-        status_chunks = _chunk_lines(status_lines, _EMBED_FIELD_VALUE_LIMIT)
-        for idx, chunk in enumerate(status_chunks, start=1):
-            name = "Event Status" if idx == 1 else f"Event Status (Part {idx})"
-            if len(embed.fields) >= _EMBED_MAX_FIELDS:
-                break
-            embed.add_field(name=name, value=chunk, inline=False)
+    if sorted_events and len(embed.fields) < _EMBED_MAX_FIELDS:
+        completed = sum(1 for status in status_by_event_id.values() if status == "ended")
+        active = sum(1 for status in status_by_event_id.values() if status == "live")
+        remaining = len(sorted_events) - completed - active
+        embed.add_field(
+            name="Schedule Status",
+            value=f"{completed} ended • {active} live • {remaining} upcoming",
+            inline=False,
+        )
 
     grouped_events: dict[dt.date, list[FusionEventRow]] = defaultdict(list)
     for event in sorted_events:
@@ -174,6 +172,13 @@ def _build_fusion_embed(
         embed.add_field(name="Schedule", value="No events available.", inline=False)
         embed.set_footer(text=f"Fusion ID: {fusion.fusion_id}")
         return embed
+
+    if len(embed.fields) < _EMBED_MAX_FIELDS:
+        embed.add_field(
+            name="Legend",
+            value="⏳ Upcoming • 🔥 Live • 🏁 Ended",
+            inline=False,
+        )
 
     # --- SIMPLE STRUCTURE: ONE DAY = ONE FIELD ---
     for day in sorted(grouped_events):


### PR DESCRIPTION
### Motivation

- Make the fusion announcement embed more compact and user-friendly by replacing long per-event status listings with a summarized schedule status and a legend. 
- Use a clearer icon for completed events to better reflect end-of-event semantics.

### Description

- Replaced the per-event status field output with a single `Schedule Status` summary that shows counts of ended, live, and upcoming events. 
- Added a `Legend` field to the embed that documents the emoji meaning (`⏳`, `🔥`, `🏁`) and only add these auxiliary fields when under the `_EMBED_MAX_FIELDS` limit. 
- Changed the ended status icon from `✅` to `🏁`. 
- Inserted a blank separator line in the summary and removed the multi-part event status chunking logic while keeping existing grouping and per-day event listing. 
- Removed an unused import of `chain`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e117bdbe58832380a830a795b3dbc0)