### PR TITLE
Refine fusion reminder tone and jump-link presentation

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -38,9 +38,14 @@ def _build_reminder_embed(
     start_at: dt.datetime,
     jump_url: str,
 ) -> discord.Embed:
+    jump_link = f"[Open Fusion Overview]({jump_url})"
     if reminder_type == "start":
-        title = f"⚠️ {event_name} is live"
-        description = "Move."
+        title = "Fusion Reminder"
+        description = (
+            f"⚠️ **{event_name} is live**\n"
+            "Time to put in some work — fragments won’t collect themselves.\n\n"
+            f"🔗 {jump_link}"
+        )
     else:
         title = f"⏳ {event_name} starts soon"
         description = f"Starts in {_PRESTART_HOURS}h. Plan accordingly."
@@ -51,7 +56,8 @@ def _build_reminder_embed(
         color=discord.Color.blurple(),
         timestamp=start_at,
     )
-    embed.add_field(name="Fusion", value=jump_url, inline=False)
+    if reminder_type != "start":
+        embed.add_field(name="Fusion", value=jump_link, inline=False)
     return embed
 
 

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -89,7 +89,14 @@ def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
     assert len(channel.sent) == 1
     assert channel.sent[0]["content"] is None
     assert channel.sent[0]["view"] is None
-    assert channel.sent[0]["embed"].title == "⚠️ Event e-start is live"
+    embed = channel.sent[0]["embed"]
+    assert embed.title == "Fusion Reminder"
+    assert (
+        embed.description == "⚠️ **Event e-start is live**\n"
+        "Time to put in some work — fragments won’t collect themselves.\n\n"
+        "🔗 [Open Fusion Overview](https://discord.test/jump)"
+    )
+    assert not embed.fields
     assert ("f-1", "e-start", "start") in persisted
 
 
@@ -125,7 +132,7 @@ def test_prestart_reminder_fires_once(monkeypatch):
     assert embed.title == "⏳ Event e-pre starts soon"
     assert embed.description == "Starts in 6h. Plan accordingly."
     assert embed.fields[0].name == "Fusion"
-    assert embed.fields[0].value == "https://discord.test/jump"
+    assert embed.fields[0].value == "[Open Fusion Overview](https://discord.test/jump)"
     assert ("e-pre", "prestart_6h") in sent
 
 


### PR DESCRIPTION
### Motivation
- Make fusion start reminders sound more Caillean/C1C and friendlier while keeping existing delivery behavior intact. 
- Replace raw Discord jump URLs in embeds with an embed-safe named markdown link so the announcement link is clearer and less noisy. 
- Preserve the jump link (it must remain accessible) and avoid changing reminder scheduling, dedupe, or button behavior.

### Description
- Modified `modules/community/fusion/reminders.py` to build a named markdown jump link (`[Open Fusion Overview](...)`) and to replace the previous terse `start` title with a Caillean-styled multiline description that includes the named link. 
- Kept the prestart reminder flow unchanged except the embed field now contains the named markdown link instead of a raw URL. 
- Left all scheduling, dedupe, mention, and view/button logic unchanged and only adjusted embed copy and link presentation. 
- Updated `tests/community/test_fusion_reminders.py` to assert the new `start` reminder description, title, and the markdown-formatted jump link for both start and prestart cases.

### Testing
- Ran `pytest -q tests/community/test_fusion_reminders.py` and all tests passed (4/4). 
- No changes to scheduler or reminder control-flow tests were required beyond verifying the embed text and link formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1267da8508323a1ce387887dcd19c)