### PR TITLE
Fix fusion publish/recovery flow to ignore stale announcement metadata

### DIFF
--- a/modules/community/fusion/announcement_refresh.py
+++ b/modules/community/fusion/announcement_refresh.py
@@ -9,7 +9,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from modules.community.fusion.announcements import resolve_announcement_channel
+from modules.community.fusion.announcements import resolve_stored_announcement
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
@@ -60,23 +60,8 @@ async def _fetch_existing_announcement(
     bot: commands.Bot,
     target: fusion_sheets.FusionRow,
 ) -> discord.Message | None:
-    if target.announcement_channel_id is None or target.announcement_message_id is None:
-        return None
-    channel = await resolve_announcement_channel(bot, target.announcement_channel_id)
-    if channel is None:
-        return None
-    try:
-        return await channel.fetch_message(target.announcement_message_id)
-    except Exception:
-        log.exception(
-            "fusion announcement refresh failed to fetch existing announcement message",
-            extra={
-                "fusion_id": target.fusion_id,
-                "announcement_channel_id": target.announcement_channel_id,
-                "announcement_message_id": target.announcement_message_id,
-            },
-        )
-        return None
+    resolution = await resolve_stored_announcement(bot, target)
+    return resolution.message
 
 
 async def process_fusion_announcement_refreshes(

--- a/modules/community/fusion/announcements.py
+++ b/modules/community/fusion/announcements.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from dataclasses import dataclass
 
 import discord
 from discord.ext import commands
@@ -13,6 +14,16 @@ from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.announcements")
+
+
+_VALID_PUBLISHED_STATUSES = {"active", "published"}
+
+
+@dataclass(slots=True)
+class AnnouncementResolution:
+    message: discord.Message | None
+    had_reference: bool
+    is_stale: bool
 
 
 async def resolve_announcement_channel(
@@ -30,6 +41,58 @@ async def resolve_announcement_channel(
     if not isinstance(channel, discord.abc.Messageable):
         return None
     return channel
+
+
+async def resolve_stored_announcement(
+    bot: commands.Bot,
+    target: fusion_sheets.FusionRow,
+) -> AnnouncementResolution:
+    has_message_id = target.announcement_message_id is not None
+    has_channel_id = target.announcement_channel_id is not None
+    had_reference = has_message_id or has_channel_id
+    if not has_message_id or not has_channel_id:
+        return AnnouncementResolution(message=None, had_reference=had_reference, is_stale=had_reference)
+
+    if target.status.casefold() not in _VALID_PUBLISHED_STATUSES:
+        log.info(
+            "fusion announcement metadata treated as stale because status is not publishable",
+            extra={
+                "fusion_id": target.fusion_id,
+                "status": target.status,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+        )
+        return AnnouncementResolution(message=None, had_reference=True, is_stale=True)
+
+    channel = await resolve_announcement_channel(bot, target.announcement_channel_id)
+    if channel is None:
+        log.warning(
+            "fusion stale announcement metadata detected (channel missing/unusable)",
+            extra={
+                "fusion_id": target.fusion_id,
+                "status": target.status,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+        )
+        return AnnouncementResolution(message=None, had_reference=True, is_stale=True)
+
+    try:
+        message = await channel.fetch_message(target.announcement_message_id)
+        return AnnouncementResolution(message=message, had_reference=True, is_stale=False)
+    except Exception:
+        log.warning(
+            "fusion stale announcement metadata detected (message missing/unresolvable)",
+            extra={
+                "fusion_id": target.fusion_id,
+                "status": target.status,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+            exc_info=True,
+        )
+        return AnnouncementResolution(message=None, had_reference=True, is_stale=True)
 
 
 async def publish_fusion_announcement(
@@ -58,13 +121,22 @@ async def publish_fusion_announcement(
         fallback_embed.set_image(url=None)
         announcement_message = await channel.send(embed=fallback_embed, view=announcement_view)
 
-    set_status_published = target.status.casefold() == "draft"
+    set_status_published = target.status.casefold() != "published"
     await fusion_sheets.update_fusion_publication(
         target.fusion_id,
         announcement_message_id=announcement_message.id,
         announcement_channel_id=channel.id,
         published_at=dt.datetime.now(dt.timezone.utc),
         set_published_status=set_status_published,
+    )
+    log.info(
+        "fusion fresh announcement metadata written back",
+        extra={
+            "fusion_id": target.fusion_id,
+            "announcement_channel_id": channel.id,
+            "announcement_message_id": announcement_message.id,
+            "set_published_status": set_status_published,
+        },
     )
     return announcement_message
 
@@ -77,17 +149,16 @@ async def ensure_fusion_announcement(
     if channel is None:
         return None
 
-    if target.announcement_message_id is not None:
-        try:
-            return await channel.fetch_message(target.announcement_message_id)
-        except Exception:
-            pass
+    resolution = await resolve_stored_announcement(bot, target)
+    if resolution.message is not None:
+        return resolution.message
 
     return await publish_fusion_announcement(bot, target)
 
 
 __all__ = [
     "ensure_fusion_announcement",
+    "resolve_stored_announcement",
     "publish_fusion_announcement",
     "resolve_announcement_channel",
 ]

--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -9,7 +9,12 @@ from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
-from modules.community.fusion.announcements import ensure_fusion_announcement, publish_fusion_announcement, resolve_announcement_channel
+from modules.community.fusion.announcements import (
+    ensure_fusion_announcement,
+    publish_fusion_announcement,
+    resolve_announcement_channel,
+    resolve_stored_announcement,
+)
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
@@ -167,16 +172,23 @@ class FusionCog(commands.Cog):
             await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
             return
 
-        if target.announcement_message_id is not None:
-            try:
-                await channel.fetch_message(target.announcement_message_id)
-                await ctx.reply(
-                    "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
-                    mention_author=False,
-                )
-                return
-            except Exception:
-                pass
+        resolution = await resolve_stored_announcement(self.bot, target)
+        if resolution.message is not None:
+            await ctx.reply(
+                "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
+                mention_author=False,
+            )
+            return
+        if resolution.had_reference and resolution.is_stale:
+            log.info(
+                "fusion publish allowed despite stale announcement metadata",
+                extra={
+                    "fusion_id": target.fusion_id,
+                    "status": target.status,
+                    "announcement_channel_id": target.announcement_channel_id,
+                    "announcement_message_id": target.announcement_message_id,
+                },
+            )
 
         try:
             announcement_message = await publish_fusion_announcement(self.bot, target)

--- a/tests/community/test_fusion_announcement_refresh.py
+++ b/tests/community/test_fusion_announcement_refresh.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from modules.community.fusion import announcement_refresh
+from modules.community.fusion.announcements import AnnouncementResolution
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
 
@@ -103,11 +104,13 @@ def test_refresh_edits_existing_announcement_and_updates_metadata(monkeypatch) -
         events = [_event(event_id="live", start_at=now - dt.timedelta(hours=1), end_at=now + dt.timedelta(hours=1))]
         fusion = _fusion_row(last_refresh=now - dt.timedelta(days=1), last_hash="")
         message = SimpleNamespace(edit=AsyncMock())
-        channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
-
         monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
         monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
-        monkeypatch.setattr(announcement_refresh, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(
+            announcement_refresh,
+            "resolve_stored_announcement",
+            AsyncMock(return_value=AnnouncementResolution(message=message, had_reference=True, is_stale=False)),
+        )
         monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
 
         await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)
@@ -123,11 +126,13 @@ def test_refresh_skips_when_existing_announcement_is_missing(monkeypatch) -> Non
         now = dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
         events = [_event(event_id="live", start_at=now - dt.timedelta(hours=1), end_at=now + dt.timedelta(hours=1))]
         fusion = _fusion_row(last_refresh=now - dt.timedelta(days=1), last_hash="")
-        channel = SimpleNamespace(fetch_message=AsyncMock(side_effect=RuntimeError("missing")))
-
         monkeypatch.setattr(fusion_sheets, "get_published_fusions", AsyncMock(return_value=[fusion]))
         monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
-        monkeypatch.setattr(announcement_refresh, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        monkeypatch.setattr(
+            announcement_refresh,
+            "resolve_stored_announcement",
+            AsyncMock(return_value=AnnouncementResolution(message=None, had_reference=True, is_stale=True)),
+        )
         monkeypatch.setattr(fusion_sheets, "update_fusion_announcement_refresh_state", AsyncMock())
 
         await announcement_refresh.process_fusion_announcement_refreshes(bot=object(), now=now)

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -314,3 +314,64 @@ def test_fusion_publish_blocks_duplicate_when_existing_message_resolves(monkeypa
         )
 
     asyncio.run(_run())
+
+
+def test_fusion_publish_recreates_when_existing_metadata_is_stale(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(side_effect=discord.NotFound(response=SimpleNamespace(status=404, reason="Not Found"), message="missing"))
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=1002))
+        bot = SimpleNamespace(get_channel=lambda _channel_id: channel, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="published")
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", AsyncMock())
+
+        await cog.fusion_publish.callback(cog, ctx)
+
+        channel.send.assert_awaited_once()
+        ctx.reply.assert_awaited_once_with(
+            "Fusion announcement published to configured channel for **Mavara**.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_fusion_command_recreates_when_status_is_draft_even_with_existing_message(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(return_value=SimpleNamespace(id=456, jump_url="https://discord.com/channels/1/123/456"))
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=1003, jump_url="https://discord.com/channels/1/123/1003"))
+        bot = SimpleNamespace(
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+        )
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable():
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="draft")
+
+        update = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
+
+        await cog.fusion.callback(cog, ctx)
+
+        channel.send.assert_awaited_once()
+        assert update.await_count == 1
+        ctx.reply.assert_awaited_once_with(
+            "🔗 Fusion’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/1003",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Prevent stale announcement identifiers in the fusion sheet from blocking publish/republish flows when the stored message or channel is missing or the row is a draft.
- Ensure commands (`!fusion`, `!fusion publish`) and the announcement refresh job share a single consistent rule for whether stored metadata is valid. 
- Preserve existing sheet schema and rendering behavior while adding clear logging for detection and recovery actions.

### Description
- Introduced `AnnouncementResolution` and `resolve_stored_announcement()` in `modules/community/fusion/announcements.py` to centralize validation of stored announcement metadata using both row `status` and live Discord resolution (channel + message). 
- Updated `publish_fusion_announcement()` to promote non-`published` rows when a fresh announcement is written and to log when fresh metadata is persisted. 
- Rewired publish/ensure/refresh entry points to use the new helper: `FusionCog.fusion_publish` now blocks only when a real message resolves, `ensure_fusion_announcement` reuses the helper for consistent self-heal, and `announcement_refresh._fetch_existing_announcement` now uses the helper to detect missing/stale announcements. 
- Final publish decision logic (stepwise):
  - Load target fusion row and validate required fields including `announcement_channel_id` and timing fields. 
  - Use `resolve_stored_announcement(bot, target)` to inspect stored `announcement_channel_id`/`announcement_message_id` and row `status`. 
  - Treat metadata as stale if `status` is not publishable (`active`/`published`) or if the channel cannot be resolved. 
  - Treat metadata as stale if the stored message fetch fails or raises `NotFound`/unresolvable errors. 
  - Only block publish as a duplicate when the stored message resolves successfully and the row status is publishable. 
  - On stale/missing metadata (or when the row is `draft`), create a fresh announcement message and write back `announcement_message_id`, `announcement_channel_id`, `published_at`, and set `status=published` when appropriate. 
  - Reuse the same helper in command ensure and automated refresh flows so behavior is consistent across all entry points. 

### Testing
- Ran full unit suite for affected areas with `pytest -q tests/community/test_fusion_cog.py tests/community/test_fusion_announcements.py tests/community/test_fusion_announcement_refresh.py`, which completed but surfaced one pre-existing unrelated failure in `test_build_embed_includes_event_status_section`. 
- Re-ran targeted tests excluding the unrelated renderer assertion with `pytest -q tests/community/test_fusion_cog.py tests/community/test_fusion_announcements.py tests/community/test_fusion_announcement_refresh.py -k 'not build_embed_includes_event_status_section'`, which passed.
- Added tests that cover stale-metadata republish and draft-forced recreation paths (updated `tests/community/test_fusion_cog.py` and `tests/community/test_fusion_announcement_refresh.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12a917d9c83239deb891c75afcc28)