### PR TITLE
Integrate Fusion module with internal logging and ops alerts

### DIFF
--- a/modules/community/fusion/announcement_refresh.py
+++ b/modules/community/fusion/announcement_refresh.py
@@ -10,6 +10,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.fusion.announcements import resolve_stored_announcement
+from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from modules.community.fusion.rendering import build_fusion_announcement_embed
 from shared.sheets import fusion as fusion_sheets
@@ -79,18 +80,32 @@ async def process_fusion_announcement_refreshes(
     reference = _utc_now(now)
     try:
         targets = await fusion_sheets.get_published_fusions()
-    except Exception:
+    except Exception as exc:
         log.exception("fusion announcement refresh failed to load published fusions")
+        await fusion_logs.send_ops_alert(
+            component="announcement_refresh",
+            summary="load_published_fusions_failed",
+            dedupe_key="fusion:announcement_refresh:load_targets",
+            error=exc,
+        )
         return
 
     for target in targets:
         try:
             try:
                 events = await fusion_sheets.get_fusion_events(target.fusion_id)
-            except Exception:
+            except Exception as exc:
+                context = {"fusion_id": target.fusion_id}
                 log.exception(
                     "fusion announcement refresh failed to load events",
-                    extra={"fusion_id": target.fusion_id},
+                    extra=context,
+                )
+                await fusion_logs.send_ops_alert(
+                    component="announcement_refresh",
+                    summary="load_events_failed",
+                    dedupe_key=f"fusion:announcement_refresh:events:{target.fusion_id}",
+                    error=exc,
+                    fields=context,
                 )
                 continue
             status_hash = _compute_status_hash(events, now=reference)
@@ -113,14 +128,22 @@ async def process_fusion_announcement_refreshes(
                 announcement_embed = build_fusion_announcement_embed(target, events, now=reference)
                 announcement_view = build_fusion_opt_in_view(target)
                 await existing_message.edit(embed=announcement_embed, view=announcement_view)
-            except Exception:
+            except Exception as exc:
+                context = {
+                    "fusion_id": target.fusion_id,
+                    "announcement_channel_id": target.announcement_channel_id,
+                    "announcement_message_id": target.announcement_message_id,
+                }
                 log.exception(
                     "fusion announcement refresh failed to edit existing announcement",
-                    extra={
-                        "fusion_id": target.fusion_id,
-                        "announcement_channel_id": target.announcement_channel_id,
-                        "announcement_message_id": target.announcement_message_id,
-                    },
+                    extra=context,
+                )
+                await fusion_logs.send_ops_alert(
+                    component="announcement_refresh",
+                    summary="edit_existing_announcement_failed",
+                    dedupe_key=f"fusion:announcement_refresh:edit:{target.fusion_id}",
+                    error=exc,
+                    fields=context,
                 )
                 continue
 
@@ -130,16 +153,32 @@ async def process_fusion_announcement_refreshes(
                     refreshed_at=reference,
                     status_hash=status_hash,
                 )
-            except Exception:
+            except Exception as exc:
+                context = {"fusion_id": target.fusion_id, "status_hash": status_hash}
                 log.exception(
                     "fusion announcement refresh failed to persist refresh state",
-                    extra={"fusion_id": target.fusion_id, "status_hash": status_hash},
+                    extra=context,
+                )
+                await fusion_logs.send_ops_alert(
+                    component="announcement_refresh",
+                    summary="persist_refresh_state_failed",
+                    dedupe_key=f"fusion:announcement_refresh:persist:{target.fusion_id}",
+                    error=exc,
+                    fields=context,
                 )
                 continue
-        except Exception:
+        except Exception as exc:
+            context = {"fusion_id": target.fusion_id}
             log.exception(
                 "fusion announcement refresh failed",
-                extra={"fusion_id": target.fusion_id},
+                extra=context,
+            )
+            await fusion_logs.send_ops_alert(
+                component="announcement_refresh",
+                summary="iteration_failed",
+                dedupe_key=f"fusion:announcement_refresh:iteration:{target.fusion_id}",
+                error=exc,
+                fields=context,
             )
 
 

--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
+from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.announcements import (
     ensure_fusion_announcement,
     publish_fusion_announcement,
@@ -91,7 +92,13 @@ class FusionCog(commands.Cog):
             active = await fusion_sheets.get_publishable_fusion()
         except Exception as exc:
             log.exception("fusion debug failed to load fusion")
-            await ctx.reply(f"Fusion config error: {exc}", mention_author=False)
+            await fusion_logs.send_ops_alert(
+                component="command_debug",
+                summary="load_fusion_failed",
+                dedupe_key="fusion:command:debug:load_fusion",
+                error=exc,
+            )
+            await ctx.reply("Fusion debug is temporarily unavailable.", mention_author=False)
             return
 
         if active is None:
@@ -102,7 +109,14 @@ class FusionCog(commands.Cog):
             events = await fusion_sheets.get_fusion_events(active.fusion_id)
         except Exception as exc:
             log.exception("fusion debug failed to load events", extra={"fusion_id": active.fusion_id})
-            await ctx.reply(f"Fusion event load failed: {exc}", mention_author=False)
+            await fusion_logs.send_ops_alert(
+                component="command_debug",
+                summary="load_events_failed",
+                dedupe_key=f"fusion:command:debug:events:{active.fusion_id}",
+                error=exc,
+                fields={"fusion_id": active.fusion_id},
+            )
+            await ctx.reply("Fusion events are temporarily unavailable.", mention_author=False)
             return
 
         lines = [
@@ -141,7 +155,13 @@ class FusionCog(commands.Cog):
             target = await fusion_sheets.get_publishable_fusion()
         except Exception as exc:
             log.exception("fusion publish failed to load fusion rows")
-            await ctx.reply(f"Could not load fusion data: {exc}", mention_author=False)
+            await fusion_logs.send_ops_alert(
+                component="command_publish",
+                summary="load_fusion_failed",
+                dedupe_key="fusion:command:publish:load_fusion",
+                error=exc,
+            )
+            await ctx.reply("Could not load fusion data right now.", mention_author=False)
             return
 
         if target is None:
@@ -197,7 +217,14 @@ class FusionCog(commands.Cog):
                 return
         except Exception as exc:
             log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
-            await ctx.reply(f"Failed to publish announcement: {exc}", mention_author=False)
+            await fusion_logs.send_ops_alert(
+                component="command_publish",
+                summary="announce_send_failed",
+                dedupe_key=f"fusion:command:publish:send:{target.fusion_id}",
+                error=exc,
+                fields={"fusion_id": target.fusion_id},
+            )
+            await ctx.reply("Failed to publish announcement right now.", mention_author=False)
             return
 
         destination = channel.mention if isinstance(channel, discord.abc.GuildChannel) else "configured channel"

--- a/modules/community/fusion/logs.py
+++ b/modules/community/fusion/logs.py
@@ -1,0 +1,69 @@
+"""Shared Fusion logging/reporting helpers built on existing runtime patterns."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+import discord
+
+from modules.common import runtime as rt
+from shared.dedupe import EventDeduper
+from shared.logfmt import human_reason
+
+log = logging.getLogger("c1c.community.fusion.logs")
+_ALERT_DEDUPER = EventDeduper(window_s=300.0, max_keys=512)
+
+
+def _render_fields(fields: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in fields.items():
+        if value in (None, "", "-"):
+            continue
+        parts.append(f"{key}={value}")
+    return " • ".join(parts)
+
+
+async def send_ops_alert(
+    *,
+    component: str,
+    summary: str,
+    dedupe_key: str | None = None,
+    error: BaseException | None = None,
+    fields: Mapping[str, Any] | None = None,
+) -> None:
+    """Emit a Fusion-focused alert to the configured internal log channel."""
+
+    key = dedupe_key or ""
+    if key and not _ALERT_DEDUPER.should_emit(key):
+        return
+
+    detail = _render_fields(fields or {})
+    reason = human_reason(error) if error is not None else "-"
+    message = f"❌ Fusion — component={component} • summary={summary} • reason={reason}"
+    if detail:
+        message = f"{message} • {detail}"
+
+    try:
+        await rt.send_log_message(message)
+    except Exception:
+        log.warning("failed to send Fusion ops alert", exc_info=True)
+
+
+def interaction_context(
+    interaction: discord.Interaction,
+    *,
+    custom_id: str | None = None,
+) -> dict[str, Any]:
+    data = getattr(interaction, "data", None) or {}
+    channel = getattr(interaction, "channel", None)
+    message = getattr(interaction, "message", None)
+    return {
+        "guild_id": getattr(getattr(interaction, "guild", None), "id", None)
+        or getattr(interaction, "guild_id", None),
+        "channel_id": getattr(channel, "id", None),
+        "message_id": getattr(message, "id", None),
+        "interaction_id": getattr(interaction, "id", None),
+        "custom_id": custom_id or data.get("custom_id"),
+        "user_id": getattr(getattr(interaction, "user", None), "id", None),
+    }

--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Literal
 
 import discord
 from discord.ext import commands
 
+from modules.community.fusion import logs as fusion_logs
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.opt_in")
@@ -35,6 +36,27 @@ _STATUS_ICONS = {
     "missed": "⚠️",
     "not_started": "⬜",
 }
+
+
+def _normalize_progress_payload(payload: object) -> tuple[dict[str, str], bool]:
+    if isinstance(payload, Mapping) and "progress" in payload and isinstance(payload.get("progress"), Mapping):
+        candidate = payload.get("progress")
+    else:
+        candidate = payload
+
+    if not isinstance(candidate, Mapping):
+        return {}, True
+
+    normalized: dict[str, str] = {}
+    for key, value in candidate.items():
+        event_id = str(key or "").strip()
+        if not event_id:
+            continue
+        status = str(value or "").strip().lower()
+        if status not in {"not_started", "in_progress", "done", "skipped", "missed"}:
+            status = "not_started"
+        normalized[event_id] = status
+    return normalized, False
 
 
 async def _send_ephemeral(interaction: discord.Interaction, message: str) -> None:
@@ -94,8 +116,16 @@ async def _resolve_opt_in_role(interaction: discord.Interaction) -> tuple[discor
 async def _handle_opt_action(interaction: discord.Interaction, *, action: Literal["in", "out"]) -> None:
     try:
         member, role = await _resolve_opt_in_role(interaction)
-    except Exception:
-        log.exception("fusion opt button failed to resolve role")
+    except Exception as exc:
+        context = fusion_logs.interaction_context(interaction, custom_id=f"fusion:opt_{action}")
+        log.exception("fusion opt button failed to resolve role", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="opt_button",
+            summary="resolve_opt_in_role_failed",
+            dedupe_key=f"fusion:opt_role:{action}",
+            error=exc,
+            fields=context,
+        )
         await _send_ephemeral(interaction, "Temporary issue. Try again shortly.")
         return
 
@@ -110,10 +140,15 @@ async def _handle_opt_action(interaction: discord.Interaction, *, action: Litera
             return
         try:
             await member.add_roles(role, reason="Fusion role opt-in button")
-        except Exception:
-            log.exception(
-                "fusion opt-in add role failed",
-                extra={"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id},
+        except Exception as exc:
+            context = {"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id, "custom_id": _FUSION_OPT_IN_CUSTOM_ID}
+            log.exception("fusion opt-in add role failed", extra=context)
+            await fusion_logs.send_ops_alert(
+                component="opt_button",
+                summary="add_role_failed",
+                dedupe_key=f"fusion:opt_in:add_role:{member.guild.id}:{role.id}",
+                error=exc,
+                fields=context,
             )
             await _send_ephemeral(interaction, "Couldn’t update your fusion role right now.")
             return
@@ -126,10 +161,15 @@ async def _handle_opt_action(interaction: discord.Interaction, *, action: Litera
 
     try:
         await member.remove_roles(role, reason="Fusion role opt-out button")
-    except Exception:
-        log.exception(
-            "fusion opt-out remove role failed",
-            extra={"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id},
+    except Exception as exc:
+        context = {"guild_id": member.guild.id, "user_id": member.id, "role_id": role.id, "custom_id": _FUSION_OPT_OUT_CUSTOM_ID}
+        log.exception("fusion opt-out remove role failed", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="opt_button",
+            summary="remove_role_failed",
+            dedupe_key=f"fusion:opt_out:remove_role:{member.guild.id}:{role.id}",
+            error=exc,
+            fields=context,
         )
         await _send_ephemeral(interaction, "Couldn’t update your fusion role right now.")
         return
@@ -291,10 +331,20 @@ class _FusionProgressStatusSelect(discord.ui.Select):
                 status,
                 now,
             )
-        except Exception:
-            log.exception(
-                "fusion progress status update failed",
-                extra={"fusion_id": view.fusion_id, "event_id": event.event_id, "user_id": view.user_id},
+        except Exception as exc:
+            context = {
+                "fusion_id": view.fusion_id,
+                "event_id": event.event_id,
+                "user_id": view.user_id,
+                "custom_id": _FUSION_PROGRESS_STATUS_CUSTOM_ID,
+            }
+            log.exception("fusion progress status update failed", extra=context)
+            await fusion_logs.send_ops_alert(
+                component="my_progress",
+                summary="status_update_failed",
+                dedupe_key=f"fusion:progress:update:{view.fusion_id}:{event.event_id}",
+                error=exc,
+                fields=context,
             )
             await _send_ephemeral(interaction, "Couldn’t save progress right now. Try again in a moment.")
             return
@@ -354,8 +404,16 @@ class FusionProgressPanelView(discord.ui.View):
 async def _handle_my_progress(interaction: discord.Interaction) -> None:
     try:
         target = await fusion_sheets.get_publishable_fusion()
-    except Exception:
-        log.exception("fusion my-progress failed to resolve active fusion")
+    except Exception as exc:
+        context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_MY_PROGRESS_CUSTOM_ID)
+        log.exception("fusion my-progress failed to resolve active fusion", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="my_progress",
+            summary="resolve_active_fusion_failed",
+            dedupe_key="fusion:my_progress:active",
+            error=exc,
+            fields=context,
+        )
         await _send_ephemeral(interaction, "Couldn’t load fusion progress right now. Try again shortly.")
         return
 
@@ -365,8 +423,17 @@ async def _handle_my_progress(interaction: discord.Interaction) -> None:
 
     try:
         events = await fusion_sheets.get_fusion_events(target.fusion_id)
-    except Exception:
-        log.exception("fusion my-progress failed to load events", extra={"fusion_id": target.fusion_id})
+    except Exception as exc:
+        context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_MY_PROGRESS_CUSTOM_ID)
+        context.update({"fusion_id": target.fusion_id})
+        log.exception("fusion my-progress failed to load events", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="my_progress",
+            summary="load_events_failed",
+            dedupe_key=f"fusion:my_progress:events:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
         await _send_ephemeral(interaction, "Couldn’t load events right now. Try again shortly.")
         return
 
@@ -379,13 +446,30 @@ async def _handle_my_progress(interaction: discord.Interaction) -> None:
             target.fusion_id,
             str(interaction.user.id),
         )
-    except Exception:
-        log.exception(
-            "fusion my-progress failed to load user progress",
-            extra={"fusion_id": target.fusion_id, "user_id": interaction.user.id},
+    except Exception as exc:
+        context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_MY_PROGRESS_CUSTOM_ID)
+        context.update({"fusion_id": target.fusion_id})
+        log.exception("fusion my-progress failed to load user progress", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="my_progress",
+            summary="load_user_progress_failed",
+            dedupe_key=f"fusion:my_progress:user:{target.fusion_id}",
+            error=exc,
+            fields=context,
         )
         await _send_ephemeral(interaction, "Couldn’t load your saved progress right now.")
         return
+
+    progress_by_event, malformed_payload = _normalize_progress_payload(progress_by_event)
+    if malformed_payload:
+        context = {"fusion_id": target.fusion_id, "user_id": interaction.user.id}
+        log.warning("fusion my-progress payload malformed; continuing with empty state", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="my_progress",
+            summary="progress_payload_malformed",
+            dedupe_key=f"fusion:my_progress:malformed:{target.fusion_id}",
+            fields=context,
+        )
 
     view = FusionProgressPanelView(
         user_id=interaction.user.id,
@@ -435,6 +519,18 @@ class FusionOptInView(discord.ui.View):
     )
     async def my_progress_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
         await _handle_my_progress(interaction)
+
+    async def on_error(self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item) -> None:
+        context = fusion_logs.interaction_context(interaction, custom_id=getattr(item, "custom_id", None))
+        log.exception("fusion opt-in view interaction failed", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="interaction",
+            summary="view_handler_failed",
+            dedupe_key=f"fusion:view_error:{context.get('custom_id')}",
+            error=error,
+            fields=context,
+        )
+        await _send_ephemeral(interaction, "Temporary issue. Try again shortly.")
 
 
 def build_fusion_opt_in_view(target: fusion_sheets.FusionRow) -> discord.ui.View:

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -10,6 +10,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.fusion.announcements import ensure_fusion_announcement
+from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from shared.sheets import fusion as fusion_sheets
 
@@ -78,8 +79,14 @@ async def process_fusion_reminders(
 
     try:
         target = await fusion_sheets.get_publishable_fusion()
-    except Exception:
+    except Exception as exc:
         log.exception("fusion reminder failed to load target fusion")
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="load_target_fusion_failed",
+            dedupe_key="fusion:reminders:load_target",
+            error=exc,
+        )
         return
 
     if target is None:
@@ -95,12 +102,27 @@ async def process_fusion_reminders(
             exc,
             extra={"fusion_id": target.fusion_id},
         )
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="durable_dedupe_unavailable_fail_open",
+            dedupe_key=f"fusion:reminders:dedupe:{target.fusion_id}",
+            error=exc,
+            fields={"fusion_id": target.fusion_id},
+        )
         sent_keys = set()
 
     try:
         events = await fusion_sheets.get_fusion_events(target.fusion_id)
-    except Exception:
-        log.exception("fusion reminder failed to load events", extra={"fusion_id": target.fusion_id})
+    except Exception as exc:
+        context = {"fusion_id": target.fusion_id}
+        log.exception("fusion reminder failed to load events", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="load_events_failed",
+            dedupe_key=f"fusion:reminders:events:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
         return
 
     for event in events:
@@ -124,9 +146,14 @@ async def process_fusion_reminders(
             try:
                 announcement_message = await ensure_fusion_announcement(bot, target)
                 if announcement_message is None:
+                    context = {
+                        "fusion_id": target.fusion_id,
+                        "event_id": event.event_id,
+                        "reminder_type": reminder_type,
+                    }
                     log.warning(
                         "fusion reminder skipped; announcement unavailable",
-                        extra={"fusion_id": target.fusion_id, "event_id": event.event_id, "reminder_type": reminder_type},
+                        extra=context,
                     )
                     continue
 
@@ -146,10 +173,24 @@ async def process_fusion_reminders(
                     sent_at=reference,
                 )
                 sent_keys.add(key)
-            except Exception:
+            except Exception as exc:
+                context = {
+                    "fusion_id": target.fusion_id,
+                    "event_id": event.event_id,
+                    "reminder_type": reminder_type,
+                }
                 log.exception(
                     "fusion reminder send failed",
-                    extra={"fusion_id": target.fusion_id, "event_id": event.event_id, "reminder_type": reminder_type},
+                    extra=context,
+                )
+                await fusion_logs.send_ops_alert(
+                    component="reminders",
+                    summary="send_failed",
+                    dedupe_key=(
+                        f"fusion:reminders:send:{target.fusion_id}:{event.event_id}:{reminder_type}"
+                    ),
+                    error=exc,
+                    fields=context,
                 )
 
 

--- a/modules/community/fusion/role_cleanup.py
+++ b/modules/community/fusion/role_cleanup.py
@@ -9,6 +9,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.fusion.announcements import resolve_announcement_channel
+from modules.community.fusion import logs as fusion_logs
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.role_cleanup")
@@ -48,8 +49,14 @@ async def process_ended_fusion_role_cleanup(
 
     try:
         ended_fusions = await fusion_sheets.get_ended_fusions(now=reference)
-    except Exception:
+    except Exception as exc:
         log.exception("fusion role cleanup failed to load ended fusions")
+        await fusion_logs.send_ops_alert(
+            component="role_cleanup",
+            summary="load_ended_fusions_failed",
+            dedupe_key="fusion:role_cleanup:load_ended",
+            error=exc,
+        )
         return
 
     for target in ended_fusions:
@@ -58,10 +65,18 @@ async def process_ended_fusion_role_cleanup(
 
         try:
             sent_keys = await fusion_sheets.get_sent_reminder_keys(target.fusion_id)
-        except Exception:
+        except Exception as exc:
+            context = {"fusion_id": target.fusion_id}
             log.exception(
                 "fusion role cleanup failed to load dedupe state",
-                extra={"fusion_id": target.fusion_id},
+                extra=context,
+            )
+            await fusion_logs.send_ops_alert(
+                component="role_cleanup",
+                summary="load_dedupe_state_failed",
+                dedupe_key=f"fusion:role_cleanup:dedupe:{target.fusion_id}",
+                error=exc,
+                fields=context,
             )
             continue
 
@@ -105,10 +120,18 @@ async def process_ended_fusion_role_cleanup(
                 reminder_type=_ROLE_CLEANUP_TYPE,
                 sent_at=reference,
             )
-        except Exception:
+        except Exception as exc:
+            context = {"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id}
             log.exception(
                 "fusion role cleanup iteration failed",
-                extra={"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id},
+                extra=context,
+            )
+            await fusion_logs.send_ops_alert(
+                component="role_cleanup",
+                summary="iteration_failed",
+                dedupe_key=f"fusion:role_cleanup:iteration:{target.fusion_id}",
+                error=exc,
+                fields=context,
             )
 
 

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from modules.community.fusion.announcement_refresh import process_fusion_announcement_refreshes
+from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.reminders import process_fusion_reminders
 from modules.community.fusion.role_cleanup import process_ended_fusion_role_cleanup
 
@@ -40,11 +41,23 @@ def schedule_fusion_jobs(runtime: "Runtime") -> None:
             if _should_log_not_ready(now):
                 log.info("fusion scheduler paused; bot not ready")
             return
-        try:
-            await process_fusion_reminders(runtime.bot)
-            await process_fusion_announcement_refreshes(runtime.bot)
-            await process_ended_fusion_role_cleanup(runtime.bot)
-        except Exception:
-            log.exception("fusion reminder scheduler tick failed")
+        jobs = (
+            ("reminders", process_fusion_reminders),
+            ("announcement_refresh", process_fusion_announcement_refreshes),
+            ("role_cleanup", process_ended_fusion_role_cleanup),
+        )
+        for job_name, job_fn in jobs:
+            try:
+                await job_fn(runtime.bot)
+            except Exception as exc:
+                context = {"job_name": job_name}
+                log.exception("fusion scheduler task failed", extra=context)
+                await fusion_logs.send_ops_alert(
+                    component="scheduler",
+                    summary="fusion_scheduler_task_failed",
+                    dedupe_key=f"fusion:scheduler:{job_name}",
+                    error=exc,
+                    fields=context,
+                )
 
     job.do(_runner)

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -184,3 +184,44 @@ def test_build_view_keeps_progress_button_without_opt_role():
     assert "fusion:opt_in" not in custom_ids
     assert "fusion:opt_out" not in custom_ids
     assert custom_ids == ["fusion:my_progress"]
+
+
+def test_my_progress_accepts_nested_progress_payload(monkeypatch):
+    async def _run() -> None:
+        now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+        target = _fusion_row(opt_in_role_id=777)
+        event = fusion_sheets.FusionEventRow(
+            fusion_id=target.fusion_id,
+            event_id="e-1",
+            event_name="Event 1",
+            event_type="tournament",
+            category="arena",
+            start_at_utc=now - dt.timedelta(hours=1),
+            end_at_utc=now + dt.timedelta(hours=1),
+            reward_amount=100.0,
+            bonus=None,
+            reward_type="fragments",
+            points_needed=1000,
+            is_estimated=False,
+            sort_order=1,
+        )
+        member = _Member(role=None)
+        guild = _Guild(role=SimpleNamespace(id=777), member=member)
+        interaction = _interaction(guild, member)
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=target))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+        monkeypatch.setattr(
+            fusion_sheets,
+            "get_user_event_progress",
+            AsyncMock(return_value={"progress": {"e-1": "done"}}),
+        )
+
+        await opt_in_view._handle_my_progress(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        kwargs = interaction.response.send_message.await_args.kwargs
+        assert kwargs["ephemeral"] is True
+        assert kwargs["embed"].title.startswith("My Progress")
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Bring Fusion into parity with the bot’s established logging, exception handling, and internal ops-alerting patterns so high-signal failures are visible to operators and interaction/scheduler failures are safe and debuggable.
- Ensure scheduler jobs never crash the whole loop, interaction handlers never fail silently, and the reported `KeyError: 'progress'` in My Progress is fixed by normalizing unexpected payload shapes.

### Description
- Add a thin Fusion helper `modules/community/fusion/logs.py` that reuses `modules.common.runtime.send_log_message`, `shared.logfmt.human_reason`, and `shared.dedupe.EventDeduper` to post deduped internal alerts and to extract interaction context for consistent fields.
- Update scheduler to run each Fusion job (reminders, announcement refresh, role cleanup) independently and emit structured `log.exception(..., extra=...)` entries plus deduped ops alerts via `fusion.logs.send_ops_alert` when a job fails.
- Harden reminder, announcement-refresh, role-cleanup, and publish/debug command code paths to add contextual `extra` fields (e.g. `fusion_id`, `event_id`, `reminder_type`, `job_name`) and to route actionable failures to the internal ops channel while keeping recoverable problems as warnings.
- Improve interaction safety in `FusionOptInView` by adding `View.on_error`, richer contextual logging/ops alerts for opt-in/out and progress updates, and by normalizing user progress payloads (support nested `{"progress": ...}` shapes) to avoid `KeyError` and similar crashes.
- Preserve user-facing behavior by sending the same clean ephemeral replies and not exposing raw exception traces; no sheet tab/column names were hard-coded or changed.

### Testing
- Ran `pytest -q tests/community/test_fusion_opt_in_view.py tests/community/test_fusion_scheduler.py tests/community/test_fusion_reminders.py tests/community/test_fusion_cog.py` and these tests passed after the changes (the progress-payload regression is covered by the new `test_my_progress_accepts_nested_progress_payload`).
- A run that included `tests/community/test_fusion_announcement_refresh.py` failed on an existing `test_build_embed_includes_event_status_section` assertion; this failure appears unrelated to the logging/reporting changes and is noted for follow-up.
- Compiled modified modules with `python -m py_compile` for the changed files to validate syntax and ensure there are no compile-time errors, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dbf6762083239581b5ff676abb94)