### PR TITLE
Harden startup lifecycle retries and add startup phase diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -238,6 +238,7 @@ async def _enforce_guild_allow_list(
 @bot.event
 async def on_ready():
     hb.note_ready()
+    runtime.startup_diag_mark(ready_reached=True)
     healthmod.set_component("discord", True)
     log.info("startup phase ready reached ok")
     log.info(
@@ -257,6 +258,7 @@ async def on_ready():
         return
 
     try:
+        runtime.startup_diag_mark(feature_init_started=True)
         await core_ready.on_ready(bot)
     except Exception:
         log.exception("READY FAILURE: core_ready.on_ready")
@@ -264,6 +266,7 @@ async def on_ready():
         return
 
     try:
+        runtime.startup_diag_mark(scheduler_start_reached=True)
         await runtime.register_ready_schedulers()
     except Exception:
         log.exception("READY FAILURE: runtime.register_ready_schedulers")
@@ -316,11 +319,13 @@ async def on_ready():
 @bot.event
 async def on_connect():
     hb.note_connected()
+    runtime.startup_diag_mark(login_reached=True)
 
 
 @bot.event
 async def on_resumed():
     hb.note_connected()
+    runtime.startup_diag_mark(login_reached=True)
 
 
 @bot.event

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -929,10 +929,32 @@ class Runtime:
         self._watchdog_params: Optional[tuple[int, int, int]] = None
         self._startup_scheduler_registered = False
         self._startup_scheduler_lock = asyncio.Lock()
+        self._startup_diag: dict[str, Any] = {}
         set_active_runtime(self)
+
+    def _reset_startup_diag(self, *, attempt: int) -> None:
+        self._startup_diag = {
+            "attempt": attempt,
+            "phase": "init",
+            "client_created": False,
+            "startup_setup_ok": False,
+            "login_reached": False,
+            "ready_reached": False,
+            "persistent_views_registered": False,
+            "scheduler_start_reached": False,
+            "feature_init_started": False,
+            "cleanup_ok": None,
+        }
+
+    def startup_diag_mark(self, **fields: object) -> None:
+        self._startup_diag.update(fields)
+
+    def startup_diag_snapshot(self) -> dict[str, Any]:
+        return dict(self._startup_diag)
 
     def _build_bot_for_attempt(self, startup_attempt: int) -> commands.Bot:
         if startup_attempt <= 1:
+            self.startup_diag_mark(client_created=True)
             return self.bot
         if self._bot_factory is None:
             raise RuntimeError(
@@ -942,12 +964,15 @@ class Runtime:
         self.bot = new_bot
         if self._bot_rebuild_hook is not None:
             self._bot_rebuild_hook(new_bot)
+        self.startup_diag_mark(client_created=True)
         return new_bot
 
     async def _dispose_bot_for_attempt(self, bot: commands.Bot) -> None:
         try:
             await bot.close()
+            self.startup_diag_mark(cleanup_ok=True)
         except Exception:
+            self.startup_diag_mark(cleanup_ok=False)
             log.exception("failed to dispose startup attempt bot/client")
 
     async def start_webserver(self, *, port: Optional[int] = None) -> None:
@@ -1360,15 +1385,11 @@ class Runtime:
 
     async def start(self, token: str) -> None:
         await self.start_webserver()
-        try:
-            await self._run_startup_setup()
-        except StartupPhaseError:
-            raise
-
         retry_started = time.monotonic()
         retry_delay_sec = _DISCORD_LOGIN_RETRY_INITIAL_SEC
         startup_attempt = 1
         root_failure_logged = False
+        self._reset_startup_diag(attempt=startup_attempt)
         attempt_bot = self._build_bot_for_attempt(startup_attempt)
         log.info("startup attempt %s created new bot/client", startup_attempt)
         await asyncio.sleep(3)
@@ -1381,12 +1402,18 @@ class Runtime:
             if elapsed > _DISCORD_LOGIN_RETRY_MAX_WINDOW_SEC:
                 raise RuntimeError("discord login retry exhausted")
             log.info("startup attempt %s begin", startup_attempt)
+            self.startup_diag_mark(attempt=startup_attempt, phase="startup_setup")
+            try:
+                await self._run_startup_setup()
+            except StartupPhaseError:
+                raise
             if _is_bot_http_session_closed(attempt_bot):
                 raise RuntimeError(
                     "startup retry refused: bot HTTP session is already closed; "
                     "cannot retry on disposed client"
                 )
             try:
+                self.startup_diag_mark(phase="discord_login")
                 _startup_phase_log("discord login", "start", attempt=startup_attempt)
                 await attempt_bot.start(token)
                 _startup_phase_log("discord login", "ok", attempt=startup_attempt)
@@ -1394,13 +1421,23 @@ class Runtime:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                self.startup_diag_mark(login_reached=bool(getattr(attempt_bot, "user", None)))
                 should_retry, detail = _is_retryable_discord_start_failure(exc)
+                if self._startup_diag.get("login_reached"):
+                    # When login was reached, repeated retries can churn logins/rate limits.
+                    should_retry = False
+                    detail = f"post_login_failure:{detail}"
                 if not should_retry:
                     _startup_phase_log(
                         "discord login",
                         "fail",
                         attempt=startup_attempt,
                         reason=detail,
+                    )
+                    log.error(
+                        "startup attempt %s failed without retry",
+                        startup_attempt,
+                        extra={"startup_diag": self.startup_diag_snapshot()},
                     )
                     raise
                 _startup_phase_log(
@@ -1430,6 +1467,7 @@ class Runtime:
                     retry_delay_sec * 2,
                 )
                 startup_attempt += 1
+                self._reset_startup_diag(attempt=startup_attempt)
                 attempt_bot = self._build_bot_for_attempt(startup_attempt)
                 log.info(
                     "startup attempt %s created new bot/client for retry",
@@ -1447,6 +1485,7 @@ class Runtime:
             _startup_phase_log("config validation", "fail", error=repr(exc))
             raise StartupPhaseError("config validation", exc) from exc
         _startup_phase_log("config validation", "ok")
+        self.startup_diag_mark(phase="extension_load")
 
         _startup_phase_log("extension load", "start")
         try:
@@ -1455,6 +1494,7 @@ class Runtime:
             _startup_phase_log("extension load", "fail", error=repr(exc))
             raise StartupPhaseError("extension load", exc) from exc
         _startup_phase_log("extension load", "ok")
+        self.startup_diag_mark(phase="persistent_view_registration")
 
         _startup_phase_log("persistent view registration", "start")
         try:
@@ -1464,10 +1504,12 @@ class Runtime:
             if not bool(registration.get("registered")):
                 error = registration.get("error") or "unknown"
                 raise RuntimeError(f"persistent view registration failed: {error}")
+            self.startup_diag_mark(persistent_views_registered=True)
         except Exception as exc:
             _startup_phase_log("persistent view registration", "fail", error=repr(exc))
             raise StartupPhaseError("persistent view registration", exc) from exc
         _startup_phase_log("persistent view registration", "ok")
+        self.startup_diag_mark(startup_setup_ok=True)
 
     async def register_ready_schedulers(self) -> None:
         async with self._startup_scheduler_lock:

--- a/tests/shared/test_runtime_startup_retry.py
+++ b/tests/shared/test_runtime_startup_retry.py
@@ -7,9 +7,8 @@ import pytest
 from modules.common import runtime
 
 
-class _RetryableLoginError(Exception):
-    status = 429
-    text = "cloudflare 1015"
+class _RetryableLoginError(asyncio.TimeoutError):
+    pass
 
 
 class _FakeBot:
@@ -19,6 +18,7 @@ class _FakeBot:
         self.start_calls = 0
         self.close_calls = 0
         self.label = label
+        self.user = None
         self.http = SimpleNamespace(_HTTPClient__session=None)
 
     def is_closed(self) -> bool:
@@ -39,14 +39,7 @@ class _FakeBot:
 
 
 def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(runtime.discord, "HTTPException", _RetryableLoginError)
-    monkeypatch.setattr(
-        runtime,
-        "_is_startup_rate_limited",
-        lambda _exc: (True, "cloudflare_rate_limited(ray_id=test)"),
-    )
     monkeypatch.setattr(runtime.Runtime, "start_webserver", AsyncMock())
-    monkeypatch.setattr(runtime.Runtime, "load_extensions", AsyncMock())
     monkeypatch.setattr(runtime, "rehydrate_tiers", lambda _bot: None)
     monkeypatch.setattr(runtime, "audit_tiers", lambda _bot, _logger: None)
     monkeypatch.setattr(
@@ -87,6 +80,10 @@ def test_runtime_startup_retry_rebuilds_bot_per_attempt(
         sleep_mock = AsyncMock(return_value=None)
         monkeypatch.setattr(runtime, "_sleep_startup_retry_backoff", sleep_mock)
 
+        setup_calls: list[str] = []
+        setup_mock = AsyncMock(side_effect=lambda: setup_calls.append("ok"))
+        monkeypatch.setattr(runtime.Runtime, "_run_startup_setup", setup_mock)
+
         bot_attempt_1 = _FakeBot([_RetryableLoginError()], label="attempt-1")
         bot_attempt_2 = _FakeBot([_RetryableLoginError()], label="attempt-2")
         bot_attempt_3 = _FakeBot([None], label="attempt-3")
@@ -110,6 +107,7 @@ def test_runtime_startup_retry_rebuilds_bot_per_attempt(
         assert rebuilt == [bot_attempt_2, bot_attempt_3]
         assert rt.bot is bot_attempt_3
         assert sleep_mock.await_count == 2
+        assert setup_mock.await_count == 3
 
     asyncio.run(runner())
 
@@ -122,6 +120,7 @@ def test_runtime_startup_retry_requires_factory_for_rebuild(
         monkeypatch.setattr(
             runtime, "_sleep_startup_retry_backoff", AsyncMock(return_value=None)
         )
+        monkeypatch.setattr(runtime.Runtime, "_run_startup_setup", AsyncMock(return_value=None))
         bot = _FakeBot([_RetryableLoginError()], label="attempt-1")
         rt = runtime.Runtime(bot=bot)
 
@@ -129,5 +128,38 @@ def test_runtime_startup_retry_requires_factory_for_rebuild(
             await rt.start("token")
         assert bot.start_calls == 1
         assert bot.close_calls == 1
+
+    asyncio.run(runner())
+
+
+def test_runtime_startup_post_login_failure_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def runner() -> None:
+        _patch_runtime_startup(monkeypatch)
+        monkeypatch.setattr(
+            runtime, "_sleep_startup_retry_backoff", AsyncMock(return_value=None)
+        )
+        setup_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr(runtime.Runtime, "_run_startup_setup", setup_mock)
+
+        class _PostLoginFailure(RuntimeError):
+            pass
+
+        bot = _FakeBot([None], label="attempt-1")
+
+        async def _start(_token: str) -> None:
+            bot.start_calls += 1
+            bot.user = object()
+            raise _PostLoginFailure("after login")
+
+        bot.start = _start  # type: ignore[assignment]
+        rt = runtime.Runtime(bot=bot, bot_factory=lambda: _FakeBot([], label="never"))
+
+        with pytest.raises(_PostLoginFailure):
+            await rt.start("token")
+        assert bot.start_calls == 1
+        assert setup_mock.await_count == 1
+        assert bot.close_calls == 0
 
     asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- A retry lifecycle bug caused repeated Discord login churn because recreated bot clients were not re-initialized (extensions/persistent views) before subsequent `bot.start` attempts.  
- This could surface as `discord_rate_limited`/Cloudflare-style failures, but the rate-limit errors were a symptom of unsafe retry choreography rather than the root cause.  
- Make dev redeploys safe by ensuring each retry attempt starts from a fully-initialized client and by making failure phases observable.  

### Description
- Run the full startup setup (`_run_startup_setup`) on every startup attempt so rebuilt clients receive `load_extensions` and persistent view registration before `bot.start`.  
- Add structured startup diagnostics to `Runtime` (`_startup_diag`, `startup_diag_mark`, `startup_diag_snapshot`) and mark key milestones (`client_created`, `login_reached`, `ready_reached`, `persistent_views_registered`, `scheduler_start_reached`, `feature_init_started`, `cleanup_ok`).  
- Prevent conservative retries for failures that occur after login was already reached in an attempt by refusing additional retry attempts when a post-login failure is detected.  
- Instrument application lifecycle events to update diagnostics (`on_connect`/`on_resumed` mark login, `on_ready` marks ready and feature/scheduler milestones).  
- Add/adjust regression tests in `tests/shared/test_runtime_startup_retry.py` to verify per-attempt setup runs, preserve rebuild/factory behavior, and ensure post-login failures do not trigger retry churn.  

### Testing
- Ran `pytest -q tests/shared/test_runtime_startup_retry.py tests/shared/test_runtime_scheduler.py` and all tests passed.  
- Existing startup/scheduler unit coverage exercised the new behavior (rebuild-on-retry, backoff, cleanup) and new assertions validate the post-login non-retry path.  
- Logs/diagnostics are emitted on non-retry failures to aid triage of future startup incidents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e611b6126c8323a32edf70a0a933a6)