### PR TITLE
Fix Fusion My Progress selected-event state synchronization

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -295,6 +295,7 @@ class _FusionProgressEventSelect(discord.ui.Select):
 
         selected_event_id = self.values[0] if self.values else ""
         view.selected_event_id = selected_event_id or None
+        view.refresh_items()
         await interaction.response.edit_message(
             embed=view.build_embed(),
             view=view,
@@ -326,7 +327,8 @@ class _FusionProgressStatusSelect(discord.ui.Select):
         if interaction.user.id != view.user_id:
             await _send_ephemeral(interaction, "This progress panel belongs to a different user.")
             return
-        if not view.selected_event_id:
+        selected_event_id = view.selected_event_id
+        if not selected_event_id:
             await _send_ephemeral(interaction, "Choose an event first.")
             return
 
@@ -335,7 +337,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
         if status is None:
             context = {
                 "fusion_id": view.fusion_id,
-                "event_id": view.selected_event_id,
+                "event_id": selected_event_id,
                 "user_id": view.user_id,
                 "status": str(selected_status),
                 "custom_id": _FUSION_PROGRESS_STATUS_CUSTOM_ID,
@@ -343,7 +345,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             log.error("fusion progress status invalid; aborting save", extra=context)
             await _send_ephemeral(interaction, "Couldn’t save progress right now. Please choose a valid status.")
             return
-        event = view.events_by_id.get(view.selected_event_id)
+        event = view.events_by_id.get(selected_event_id)
         if event is None:
             await _send_ephemeral(interaction, "That event is no longer available. Reopen My Progress.")
             return
@@ -385,6 +387,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             return
 
         view.progress_by_event[event.event_id] = status
+        view.selected_event_id = event.event_id
         view.last_update = (event.event_name, status)
         view.refresh_items()
         await interaction.response.edit_message(
@@ -415,11 +418,20 @@ class FusionProgressPanelView(discord.ui.View):
         self.last_update: tuple[str, str] | None = None
         self.refresh_items()
 
+    def _coerce_selected_event_id(self) -> None:
+        if not self.events:
+            self.selected_event_id = None
+            return
+        if self.selected_event_id in self.events_by_id:
+            return
+        self.selected_event_id = self.events[0].event_id
+
     def refresh_items(self) -> None:
         self.clear_items()
         if not self.events:
             return
 
+        self._coerce_selected_event_id()
         self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id))
         selected_status = None
         if self.selected_event_id:

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -33,6 +33,7 @@ def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
 class _Response:
     def __init__(self) -> None:
         self.send_message = AsyncMock()
+        self.edit_message = AsyncMock()
         self._is_done = False
 
     def is_done(self) -> bool:
@@ -277,3 +278,54 @@ def test_coerce_status_for_save_accepts_canonical_and_index_values():
     assert opt_in_view._coerce_status_for_save("2") == "done"
     assert opt_in_view._coerce_status_for_save(3) == "skipped"
     assert opt_in_view._coerce_status_for_save("999") is None
+
+
+def test_my_progress_panel_keeps_selected_event_in_sync_across_second_save(monkeypatch):
+    async def _run() -> None:
+        events = [_event_row("e1"), _event_row("e2")]
+        view = opt_in_view.FusionProgressPanelView(
+            user_id=10,
+            target=_fusion_row(opt_in_role_id=777),
+            events=events,
+            progress_by_event={},
+        )
+        upsert_mock = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "upsert_user_event_progress", upsert_mock)
+
+        interaction = _interaction(guild=None, member=SimpleNamespace(id=10))
+
+        event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+        assert event_select.options[0].default is True
+        assert event_select.options[1].default is False
+
+        event_select._values = ["e1"]
+        await event_select.callback(interaction)
+        status_select = next(item for item in view.children if item.custom_id == "fusion:progress:status")
+        status_select._values = ["done"]
+        await status_select.callback(interaction)
+
+        event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+        event_select._values = ["e2"]
+        await event_select.callback(interaction)
+
+        assert view.selected_event_id == "e2"
+        event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+        defaults = {option.value: option.default for option in event_select.options}
+        assert defaults == {"e1": False, "e2": True}
+
+        status_select = next(item for item in view.children if item.custom_id == "fusion:progress:status")
+        status_select._values = ["in_progress"]
+        await status_select.callback(interaction)
+
+        assert upsert_mock.await_count == 2
+        first_call = upsert_mock.await_args_list[0].args
+        second_call = upsert_mock.await_args_list[1].args
+        assert first_call[2] == "e1"
+        assert second_call[2] == "e2"
+
+        embed = view.build_embed()
+        selected_field = next(field for field in embed.fields if field.name == "Selected Event")
+        assert "Event e2" in selected_field.value
+        assert view.progress_by_event["e2"] == "in_progress"
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Users could switch the selected event in the "My Progress" panel and see the embed update while the event dropdown reverted to a stale selection, preventing reliable multi-event updates in a single session.
- The panel needed a single canonical selected-event source so rebuilds always preserve the intended selection (`view.selected_event_id`).

### Description
- Made `FusionProgressPanelView.selected_event_id` the canonical source of truth and added `def _coerce_selected_event_id()` to validate/coerce it against `events_by_id` before rebuilding components in `refresh_items()` in `modules/community/fusion/opt_in_view.py`.
- Immediately rebuild panel items after an event selection by calling `view.refresh_items()` in the event select callback so the recreated select options use `default=True` for the canonical selection.
- Updated the status select callback to capture `selected_event_id = view.selected_event_id` and to lookup/save against that value (and to set `view.selected_event_id = event.event_id` after a successful save) so saves always target the current selection.
- Added a regression test `test_my_progress_panel_keeps_selected_event_in_sync_across_second_save` and minor test harness updates in `tests/community/test_fusion_opt_in_view.py` to exercise the sequence: open panel, save A, switch to B, save B, and assert the second save targeted B and UI stayed in sync.

### Testing
- Ran `pytest -q tests/community/test_fusion_opt_in_view.py` and the test suite passed (regression test included) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7409f21a48323906ff16a4426607b)