### PR TITLE
Add top-level exception guard in coreops on_ready

### DIFF
--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -16,39 +16,42 @@ log = logging.getLogger("modules.coreops.ready")
 
 async def on_ready(bot: commands.Bot) -> None:
     """Run startup wiring that must execute after the bot is ready."""
-
-    # Existing startup wiring …
-    # Register onboarding persistent views *after* the bot is ready to avoid race conditions.
     try:
-        panels.register_views(bot)
-    except Exception:
-        log.exception("CORE_READY FAILURE: panels.register_views")
-        return
+        # Existing startup wiring …
+        # Register onboarding persistent views *after* the bot is ready to avoid race conditions.
+        try:
+            panels.register_views(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: panels.register_views")
+            return
 
-    try:
-        register_persistent_fusion_views(bot)
-    except Exception:
-        log.exception("CORE_READY FAILURE: register_persistent_fusion_views")
-        return
+        try:
+            register_persistent_fusion_views(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: register_persistent_fusion_views")
+            return
 
-    # Ensure both onboarding watchers are wired
-    try:
-        await watcher_welcome.setup(bot)
-    except Exception:
-        log.exception("CORE_READY FAILURE: watcher_welcome.setup")
-        return
+        # Ensure both onboarding watchers are wired
+        try:
+            await watcher_welcome.setup(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: watcher_welcome.setup")
+            return
 
-    try:
-        await watcher_promo.setup(bot)
-    except Exception:
-        log.exception("CORE_READY FAILURE: watcher_promo.setup")
-        return
+        try:
+            await watcher_promo.setup(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: watcher_promo.setup")
+            return
 
-    # Guard against bots without a .logger attribute; fall back to module logger.
-    try:
-        logger = getattr(bot, "logger", None)
-        if logger is None:
-            logger = log
-        logger.info("on_ready: onboarding views registered (post-ready)")
+        # Guard against bots without a .logger attribute; fall back to module logger.
+        try:
+            logger = getattr(bot, "logger", None)
+            if logger is None:
+                logger = log
+            logger.info("on_ready: onboarding views registered (post-ready)")
+        except Exception:
+            pass
     except Exception:
-        pass
+        log.exception("core_ready.on_ready failed")
+        raise


### PR DESCRIPTION
### Motivation
- Provide a single catch-all log for unexpected errors during post-ready startup wiring so failures that escape step-level handlers are recorded and propagated.

### Description
- Wrapped the internals of `modules/coreops/ready.py:on_ready` in a top-level `try/except`, added `log.exception("core_ready.on_ready failed")`, and re-raised the exception while keeping existing per-step `try/except` guards intact.

### Testing
- Ran `python -m py_compile modules/coreops/ready.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e749eb3f1c8323a10d7c3787ea194a)