### PR TITLE
Make promo watcher setup idempotent and improve startup error logging

### DIFF
--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -40,8 +40,12 @@ async def on_ready(bot: commands.Bot) -> None:
 
         try:
             await watcher_promo.setup(bot)
-        except Exception:
-            log.exception("CORE_READY FAILURE: watcher_promo.setup")
+        except Exception as exc:
+            log.exception(
+                "CORE_READY FAILURE: watcher_promo.setup (%s: %s)",
+                type(exc).__name__,
+                exc,
+            )
             return
 
         # Guard against bots without a .logger attribute; fall back to module logger.

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -1023,4 +1023,8 @@ class PromoTicketWatcher(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(PromoTicketWatcher(bot))
+    existing = bot.get_cog("PromoTicketWatcher")
+    if existing is None:
+        await bot.add_cog(PromoTicketWatcher(bot))
+    elif not isinstance(existing, PromoTicketWatcher):
+        raise RuntimeError("cog name collision for PromoTicketWatcher")

--- a/tests/onboarding/test_promo_watcher.py
+++ b/tests/onboarding/test_promo_watcher.py
@@ -257,3 +257,25 @@ def test_promo_watcher_respects_feature_flags(monkeypatch: pytest.MonkeyPatch):
         await watcher.on_thread_create(thread)
 
     asyncio.run(runner())
+
+
+def test_setup_is_idempotent_for_existing_promo_watcher() -> None:
+    class DummyBot:
+        def __init__(self) -> None:
+            self._cogs = {}
+            self.add_calls = 0
+
+        def get_cog(self, name: str):
+            return self._cogs.get(name)
+
+        async def add_cog(self, cog) -> None:
+            self.add_calls += 1
+            self._cogs[type(cog).__name__] = cog
+
+    async def _run() -> None:
+        bot = DummyBot()
+        await watcher_promo.setup(bot)
+        await watcher_promo.setup(bot)
+        assert bot.add_calls == 1
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Startup emitted `CORE_READY FAILURE: watcher_promo_setup` because the promo watcher was being registered twice during startup, causing a duplicate-cog error. 
- The wrapper log in `on_ready` hid the original exception details making root-cause diagnosis harder. 

### Description
- Make `modules.onboarding.watcher_promo.setup()` idempotent by checking `bot.get_cog("PromoTicketWatcher")` before calling `bot.add_cog(...)` and preserve collision safety by raising on name-collision with a different cog type. 
- Improve local exception logging at the `watcher_promo.setup(bot)` call site in `modules/coreops/ready.py` to include the exception class name and message in the wrapper log line. 
- Add a regression test `test_setup_is_idempotent_for_existing_promo_watcher` to ensure calling `setup()` twice only adds the cog once. 

### Testing
- Ran `pytest -q tests/coreops/test_ready.py tests/onboarding/test_promo_watcher.py` and observed two failing tests caused by missing runtime configuration (`ONBOARDING_SHEET_ID not set`), which is unrelated to the idempotency change. 
- Ran the new regression check `pytest -q tests/coreops/test_ready.py tests/onboarding/test_promo_watcher.py::test_setup_is_idempotent_for_existing_promo_watcher` and it passed. 
- The change preserves collision semantics and does not alter Fusion behavior or other onboarding flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e757f866d083238b6e1b3552a0f262)