### PR TITLE
Fusion: show status icons and reorder My Progress event dropdown

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -22,6 +22,7 @@ _FUSION_PROGRESS_EVENT_CUSTOM_ID = "fusion:progress:event"
 _FUSION_PROGRESS_STATUS_CUSTOM_ID = "fusion:progress:status"
 
 _DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
+_EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done")
 _STATUS_LABELS = {
     "not_started": "Not Started",
     "in_progress": "In Progress",
@@ -43,6 +44,30 @@ _STATUS_INDEX_TO_CANONICAL = {
     "2": "done",
     "3": "skipped",
 }
+_EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
+
+
+def _effective_display_status(
+    *,
+    event: fusion_sheets.FusionEventRow,
+    progress_by_event: Mapping[str, str],
+    now: dt.datetime | None = None,
+) -> str:
+    status = progress_by_event.get(event.event_id, "not_started")
+    if status not in _ALLOWED_PROGRESS_STATES:
+        status = "not_started"
+    if status == "done":
+        return status
+
+    if now is None:
+        now = dt.datetime.now(dt.timezone.utc)
+    timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_my_progress")
+    if timing is None:
+        return status
+    start_at, end_at = timing
+    if fusion_sheets.derive_event_status(start_at_utc=start_at, end_at_utc=end_at, now=now) == "ended":
+        return "missed"
+    return status
 
 
 def _coerce_status_for_save(raw_status: object) -> str | None:
@@ -204,18 +229,7 @@ def _build_progress_summary_embed(
     display_status_by_event: dict[str, str] = {}
     fragments_done = 0.0
     for event in events:
-        has_saved_status = event.event_id in progress_by_event
-        status = progress_by_event.get(event.event_id, "not_started")
-        if not has_saved_status and status == "not_started":
-            timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_my_progress")
-            if timing is not None:
-                start_at, end_at = timing
-                if fusion_sheets.derive_event_status(
-                    start_at_utc=start_at,
-                    end_at_utc=end_at,
-                    now=now,
-                ) == "ended":
-                    status = "missed"
+        status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=now)
         if status not in counts:
             status = "not_started"
         display_status_by_event[event.event_id] = status
@@ -266,12 +280,31 @@ def _build_progress_summary_embed(
 
 
 class _FusionProgressEventSelect(discord.ui.Select):
-    def __init__(self, events: Sequence[fusion_sheets.FusionEventRow], selected_event_id: str | None) -> None:
+    def __init__(
+        self,
+        events: Sequence[fusion_sheets.FusionEventRow],
+        selected_event_id: str | None,
+        progress_by_event: Mapping[str, str],
+    ) -> None:
+        now = dt.datetime.now(dt.timezone.utc)
+        event_rows = list(enumerate(events))
+        ordered_events = sorted(
+            event_rows,
+            key=lambda item: (
+                _EVENT_DROPDOWN_STATUS_RANK.get(
+                    _effective_display_status(event=item[1], progress_by_event=progress_by_event, now=now),
+                    len(_EVENT_DROPDOWN_STATUS_RANK),
+                ),
+                item[0],
+            ),
+        )
         options: list[discord.SelectOption] = []
-        for event in events[:25]:
+        for _, event in ordered_events[:25]:
+            status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=now)
+            icon = _STATUS_ICONS.get(status, _STATUS_ICONS["not_started"])
             options.append(
                 discord.SelectOption(
-                    label=event.event_name[:100] or event.event_id[:100],
+                    label=f"{icon} {event.event_name or event.event_id}"[:100],
                     value=event.event_id,
                     default=event.event_id == selected_event_id,
                 )
@@ -432,7 +465,7 @@ class FusionProgressPanelView(discord.ui.View):
             return
 
         self._coerce_selected_event_id()
-        self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id))
+        self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id, self.progress_by_event))
         selected_status = None
         if self.selected_event_id:
             selected_status = self.progress_by_event.get(self.selected_event_id, "not_started")

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -78,21 +78,28 @@ def _interaction(guild, member):
     )
 
 
-def _event_row(event_id: str) -> fusion_sheets.FusionEventRow:
+def _event_row(
+    event_id: str,
+    *,
+    event_name: str | None = None,
+    start_at_utc: dt.datetime | None = None,
+    end_at_utc: dt.datetime | None = None,
+    sort_order: int = 1,
+) -> fusion_sheets.FusionEventRow:
     return fusion_sheets.FusionEventRow(
         fusion_id="f-1",
         event_id=event_id,
-        event_name=f"Event {event_id}",
+        event_name=event_name or f"Event {event_id}",
         event_type="dungeon",
         category="Tournaments",
-        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
-        end_at_utc=dt.datetime(2026, 4, 9, tzinfo=dt.timezone.utc),
+        start_at_utc=start_at_utc or dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=end_at_utc or dt.datetime(2026, 4, 9, tzinfo=dt.timezone.utc),
         reward_amount=5.0,
         bonus=None,
         reward_type="fragments",
         points_needed=None,
         is_estimated=False,
-        sort_order=1,
+        sort_order=sort_order,
     )
 
 
@@ -329,3 +336,65 @@ def test_my_progress_panel_keeps_selected_event_in_sync_across_second_save(monke
         assert view.progress_by_event["e2"] == "in_progress"
 
     asyncio.run(_run())
+
+
+def test_event_dropdown_uses_effective_status_icons_and_sort_order():
+    now = dt.datetime(2026, 4, 21, tzinfo=dt.timezone.utc)
+    future_start = dt.datetime(2026, 4, 25, tzinfo=dt.timezone.utc)
+    future_end = dt.datetime(2026, 4, 26, tzinfo=dt.timezone.utc)
+    past_start = dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc)
+    past_end = dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc)
+    events = [
+        _event_row("e_done_ended", event_name="Done Ended", start_at_utc=past_start, end_at_utc=past_end),
+        _event_row("e_not_started", event_name="Not Started", start_at_utc=future_start, end_at_utc=future_end),
+        _event_row("e_in_progress", event_name="In Progress", start_at_utc=future_start, end_at_utc=future_end),
+        _event_row("e_missed", event_name="Missed", start_at_utc=past_start, end_at_utc=past_end),
+        _event_row("e_skipped", event_name="Skipped", start_at_utc=future_start, end_at_utc=future_end),
+    ]
+    progress_by_event = {
+        "e_done_ended": "done",
+        "e_in_progress": "in_progress",
+        "e_skipped": "skipped",
+    }
+
+    select = opt_in_view._FusionProgressEventSelect(events, selected_event_id=None, progress_by_event=progress_by_event)
+    labels = [option.label for option in select.options]
+    assert labels == [
+        "⬜ Not Started",
+        "🟡 In Progress",
+        "⚠️ Missed",
+        "⏭️ Skipped",
+        "✅ Done Ended",
+    ]
+
+    assert (
+        opt_in_view._effective_display_status(event=events[3], progress_by_event=progress_by_event, now=now) == "missed"
+    )
+    assert (
+        opt_in_view._effective_display_status(event=events[0], progress_by_event=progress_by_event, now=now) == "done"
+    )
+
+
+def test_event_dropdown_keeps_selected_event_after_sorting_rebuild():
+    past_start = dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc)
+    past_end = dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc)
+    future_start = dt.datetime(2026, 4, 25, tzinfo=dt.timezone.utc)
+    future_end = dt.datetime(2026, 4, 26, tzinfo=dt.timezone.utc)
+    events = [
+        _event_row("e_done", event_name="Done", start_at_utc=past_start, end_at_utc=past_end),
+        _event_row("e_missed", event_name="Missed", start_at_utc=past_start, end_at_utc=past_end),
+        _event_row("e_not_started", event_name="Not Started", start_at_utc=future_start, end_at_utc=future_end),
+    ]
+    view = opt_in_view.FusionProgressPanelView(
+        user_id=10,
+        target=_fusion_row(opt_in_role_id=777),
+        events=events,
+        progress_by_event={"e_done": "done"},
+    )
+    view.selected_event_id = "e_missed"
+    view.refresh_items()
+
+    event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+    defaults = {option.value: option.default for option in event_select.options}
+    assert defaults["e_missed"] is True
+    assert view.selected_event_id == "e_missed"


### PR DESCRIPTION
### Motivation
- Improve scanability of the Fusion “My Progress” event dropdown so users can see at a glance which events are untouched, in-progress, missed, skipped, or done without opening each item.
- Use icon-only status prefixes and an actionable sort order while keeping the UI compact and mobile-friendly and avoiding extra text/legends.

### Description
- Add `_effective_display_status` helper that derives the effective display state (including `missed` when an event has ended and is not `done`) and use it for both dropdown icons and the summary embed counts.
- Introduce `_EVENT_DROPDOWN_STATUS_ORDER` and a rank map, then sort dropdown options by effective status (not_started → in_progress → missed → skipped → done) while preserving stable ordering within each bucket.
- Render each dropdown option as an icon followed by the event name in the exact format `"<icon> <event name>"` using the provided icon mapping and keep existing selection/save behavior by continuing to track `view.selected_event_id` and rebuilding the select with the same default.
- Files changed: `modules/community/fusion/opt_in_view.py` (logic and UI rendering) and `tests/community/test_fusion_opt_in_view.py` (added/updated tests covering icon labels, effective missed/done behavior, sort order, and selected-option persistence).

### Testing
- Ran `pytest -q tests/community/test_fusion_opt_in_view.py` and all tests passed (full output: 100% green with minor pytest config warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75d8516248323b3c02bf7f0330b25)