### PR TITLE
Support bonus completion states in Fusion My Progress

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -22,27 +22,30 @@ _FUSION_PROGRESS_EVENT_CUSTOM_ID = "fusion:progress:event"
 _FUSION_PROGRESS_STATUS_CUSTOM_ID = "fusion:progress:status"
 
 _DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
-_EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done")
+_EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done", "done_bonus")
 _STATUS_LABELS = {
     "not_started": "Not Started",
     "in_progress": "In Progress",
     "done": "Done",
+    "done_bonus": "Done + Bonus",
     "skipped": "Skipped",
     "missed": "Missed",
 }
 _STATUS_ICONS = {
     "done": "✅",
+    "done_bonus": "✅",
     "in_progress": "🟡",
     "skipped": "⏭️",
     "missed": "⚠️",
     "not_started": "⬜",
 }
-_ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "skipped"})
+_ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "done_bonus", "skipped"})
 _STATUS_INDEX_TO_CANONICAL = {
     "0": "not_started",
     "1": "in_progress",
     "2": "done",
-    "3": "skipped",
+    "3": "done_bonus",
+    "4": "skipped",
 }
 _EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
 
@@ -56,7 +59,7 @@ def _effective_display_status(
     status = progress_by_event.get(event.event_id, "not_started")
     if status not in _ALLOWED_PROGRESS_STATES:
         status = "not_started"
-    if status == "done":
+    if status in {"done", "done_bonus"}:
         return status
 
     if now is None:
@@ -92,10 +95,25 @@ def _normalize_progress_payload(payload: object) -> tuple[dict[str, str], bool]:
         if not event_id:
             continue
         status = str(value or "").strip().lower()
-        if status not in {"not_started", "in_progress", "done", "skipped", "missed"}:
+        if status not in {"not_started", "in_progress", "done", "done_bonus", "skipped", "missed"}:
             status = "not_started"
         normalized[event_id] = status
     return normalized, False
+
+
+def _event_bonus_amount(event: fusion_sheets.FusionEventRow) -> float:
+    return event.bonus if event.bonus is not None else 0.0
+
+
+def _event_has_bonus(event: fusion_sheets.FusionEventRow) -> bool:
+    return _event_bonus_amount(event) > 0
+
+
+def _event_fragments_label(event: fusion_sheets.FusionEventRow) -> str:
+    bonus = _event_bonus_amount(event)
+    if bonus > 0:
+        return f"{event.reward_amount:g} + {bonus:g} bonus frags"
+    return f"{event.reward_amount:g} frags"
 
 
 async def _send_ephemeral(interaction: discord.Interaction, message: str) -> None:
@@ -230,6 +248,11 @@ def _build_progress_summary_embed(
     fragments_done = 0.0
     for event in events:
         status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=now)
+        if status == "done_bonus":
+            display_status_by_event[event.event_id] = status
+            counts["done"] += 1
+            fragments_done += event.reward_amount + _event_bonus_amount(event)
+            continue
         if status not in counts:
             status = "not_started"
         display_status_by_event[event.event_id] = status
@@ -266,7 +289,7 @@ def _build_progress_summary_embed(
             icon = _STATUS_ICONS.get(current, _STATUS_ICONS["not_started"])
             embed.add_field(
                 name="Selected Event",
-                value=f"{icon} {selected.event_name}\n{selected.reward_amount:g} frags",
+                value=f"{icon} {selected.event_name}\n{_event_fragments_label(selected)}",
                 inline=False,
             )
 
@@ -336,13 +359,15 @@ class _FusionProgressEventSelect(discord.ui.Select):
 
 
 class _FusionProgressStatusSelect(discord.ui.Select):
-    def __init__(self, selected_status: str | None) -> None:
+    def __init__(self, selected_status: str | None, *, selected_event: fusion_sheets.FusionEventRow | None) -> None:
         options = [
             discord.SelectOption(label="Not Started", value="not_started", default=selected_status == "not_started"),
             discord.SelectOption(label="In Progress", value="in_progress", default=selected_status == "in_progress"),
             discord.SelectOption(label="Done", value="done", default=selected_status == "done"),
-            discord.SelectOption(label="Skipped", value="skipped", default=selected_status == "skipped"),
         ]
+        if selected_event is not None and _event_has_bonus(selected_event):
+            options.append(discord.SelectOption(label="Done + Bonus", value="done_bonus", default=selected_status == "done_bonus"))
+        options.append(discord.SelectOption(label="Skipped", value="skipped", default=selected_status == "skipped"))
         super().__init__(
             placeholder="Set status",
             min_values=1,
@@ -467,9 +492,13 @@ class FusionProgressPanelView(discord.ui.View):
         self._coerce_selected_event_id()
         self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id, self.progress_by_event))
         selected_status = None
+        selected_event = None
         if self.selected_event_id:
             selected_status = self.progress_by_event.get(self.selected_event_id, "not_started")
-        self.add_item(_FusionProgressStatusSelect(selected_status))
+            selected_event = self.events_by_id.get(self.selected_event_id)
+            if selected_status == "done_bonus" and selected_event is not None and not _event_has_bonus(selected_event):
+                selected_status = "done"
+        self.add_item(_FusionProgressStatusSelect(selected_status, selected_event=selected_event))
 
     def build_embed(self) -> discord.Embed:
         return _build_progress_summary_embed(

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -25,7 +25,7 @@ _FUSION_BUCKET = "fusion"
 _FUSION_EVENTS_BUCKET = "fusion_events"
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
-_PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "skipped"}
+_PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "done_bonus", "skipped"}
 _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "fusion_id": ("fusion_id",),
     "event_id": ("event_id",),

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -283,7 +284,8 @@ def test_coerce_status_for_save_accepts_canonical_and_index_values():
     assert opt_in_view._coerce_status_for_save("not_started") == "not_started"
     assert opt_in_view._coerce_status_for_save("in_progress") == "in_progress"
     assert opt_in_view._coerce_status_for_save("2") == "done"
-    assert opt_in_view._coerce_status_for_save(3) == "skipped"
+    assert opt_in_view._coerce_status_for_save("3") == "done_bonus"
+    assert opt_in_view._coerce_status_for_save(4) == "skipped"
     assert opt_in_view._coerce_status_for_save("999") is None
 
 
@@ -398,3 +400,60 @@ def test_event_dropdown_keeps_selected_event_after_sorting_rebuild():
     defaults = {option.value: option.default for option in event_select.options}
     assert defaults["e_missed"] is True
     assert view.selected_event_id == "e_missed"
+
+
+def test_fragments_done_counts_done_bonus_with_bonus_and_done_without_bonus():
+    events = [
+        _event_row("e_done", event_name="Base Done"),
+        _event_row("e_done_bonus", event_name="Bonus Done"),
+    ]
+    events[1] = replace(events[1], reward_amount=25.0, bonus=50.0)
+    progress_by_event = {"e_done": "done", "e_done_bonus": "done_bonus"}
+
+    embed = opt_in_view._build_progress_summary_embed(
+        target=_fusion_row(opt_in_role_id=777),
+        events=events,
+        progress_by_event=progress_by_event,
+        selected_event_id="e_done_bonus",
+    )
+
+    fragments_field = next(field for field in embed.fields if field.name == "Fragments")
+    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    selected_field = next(field for field in embed.fields if field.name == "Selected Event")
+    assert fragments_field.value == "80 / 450 fragments earned"
+    assert "✅ Done: 2" in summary_field.value
+    assert "25 + 50 bonus frags" in selected_field.value
+
+
+def test_done_on_bonus_event_counts_base_only():
+    event = replace(_event_row("e_bonus"), reward_amount=25.0, bonus=50.0)
+    embed = opt_in_view._build_progress_summary_embed(
+        target=_fusion_row(opt_in_role_id=777),
+        events=[event],
+        progress_by_event={"e_bonus": "done"},
+        selected_event_id="e_bonus",
+    )
+    fragments_field = next(field for field in embed.fields if field.name == "Fragments")
+    assert fragments_field.value == "25 / 450 fragments earned"
+
+
+def test_status_options_include_done_bonus_only_when_event_has_bonus():
+    bonus_event = replace(_event_row("e_bonus"), bonus=10.0)
+    plain_event = _event_row("e_plain")
+
+    bonus_select = opt_in_view._FusionProgressStatusSelect("done_bonus", selected_event=bonus_event)
+    plain_select = opt_in_view._FusionProgressStatusSelect("done", selected_event=plain_event)
+
+    assert [option.value for option in bonus_select.options] == [
+        "not_started",
+        "in_progress",
+        "done",
+        "done_bonus",
+        "skipped",
+    ]
+    assert [option.value for option in plain_select.options] == [
+        "not_started",
+        "in_progress",
+        "done",
+        "skipped",
+    ]

--- a/tests/shared/sheets/test_fusion_user_event_progress_schema.py
+++ b/tests/shared/sheets/test_fusion_user_event_progress_schema.py
@@ -43,7 +43,8 @@ def test_get_user_event_progress_uses_configured_tab_and_columns(monkeypatch: py
         return [
             ["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"],
             ["f-1", "42", "e-1", "done", "2026-01-01T00:00:00+00:00"],
-            ["f-1", "42", "e-2", "unknown", "2026-01-01T00:00:00+00:00"],
+            ["f-1", "42", "e-2", "done_bonus", "2026-01-01T00:00:00+00:00"],
+            ["f-1", "42", "e-3", "unknown", "2026-01-01T00:00:00+00:00"],
             ["f-2", "42", "e-9", "done", "2026-01-01T00:00:00+00:00"],
         ]
 
@@ -51,7 +52,7 @@ def test_get_user_event_progress_uses_configured_tab_and_columns(monkeypatch: py
 
     progress = asyncio.run(fusion_sheets.get_user_event_progress("f-1", "42"))
 
-    assert progress == {"e-1": "done", "e-2": "not_started"}
+    assert progress == {"e-1": "done", "e-2": "done_bonus", "e-3": "not_started"}
 
 
 def test_upsert_user_event_progress_updates_existing_row(monkeypatch: pytest.MonkeyPatch):
@@ -117,14 +118,14 @@ def test_upsert_user_event_progress_appends_when_missing(monkeypatch: pytest.Mon
             "f-1",
             "42",
             "e-2",
-            "in_progress",
+            "done_bonus",
             dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.timezone.utc),
         )
     )
 
     assert not worksheet.updated
     assert worksheet.appended
-    assert worksheet.appended[0][0:4] == ["f-1", "42", "e-2", "in_progress"]
+    assert worksheet.appended[0][0:4] == ["f-1", "42", "e-2", "done_bonus"]
 
 
 def test_get_user_event_progress_requires_expected_headers(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### Motivation
- Fusion events can include optional bonus fragments but the tracker only had a single `done` state and could not distinguish base-only vs full (base+bonus) completion, causing inaccurate fragment totals.
- Users should be able to log whether they completed the bonus without entering fragment counts manually and without changing sheet schema.

### Description
- Introduce a new canonical progress state `done_bonus` and accept it in sheet read/write validation (`shared/sheets/fusion.py`).
- Display logic: show a “Done + Bonus” status option only for events where `bonus > 0`, reuse the ✅ icon for `done_bonus`, and keep the UI compact and mobile-friendly (`modules/community/fusion/opt_in_view.py`).
- Fragment math: `done` adds `reward_amount`, `done_bonus` adds `reward_amount + bonus` (missing/empty bonus treated as `0`), and `done_bonus` counts toward the existing “Done” summary bucket.
- Selected Event embed now shows payout cleanly (e.g. `25 + 50 bonus frags`).
- Tests updated/added to cover coercion, UI options, fragment totals, summary behavior, and sheet read/write acceptance of `done_bonus`.

### Testing
- Updated tests: `tests/community/test_fusion_opt_in_view.py`, `tests/shared/sheets/test_fusion_user_event_progress_schema.py`.
- Ran: `pytest -q tests/community/test_fusion_opt_in_view.py tests/shared/sheets/test_fusion_user_event_progress_schema.py`, which completed successfully (all tests passed).

[meta]
labels: enhancement, comp:commands, comp:data-sheets, tests, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7725dd9308323b20bc15ee82fd692)