### PR TITLE
Add manual Summary/Detailed public sharing for My Progress

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -10,7 +10,9 @@ from typing import Literal
 import discord
 from discord.ext import commands
 
+from modules.community.fusion import announcements as fusion_announcements
 from modules.community.fusion import logs as fusion_logs
+from modules.community.fusion.progress_share import build_progress_share_embed, build_share_snapshot
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.opt_in")
@@ -20,6 +22,8 @@ _FUSION_OPT_OUT_CUSTOM_ID = "fusion:opt_out"
 _FUSION_MY_PROGRESS_CUSTOM_ID = "fusion:my_progress"
 _FUSION_PROGRESS_EVENT_CUSTOM_ID = "fusion:progress:event"
 _FUSION_PROGRESS_STATUS_CUSTOM_ID = "fusion:progress:status"
+_FUSION_PROGRESS_SHARE_SUMMARY_CUSTOM_ID = "fusion:progress:share:summary"
+_FUSION_PROGRESS_SHARE_DETAILED_CUSTOM_ID = "fusion:progress:share:detailed"
 
 _DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
 _EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done", "done_bonus")
@@ -39,6 +43,7 @@ _STATUS_ICONS = {
     "missed": "⚠️",
     "not_started": "⬜",
 }
+_SHARE_MODE_LABELS = {"summary": "Summary", "detailed": "Detailed"}
 _ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "done_bonus", "skipped"})
 _STATUS_INDEX_TO_CANONICAL = {
     "0": "not_started",
@@ -242,23 +247,7 @@ def _build_progress_summary_embed(
     selected_event_id: str | None = None,
     last_update: tuple[str, str] | None = None,
 ) -> discord.Embed:
-    now = dt.datetime.now(dt.timezone.utc)
-    counts = {status: 0 for status in _DISPLAY_STATUS_ORDER}
-    display_status_by_event: dict[str, str] = {}
-    fragments_done = 0.0
-    for event in events:
-        status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=now)
-        if status == "done_bonus":
-            display_status_by_event[event.event_id] = status
-            counts["done"] += 1
-            fragments_done += event.reward_amount + _event_bonus_amount(event)
-            continue
-        if status not in counts:
-            status = "not_started"
-        display_status_by_event[event.event_id] = status
-        counts[status] += 1
-        if status == "done":
-            fragments_done += event.reward_amount
+    snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event)
 
     embed = discord.Embed(
         title=f"My Progress — {target.fusion_name}",
@@ -268,24 +257,24 @@ def _build_progress_summary_embed(
     embed.add_field(
         name="Summary",
         value=(
-            f"✅ Done: {counts['done']}\n"
-            f"🟡 In Progress: {counts['in_progress']}\n"
-            f"⏭️ Skipped: {counts['skipped']}\n"
-            f"⚠️ Missed: {counts['missed']}\n"
-            f"⬜ Not Started: {counts['not_started']}"
+            f"✅ Done: {snapshot.counts['done']}\n"
+            f"🟡 In Progress: {snapshot.counts['in_progress']}\n"
+            f"⏭️ Skipped: {snapshot.counts['skipped']}\n"
+            f"⚠️ Missed: {snapshot.counts['missed']}\n"
+            f"⬜ Not Started: {snapshot.counts['not_started']}"
         ),
         inline=False,
     )
     embed.add_field(
         name="Fragments",
-        value=f"{fragments_done:g} / {target.available:g} fragments earned",
+        value=f"{snapshot.completed_reward_total:g} / {target.available:g} fragments earned",
         inline=False,
     )
 
     if selected_event_id:
         selected = next((event for event in events if event.event_id == selected_event_id), None)
         if selected is not None:
-            current = display_status_by_event.get(selected.event_id, "not_started")
+            current = snapshot.display_status_by_event.get(selected.event_id, "not_started")
             icon = _STATUS_ICONS.get(current, _STATUS_ICONS["not_started"])
             embed.add_field(
                 name="Selected Event",
@@ -454,6 +443,117 @@ class _FusionProgressStatusSelect(discord.ui.Select):
         )
 
 
+class FusionProgressShareModeView(discord.ui.View):
+    """Ephemeral controls used to publish a manual progress share."""
+
+    def __init__(
+        self,
+        *,
+        user_id: int,
+        target: fusion_sheets.FusionRow,
+        events: Sequence[fusion_sheets.FusionEventRow],
+        progress_by_event: Mapping[str, str],
+    ) -> None:
+        super().__init__(timeout=300)
+        self.user_id = int(user_id)
+        self.target = target
+        self.events = list(events)
+        self.progress_by_event = dict(progress_by_event)
+
+    async def _handle_share(self, interaction: discord.Interaction, *, mode: Literal["summary", "detailed"]) -> None:
+        if interaction.user.id != self.user_id:
+            await _send_ephemeral(interaction, "This share panel belongs to a different user.")
+            return
+
+        client = getattr(interaction, "client", None)
+        channel = None
+        if client is not None:
+            channel = await fusion_announcements.resolve_announcement_channel(client, self.target.announcement_channel_id)
+        if channel is None:
+            await _send_ephemeral(interaction, "Couldn’t find the fusion share channel right now.")
+            return
+
+        share_embed = build_progress_share_embed(
+            target=self.target,
+            events=self.events,
+            progress_by_event=self.progress_by_event,
+            user_display_name=interaction.user.display_name,
+            mode=mode,
+        )
+        try:
+            await channel.send(embed=share_embed)
+        except Exception as exc:
+            context = {
+                "fusion_id": self.target.fusion_id,
+                "channel_id": self.target.announcement_channel_id,
+                "user_id": self.user_id,
+                "mode": mode,
+            }
+            log.exception("fusion progress share failed to send", extra=context)
+            await fusion_logs.send_ops_alert(
+                component="my_progress_share",
+                summary="share_send_failed",
+                dedupe_key=f"fusion:progress:share:{self.target.fusion_id}:{mode}",
+                error=exc,
+                fields=context,
+            )
+            await _send_ephemeral(interaction, "Couldn’t share progress right now. Try again shortly.")
+            return
+
+        await _send_ephemeral(interaction, f"Shared publicly ({_SHARE_MODE_LABELS[mode]}).")
+
+    @discord.ui.button(
+        label="Summary",
+        style=discord.ButtonStyle.primary,
+        custom_id=_FUSION_PROGRESS_SHARE_SUMMARY_CUSTOM_ID,
+        row=0,
+    )
+    async def share_summary_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        await self._handle_share(interaction, mode="summary")
+
+    @discord.ui.button(
+        label="Detailed",
+        style=discord.ButtonStyle.secondary,
+        custom_id=_FUSION_PROGRESS_SHARE_DETAILED_CUSTOM_ID,
+        row=0,
+    )
+    async def share_detailed_button(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        await self._handle_share(interaction, mode="detailed")
+
+
+class _FusionProgressShareButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Share",
+            style=discord.ButtonStyle.secondary,
+            custom_id="fusion:progress:share",
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FusionProgressPanelView):
+            return
+        share_view = FusionProgressShareModeView(
+            user_id=view.user_id,
+            target=view.target,
+            events=view.events,
+            progress_by_event=view.progress_by_event,
+        )
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                "Choose a share mode to post your current progress publicly.",
+                view=share_view,
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Choose a share mode to post your current progress publicly.",
+            view=share_view,
+            ephemeral=True,
+        )
+
+
 class FusionProgressPanelView(discord.ui.View):
     """Ephemeral progress panel for one user and one fusion."""
 
@@ -499,6 +599,13 @@ class FusionProgressPanelView(discord.ui.View):
             if selected_status == "done_bonus" and selected_event is not None and not _event_has_bonus(selected_event):
                 selected_status = "done"
         self.add_item(_FusionProgressStatusSelect(selected_status, selected_event=selected_event))
+        self.add_item(_FusionProgressShareButton())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await _send_ephemeral(interaction, "This progress panel belongs to a different user.")
+            return False
+        return True
 
     def build_embed(self) -> discord.Embed:
         return _build_progress_summary_embed(

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -1,0 +1,160 @@
+"""Public sharing embed renderers for user fusion progress."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import discord
+
+from shared.sheets import fusion as fusion_sheets
+
+ShareMode = Literal["summary", "detailed"]
+
+_DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
+_STATUS_LABELS = {
+    "not_started": "Not Started",
+    "in_progress": "In Progress",
+    "done": "Done",
+    "done_bonus": "Done + Bonus",
+    "skipped": "Skipped",
+    "missed": "Missed",
+}
+_STATUS_ICONS = {
+    "done": "✅",
+    "done_bonus": "✅",
+    "in_progress": "🟡",
+    "skipped": "⏭️",
+    "missed": "⚠️",
+    "not_started": "⬜",
+}
+_ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "done_bonus", "skipped"})
+
+
+@dataclass(slots=True)
+class ProgressShareSnapshot:
+    counts: dict[str, int]
+    display_status_by_event: dict[str, str]
+    completed_reward_total: float
+
+
+def _event_bonus_amount(event: fusion_sheets.FusionEventRow) -> float:
+    return event.bonus if event.bonus is not None else 0.0
+
+
+def _effective_display_status(
+    *,
+    event: fusion_sheets.FusionEventRow,
+    progress_by_event: Mapping[str, str],
+    now: dt.datetime,
+) -> str:
+    status = progress_by_event.get(event.event_id, "not_started")
+    if status not in _ALLOWED_PROGRESS_STATES:
+        status = "not_started"
+    if status in {"done", "done_bonus"}:
+        return status
+
+    timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_my_progress_share")
+    if timing is None:
+        return status
+    start_at, end_at = timing
+    if fusion_sheets.derive_event_status(start_at_utc=start_at, end_at_utc=end_at, now=now) == "ended":
+        return "missed"
+    return status
+
+
+def build_share_snapshot(
+    *,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str],
+    now: dt.datetime | None = None,
+) -> ProgressShareSnapshot:
+    current_time = now or dt.datetime.now(dt.timezone.utc)
+    counts = {status: 0 for status in _DISPLAY_STATUS_ORDER}
+    display_status_by_event: dict[str, str] = {}
+    completed_reward_total = 0.0
+
+    for event in events:
+        status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=current_time)
+        if status == "done_bonus":
+            display_status_by_event[event.event_id] = status
+            counts["done"] += 1
+            completed_reward_total += event.reward_amount + _event_bonus_amount(event)
+            continue
+        if status not in counts:
+            status = "not_started"
+        display_status_by_event[event.event_id] = status
+        counts[status] += 1
+        if status == "done":
+            completed_reward_total += event.reward_amount
+
+    return ProgressShareSnapshot(
+        counts=counts,
+        display_status_by_event=display_status_by_event,
+        completed_reward_total=completed_reward_total,
+    )
+
+
+def _build_overall_progress_line(
+    *,
+    target: fusion_sheets.FusionRow,
+    snapshot: ProgressShareSnapshot,
+) -> str:
+    reward_type = str(target.reward_type or "").strip().casefold()
+    if reward_type == "fragments":
+        return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g} fragments"
+    if reward_type:
+        return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g} {reward_type}"
+    return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g}"
+
+
+def _build_summary_block(*, snapshot: ProgressShareSnapshot, overall_progress_line: str) -> str:
+    return (
+        f"✅ Done: {snapshot.counts['done']}\n"
+        f"🟡 In Progress: {snapshot.counts['in_progress']}\n"
+        f"⏭️ Skipped: {snapshot.counts['skipped']}\n"
+        f"⚠️ Missed: {snapshot.counts['missed']}\n"
+        f"⬜ Not Started: {snapshot.counts['not_started']}\n"
+        f"{overall_progress_line}"
+    )
+
+
+def build_progress_share_embed(
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str],
+    user_display_name: str,
+    mode: ShareMode,
+) -> discord.Embed:
+    snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event)
+    overall_progress_line = _build_overall_progress_line(target=target, snapshot=snapshot)
+
+    embed = discord.Embed(
+        title=f"Progress Share — {target.fusion_name}",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="User", value=user_display_name, inline=False)
+    embed.add_field(
+        name="Summary",
+        value=_build_summary_block(snapshot=snapshot, overall_progress_line=overall_progress_line),
+        inline=False,
+    )
+
+    if mode == "detailed":
+        sorted_events = sorted(events, key=lambda row: (row.sort_order, row.start_at_utc, row.event_id))
+        detail_lines = []
+        for event in sorted_events:
+            status = snapshot.display_status_by_event.get(event.event_id, "not_started")
+            icon = _STATUS_ICONS.get(status, _STATUS_ICONS["not_started"])
+            label = _STATUS_LABELS.get(status, "Not Started")
+            detail_lines.append(f"{icon} {event.event_name}: {label}")
+        embed.add_field(name="Event Breakdown", value="\n".join(detail_lines)[:1024] or "No events available.", inline=False)
+
+    embed.set_footer(text=f"Share Mode: {mode.title()}")
+    return embed
+
+
+__all__ = ["ShareMode", "ProgressShareSnapshot", "build_progress_share_embed", "build_share_snapshot"]

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -44,6 +44,7 @@ class _Response:
 class _Member:
     def __init__(self, role):
         self.id = 10
+        self.display_name = "Test User"
         self.guild = SimpleNamespace(id=1)
         self.roles = [] if role is None else [role]
         self.add_roles = AsyncMock(side_effect=self._add)
@@ -74,6 +75,7 @@ def _interaction(guild, member):
     return SimpleNamespace(
         guild=guild,
         user=member,
+        client=SimpleNamespace(),
         response=_Response(),
         followup=SimpleNamespace(send=AsyncMock()),
     )
@@ -457,3 +459,52 @@ def test_status_options_include_done_bonus_only_when_event_has_bonus():
         "done",
         "skipped",
     ]
+
+
+def test_my_progress_share_button_opens_share_mode_panel():
+    async def _run() -> None:
+        events = [_event_row("e1")]
+        view = opt_in_view.FusionProgressPanelView(
+            user_id=10,
+            target=_fusion_row(opt_in_role_id=777),
+            events=events,
+            progress_by_event={},
+        )
+        interaction = _interaction(guild=None, member=SimpleNamespace(id=10, display_name="Tester"))
+        share_button = next(item for item in view.children if item.custom_id == "fusion:progress:share")
+
+        await share_button.callback(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        kwargs = interaction.response.send_message.await_args.kwargs
+        assert isinstance(kwargs["view"], opt_in_view.FusionProgressShareModeView)
+        assert kwargs["ephemeral"] is True
+
+    asyncio.run(_run())
+
+
+def test_share_mode_summary_posts_to_fusion_announcement_channel(monkeypatch):
+    async def _run() -> None:
+        events = [_event_row("e1", event_name="Dungeon Dash")]
+        channel = SimpleNamespace(send=AsyncMock())
+        member = SimpleNamespace(id=10, display_name="Tester")
+        interaction = _interaction(guild=None, member=member)
+
+        view = opt_in_view.FusionProgressShareModeView(
+            user_id=10,
+            target=_fusion_row(opt_in_role_id=777),
+            events=events,
+            progress_by_event={"e1": "done"},
+        )
+        monkeypatch.setattr(opt_in_view.fusion_announcements, "resolve_announcement_channel", AsyncMock(return_value=channel))
+        summary_button = next(item for item in view.children if item.custom_id == "fusion:progress:share:summary")
+
+        await summary_button.callback(interaction)
+
+        channel.send.assert_awaited_once()
+        embed = channel.send.await_args.kwargs["embed"]
+        assert embed.title == "Progress Share — Mavara"
+        summary_field = next(field for field in embed.fields if field.name == "Summary")
+        assert "✅ Done: 1" in summary_field.value
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_progress_share.py
+++ b/tests/community/test_fusion_progress_share.py
@@ -1,0 +1,74 @@
+import datetime as dt
+
+from modules.community.fusion import progress_share
+from shared.sheets import fusion as fusion_sheets
+
+
+def _fusion_row() -> fusion_sheets.FusionRow:
+    return fusion_sheets.FusionRow(
+        fusion_id="f-1",
+        fusion_name="Mavara",
+        champion="Mavara",
+        champion_image_url="",
+        fusion_type="traditional",
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 22, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=777,
+        announcement_message_id=456,
+        published_at=dt.datetime(2026, 4, 7, tzinfo=dt.timezone.utc),
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
+        status="active",
+    )
+
+
+def _event_row(event_id: str, event_name: str) -> fusion_sheets.FusionEventRow:
+    return fusion_sheets.FusionEventRow(
+        fusion_id="f-1",
+        event_id=event_id,
+        event_name=event_name,
+        event_type="dungeon",
+        category="Tournaments",
+        start_at_utc=dt.datetime(2026, 4, 28, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, 29, tzinfo=dt.timezone.utc),
+        reward_amount=5.0,
+        bonus=None,
+        reward_type="fragments",
+        points_needed=None,
+        is_estimated=False,
+        sort_order=1,
+    )
+
+
+def test_build_progress_share_embed_summary_mode_has_generic_summary_block():
+    embed = progress_share.build_progress_share_embed(
+        target=_fusion_row(),
+        events=[_event_row("e1", "Dungeon Dash")],
+        progress_by_event={"e1": "done"},
+        user_display_name="Tester",
+        mode="summary",
+    )
+
+    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    assert "✅ Done: 1" in summary_field.value
+    assert "Progress: 5 / 450 fragments" in summary_field.value
+    assert all(field.name != "Event Breakdown" for field in embed.fields)
+
+
+def test_build_progress_share_embed_detailed_mode_adds_event_breakdown():
+    embed = progress_share.build_progress_share_embed(
+        target=_fusion_row(),
+        events=[_event_row("e1", "Dungeon Dash"), _event_row("e2", "Arena Rush")],
+        progress_by_event={"e1": "done", "e2": "in_progress"},
+        user_display_name="Tester",
+        mode="detailed",
+    )
+
+    detail_field = next(field for field in embed.fields if field.name == "Event Breakdown")
+    assert "Dungeon Dash: Done" in detail_field.value
+    assert "Arena Rush: In Progress" in detail_field.value


### PR DESCRIPTION
### Motivation
- Preserve private-by-default personal progress tracking while enabling an explicit, one-shot public share action.
- Implement a generic, fusion-type-agnostic sharing model (Summary / Detailed) so future tracker/fusion types can reuse the flow and renderer without renaming UX labels.

### Description
- Add a new renderer module `modules/community/fusion/progress_share.py` exposing `build_progress_share_embed` and `build_share_snapshot` that compute status counts and a fusion-aware overall progress line (currently formats fragments for `reward_type='fragments'`).
- Add a `Share` action to the private `My Progress` panel by introducing `_FusionProgressShareButton` and an ephemeral chooser `FusionProgressShareModeView` that offers `Summary` and `Detailed` share modes and posts the selected embed.
- Reuse existing channel resolution via `resolve_announcement_channel` to post to the canonical fusion announcement/context channel, and reuse the new snapshot logic in the private panel to avoid duplication.
- Add tests: `tests/community/test_fusion_progress_share.py` for renderer behavior and updates to `tests/community/test_fusion_opt_in_view.py` for share-button and public-post flow.

### Testing
- Ran `pytest -q tests/community/test_fusion_opt_in_view.py tests/community/test_fusion_progress_share.py` and the test suite passed (all tests in those files succeeded).
- No changes were made to intents, OAuth scopes, sheet IDs, or runtime env keys as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b01808088323bcbc7ea23d21a9e9)