### PR TITLE
Mark Fusion rows as ended during post-end role cleanup

### DIFF
--- a/modules/community/fusion/role_cleanup.py
+++ b/modules/community/fusion/role_cleanup.py
@@ -60,6 +60,19 @@ async def process_ended_fusion_role_cleanup(
         return
 
     for target in ended_fusions:
+        try:
+            await fusion_sheets.transition_fusion_to_ended(target.fusion_id)
+        except Exception as exc:
+            context = {"fusion_id": target.fusion_id}
+            log.exception("fusion status transition to ended failed", extra=context)
+            await fusion_logs.send_ops_alert(
+                component="role_cleanup",
+                summary="status_transition_failed",
+                dedupe_key=f"fusion:role_cleanup:status:{target.fusion_id}",
+                error=exc,
+                fields=context,
+            )
+
         if target.opt_in_role_id is None:
             continue
 

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -957,6 +957,37 @@ async def update_fusion_announcement_refresh_state(
     await cache.refresh_now(_FUSION_BUCKET, actor="fusion_announcement_refresh")
 
 
+async def transition_fusion_to_ended(fusion_id: str) -> bool:
+    """Set the configured Fusion row status to ended, if not already ended."""
+
+    tab_name = _resolve_tab_name("FUSION_TAB")
+    sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
+    row_idx = _resolve_fusion_row_index(
+        fusion_id=fusion_id,
+        header=header,
+        matrix=matrix,
+        tab_name=tab_name,
+    )
+    _require_fusion_headers(tab_name=tab_name, header=header, required=("status",))
+
+    status_idx = header.index("status")
+    matrix_row = matrix[row_idx - 1] if row_idx - 1 < len(matrix) else []
+    current_status = str(matrix_row[status_idx] if status_idx < len(matrix_row) else "").strip().lower()
+    if current_status == "ended":
+        return False
+
+    worksheet = await aget_worksheet(sheet_id, tab_name)
+    await acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(status_idx)}{row_idx}",
+        [["ended"]],
+        value_input_option="RAW",
+    )
+    register_cache_buckets()
+    await cache.refresh_now(_FUSION_BUCKET, actor="fusion_status_ended")
+    return True
+
+
 __all__ = [
     "FusionEventRow",
     "FusionRow",
@@ -976,5 +1007,6 @@ __all__ = [
     "upsert_user_event_progress",
     "update_fusion_publication",
     "update_fusion_announcement_refresh_state",
+    "transition_fusion_to_ended",
     "register_cache_buckets",
 ]

--- a/tests/community/test_fusion_role_cleanup.py
+++ b/tests/community/test_fusion_role_cleanup.py
@@ -65,6 +65,7 @@ def test_ended_fusion_triggers_role_cleanup(monkeypatch):
         bot = SimpleNamespace(guilds=[guild])
 
         monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
@@ -74,6 +75,7 @@ def test_ended_fusion_triggers_role_cleanup(monkeypatch):
 
         for member in members:
             member.remove_roles.assert_awaited_once_with(role, reason="Fusion ended: f-ended")
+        fusion_sheets.transition_fusion_to_ended.assert_awaited_once_with("f-ended")
         fusion_sheets.mark_reminder_sent.assert_awaited_once()
 
     asyncio.run(_run())
@@ -88,6 +90,7 @@ def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
         bot = SimpleNamespace(guilds=[guild])
 
         monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=False))
         monkeypatch.setattr(
             fusion_sheets,
             "get_sent_reminder_keys",
@@ -99,6 +102,7 @@ def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
         await role_cleanup.process_ended_fusion_role_cleanup(bot)
 
         member.remove_roles.assert_not_awaited()
+        fusion_sheets.transition_fusion_to_ended.assert_awaited_once_with("f-ended")
         fusion_sheets.mark_reminder_sent.assert_not_awaited()
 
     asyncio.run(_run())
@@ -111,6 +115,7 @@ def test_missing_role_is_handled_safely(monkeypatch):
         bot = SimpleNamespace(guilds=[guild])
 
         monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
@@ -132,6 +137,7 @@ def test_partial_member_failure_does_not_abort(monkeypatch):
         bot = SimpleNamespace(guilds=[guild])
 
         monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -234,3 +234,55 @@ def test_get_upcoming_events_uses_validated_timestamps_for_sorting(
     result = asyncio.run(fusion.get_upcoming_events("f-1", now=now))
 
     assert [row.event_id for row in result] == ["naive-earlier", "aware"]
+
+
+def test_transition_fusion_to_ended_updates_status_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    worksheet = AsyncMock()
+
+    async def _afetch_values(_sheet_id: str, _tab_name: str):
+        return [
+            ["fusion_id", "status"],
+            ["f-1", "published"],
+        ]
+
+    async def _acall_with_backoff(fn, *args, **kwargs):
+        return await fn(*args, **kwargs)
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
+    monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
+    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(fusion.cache, "refresh_now", AsyncMock())
+
+    changed = asyncio.run(fusion.transition_fusion_to_ended("f-1"))
+
+    assert changed is True
+    worksheet.update.assert_awaited_once_with("B2", [["ended"]], value_input_option="RAW")
+    fusion.cache.refresh_now.assert_awaited_once_with("fusion", actor="fusion_status_ended")
+
+
+def test_transition_fusion_to_ended_is_noop_when_already_ended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worksheet = AsyncMock()
+
+    async def _afetch_values(_sheet_id: str, _tab_name: str):
+        return [
+            ["fusion_id", "status"],
+            ["f-1", "ended"],
+        ]
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
+    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(fusion.cache, "refresh_now", AsyncMock())
+
+    changed = asyncio.run(fusion.transition_fusion_to_ended("f-1"))
+
+    assert changed is False
+    worksheet.update.assert_not_awaited()
+    fusion.cache.refresh_now.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Role cleanup removed opt-in roles when fusions finished but did not update the Fusion row status in the Fusion sheet, producing a mismatch between behavior and persisted data. 
- The change ensures the sheet state is reconciled in the same end-of-fusion path that performs role cleanup using the same end condition. 
- Implementation must be idempotent, restart-safe, and follow existing config-driven sheet access patterns (no hardcoded tab/column names). 

### Description
- Added `transition_fusion_to_ended(fusion_id: str) -> bool` to `shared/sheets/fusion.py` which resolves the configured Fusion tab, validates headers, reads the current status, writes `ended` only if needed, refreshes the Fusion cache on change, and returns whether a write occurred. 
- Integrated a call to `transition_fusion_to_ended` at the start of each iteration in `modules/community/fusion/role_cleanup.py` so the Fusion row is transitioned in the same flow that removes opt-in roles. 
- Kept existing one-shot/dedupe behavior for role cleanup unchanged; the transition is attempted regardless but is idempotent (no rewrite when already `ended`). 
- Added/updated unit tests covering the sheet transition (write and no-op cases) and updated role-cleanup tests to assert the transition is invoked. 

### Testing
- `pytest -q tests/community/test_fusion_role_cleanup.py tests/shared/sheets/test_fusion.py` — passed. 
- `pytest -q tests/community/test_fusion_reminders.py tests/community/test_fusion_cog.py tests/community/test_fusion_opt_in_view.py tests/community/test_fusion_announcement_refresh.py` — one failing test (`tests/community/test_fusion_announcement_refresh.py::test_build_embed_includes_event_status_section`) observed during a broader run. 
- Targeted focused test runs exercised related flows and passed, e.g. `pytest -q tests/community/test_fusion_reminders.py::test_start_reminder_fires_once_and_is_restart_safe tests/community/test_fusion_reminders.py::test_announcement_self_heals_before_sending tests/community/test_fusion_cog.py::test_fusion_command_recreates_missing_announcement tests/community/test_fusion_opt_in_view.py::test_event_dropdown_uses_effective_status_icons_and_sort_order tests/community/test_fusion_announcement_refresh.py::test_refresh_edits_existing_announcement_and_updates_metadata` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e662a1808323a1970232590712c1)