### PR TITLE
Generalize fusion tracker for Titan support and lock down draft publish paths

### DIFF
--- a/modules/community/fusion/announcements.py
+++ b/modules/community/fusion/announcements.py
@@ -153,6 +153,11 @@ async def ensure_fusion_announcement(
     if resolution.message is not None:
         return resolution.message
 
+    status = str(target.status or "").strip().casefold()
+    was_published = target.published_at is not None
+    if status not in _VALID_PUBLISHED_STATUSES or not was_published:
+        return None
+
     return await publish_fusion_announcement(bot, target)
 
 

--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -32,6 +32,47 @@ class FusionCog(commands.Cog):
     ) -> discord.Message | None:
         return await ensure_fusion_announcement(self.bot, target)
 
+    async def _tracker_entrypoint(
+        self,
+        ctx: commands.Context,
+        *,
+        tracker_kind: str,
+        tracker_label: str,
+    ) -> None:
+        try:
+            target = await fusion_sheets.get_publishable_fusion(tracker_kind=tracker_kind)
+        except Exception:
+            log.exception("%s command failed to load rows", tracker_label)
+            await ctx.reply(f"Couldn’t check the {tracker_label} right now. Try again in a moment.", mention_author=False)
+            return
+
+        if target is None:
+            await ctx.reply(f"No {tracker_label} running. Enjoy the peace while it lasts.", mention_author=False)
+            return
+
+        try:
+            announcement_message = await self._ensure_fusion_announcement(target)
+        except Exception:
+            log.exception("%s command failed to resolve announcement", tracker_label, extra={"fusion_id": target.fusion_id})
+            announcement_message = None
+
+        if announcement_message is not None:
+            await ctx.reply(
+                f"🔗 {tracker_label.title()}’s up. Don’t get lost:\n{announcement_message.jump_url}",
+                mention_author=False,
+            )
+            return
+
+        try:
+            events = await fusion_sheets.get_fusion_events(target.fusion_id)
+            emergency_embed = build_fusion_announcement_embed(target, events)
+            await ctx.reply(embed=emergency_embed, mention_author=False)
+            return
+        except Exception:
+            log.exception("%s command emergency embed fallback failed", tracker_label, extra={"fusion_id": target.fusion_id})
+            await ctx.reply(f"Couldn’t check the {tracker_label} right now. Try again in a moment.", mention_author=False)
+            return
+
     @tier("user")
     @help_metadata(
         function_group="milestones",
@@ -45,39 +86,18 @@ class FusionCog(commands.Cog):
         help="Fusion reminder data commands.",
     )
     async def fusion(self, ctx: commands.Context) -> None:
-        try:
-            target = await fusion_sheets.get_publishable_fusion()
-        except Exception:
-            log.exception("fusion command failed to load fusion rows")
-            await ctx.reply("Couldn’t check the fusion right now. Try again in a moment.", mention_author=False)
-            return
+        await self._tracker_entrypoint(ctx, tracker_kind="fusion", tracker_label="fusion")
 
-        if target is None:
-            await ctx.reply("No fusion running. Enjoy the peace while it lasts.", mention_author=False)
-            return
-
-        try:
-            announcement_message = await self._ensure_fusion_announcement(target)
-        except Exception:
-            log.exception("fusion command failed to resolve announcement", extra={"fusion_id": target.fusion_id})
-            announcement_message = None
-
-        if announcement_message is not None:
-            await ctx.reply(
-                f"🔗 Fusion’s up. Don’t get lost:\n{announcement_message.jump_url}",
-                mention_author=False,
-            )
-            return
-
-        try:
-            events = await fusion_sheets.get_fusion_events(target.fusion_id)
-            emergency_embed = build_fusion_announcement_embed(target, events)
-            await ctx.reply(embed=emergency_embed, mention_author=False)
-            return
-        except Exception:
-            log.exception("fusion command emergency embed fallback failed", extra={"fusion_id": target.fusion_id})
-            await ctx.reply("Couldn’t check the fusion right now. Try again in a moment.", mention_author=False)
-            return
+    @tier("user")
+    @help_metadata(
+        function_group="milestones",
+        section="community",
+        access_tier="user",
+        usage="!titan",
+    )
+    @commands.command(name="titan", help="Titan reminder data commands.")
+    async def titan(self, ctx: commands.Context) -> None:
+        await self._tracker_entrypoint(ctx, tracker_kind="titan", tracker_label="titan")
 
     @tier("user")
     @help_metadata(
@@ -89,7 +109,7 @@ class FusionCog(commands.Cog):
     @fusion.command(name="debug", help="Debug active fusion + first events from sheets cache.")
     async def fusion_debug(self, ctx: commands.Context) -> None:
         try:
-            active = await fusion_sheets.get_publishable_fusion()
+            active = await fusion_sheets.get_publishable_fusion(include_draft=True)
         except Exception as exc:
             log.exception("fusion debug failed to load fusion")
             await fusion_logs.send_ops_alert(
@@ -152,7 +172,11 @@ class FusionCog(commands.Cog):
     @admin_only()
     async def fusion_publish(self, ctx: commands.Context) -> None:
         try:
-            target = await fusion_sheets.get_publishable_fusion()
+            target = await fusion_sheets.get_publishable_fusion(
+                include_draft=True,
+                tracker_kind="fusion",
+                prefer_draft=True,
+            )
         except Exception as exc:
             log.exception("fusion publish failed to load fusion rows")
             await fusion_logs.send_ops_alert(

--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -114,11 +114,12 @@ def _event_has_bonus(event: fusion_sheets.FusionEventRow) -> bool:
     return _event_bonus_amount(event) > 0
 
 
-def _event_fragments_label(event: fusion_sheets.FusionEventRow) -> str:
+def _event_reward_label(event: fusion_sheets.FusionEventRow) -> str:
+    reward_unit = str(event.reward_type or "").strip() or "rewards"
     bonus = _event_bonus_amount(event)
     if bonus > 0:
-        return f"{event.reward_amount:g} + {bonus:g} bonus frags"
-    return f"{event.reward_amount:g} frags"
+        return f"{event.reward_amount:g} + {bonus:g} bonus {reward_unit}"
+    return f"{event.reward_amount:g} {reward_unit}"
 
 
 async def _send_ephemeral(interaction: discord.Interaction, message: str) -> None:
@@ -248,6 +249,7 @@ def _build_progress_summary_embed(
     last_update: tuple[str, str] | None = None,
 ) -> discord.Embed:
     snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event)
+    reward_unit = str(target.reward_type or "").strip() or "rewards"
 
     embed = discord.Embed(
         title=f"My Progress — {target.fusion_name}",
@@ -266,8 +268,8 @@ def _build_progress_summary_embed(
         inline=False,
     )
     embed.add_field(
-        name="Fragments",
-        value=f"{snapshot.completed_reward_total:g} / {target.available:g} fragments earned",
+        name=reward_unit.title(),
+        value=f"{snapshot.completed_reward_total:g} / {target.available:g} {reward_unit} earned",
         inline=False,
     )
 
@@ -278,7 +280,7 @@ def _build_progress_summary_embed(
             icon = _STATUS_ICONS.get(current, _STATUS_ICONS["not_started"])
             embed.add_field(
                 name="Selected Event",
-                value=f"{icon} {selected.event_name}\n{_event_fragments_label(selected)}",
+                value=f"{icon} {selected.event_name}\n{_event_reward_label(selected)}",
                 inline=False,
             )
 

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -102,12 +102,10 @@ def _build_overall_progress_line(
     target: fusion_sheets.FusionRow,
     snapshot: ProgressShareSnapshot,
 ) -> str:
-    reward_type = str(target.reward_type or "").strip().casefold()
-    if reward_type == "fragments":
-        return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g} fragments"
+    reward_type = str(target.reward_type or "").strip()
     if reward_type:
         return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g} {reward_type}"
-    return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g}"
+    return f"Progress: {snapshot.completed_reward_total:g} / {target.available:g} rewards"
 
 
 def _build_summary_block(*, snapshot: ProgressShareSnapshot, overall_progress_line: str) -> str:

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -38,13 +38,14 @@ def _build_reminder_embed(
     reminder_type: str,
     start_at: dt.datetime,
     jump_url: str,
+    reward_unit: str,
 ) -> discord.Embed:
     jump_link = f"[Open Fusion Overview]({jump_url})"
     if reminder_type == "start":
         title = "Fusion Reminder"
         description = (
             f"⚠️ **{event_name} is live**\n"
-            "Time to put in some work — fragments won’t collect themselves.\n\n"
+            f"Time to put in some work — {reward_unit} won’t collect themselves.\n\n"
             f"🔗 {jump_link}"
         )
     else:
@@ -162,6 +163,7 @@ async def process_fusion_reminders(
                     reminder_type=reminder_type,
                     start_at=start_at,
                     jump_url=announcement_message.jump_url,
+                    reward_unit=(str(target.reward_type or "").strip() or "rewards"),
                 )
                 mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
                 reminder_view = build_fusion_opt_in_view(target)

--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -44,10 +44,11 @@ def _status_icon(status: str) -> str:
 def _format_event_line(event: FusionEventRow, *, status: str) -> str:
     has_bonus = event.bonus is not None and event.bonus > 0
     points_text = f"{event.points_needed} pts" if event.points_needed is not None else "pts TBA"
-    bonus_text = f" (+{event.bonus:g} bonus)" if has_bonus else ""
+    reward_unit = str(event.reward_type or "").strip() or "rewards"
+    bonus_text = f" (+{event.bonus:g} bonus {reward_unit})" if has_bonus else ""
     return (
         f"{_status_icon(status)} {event.event_name} — "
-        f"{points_text} for {event.reward_amount:g} frags{bonus_text}"
+        f"{points_text} for {event.reward_amount:g} {reward_unit}{bonus_text}"
     )
 
 
@@ -115,11 +116,12 @@ def _build_fusion_embed(
     sorted_events = sorted(events, key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     event_days = [event.start_at_utc.astimezone(dt.timezone.utc).date() for event in sorted_events]
 
+    reward_unit = str(fusion.reward_type or "").strip() or "rewards"
     summary_lines = [
         f"Type: {_humanize_type(fusion.fusion_type)}",
         f"Runs: {_format_dt_utc(fusion.start_at_utc)} -> {_format_dt_utc(fusion.end_at_utc)}",
         "",
-        f"Target: {fusion.needed:g} fragments needed / {fusion.available:g} available",
+        f"Target: {fusion.needed:g} {reward_unit} needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
     ]
     if fusion.fusion_structure.strip():

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -847,22 +847,44 @@ async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:
     ended.sort(key=lambda row: (row.end_at_utc, row.fusion_id), reverse=True)
     return ended
 
-async def get_publishable_fusion() -> FusionRow | None:
-    """Return the best fusion row for publish flow selection."""
+def _tracker_kind(row: FusionRow) -> str:
+    return "titan" if str(row.fusion_type or "").strip().casefold() == "titan" else "fusion"
+
+
+async def get_publishable_fusion(
+    *,
+    include_draft: bool = False,
+    tracker_kind: str | None = None,
+    prefer_draft: bool = False,
+) -> FusionRow | None:
+    """Return the best fusion/titan row for command and publish flow selection."""
 
     fusion_bucket, _ = register_cache_buckets()
     rows = [row for row in await _cached_rows(fusion_bucket) if isinstance(row, FusionRow)]
     if not rows:
         return None
 
-    for status in ("active", "published", "draft"):
+    allowed_statuses: tuple[str, ...]
+    if include_draft and prefer_draft:
+        allowed_statuses = ("draft", "active", "published")
+    elif include_draft:
+        allowed_statuses = ("active", "published", "draft")
+    else:
+        allowed_statuses = ("active", "published")
+
+    normalized_kind = str(tracker_kind or "").strip().casefold()
+    if normalized_kind:
+        rows = [row for row in rows if _tracker_kind(row) == normalized_kind]
+    if not rows:
+        return None
+
+    for status in allowed_statuses:
         matches = [row for row in rows if row.status.casefold() == status]
         if matches:
             matches.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
             return matches[0]
 
-    rows.sort(key=lambda row: (row.start_at_utc, row.fusion_id), reverse=True)
-    return rows[0]
+    return None
 
 
 async def update_fusion_publication(

--- a/tests/community/test_fusion_announcements.py
+++ b/tests/community/test_fusion_announcements.py
@@ -104,3 +104,19 @@ def test_publish_announcement_retries_without_image_on_http_exception(monkeypatc
         assert not str(second_call.image.url or "").strip()
 
     asyncio.run(_run())
+
+
+def test_ensure_announcement_does_not_self_heal_draft(monkeypatch):
+    async def _run() -> None:
+        target = _fusion_row(opt_in_role_id=777)
+        monkeypatch.setattr(announcements, "resolve_announcement_channel", AsyncMock(return_value=SimpleNamespace()))
+        monkeypatch.setattr(announcements, "resolve_stored_announcement", AsyncMock(return_value=announcements.AnnouncementResolution(message=None, had_reference=True, is_stale=True)))
+        publish_mock = AsyncMock()
+        monkeypatch.setattr(announcements, "publish_fusion_announcement", publish_mock)
+
+        result = await announcements.ensure_fusion_announcement(SimpleNamespace(), target)
+
+        assert result is None
+        publish_mock.assert_not_awaited()
+
+    asyncio.run(_run())

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -31,7 +31,7 @@ def _fusion_row(
         announcement_channel_id=announcement_channel_id,
         opt_in_role_id=None,
         announcement_message_id=announcement_message_id,
-        published_at=None,
+        published_at=dt.datetime(2026, 4, 7, tzinfo=dt.timezone.utc) if status in {"published", "active"} else None,
         last_announcement_refresh_at=None,
         last_announcement_status_hash="",
         status=status,
@@ -61,7 +61,7 @@ def test_fusion_command_returns_jump_url(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -84,7 +84,7 @@ def test_fusion_command_handles_no_fusion(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return None
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -112,7 +112,7 @@ def test_fusion_command_recreates_missing_announcement(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         update = AsyncMock()
@@ -148,7 +148,7 @@ def test_fusion_command_recreates_when_message_metadata_is_incomplete(monkeypatc
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row(announcement_channel_id=123, announcement_message_id=None)
 
         update = AsyncMock()
@@ -182,7 +182,7 @@ def test_fusion_command_does_not_recreate_existing_announcement(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -202,7 +202,7 @@ def test_fusion_command_uses_generic_message_when_data_load_fails(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             raise RuntimeError("sheets offline")
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -224,7 +224,7 @@ def test_fusion_command_falls_back_to_emergency_embed_when_announcement_unavaila
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         ensure = AsyncMock(side_effect=RuntimeError("discord outage"))
@@ -249,7 +249,7 @@ def test_fusion_command_uses_generic_message_when_emergency_embed_fails(monkeypa
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -274,7 +274,7 @@ def test_fusion_publish_persists_announcement_channel_id(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row(announcement_channel_id=123, announcement_message_id=None, status="draft")
 
         update = AsyncMock()
@@ -301,7 +301,7 @@ def test_fusion_publish_blocks_duplicate_when_existing_message_resolves(monkeypa
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="published")
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -326,7 +326,7 @@ def test_fusion_publish_recreates_when_existing_metadata_is_stale(monkeypatch):
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="published")
 
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
@@ -345,33 +345,45 @@ def test_fusion_publish_recreates_when_existing_metadata_is_stale(monkeypatch):
     asyncio.run(_run())
 
 
-def test_fusion_command_recreates_when_status_is_draft_even_with_existing_message(monkeypatch):
+def test_fusion_command_does_not_publish_or_surface_draft_tracker(monkeypatch):
     async def _run() -> None:
-        channel = FakeMessageable(123)
-        channel.fetch_message = AsyncMock(return_value=SimpleNamespace(id=456, jump_url="https://discord.com/channels/1/123/456"))
-        channel.send = AsyncMock(return_value=SimpleNamespace(id=1003, jump_url="https://discord.com/channels/1/123/1003"))
-        bot = SimpleNamespace(
-            get_channel=lambda _channel_id: channel,
-            fetch_channel=AsyncMock(return_value=channel),
-        )
+        bot = SimpleNamespace(get_channel=lambda _channel_id: None, fetch_channel=AsyncMock())
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
-            return _fusion_row(announcement_channel_id=123, announcement_message_id=456, status="draft")
+        async def _fake_get_publishable(**_kwargs):
+            return None
 
-        update = AsyncMock()
         monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
-        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
-        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
-        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
 
         await cog.fusion.callback(cog, ctx)
 
-        channel.send.assert_awaited_once()
-        assert update.await_count == 1
         ctx.reply.assert_awaited_once_with(
-            "🔗 Fusion’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/1003",
+            "No fusion running. Enjoy the peace while it lasts.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
+def test_titan_command_returns_jump_url(monkeypatch):
+    async def _run() -> None:
+        message = SimpleNamespace(jump_url="https://discord.com/channels/1/123/456")
+        channel = FakeMessageable(123)
+        channel.fetch_message = AsyncMock(return_value=message)
+        bot = SimpleNamespace(get_channel=lambda _channel_id: channel, fetch_channel=AsyncMock(return_value=channel))
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+
+        async def _fake_get_publishable(**_kwargs):
+            return _fusion_row(status="published")
+
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+
+        await cog.titan.callback(cog, ctx)
+
+        ctx.reply.assert_awaited_once_with(
+            "🔗 Titan’s up. Don’t get lost:\nhttps://discord.com/channels/1/123/456",
             mention_author=False,
         )
 
@@ -384,7 +396,7 @@ def test_fusion_publish_load_failure_still_replies_when_internal_log_delivery_fa
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             raise RuntimeError("sheet unavailable")
 
         async def _boom(*_args, **_kwargs):
@@ -407,7 +419,7 @@ def test_fusion_publish_announce_failure_still_replies_when_internal_log_deliver
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row(announcement_channel_id=123, announcement_message_id=None, status="draft")
 
         async def _boom(*_args, **_kwargs):
@@ -430,7 +442,7 @@ def test_fusion_debug_event_failure_still_replies_when_internal_log_delivery_fai
         cog = FusionCog(bot)
         ctx = SimpleNamespace(reply=AsyncMock())
 
-        async def _fake_get_publishable():
+        async def _fake_get_publishable(**_kwargs):
             return _fusion_row()
 
         async def _boom(*_args, **_kwargs):

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -404,7 +404,7 @@ def test_event_dropdown_keeps_selected_event_after_sorting_rebuild():
     assert view.selected_event_id == "e_missed"
 
 
-def test_fragments_done_counts_done_bonus_with_bonus_and_done_without_bonus():
+def test_reward_totals_and_selected_event_labels_are_data_driven():
     events = [
         _event_row("e_done", event_name="Base Done"),
         _event_row("e_done_bonus", event_name="Bonus Done"),
@@ -424,7 +424,7 @@ def test_fragments_done_counts_done_bonus_with_bonus_and_done_without_bonus():
     selected_field = next(field for field in embed.fields if field.name == "Selected Event")
     assert fragments_field.value == "80 / 450 fragments earned"
     assert "✅ Done: 2" in summary_field.value
-    assert "25 + 50 bonus frags" in selected_field.value
+    assert "25 + 50 bonus fragments" in selected_field.value
 
 
 def test_done_on_bonus_event_counts_base_only():
@@ -437,6 +437,22 @@ def test_done_on_bonus_event_counts_base_only():
     )
     fragments_field = next(field for field in embed.fields if field.name == "Fragments")
     assert fragments_field.value == "25 / 450 fragments earned"
+
+
+def test_my_progress_uses_tracker_reward_type_for_titan():
+    event = replace(_event_row("e_points"), reward_amount=25.0, bonus=50.0, reward_type="points")
+    titan = replace(_fusion_row(opt_in_role_id=777), reward_type="points", available=1750, fusion_type="titan")
+    embed = opt_in_view._build_progress_summary_embed(
+        target=titan,
+        events=[event],
+        progress_by_event={"e_points": "done_bonus"},
+        selected_event_id="e_points",
+    )
+
+    points_field = next(field for field in embed.fields if field.name == "Points")
+    selected_field = next(field for field in embed.fields if field.name == "Selected Event")
+    assert points_field.value == "75 / 1750 points earned"
+    assert "25 + 50 bonus points" in selected_field.value
 
 
 def test_status_options_include_done_bonus_only_when_event_has_bonus():

--- a/tests/community/test_fusion_progress_share.py
+++ b/tests/community/test_fusion_progress_share.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from dataclasses import replace
 
 from modules.community.fusion import progress_share
 from shared.sheets import fusion as fusion_sheets
@@ -72,3 +73,18 @@ def test_build_progress_share_embed_detailed_mode_adds_event_breakdown():
     detail_field = next(field for field in embed.fields if field.name == "Event Breakdown")
     assert "Dungeon Dash: Done" in detail_field.value
     assert "Arena Rush: In Progress" in detail_field.value
+
+
+def test_build_progress_share_embed_uses_dynamic_reward_unit():
+    titan = replace(_fusion_row(), reward_type="points", available=1750, fusion_type="titan")
+    event = replace(_event_row("e1", "Dungeon Dash"), reward_amount=25.0, reward_type="points")
+    embed = progress_share.build_progress_share_embed(
+        target=titan,
+        events=[event],
+        progress_by_event={"e1": "done"},
+        user_display_name="Tester",
+        mode="summary",
+    )
+
+    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    assert "Progress: 25 / 1750 points" in summary_field.value

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -58,7 +58,7 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
 
     assert "Target: 400 fragments needed / 450 available" in (embed.description or "")
     assert embed.fields[0].name == "Key Milestones"
-    assert embed.fields[1].name == "Event Status"
+    assert embed.fields[1].name == "Schedule Status"
     assert len(embed.fields) >= 4
     for field in embed.fields[2:]:
         assert "Schedule (Part" not in field.name
@@ -89,3 +89,13 @@ def test_build_fusion_embed_skips_invalid_champion_image_url() -> None:
     embed = build_fusion_announcement_embed(fusion, [])
 
     assert not str(embed.image.url or "").strip()
+
+
+def test_build_fusion_embed_uses_dynamic_reward_labels_for_titan() -> None:
+    titan = replace(_fusion(), fusion_type="titan", reward_type="points", needed=1750, available=2000)
+    event = replace(_event(8, 1), reward_type="points", reward_amount=25, bonus=50)
+
+    embed = build_fusion_announcement_embed(titan, [event])
+
+    assert "Target: 1750 points needed / 2000 available" in (embed.description or "")
+    assert "for 25 points (+50 bonus points)" in embed.fields[-1].value

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -234,3 +234,62 @@ def test_get_upcoming_events_uses_validated_timestamps_for_sorting(
     result = asyncio.run(fusion.get_upcoming_events("f-1", now=now))
 
     assert [row.event_id for row in result] == ["naive-earlier", "aware"]
+
+
+def _fusion_row(*, fusion_id: str, status: str, fusion_type: str, start_day: int) -> fusion.FusionRow:
+    return fusion.FusionRow(
+        fusion_id=fusion_id,
+        fusion_name=fusion_id,
+        champion="Champion",
+        champion_image_url="",
+        fusion_type=fusion_type,
+        fusion_structure="",
+        reward_type="fragments",
+        needed=400,
+        available=450,
+        start_at_utc=dt.datetime(2026, 4, start_day, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 4, start_day + 10, tzinfo=dt.timezone.utc),
+        announcement_channel_id=123,
+        opt_in_role_id=None,
+        announcement_message_id=None,
+        published_at=None,
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
+        status=status,
+    )
+
+
+def test_get_publishable_fusion_excludes_drafts_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [_fusion_row(fusion_id="draft-1", status="draft", fusion_type="traditional", start_day=8)]
+    monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=tuple(rows)))
+
+    result = asyncio.run(fusion.get_publishable_fusion())
+
+    assert result is None
+
+
+def test_get_publishable_fusion_filters_by_tracker_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        _fusion_row(fusion_id="fusion-1", status="published", fusion_type="traditional", start_day=8),
+        _fusion_row(fusion_id="titan-1", status="published", fusion_type="titan", start_day=9),
+    ]
+    monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=tuple(rows)))
+
+    titan = asyncio.run(fusion.get_publishable_fusion(tracker_kind="titan"))
+    standard = asyncio.run(fusion.get_publishable_fusion(tracker_kind="fusion"))
+
+    assert titan is not None and titan.fusion_id == "titan-1"
+    assert standard is not None and standard.fusion_id == "fusion-1"
+
+
+def test_get_publishable_fusion_publish_flow_prefers_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        _fusion_row(fusion_id="published-1", status="published", fusion_type="traditional", start_day=9),
+        _fusion_row(fusion_id="draft-1", status="draft", fusion_type="traditional", start_day=8),
+    ]
+    monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=tuple(rows)))
+
+    result = asyncio.run(fusion.get_publishable_fusion(include_draft=True, prefer_draft=True))
+
+    assert result is not None
+    assert result.fusion_id == "draft-1"


### PR DESCRIPTION
### Motivation

- Support Titan events with the same tracker mechanics while removing fragment-specific wording to make all labels data-driven.
- Prevent accidental publishing/self-heal of draft tracker rows by enforcing strict gating rules for normal commands and rebuild paths.
- Reuse the existing tracker backend rather than duplicating Fusion vs Titan implementations.

### Description

- Generalized tracker selection by changing `shared/sheets/fusion.get_publishable_fusion` to accept `include_draft`, `prefer_draft`, and `tracker_kind` and added `_tracker_kind` to filter Titan vs Fusion rows, used by command and publish flows (`shared/sheets/fusion.py`).
- Made rendering data-driven by replacing hardcoded fragment wording with `reward_type`/`reward_unit` from `FusionRow`/`FusionEventRow` across announcement rendering, schedule lines, My Progress panel, progress share, and reminders (`modules/community/fusion/rendering.py`, `modules/community/fusion/opt_in_view.py`, `modules/community/fusion/progress_share.py`, `modules/community/fusion/reminders.py`).
- Enforced strict publish/self-heal gating by updating `ensure_fusion_announcement` to only self-heal when status is publishable and `published_at` is present, and kept explicit publish behavior for `!fusion publish` (which now calls `get_publishable_fusion(include_draft=True, prefer_draft=True)`) (`modules/community/fusion/announcements.py`, `modules/community/fusion/cog.py`).
- Added a shared command entrypoint `_tracker_entrypoint` and new `!titan` command that reuses the same backend flow as `!fusion` without duplicating logic (`modules/community/fusion/cog.py`).
- Updated and added tests to validate dynamic reward labels, My Progress totals and labels, Titan command behavior, and strict publish gating semantics (`tests/community/*`, `tests/shared/sheets/test_fusion.py`).

### Testing

- Ran the focused fusion/titan test suite: `pytest -q tests/community/test_fusion_rendering.py tests/community/test_fusion_progress_share.py tests/community/test_fusion_opt_in_view.py tests/community/test_fusion_cog.py tests/community/test_fusion_announcements.py tests/community/test_fusion_reminders.py tests/shared/sheets/test_fusion.py` and all tests passed.
- Verified the announcement self-heal path no longer calls publish for draft rows by unit tests in `tests/community/test_fusion_announcements.py` which passed.
- Exercised publish selection logic via `tests/shared/sheets/test_fusion.py` ensuring `include_draft`/`prefer_draft` behavior and tracker-kind filtering, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ee62cd508323b3eccfadba2c1ec3)