### PR TITLE
Shard tracker: add clan sharing and weekly reminder scheduler with sheet-backed config

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -306,6 +306,9 @@ Feature Toggles:
 - `SHARD_MERCY_CHANNEL_ID` — Discord channel ID dedicated to shard tracking.
   Commands run outside this channel reply with a routing reminder; the value is
   read from the same milestones Config tab so shard routing stays sheet-driven.
+- `SHARD_CLANS_TAB` — worksheet name used for clan sharing + weekly shard reminders.
+- `SHARD_REMINDER_TAB` — worksheet name for durable weekly reminder dedupe rows
+  (`clan_key`, `window_key`, `reminder_type`, `sent_at_utc`).
 
 ### Feature toggles worksheet
 

--- a/docs/ops/modules/ShardTracker.md
+++ b/docs/ops/modules/ShardTracker.md
@@ -33,6 +33,8 @@ keep a private, button-driven tracker thread.
 - **Config tab:** `MILESTONES_CONFIG_TAB` (defaults to `Config`). Required keys:
   - `SHARD_MERCY_TAB` — worksheet name that stores shard rows.
   - `SHARD_MERCY_CHANNEL_ID` — numeric ID for the dedicated Discord channel.
+  - `SHARD_CLANS_TAB` — worksheet name for clan sharing + weekly reminders.
+  - `SHARD_REMINDER_TAB` — worksheet for durable weekly reminder sent tracking.
 - **Worksheet schema:** row 1 contains the canonical headers listed below.
   `discord_id` is the primary key and all headers must remain in this order.
 
@@ -48,6 +50,14 @@ keep a private, button-driven tracker thread.
 
 Rows are created automatically the first time a user opens the tracker; all
 fields initialize to zero and timestamps stay blank until a LEGO is recorded.
+
+### SHARD_CLANS_TAB schema
+
+Required headers:
+
+`clan_key`, `enabled`, `share_channel_id`, `share_thread_id`, `reminder_enabled`,
+`opt_in_role_id`, `reminder_day`, `reminder_time_utc`, `Title`, `Body`,
+`Footer`, `ColorHex`, `EmojiNameOrId`
 
 ## Mercy Math Reference
 

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1510,6 +1510,7 @@ class Runtime:
         from modules.ops import server_map as server_map_module
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
+        from modules.community.shard_tracker.scheduler import schedule_shard_jobs
 
         toggles = shared_config.features
         ensure_cache_registration()
@@ -1602,6 +1603,7 @@ class Runtime:
         server_map_module.schedule_server_map_job(self)
         schedule_leagues_jobs(self)
         schedule_fusion_jobs(self)
+        schedule_shard_jobs(self)
 
     async def close(self) -> None:
         await self.shutdown_webserver()

--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, time, timedelta, timezone
 import logging
 import os
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Literal, Optional
 
 import discord
 from discord import PartialEmoji
@@ -20,6 +21,7 @@ from shared.config import get_admin_role_ids
 from shared.logfmt import user_label
 
 from .data import (
+    ShardClanRow,
     ShardRecord,
     ShardSheetStore,
     ShardTrackerConfigError,
@@ -32,6 +34,7 @@ from .views import (
     ShardDisplay,
     ShardTrackerController,
     ShardTrackerView,
+    ShardReminderOptView,
     build_detail_embed,
     build_last_pulls_embed,
     build_overview_embed,
@@ -280,6 +283,14 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                     mythical_mercy=max(0, record.primals_since_mythic),
                 )
                 await interaction.response.send_modal(modal)
+                return
+
+            if action_name == "share":
+                await self._handle_share_summary_action(
+                    interaction=interaction,
+                    record=record,
+                    default_clan_key=None,
+                )
                 return
 
     # === Internal helpers ===
@@ -888,6 +899,296 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         )
         return embed, view
 
+    async def _handle_share_summary_action(
+        self,
+        *,
+        interaction: discord.Interaction,
+        record: ShardRecord,
+        default_clan_key: str | None,
+    ) -> None:
+        try:
+            clans = await self.store.get_enabled_clans()
+        except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+            await interaction.response.send_message(self._config_error_message(str(exc)), ephemeral=True)
+            await self._notify_admins(str(exc))
+            return
+
+        selected = await self._resolve_clan_selection(
+            interaction=interaction,
+            clans=clans,
+            default_clan_key=default_clan_key,
+            action="share",
+        )
+        if selected is None:
+            return
+        destination = self._resolve_share_destination(selected)
+        if destination is None:
+            await interaction.followup.send(
+                f"Clan `{selected.clan_key}` is enabled but has no valid share destination configured.",
+                ephemeral=True,
+            )
+            await self._notify_admins(
+                f"SHARD_CLANS_TAB clan={selected.clan_key} missing/invalid share destination"
+            )
+            return
+
+        embed = self._build_share_embed(interaction.user, record, selected)
+        await destination.send(embed=embed)
+        await interaction.followup.send(
+            f"Shared your shard summary to {destination.mention} for `{selected.clan_key}`.",
+            ephemeral=True,
+        )
+
+    async def handle_reminder_opt_action(
+        self,
+        *,
+        interaction: discord.Interaction,
+        action: Literal["in", "out"],
+        clan_key: str | None,
+    ) -> None:
+        try:
+            clans = await self.store.get_enabled_clans()
+        except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+            await interaction.response.send_message(self._config_error_message(str(exc)), ephemeral=True)
+            await self._notify_admins(str(exc))
+            return
+        selected = await self._resolve_clan_selection(
+            interaction=interaction,
+            clans=clans,
+            default_clan_key=clan_key,
+            action="opt_in" if action == "in" else "opt_out",
+        )
+        if selected is None:
+            return
+        if selected.opt_in_role_id is None:
+            await interaction.followup.send(
+                f"Clan `{selected.clan_key}` has no opt-in role configured.",
+                ephemeral=True,
+            )
+            return
+        guild = interaction.guild
+        if guild is None:
+            await interaction.followup.send("Reminder role actions only work in a server.", ephemeral=True)
+            return
+        member = interaction.user if isinstance(interaction.user, discord.Member) else guild.get_member(interaction.user.id)
+        if member is None:
+            await interaction.followup.send("Couldn’t resolve your member record right now.", ephemeral=True)
+            return
+        role = guild.get_role(selected.opt_in_role_id)
+        if role is None:
+            await interaction.followup.send(
+                f"Reminder role for `{selected.clan_key}` is missing in this server.",
+                ephemeral=True,
+            )
+            return
+        try:
+            if action == "in":
+                if role in member.roles:
+                    await interaction.followup.send("Already opted in.", ephemeral=True)
+                    return
+                await member.add_roles(role, reason=f"Shard reminder opt-in ({selected.clan_key})")
+                await interaction.followup.send("Opted in for weekly shard reminders.", ephemeral=True)
+                return
+            if role not in member.roles:
+                await interaction.followup.send("You’re already opted out.", ephemeral=True)
+                return
+            await member.remove_roles(role, reason=f"Shard reminder opt-out ({selected.clan_key})")
+            await interaction.followup.send("Opted out from weekly shard reminders.", ephemeral=True)
+        except discord.Forbidden:
+            await interaction.followup.send("I don’t have permission to update that role.", ephemeral=True)
+        except Exception:
+            log.exception("shard reminder role update failed")
+            await interaction.followup.send("Couldn’t update your reminder role right now.", ephemeral=True)
+
+    async def handle_clan_choice(
+        self,
+        *,
+        interaction: discord.Interaction,
+        action: Literal["share", "opt_in", "opt_out"],
+        clan_key: str,
+    ) -> None:
+        if action in {"opt_in", "opt_out"}:
+            await self.handle_reminder_opt_action(
+                interaction=interaction,
+                action="in" if action == "opt_in" else "out",
+                clan_key=clan_key,
+            )
+            return
+        async with self._user_lock(interaction.user.id):
+            try:
+                record = await self.store.load_record(
+                    interaction.user.id,
+                    interaction.user.display_name or interaction.user.name,
+                )
+            except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+                await interaction.response.send_message(self._config_error_message(str(exc)), ephemeral=True)
+                await self._notify_admins(str(exc))
+                return
+        await self._handle_share_summary_action(
+            interaction=interaction,
+            record=record,
+            default_clan_key=clan_key,
+        )
+
+    async def _resolve_clan_selection(
+        self,
+        *,
+        interaction: discord.Interaction,
+        clans: list[ShardClanRow],
+        default_clan_key: str | None,
+        action: Literal["share", "opt_in", "opt_out"],
+    ) -> ShardClanRow | None:
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=True)
+        if not clans:
+            await interaction.followup.send("No enabled shard clans are configured.", ephemeral=True)
+            return None
+        if default_clan_key:
+            selected = next((row for row in clans if row.clan_key.lower() == default_clan_key.lower()), None)
+            if selected is not None:
+                return selected
+        if len(clans) == 1:
+            return clans[0]
+        view = _ShardClanChoiceView(controller=self, clans=clans, action=action)
+        await interaction.followup.send(
+            "Choose a clan to continue.",
+            view=view,
+            ephemeral=True,
+        )
+        return None
+
+    def _resolve_share_destination(self, clan: ShardClanRow) -> discord.abc.Messageable | None:
+        if clan.share_thread_id:
+            target = self.bot.get_channel(clan.share_thread_id)
+            if isinstance(target, discord.Thread):
+                return target
+        if clan.share_channel_id:
+            target = self.bot.get_channel(clan.share_channel_id)
+            if isinstance(target, (discord.TextChannel, discord.Thread)):
+                return target
+        return None
+
+    def _build_share_embed(
+        self,
+        member: discord.abc.User,
+        record: ShardRecord,
+        clan: ShardClanRow,
+    ) -> discord.Embed:
+        displays = [self._build_display(record, kind) for kind in SHARD_KINDS.values()]
+        mythic = self._build_mythic_display(record)
+        embed = build_overview_embed(member=member, displays=displays, mythic=mythic)
+        embed.title = f"Shard Snapshot — {member.display_name}"
+        embed.description = f"Shared to `{clan.clan_key}`."
+        return embed
+
+    def _build_clan_reminder_embed(
+        self,
+        *,
+        clan: ShardClanRow,
+        guild: discord.Guild | None,
+    ) -> discord.Embed:
+        color = self._parse_color_hex(clan.color_hex)
+        embed = discord.Embed(
+            title=clan.title,
+            description=clan.body,
+            colour=color,
+            timestamp=datetime.now(timezone.utc),
+        )
+        footer_icon = self._resolve_footer_icon_url(guild, clan.emoji_name_or_id)
+        embed.set_footer(text=clan.footer, icon_url=footer_icon)
+        return embed
+
+    async def process_weekly_clan_reminders(self, *, now: datetime | None = None) -> None:
+        reference = now.astimezone(timezone.utc) if now else datetime.now(timezone.utc)
+        try:
+            clans = await self.store.get_enabled_clans()
+        except Exception:
+            log.exception("failed to load shard clans for weekly reminders")
+            return
+        for clan in clans:
+            if not clan.reminder_enabled:
+                continue
+            if not clan.opt_in_role_id:
+                await self._notify_admins(f"SHARD_CLANS_TAB clan={clan.clan_key} missing opt_in_role_id")
+                continue
+            scheduled = self._scheduled_window_start(clan, reference)
+            if scheduled is None:
+                await self._notify_admins(f"SHARD_CLANS_TAB clan={clan.clan_key} has invalid reminder_day/time")
+                continue
+            window_key = scheduled.date().isoformat()
+            if reference < scheduled or reference > (scheduled + timedelta(minutes=30)):
+                continue
+            try:
+                sent_keys = await self.store.get_sent_weekly_reminder_keys(clan.clan_key)
+            except Exception:
+                log.exception("failed loading shard reminder dedupe", extra={"clan_key": clan.clan_key})
+                sent_keys = set()
+            if window_key in sent_keys:
+                continue
+            destination = self._resolve_share_destination(clan)
+            if destination is None:
+                await self._notify_admins(f"SHARD_CLANS_TAB clan={clan.clan_key} destination missing")
+                continue
+            if not clan.title or not clan.body or not clan.footer:
+                await self._notify_admins(f"SHARD_CLANS_TAB clan={clan.clan_key} missing reminder embed fields")
+                continue
+            embed = self._build_clan_reminder_embed(clan=clan, guild=getattr(destination, "guild", None))
+            mention = f"<@&{clan.opt_in_role_id}>"
+            await destination.send(content=mention, embed=embed, view=ShardReminderOptView())
+            await self.store.mark_weekly_reminder_sent(clan_key=clan.clan_key, window_key=window_key, sent_at=reference)
+
+    def _scheduled_window_start(self, clan: ShardClanRow, now_utc: datetime) -> datetime | None:
+        day_names = {
+            "monday": 0,
+            "tuesday": 1,
+            "wednesday": 2,
+            "thursday": 3,
+            "friday": 4,
+            "saturday": 5,
+            "sunday": 6,
+        }
+        day_token = clan.reminder_day.strip().lower()
+        if day_token not in day_names:
+            return None
+        time_token = clan.reminder_time_utc.strip()
+        try:
+            hour, minute = [int(part) for part in time_token.split(":", 1)]
+            scheduled_time = time(hour=hour, minute=minute, tzinfo=timezone.utc)
+        except Exception:
+            return None
+        now_day = now_utc.weekday()
+        delta_days = (now_day - day_names[day_token]) % 7
+        candidate_date = (now_utc - timedelta(days=delta_days)).date()
+        return datetime.combine(candidate_date, scheduled_time)
+
+    @staticmethod
+    def _parse_color_hex(value: str) -> discord.Colour:
+        text = str(value or "").strip()
+        if text.startswith("#"):
+            text = text[1:]
+        elif text.lower().startswith("0x"):
+            text = text[2:]
+        try:
+            return discord.Colour(int(text, 16))
+        except Exception:
+            try:
+                return discord.Colour(int(str(value or "").strip()))
+            except Exception:
+                return discord.Colour.blurple()
+
+    @staticmethod
+    def _resolve_footer_icon_url(guild: discord.Guild | None, emoji_token: str) -> str | None:
+        token = str(emoji_token or "").strip()
+        if not token or guild is None:
+            return None
+        try:
+            emoji_id = int(token)
+        except ValueError:
+            emoji = emoji_pipeline.emoji_for_tag(guild, token)
+            return str(emoji.url) if emoji else None
+        emoji = guild.get_emoji(emoji_id)
+        return str(emoji.url) if emoji else None
+
     def _build_display(self, record: ShardRecord, kind: ShardKind) -> ShardDisplay:
         owned = max(0, getattr(record, kind.stash_field, 0))
         since = max(0, getattr(record, kind.mercy_field, 0))
@@ -1041,6 +1342,43 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         from datetime import datetime, timezone
 
         return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+class _ShardClanChoiceView(discord.ui.View):
+    def __init__(
+        self,
+        *,
+        controller: ShardTracker,
+        clans: list[ShardClanRow],
+        action: Literal["share", "opt_in", "opt_out"],
+    ) -> None:
+        super().__init__(timeout=120)
+        options = [discord.SelectOption(label=row.clan_key[:100], value=row.clan_key[:100]) for row in clans[:25]]
+        self.add_item(_ShardClanChoiceSelect(controller=controller, action=action, options=options))
+
+
+class _ShardClanChoiceSelect(discord.ui.Select[_ShardClanChoiceView]):
+    def __init__(
+        self,
+        *,
+        controller: ShardTracker,
+        action: Literal["share", "opt_in", "opt_out"],
+        options: list[discord.SelectOption],
+    ) -> None:
+        super().__init__(placeholder="Select clan", min_values=1, max_values=1, options=options)
+        self.controller = controller
+        self.action = action
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        clan_key = str(self.values[0] if self.values else "").strip()
+        if not clan_key:
+            await interaction.response.send_message("Select a clan first.", ephemeral=True)
+            return
+        await self.controller.handle_clan_choice(
+            interaction=interaction,
+            action=self.action,
+            clan_key=clan_key,
+        )
 
 
 class _NumberModal(discord.ui.Modal):

--- a/modules/community/shard_tracker/data.py
+++ b/modules/community/shard_tracker/data.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Sequence
 
@@ -41,12 +41,51 @@ EXPECTED_HEADERS: List[str] = [
     "last_updated_iso",
 ]
 
+SHARD_CLANS_REQUIRED_HEADERS: tuple[str, ...] = (
+    "clan_key",
+    "enabled",
+    "share_channel_id",
+    "share_thread_id",
+    "reminder_enabled",
+    "opt_in_role_id",
+    "reminder_day",
+    "reminder_time_utc",
+    "title",
+    "body",
+    "footer",
+    "colorhex",
+    "emojinameorid",
+)
+SHARD_REMINDER_REQUIRED_HEADERS: tuple[str, ...] = (
+    "clan_key",
+    "window_key",
+    "reminder_type",
+    "sent_at_utc",
+)
+
 
 @dataclass(slots=True)
 class ShardTrackerConfig:
     sheet_id: str
     tab_name: str
     channel_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShardClanRow:
+    clan_key: str
+    enabled: bool
+    share_channel_id: int | None
+    share_thread_id: int | None
+    reminder_enabled: bool
+    opt_in_role_id: int | None
+    reminder_day: str
+    reminder_time_utc: str
+    title: str
+    body: str
+    footer: str
+    color_hex: str
+    emoji_name_or_id: str
 
 
 @dataclass(slots=True)
@@ -209,6 +248,131 @@ class ShardSheetStore:
                 value_input_option="RAW",
             )
 
+    async def get_enabled_clans(self) -> list[ShardClanRow]:
+        rows = await self._load_shard_clans()
+        return [row for row in rows if row.enabled]
+
+    async def get_enabled_clan(self, clan_key: str) -> ShardClanRow | None:
+        key = str(clan_key or "").strip().lower()
+        if not key:
+            return None
+        for row in await self.get_enabled_clans():
+            if row.clan_key.lower() == key:
+                return row
+        return None
+
+    async def _load_shard_clans(self) -> list[ShardClanRow]:
+        config = await self.get_config()
+        tab_name = _config_tab_name("SHARD_CLANS_TAB")
+        matrix = await async_core.afetch_values(config.sheet_id, tab_name)
+        if not matrix:
+            raise ShardTrackerSheetError(f"Shard clans sheet is empty (tab={tab_name})")
+
+        header = [self._normalize(cell) for cell in matrix[0]]
+        missing = [col for col in SHARD_CLANS_REQUIRED_HEADERS if col not in header]
+        if missing:
+            raise ShardTrackerSheetError(
+                f"Shard clans sheet missing required headers (tab={tab_name}, missing={missing})"
+            )
+
+        index = {name: header.index(name) for name in SHARD_CLANS_REQUIRED_HEADERS}
+        rows: list[ShardClanRow] = []
+        for row in matrix[1:]:
+            clan_key = self._cell(row, index["clan_key"])
+            if not clan_key:
+                continue
+            rows.append(
+                ShardClanRow(
+                    clan_key=clan_key,
+                    enabled=_parse_bool(self._cell(row, index["enabled"])),
+                    share_channel_id=_parse_snowflake(self._cell(row, index["share_channel_id"])),
+                    share_thread_id=_parse_snowflake(self._cell(row, index["share_thread_id"])),
+                    reminder_enabled=_parse_bool(self._cell(row, index["reminder_enabled"])),
+                    opt_in_role_id=_parse_snowflake(self._cell(row, index["opt_in_role_id"])),
+                    reminder_day=self._cell(row, index["reminder_day"]),
+                    reminder_time_utc=self._cell(row, index["reminder_time_utc"]),
+                    title=self._cell(row, index["title"]),
+                    body=self._cell(row, index["body"]),
+                    footer=self._cell(row, index["footer"]),
+                    color_hex=self._cell(row, index["colorhex"]),
+                    emoji_name_or_id=self._cell(row, index["emojinameorid"]),
+                )
+            )
+        return rows
+
+    async def get_sent_weekly_reminder_keys(self, clan_key: str) -> set[str]:
+        tab_name = _config_tab_name("SHARD_REMINDER_TAB")
+        config = await self.get_config()
+        matrix = await async_core.afetch_values(config.sheet_id, tab_name)
+        if not matrix:
+            return set()
+        header = [self._normalize(cell) for cell in matrix[0]]
+        missing = [col for col in SHARD_REMINDER_REQUIRED_HEADERS if col not in header]
+        if missing:
+            raise ShardTrackerSheetError(
+                f"Shard reminder sheet missing required headers (tab={tab_name}, missing={missing})"
+            )
+        index = {name: header.index(name) for name in SHARD_REMINDER_REQUIRED_HEADERS}
+        target_clan = str(clan_key or "").strip()
+        keys: set[str] = set()
+        for row in matrix[1:]:
+            row_clan = self._cell(row, index["clan_key"])
+            if row_clan != target_clan:
+                continue
+            window_key = self._cell(row, index["window_key"])
+            reminder_type = self._cell(row, index["reminder_type"])
+            if window_key and reminder_type == "weekly":
+                keys.add(window_key)
+        return keys
+
+    async def mark_weekly_reminder_sent(
+        self,
+        *,
+        clan_key: str,
+        window_key: str,
+        sent_at: datetime,
+    ) -> None:
+        tab_name = _config_tab_name("SHARD_REMINDER_TAB")
+        config = await self.get_config()
+        matrix = await async_core.afetch_values(config.sheet_id, tab_name)
+        if not matrix:
+            raise ShardTrackerSheetError(f"Shard reminder sheet is empty (tab={tab_name})")
+        header = [self._normalize(cell) for cell in matrix[0]]
+        missing = [col for col in SHARD_REMINDER_REQUIRED_HEADERS if col not in header]
+        if missing:
+            raise ShardTrackerSheetError(
+                f"Shard reminder sheet missing required headers (tab={tab_name}, missing={missing})"
+            )
+        index = {name: header.index(name) for name in SHARD_REMINDER_REQUIRED_HEADERS}
+        target_clan = str(clan_key or "").strip()
+        target_window = str(window_key or "").strip()
+        sent_token = sent_at.astimezone(timezone.utc).isoformat()
+        worksheet = await async_core.aget_worksheet(config.sheet_id, tab_name)
+        for row_idx, row in enumerate(matrix[1:], start=2):
+            row_clan = self._cell(row, index["clan_key"])
+            row_window = self._cell(row, index["window_key"])
+            row_type = self._cell(row, index["reminder_type"])
+            if (row_clan, row_window, row_type) != (target_clan, target_window, "weekly"):
+                continue
+            col = _column_label(index["sent_at_utc"])
+            await async_core.acall_with_backoff(
+                worksheet.update,
+                f"{col}{row_idx}",
+                [[sent_token]],
+                value_input_option="RAW",
+            )
+            return
+        row_values = [""] * len(header)
+        row_values[index["clan_key"]] = target_clan
+        row_values[index["window_key"]] = target_window
+        row_values[index["reminder_type"]] = "weekly"
+        row_values[index["sent_at_utc"]] = sent_token
+        await async_core.acall_with_backoff(
+            worksheet.append_row,
+            row_values,
+            value_input_option="RAW",
+        )
+
     async def _append_row(self, config: ShardTrackerConfig, record: ShardRecord) -> int:
         worksheet = await async_core.aget_worksheet(config.sheet_id, config.tab_name)
         async with self._sheet_lock:
@@ -294,6 +458,12 @@ class ShardSheetStore:
         except (TypeError, ValueError):
             return 0
 
+    @staticmethod
+    def _cell(row: Sequence[object], idx: int) -> str:
+        if idx < 0 or idx >= len(row):
+            return ""
+        return str(row[idx] or "").strip()
+
 
 def _config_value(key: str, default: object = None) -> object:
     getter = getattr(runtime_config, "get", None)
@@ -303,6 +473,14 @@ def _config_value(key: str, default: object = None) -> object:
         except Exception:
             return default
     return getattr(runtime_config, key, default)
+
+
+def _config_tab_name(key: str) -> str:
+    value = _config_value(key, "")
+    text = str(value or "").strip()
+    if text:
+        return text
+    raise ShardTrackerConfigError(f"{key} missing in milestones Config tab")
 
 
 def _parse_channel_id(value: object) -> int:
@@ -319,6 +497,26 @@ def _parse_channel_id(value: object) -> int:
     except (TypeError, ValueError):
         return 0
     return parsed if parsed > 0 else 0
+
+
+def _parse_snowflake(value: object) -> int | None:
+    parsed = _parse_channel_id(value)
+    return parsed if parsed > 0 else None
+
+
+def _parse_bool(value: object) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y"}
+
+
+def _column_label(index: int) -> str:
+    if index < 0:
+        raise ValueError("column index must be non-negative")
+    value = index + 1
+    label = ""
+    while value > 0:
+        value, remainder = divmod(value - 1, 26)
+        label = chr(65 + remainder) + label
+    return label or "A"
 
 
 def _log_config_snapshot(
@@ -361,4 +559,3 @@ def _log_config_snapshot(
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-

--- a/modules/community/shard_tracker/scheduler.py
+++ b/modules/community/shard_tracker/scheduler.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from modules.common.runtime import Runtime
+
+log = logging.getLogger("c1c.shards.scheduler")
+
+
+def schedule_shard_jobs(runtime: "Runtime") -> None:
+    if any(getattr(job, "name", None) == "shard_weekly_reminders" for job in runtime.scheduler.jobs):
+        return
+
+    job = runtime.scheduler.every(minutes=30.0, tag="shards", name="shard_weekly_reminders")
+
+    async def _runner() -> None:
+        if runtime.bot.is_closed() or not runtime.bot.is_ready():
+            return
+        cog = runtime.bot.get_cog("ShardTracker")
+        if cog is None:
+            return
+        try:
+            await cog.process_weekly_clan_reminders(now=dt.datetime.now(dt.timezone.utc))
+        except Exception:
+            log.exception("shard weekly reminder job failed")
+
+    job.do(_runner)

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -112,6 +112,16 @@ class ShardTrackerView(discord.ui.View):
                 controller=self._controller,
             )
         )
+        self.add_item(
+            _ShardButton(
+                custom_id=f"action:share:{self.active_tab}",
+                label="Share to Clan",
+                emoji=None,
+                style=discord.ButtonStyle.secondary,
+                owner_id=self.owner_id,
+                controller=self._controller,
+            )
+        )
 
     def _add_legendary_button(self) -> None:
         label = "Got Legendary/Mythical" if self.active_tab == "primal" else "Got Legendary"
@@ -200,6 +210,43 @@ class ShardTrackerController:
         active_tab: str,
     ) -> None:
         raise NotImplementedError
+
+
+class ShardReminderOptView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+        self.add_item(
+            _ShardReminderButton(
+                custom_id="shard:opt_in",
+                label="Opt In",
+                style=discord.ButtonStyle.success,
+            )
+        )
+        self.add_item(
+            _ShardReminderButton(
+                custom_id="shard:opt_out",
+                label="Opt Out",
+                style=discord.ButtonStyle.secondary,
+            )
+        )
+
+
+class _ShardReminderButton(discord.ui.Button[ShardReminderOptView]):
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        controller = getattr(interaction.client, "get_cog", lambda _name: None)("ShardTracker")
+        if controller is None:
+            await interaction.response.send_message("Shard tracker is unavailable.", ephemeral=True)
+            return
+        parts = str(self.custom_id or "").split(":")
+        if len(parts) != 2:
+            await interaction.response.send_message("Invalid shard reminder action.", ephemeral=True)
+            return
+        action = "in" if parts[1] == "opt_in" else "out"
+        await controller.handle_reminder_opt_action(interaction=interaction, action=action, clan_key=None)
+
+
+def register_persistent_shard_views(bot: discord.Client) -> None:
+    bot.add_view(ShardReminderOptView())
 
 
 def build_overview_embed(

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -7,6 +7,7 @@ import logging
 from discord.ext import commands
 
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
+from modules.community.shard_tracker.views import register_persistent_shard_views
 from modules.onboarding import watcher_promo, watcher_welcome
 from modules.onboarding.ui import panels
 
@@ -29,6 +30,11 @@ async def on_ready(bot: commands.Bot) -> None:
             register_persistent_fusion_views(bot)
         except Exception:
             log.exception("CORE_READY FAILURE: register_persistent_fusion_views")
+            return
+        try:
+            register_persistent_shard_views(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: register_persistent_shard_views")
             return
 
         # Ensure both onboarding watchers are wired


### PR DESCRIPTION
### Motivation

- Enable users to share shard snapshots to configured clans and provide opt-in weekly reminders for clans. 
- Persist clan configuration and weekly reminder dedupe in the milestones sheets so server operators can manage destinations and schedules without code changes. 
- Run reminder delivery via the bot scheduler to surface reminders automatically on the configured cadence. 

### Description

- Add new sheet-backed configuration and docs updates in `docs/ops/Config.md` and `docs/ops/modules/ShardTracker.md` for `SHARD_CLANS_TAB` and `SHARD_REMINDER_TAB`. 
- Implement data model and sheet helpers in `modules/community/shard_tracker/data.py` including `ShardClanRow`, parsing helpers (`_parse_bool`, `_parse_snowflake`, `_config_tab_name`, `_column_label`), and reminder dedupe methods `get_sent_weekly_reminder_keys` and `mark_weekly_reminder_sent`. 
- Extend the Shard tracker cog (`modules/community/shard_tracker/cog.py`) with UI and flows to `Share to Clan`, resolve clan selections, build/share embed destinations, opt-in/opt-out role handling, weekly reminder processing (`process_weekly_clan_reminders`), color/emoji helpers, and related view/interaction handlers. 
- Add persistent reminder view and buttons in `modules/community/shard_tracker/views.py`, register them on ready in `modules/coreops/ready.py`, and wire a scheduler in `modules/community/shard_tracker/scheduler.py` with runtime registration in `modules/common/runtime.py` to run the weekly reminder job every 30 minutes. 

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c1b89388323ac1244431b5a5f1e)