### PR TITLE
Fix shard reminder scheduler lifecycle visibility after startup/restart

### DIFF
--- a/modules/community/shard_tracker/scheduler.py
+++ b/modules/community/shard_tracker/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import asyncio
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,13 +11,33 @@ if TYPE_CHECKING:
 log = logging.getLogger("c1c.shards.scheduler")
 
 
+def _log_scheduler_task_exit(task: asyncio.Task[None]) -> None:
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        log.info("shard reminder scheduler cancelled")
+        return
+    except Exception:
+        log.exception("shard reminder scheduler failed while reading task exception")
+        return
+
+    if exc is not None:
+        log.exception("shard reminder scheduler failed", exc_info=exc)
+        return
+
+    log.warning("shard reminder scheduler stopped")
+
+
 def schedule_shard_jobs(runtime: "Runtime") -> None:
     if any(getattr(job, "name", None) == "shard_weekly_reminders" for job in runtime.scheduler.jobs):
+        log.info("shard reminder scheduler already registered; skipping duplicate job")
         return
 
     job = runtime.scheduler.every(minutes=30.0, tag="shards", name="shard_weekly_reminders")
+    log.info("shard reminder scheduler started")
 
     async def _runner() -> None:
+        log.info("shard reminder scheduler tick")
         if runtime.bot.is_closed() or not runtime.bot.is_ready():
             return
         cog = runtime.bot.get_cog("ShardTracker")
@@ -27,4 +48,6 @@ def schedule_shard_jobs(runtime: "Runtime") -> None:
         except Exception:
             log.exception("shard weekly reminder job failed")
 
-    job.do(_runner)
+    task = job.do(_runner)
+    if isinstance(task, asyncio.Task):
+        task.add_done_callback(_log_scheduler_task_exit)

--- a/tests/community/test_shard_scheduler.py
+++ b/tests/community/test_shard_scheduler.py
@@ -1,0 +1,72 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.community.shard_tracker import scheduler as shard_scheduler
+
+
+class _FakeJob:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self._runner = None
+
+    def do(self, runner):
+        self._runner = runner
+        return None
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.jobs = []
+
+    def every(self, **kwargs):
+        job = _FakeJob(name=kwargs.get("name", ""))
+        self.jobs.append(job)
+        return job
+
+
+def test_schedule_shard_jobs_is_idempotent(caplog) -> None:
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+
+    caplog.set_level(logging.INFO, logger="c1c.shards.scheduler")
+    shard_scheduler.schedule_shard_jobs(runtime)
+    shard_scheduler.schedule_shard_jobs(runtime)
+
+    assert len(runtime.scheduler.jobs) == 1
+    assert runtime.scheduler.jobs[0].name == "shard_weekly_reminders"
+    assert "shard reminder scheduler started" in caplog.text
+    assert "shard reminder scheduler already registered" in caplog.text
+
+
+def test_shard_scheduler_tick_runs_weekly_reminder(caplog) -> None:
+    reminder = AsyncMock()
+    runtime = SimpleNamespace(
+        bot=SimpleNamespace(
+            is_closed=lambda: False,
+            is_ready=lambda: True,
+            get_cog=lambda _name: SimpleNamespace(process_weekly_clan_reminders=reminder),
+        ),
+        scheduler=_FakeScheduler(),
+    )
+
+    shard_scheduler.schedule_shard_jobs(runtime)
+    runner = runtime.scheduler.jobs[0]._runner
+    assert runner is not None
+
+    caplog.set_level(logging.INFO, logger="c1c.shards.scheduler")
+    asyncio.run(runner())
+
+    reminder.assert_awaited_once()
+    assert "shard reminder scheduler tick" in caplog.text
+
+
+def test_log_scheduler_task_exit_logs_clean_stop(caplog) -> None:
+    class _DoneTask:
+        def exception(self):
+            return None
+
+    caplog.set_level(logging.WARNING, logger="c1c.shards.scheduler")
+    shard_scheduler._log_scheduler_task_exit(_DoneTask())
+
+    assert "shard reminder scheduler stopped" in caplog.text


### PR DESCRIPTION
### Motivation
- The shard reminder scheduler could start silently or stop without visible logs after bot startup/restart, making failures invisible in production logs. 
- The goal is to ensure the scheduler is started reliably from the runtime startup path and that lifecycle events and failures are observable. 

### Description
- Added explicit lifecycle logs in `modules/community/shard_tracker/scheduler.py` including `shard reminder scheduler started`, `shard reminder scheduler tick`, and a duplicate-registration info log. 
- Introduced a task-exit callback `_log_scheduler_task_exit` that logs cancellation, clean stops, and failures with exception context so silent exits are visible. 
- Wire the callback by capturing the task returned from `job.do(...)` and calling `task.add_done_callback(_log_scheduler_task_exit)`. 
- Added focused unit tests in `tests/community/test_shard_scheduler.py` to assert idempotent registration logging, tick execution, and task-exit logging behavior. 

### Testing
- Ran `pytest -q tests/community/test_shard_scheduler.py tests/community/test_fusion_scheduler.py` and both test files passed (pytest emitted an unrelated config warning). 
- Tests cover idempotent scheduler registration, that the runner invokes `process_weekly_clan_reminders`, and that `_log_scheduler_task_exit` emits a clean-stop warning when the task has no exception.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea70afffb08323970e2663520f39eb)