### PR TITLE
Add reset reminder scheduler with persistent opt-in/out role buttons

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1511,6 +1511,7 @@ class Runtime:
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
         from modules.community.shard_tracker.scheduler import schedule_shard_jobs
+        from modules.community.reset_reminders.scheduler import schedule_reset_reminder_jobs
 
         toggles = shared_config.features
         ensure_cache_registration()
@@ -1604,6 +1605,7 @@ class Runtime:
         schedule_leagues_jobs(self)
         schedule_fusion_jobs(self)
         schedule_shard_jobs(self)
+        schedule_reset_reminder_jobs(self)
 
     async def close(self) -> None:
         await self.shutdown_webserver()

--- a/modules/community/reset_reminders/__init__.py
+++ b/modules/community/reset_reminders/__init__.py
@@ -1,0 +1,15 @@
+from .models import ResetReminder
+from .scheduler import (
+    process_reset_reminders,
+    register_persistent_reset_views,
+    schedule_reset_reminder_jobs,
+)
+from .views import ResetReminderView
+
+__all__ = [
+    "ResetReminder",
+    "ResetReminderView",
+    "process_reset_reminders",
+    "register_persistent_reset_views",
+    "schedule_reset_reminder_jobs",
+]

--- a/modules/community/reset_reminders/models.py
+++ b/modules/community/reset_reminders/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True, slots=True)
+class ResetReminder:
+    reset_id: str
+    label: str
+    status: str
+    reference_date_utc: datetime
+    cycle_days: int
+    lead_minutes: int
+    role_id: int
+    channel_id: int
+    thread_id: Optional[int]
+    embed_title: str
+    embed_description: str
+    embed_footer: str
+    button_label_opt_in: str
+    button_label_opt_out: str
+    last_sent_for_reset_utc: Optional[datetime]
+    last_message_id: Optional[int]

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import discord
+from discord.ext import commands
+
+from modules.common.embeds import get_embed_colour
+from modules.community.reset_reminders.models import ResetReminder
+from modules.community.reset_reminders.views import ResetReminderView
+from shared.config import cfg, get_milestones_sheet_id
+from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
+
+if TYPE_CHECKING:
+    from modules.common.runtime import Runtime
+
+log = logging.getLogger("c1c.community.reset_reminders.scheduler")
+
+_RESET_REMINDER_TAB_KEY = "RESET_REMINDER_TAB"
+_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "reset_id",
+    "label",
+    "status",
+    "reference_date_utc",
+    "cycle_days",
+    "lead_minutes",
+    "role_id",
+    "channel_id",
+    "thread_id",
+    "embed_title",
+    "embed_description",
+    "embed_footer",
+    "button_label_opt_in",
+    "button_label_opt_out",
+    "last_sent_for_reset_utc",
+    "last_message_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ResetReminderRecord:
+    row_number: int
+    reminder: ResetReminder
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _column_label(index: int) -> str:
+    value = index + 1
+    label = ""
+    while value > 0:
+        value, remainder = divmod(value - 1, 26)
+        label = chr(65 + remainder) + label
+    return label or "A"
+
+
+def _sheet_id() -> str:
+    sheet_id = get_milestones_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("MILESTONES_SHEET_ID not set")
+    return sheet_id
+
+
+def _tab_name() -> str:
+    tab_name = str(cfg.get(_RESET_REMINDER_TAB_KEY) or "").strip()
+    if not tab_name:
+        raise RuntimeError(f"{_RESET_REMINDER_TAB_KEY} missing in milestones Config tab")
+    return tab_name
+
+
+def _cell(row: list[Any], index: int) -> str:
+    if index < 0 or index >= len(row):
+        return ""
+    return str(row[index] or "").strip()
+
+
+def _parse_dt(value: object) -> dt.datetime:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("missing datetime")
+    parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _parse_dt_optional(value: object) -> dt.datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        return _parse_dt(raw)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: object) -> int:
+    text = str(value or "").strip()
+    if not text:
+        return 0
+    return int(text)
+
+
+def _parse_optional_int(value: object) -> int | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return int(text)
+
+
+def _resolve_header_map(header: list[Any]) -> dict[str, int]:
+    normalized = [_normalize(cell) for cell in header]
+    indices = {name: idx for idx, name in enumerate(normalized) if name}
+    missing = [column for column in _REQUIRED_COLUMNS if column not in indices]
+    if missing:
+        raise RuntimeError(f"Reset reminder tab missing required columns: {missing}")
+    return indices
+
+
+async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord]]:
+    tab_name = _tab_name()
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return tab_name, {}, []
+
+    header_map = _resolve_header_map(matrix[0])
+    records: list[_ResetReminderRecord] = []
+
+    for row_number, row in enumerate(matrix[1:], start=2):
+        try:
+            status = _cell(row, header_map["status"])
+            if active_only and status.lower() != "active":
+                continue
+
+            role_id = _parse_int(_cell(row, header_map["role_id"]))
+            channel_id = _parse_int(_cell(row, header_map["channel_id"]))
+            cycle_days = _parse_int(_cell(row, header_map["cycle_days"]))
+            lead_minutes = _parse_int(_cell(row, header_map["lead_minutes"]))
+            reminder = ResetReminder(
+                reset_id=_cell(row, header_map["reset_id"]),
+                label=_cell(row, header_map["label"]),
+                status=status,
+                reference_date_utc=_parse_dt(_cell(row, header_map["reference_date_utc"])),
+                cycle_days=cycle_days,
+                lead_minutes=lead_minutes,
+                role_id=role_id,
+                channel_id=channel_id,
+                thread_id=_parse_optional_int(_cell(row, header_map["thread_id"])),
+                embed_title=_cell(row, header_map["embed_title"]),
+                embed_description=_cell(row, header_map["embed_description"]),
+                embed_footer=_cell(row, header_map["embed_footer"]),
+                button_label_opt_in=_cell(row, header_map["button_label_opt_in"]),
+                button_label_opt_out=_cell(row, header_map["button_label_opt_out"]),
+                last_sent_for_reset_utc=_parse_dt_optional(_cell(row, header_map["last_sent_for_reset_utc"])),
+                last_message_id=_parse_optional_int(_cell(row, header_map["last_message_id"])),
+            )
+            records.append(_ResetReminderRecord(row_number=row_number, reminder=reminder))
+        except Exception:
+            log.exception("invalid reset reminder row skipped", extra={"tab": tab_name, "row_number": row_number})
+            continue
+
+    return tab_name, header_map, records
+
+
+def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
+    if now is None:
+        return dt.datetime.now(dt.timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=dt.timezone.utc)
+    return now.astimezone(dt.timezone.utc)
+
+
+def _next_reset(reference_date_utc: dt.datetime, cycle_days: int, now_utc: dt.datetime) -> dt.datetime:
+    cycle = dt.timedelta(days=cycle_days)
+    delta = now_utc - reference_date_utc
+    cycles_passed = math.floor(delta / cycle)
+    return reference_date_utc + (cycles_passed + 1) * cycle
+
+
+async def register_persistent_reset_views(bot: commands.Bot) -> None:
+    _, _, records = await _load_reset_reminder_records(active_only=True)
+    for record in records:
+        reminder = record.reminder
+        bot.add_view(
+            ResetReminderView(
+                role_id=reminder.role_id,
+                label_opt_in=reminder.button_label_opt_in,
+                label_opt_out=reminder.button_label_opt_out,
+            )
+        )
+
+
+async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) -> discord.abc.Messageable | None:
+    base_channel = bot.get_channel(reminder.channel_id)
+    if base_channel is None:
+        try:
+            base_channel = await bot.fetch_channel(reminder.channel_id)
+        except Exception:
+            return None
+
+    if reminder.thread_id:
+        thread = bot.get_channel(reminder.thread_id)
+        if thread is None:
+            try:
+                thread = await bot.fetch_channel(reminder.thread_id)
+            except Exception:
+                return None
+        if isinstance(thread, discord.abc.Messageable):
+            return thread
+        return None
+
+    if isinstance(base_channel, discord.abc.Messageable):
+        return base_channel
+    return None
+
+
+async def _update_row_after_send(
+    *,
+    tab_name: str,
+    header_map: dict[str, int],
+    row_number: int,
+    next_reset: dt.datetime,
+    message_id: int,
+) -> None:
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+
+    sent_col = _column_label(header_map["last_sent_for_reset_utc"])
+    message_col = _column_label(header_map["last_message_id"])
+
+    await acall_with_backoff(
+        worksheet.update,
+        f"{sent_col}{row_number}:{message_col}{row_number}",
+        [[next_reset.astimezone(dt.timezone.utc).isoformat(), str(message_id)]],
+        value_input_option="RAW",
+    )
+
+
+async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None = None) -> None:
+    is_closed = getattr(bot, "is_closed", None)
+    is_ready = getattr(bot, "is_ready", None)
+    if callable(is_closed) and is_closed():
+        return
+    if callable(is_ready) and not is_ready():
+        return
+
+    now_utc = _utc_now(now)
+
+    try:
+        tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
+    except Exception:
+        log.exception("failed to load reset reminders")
+        return
+
+    if not records:
+        return
+
+    for record in records:
+        reminder = record.reminder
+
+        if reminder.cycle_days <= 0:
+            log.warning("reset reminder skipped; cycle_days must be > 0", extra={"reset_id": reminder.reset_id})
+            continue
+
+        if reminder.reference_date_utc > now_utc:
+            continue
+
+        if reminder.role_id <= 0 or reminder.channel_id <= 0:
+            log.warning(
+                "reset reminder skipped; missing role/channel",
+                extra={"reset_id": reminder.reset_id, "role_id": reminder.role_id, "channel_id": reminder.channel_id},
+            )
+            continue
+
+        try:
+            next_reset = _next_reset(reminder.reference_date_utc, reminder.cycle_days, now_utc)
+        except Exception:
+            log.exception("reset reminder skipped; failed to compute cycle", extra={"reset_id": reminder.reset_id})
+            continue
+
+        trigger_time = next_reset - dt.timedelta(minutes=reminder.lead_minutes)
+        if now_utc < trigger_time:
+            continue
+
+        if reminder.last_sent_for_reset_utc == next_reset:
+            continue
+
+        target = await _resolve_target_channel(bot, reminder)
+        if target is None:
+            log.warning("reset reminder skipped; target channel not found", extra={"reset_id": reminder.reset_id})
+            continue
+
+        if reminder.last_message_id:
+            try:
+                old_message = await target.fetch_message(reminder.last_message_id)
+                await old_message.delete()
+            except Exception:
+                log.debug(
+                    "failed to delete old reset reminder",
+                    extra={"reset_id": reminder.reset_id, "last_message_id": reminder.last_message_id},
+                )
+
+        embed = discord.Embed(
+            title=reminder.embed_title or reminder.label,
+            description=reminder.embed_description,
+            color=get_embed_colour("community"),
+            timestamp=next_reset,
+        )
+        if reminder.embed_footer:
+            embed.set_footer(text=reminder.embed_footer)
+
+        view = ResetReminderView(
+            role_id=reminder.role_id,
+            label_opt_in=reminder.button_label_opt_in,
+            label_opt_out=reminder.button_label_opt_out,
+        )
+
+        try:
+            message = await target.send(
+                content=f"<@&{reminder.role_id}>",
+                embed=embed,
+                view=view,
+            )
+        except Exception:
+            log.exception("reset reminder send failed", extra={"reset_id": reminder.reset_id})
+            continue
+
+        try:
+            await _update_row_after_send(
+                tab_name=tab_name,
+                header_map=header_map,
+                row_number=record.row_number,
+                next_reset=next_reset,
+                message_id=message.id,
+            )
+        except Exception:
+            log.exception("reset reminder sheet update failed", extra={"reset_id": reminder.reset_id})
+
+
+def schedule_reset_reminder_jobs(runtime: "Runtime") -> None:
+    if any(getattr(job, "name", None) == "reset_reminders" for job in runtime.scheduler.jobs):
+        log.info("reset reminder scheduler already registered; skipping duplicate job")
+        return
+
+    job = runtime.scheduler.every(minutes=1.0, tag="community", name="reset_reminders")
+
+    async def _runner() -> None:
+        await process_reset_reminders(runtime.bot)
+
+    job.do(_runner)
+
+
+__all__ = [
+    "ResetReminder",
+    "ResetReminderView",
+    "process_reset_reminders",
+    "register_persistent_reset_views",
+    "schedule_reset_reminder_jobs",
+]

--- a/modules/community/reset_reminders/views.py
+++ b/modules/community/reset_reminders/views.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+
+log = logging.getLogger("c1c.community.reset_reminders.views")
+
+
+class ResetReminderView(discord.ui.View):
+    def __init__(self, role_id: int, label_opt_in: str, label_opt_out: str):
+        super().__init__(timeout=None)
+        self.role_id = role_id
+
+        self.add_item(
+            _ResetReminderButton(
+                role_id=role_id,
+                action="in",
+                label=label_opt_in,
+            )
+        )
+        self.add_item(
+            _ResetReminderButton(
+                role_id=role_id,
+                action="out",
+                label=label_opt_out,
+            )
+        )
+
+
+class _ResetReminderButton(discord.ui.Button[ResetReminderView]):
+    def __init__(self, *, role_id: int, action: str, label: str) -> None:
+        custom_id = f"reset_reminder:{role_id}:{action}"
+        style = discord.ButtonStyle.success if action == "in" else discord.ButtonStyle.secondary
+        super().__init__(label=label, style=style, custom_id=custom_id)
+        self.role_id = role_id
+        self.action = action
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        member = interaction.user if isinstance(interaction.user, discord.Member) else None
+        guild = interaction.guild
+        if guild is None or member is None:
+            await _reply(interaction, "This button only works inside the server.")
+            return
+
+        role = guild.get_role(self.role_id)
+        if role is None:
+            log.warning(
+                "reset reminder role missing",
+                extra={"role_id": self.role_id, "guild_id": guild.id, "action": self.action},
+            )
+            await _reply(interaction, "That reminder role is missing. Please contact staff.")
+            return
+
+        try:
+            if self.action == "in":
+                await member.add_roles(role, reason="reset reminder opt-in")
+                await _reply(interaction, f"You are now subscribed to {role.mention} reminders.")
+                return
+
+            await member.remove_roles(role, reason="reset reminder opt-out")
+            await _reply(interaction, f"You are no longer subscribed to {role.mention} reminders.")
+        except discord.Forbidden:
+            log.exception(
+                "reset reminder role update forbidden",
+                extra={"role_id": self.role_id, "guild_id": guild.id, "user_id": member.id, "action": self.action},
+            )
+            await _reply(interaction, "I do not have permission to update that role.")
+        except Exception:
+            log.exception(
+                "reset reminder role update failed",
+                extra={"role_id": self.role_id, "guild_id": guild.id, "user_id": member.id, "action": self.action},
+            )
+            await _reply(interaction, "Something went wrong while updating your reminder role.")
+
+
+async def _reply(interaction: discord.Interaction, message: str) -> None:
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+        return
+    await interaction.response.send_message(message, ephemeral=True)
+
+
+__all__ = ["ResetReminderView"]

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
 from modules.community.shard_tracker.views import register_persistent_shard_views
+from modules.community.reset_reminders.scheduler import register_persistent_reset_views
 from modules.onboarding import watcher_promo, watcher_welcome
 from modules.onboarding.ui import panels
 
@@ -35,6 +36,12 @@ async def on_ready(bot: commands.Bot) -> None:
             register_persistent_shard_views(bot)
         except Exception:
             log.exception("CORE_READY FAILURE: register_persistent_shard_views")
+            return
+
+        try:
+            await register_persistent_reset_views(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: register_persistent_reset_views")
             return
 
         # Ensure both onboarding watchers are wired

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -1,0 +1,121 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+from modules.community.reset_reminders import scheduler
+
+
+class _FakeJob:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self._runner = None
+
+    def do(self, runner):
+        self._runner = runner
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.jobs = []
+
+    def every(self, **kwargs):
+        job = _FakeJob(name=kwargs.get("name", ""))
+        self.jobs.append(job)
+        return job
+
+
+class _DummyMessage:
+    def __init__(self, message_id: int) -> None:
+        self.id = message_id
+        self.deleted = False
+
+    async def delete(self) -> None:
+        self.deleted = True
+
+
+class _DummyChannel:
+    def __init__(self) -> None:
+        self.last_message = _DummyMessage(111)
+        self.sent = []
+
+    async def fetch_message(self, message_id: int):
+        assert message_id == 111
+        return self.last_message
+
+    async def send(self, *, content=None, embed=None, view=None):
+        self.sent.append({"content": content, "embed": embed, "view": view})
+        return _DummyMessage(222)
+
+
+class _DummyBot:
+    def __init__(self, channel) -> None:
+        self._channel = channel
+
+    def is_closed(self) -> bool:
+        return False
+
+    def is_ready(self) -> bool:
+        return True
+
+    def get_channel(self, channel_id: int):
+        assert channel_id == 123
+        return self._channel
+
+
+def test_schedule_reset_jobs_is_idempotent() -> None:
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+
+    scheduler.schedule_reset_reminder_jobs(runtime)
+    scheduler.schedule_reset_reminder_jobs(runtime)
+
+    assert len(runtime.scheduler.jobs) == 1
+    assert runtime.scheduler.jobs[0].name == "reset_reminders"
+
+
+def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> None:
+    now = dt.datetime(2026, 5, 22, 23, 30, tzinfo=dt.timezone.utc)
+    reminder = scheduler.ResetReminder(
+        reset_id="doom_tower",
+        label="Doom Tower",
+        status="active",
+        reference_date_utc=dt.datetime(2026, 3, 24, 0, 0, tzinfo=dt.timezone.utc),
+        cycle_days=30,
+        lead_minutes=60,
+        role_id=999,
+        channel_id=123,
+        thread_id=None,
+        embed_title="",
+        embed_description="Reset incoming",
+        embed_footer="footer",
+        button_label_opt_in="Opt in",
+        button_label_opt_out="Opt out",
+        last_sent_for_reset_utc=None,
+        last_message_id=111,
+    )
+    record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    updates = []
+
+    async def _load(*, active_only: bool):
+        return "ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record]
+
+    async def _update(**kwargs):
+        updates.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
+    monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+
+    channel = _DummyChannel()
+
+    async def _resolve_target(_bot, _reminder):
+        return channel
+
+    monkeypatch.setattr(scheduler, "_resolve_target_channel", _resolve_target)
+    bot = _DummyBot(channel)
+
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+
+    assert channel.last_message.deleted is True
+    assert len(channel.sent) == 1
+    assert channel.sent[0]["content"] == "<@&999>"
+    assert len(updates) == 1
+    assert updates[0]["row_number"] == 7

--- a/tests/coreops/test_ready.py
+++ b/tests/coreops/test_ready.py
@@ -10,11 +10,14 @@ def test_on_ready_registers_fusion_persistent_view(monkeypatch):
         bot = SimpleNamespace(logger=None)
         monkeypatch.setattr(ready.panels, "register_views", Mock())
         monkeypatch.setattr(ready, "register_persistent_fusion_views", Mock())
+        monkeypatch.setattr(ready, "register_persistent_shard_views", Mock())
         monkeypatch.setattr(ready.watcher_welcome, "setup", AsyncMock())
+        monkeypatch.setattr(ready, "register_persistent_reset_views", AsyncMock())
         monkeypatch.setattr(ready.watcher_promo, "setup", AsyncMock())
 
         await ready.on_ready(bot)
 
         ready.register_persistent_fusion_views.assert_called_once_with(bot)
+        ready.register_persistent_reset_views.assert_awaited_once_with(bot)
 
     asyncio.run(_run())

--- a/tests/shared/test_runtime_startup_retry.py
+++ b/tests/shared/test_runtime_startup_retry.py
@@ -70,6 +70,9 @@ def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "modules.community.fusion.scheduler.schedule_fusion_jobs", lambda _runtime: None
     )
+    monkeypatch.setattr(
+        "modules.community.reset_reminders.scheduler.schedule_reset_reminder_jobs", lambda _runtime: None
+    )
 
 
 def test_runtime_startup_retry_rebuilds_bot_per_attempt(


### PR DESCRIPTION
### Motivation
- Automate cycle-based reset reminders (Cursed City / Doom Tower) driven from the milestones sheet so staff don't need to post reminders manually.
- Ensure reminders follow existing contracts: no hardcoded tab/column names, use sheet-config + header mapping, persistent views for buttons, embeds for messages, and safe scheduler integration.

### Description
- Add new package `modules/community/reset_reminders/` with `models.py`, `views.py`, `scheduler.py`, and `__init__.py` implementing the `ResetReminder` model, `ResetReminderView` persistent opt-in/opt-out button UI, and the scheduler loop that loads active rows and sends cycle reminders.
- Scheduler resolves tab via config key `RESET_REMINDER_TAB`, maps columns from the sheet header (no index hardcoding), computes `next_reset`/`trigger_time`, deletes prior reminder message when present, sends mention + embed + `ResetReminderView`, and updates `last_sent_for_reset_utc` and `last_message_id` back to the sheet.
- Register persistent views at startup by wiring `register_persistent_reset_views` into `modules/coreops/ready.on_ready` so buttons remain active across restarts, and register scheduled job by adding `schedule_reset_reminder_jobs` to runtime scheduler registration.
- Add tests: `tests/community/test_reset_reminder_scheduler.py` for scheduler behavior and idempotency, and update `tests/coreops/test_ready.py` and startup mocks to cover persistent view wiring and scheduler registration.
- New config requirement: add `RESET_REMINDER_TAB` in the milestones config to point to the tab containing the reset rows; no gateway intents, OAuth scopes, or role permission scope changes were made.

### Testing
- Ran `pytest -q tests/community/test_reset_reminder_scheduler.py` and the test passed.
- Ran `pytest -q tests/coreops/test_ready.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea831d82908323bcac890869bea773)