### PR TITLE
Add emoji image attachment support to shard weekly reminders

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import io
 from datetime import datetime, time, timedelta, timezone
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Dict, Iterable, Literal, Optional
 
@@ -129,6 +131,7 @@ _SKIP_MISSING_TEMPLATE = "missing template field"
 _SKIP_ALREADY_SENT = "already sent/dedupe"
 _SKIP_DESTINATION_NOT_FOUND = "destination not found"
 _SKIP_PERMISSION_FAILURE = "permission failure"
+_CUSTOM_EMOJI_MARKUP_RE = re.compile(r"^<(?P<animated>a?):(?P<name>[A-Za-z0-9_~]+):(?P<id>\d+)>$")
 
 
 @dataclass(slots=True)
@@ -1302,13 +1305,25 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             log.info("shard reminder row eligible", extra={"clan_key": clan.clan_key, "window_key": window_key})
             embed = self._build_clan_reminder_embed(clan=clan, guild=getattr(destination, "guild", None))
             mention = f"<@&{clan.opt_in_role_id}>"
+            emoji_file = await self._build_reminder_emoji_file(
+                guild=getattr(destination, "guild", None),
+                emoji_token=clan.emoji_name_or_id,
+                clan_key=clan.clan_key,
+            )
+            send_kwargs = {
+                "content": mention,
+                "embed": embed,
+                "view": ShardReminderOptView(),
+            }
+            if emoji_file is not None:
+                send_kwargs["files"] = [emoji_file]
             stats.send_attempted += 1
             log.info(
                 "shard reminder send attempt started",
                 extra={"clan_key": clan.clan_key, "window_key": window_key, "source": source},
             )
             try:
-                message = await destination.send(content=mention, embed=embed, view=ShardReminderOptView())
+                message = await destination.send(**send_kwargs)
                 await self.store.mark_weekly_reminder_sent(
                     clan_key=clan.clan_key, window_key=window_key, sent_at=reference
                 )
@@ -1380,6 +1395,72 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             return str(emoji.url) if emoji else None
         emoji = guild.get_emoji(emoji_id)
         return str(emoji.url) if emoji else None
+
+    async def _build_reminder_emoji_file(
+        self,
+        *,
+        guild: discord.Guild | None,
+        emoji_token: str,
+        clan_key: str,
+    ) -> discord.File | None:
+        token = str(emoji_token or "").strip()
+        if not token:
+            return None
+        emoji = self._resolve_reminder_emoji(guild, token)
+        if emoji is None:
+            log.warning("shard reminder emoji unresolved", extra={"clan_key": clan_key})
+            return None
+        try:
+            raw = await emoji.read()
+        except Exception:
+            log.warning("shard reminder emoji download failed", extra={"clan_key": clan_key})
+            return None
+        extension = "gif" if bool(getattr(emoji, "animated", False)) else "png"
+        filename = f"shard_reminder_emoji.{extension}"
+        file = discord.File(io.BytesIO(raw), filename=filename)
+        log.info(
+            "shard reminder emoji attachment resolved",
+            extra={"clan_key": clan_key, "emoji_id": getattr(emoji, "id", None), "filename": filename},
+        )
+        return file
+
+    def _resolve_reminder_emoji(
+        self,
+        guild: discord.Guild | None,
+        token: str,
+    ) -> discord.Emoji | None:
+        markup = _CUSTOM_EMOJI_MARKUP_RE.match(token)
+        emoji_id: int | None = None
+        emoji_name: str | None = None
+        if markup:
+            emoji_id = int(markup.group("id"))
+            emoji_name = markup.group("name")
+        elif token.isdigit():
+            emoji_id = int(token)
+        else:
+            emoji_name = token
+
+        if emoji_id is not None:
+            if guild is not None:
+                emoji = guild.get_emoji(emoji_id)
+                if emoji is not None:
+                    return emoji
+            get_emoji = getattr(self.bot, "get_emoji", None)
+            if callable(get_emoji):
+                emoji = get_emoji(emoji_id)
+                if emoji is not None:
+                    return emoji
+
+        if emoji_name:
+            if guild is not None:
+                emoji = emoji_pipeline.emoji_for_tag(guild, emoji_name)
+                if emoji is not None:
+                    return emoji
+            bot_emojis = getattr(self.bot, "emojis", ())
+            for emoji in bot_emojis:
+                if getattr(emoji, "name", "") == emoji_name:
+                    return emoji
+        return None
 
     def _build_display(self, record: ShardRecord, kind: ShardKind) -> ShardDisplay:
         owned = max(0, getattr(record, kind.stash_field, 0))

--- a/tests/community/shard_tracker/test_reminders.py
+++ b/tests/community/shard_tracker/test_reminders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -14,16 +15,18 @@ from modules.community.shard_tracker.data import ShardClanRow
 
 
 class _Destination:
-    def __init__(self) -> None:
-        self.guild = None
+    def __init__(self, guild=None) -> None:
+        self.guild = guild
         self.sent = 0
+        self.last_kwargs = None
 
     async def send(self, **kwargs):
         self.sent += 1
+        self.last_kwargs = kwargs
         return SimpleNamespace(id=555)
 
 
-def _clan(*, reminder_time_utc: str = "08:00") -> ShardClanRow:
+def _clan(*, reminder_time_utc: str = "08:00", emoji_name_or_id: str = "") -> ShardClanRow:
     return ShardClanRow(
         clan_key="alpha",
         enabled=True,
@@ -37,8 +40,27 @@ def _clan(*, reminder_time_utc: str = "08:00") -> ShardClanRow:
         body="Body",
         footer="Footer",
         color_hex="#112233",
-        emoji_name_or_id="",
+        emoji_name_or_id=emoji_name_or_id,
     )
+
+
+class _FakeEmoji:
+    def __init__(self, *, emoji_id: int, name: str, animated: bool = False) -> None:
+        self.id = emoji_id
+        self.name = name
+        self.animated = animated
+
+    async def read(self) -> bytes:
+        return b"emoji-bytes"
+
+
+class _FakeGuild:
+    def __init__(self, emojis: list[_FakeEmoji]) -> None:
+        self.emojis = emojis
+        self._by_id = {emoji.id: emoji for emoji in emojis}
+
+    def get_emoji(self, emoji_id: int):
+        return self._by_id.get(emoji_id)
 
 
 def test_weekly_reminder_skips_outside_window() -> None:
@@ -60,6 +82,92 @@ def test_weekly_reminder_skips_outside_window() -> None:
         assert stats.eligible == 0
         assert stats.sent == 0
         assert stats.skip_reasons.get(_SKIP_NOT_IN_TIME_WINDOW) == 1
+
+    asyncio.run(runner())
+
+
+def test_weekly_reminder_blank_emoji_sends_without_file() -> None:
+    async def runner() -> None:
+        destination = _Destination()
+        bot = SimpleNamespace(get_channel=lambda _id: destination)
+        cog = ShardTracker(bot)
+        cog._notify_admins = AsyncMock()
+        cog._resolve_share_destination = lambda _clan: (destination, None)
+        cog.store.get_clans = AsyncMock(return_value=[_clan(reminder_time_utc="08:00")])
+        cog.store.get_sent_weekly_reminder_keys = AsyncMock(return_value=set())
+        cog.store.mark_weekly_reminder_sent = AsyncMock()
+
+        stats = await cog.process_weekly_clan_reminders(
+            now=datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc),
+            force_window=True,
+            source="test",
+        )
+
+        assert stats.sent == 1
+        assert destination.last_kwargs is not None
+        assert "files" not in destination.last_kwargs
+
+    asyncio.run(runner())
+
+
+def test_weekly_reminder_invalid_emoji_warns_and_sends_without_file(caplog) -> None:
+    async def runner() -> None:
+        destination = _Destination()
+        bot = SimpleNamespace(get_channel=lambda _id: destination, get_emoji=lambda _id: None, emojis=[])
+        cog = ShardTracker(bot)
+        cog._notify_admins = AsyncMock()
+        cog._resolve_share_destination = lambda _clan: (destination, None)
+        clan = _clan(reminder_time_utc="08:00", emoji_name_or_id="missing_emoji")
+        cog.store.get_clans = AsyncMock(return_value=[clan])
+        cog.store.get_sent_weekly_reminder_keys = AsyncMock(return_value=set())
+        cog.store.mark_weekly_reminder_sent = AsyncMock()
+
+        with caplog.at_level(logging.WARNING, logger="c1c.shards.cog"):
+            stats = await cog.process_weekly_clan_reminders(
+                now=datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc),
+                force_window=True,
+                source="test",
+            )
+
+        assert stats.sent == 1
+        assert destination.last_kwargs is not None
+        assert "files" not in destination.last_kwargs
+        assert "shard reminder emoji unresolved" in caplog.text
+        assert any(getattr(record, "clan_key", None) == "alpha" for record in caplog.records)
+
+    asyncio.run(runner())
+
+
+def test_weekly_reminder_valid_emoji_adds_file_attachment() -> None:
+    async def runner() -> None:
+        emoji = _FakeEmoji(emoji_id=123456789012345678, name="shardanim", animated=True)
+        guild = _FakeGuild([emoji])
+        destination = _Destination(guild=guild)
+        destination.guild = guild
+        bot = SimpleNamespace(
+            get_channel=lambda _id: destination,
+            get_emoji=lambda emoji_id: guild.get_emoji(emoji_id),
+            emojis=[emoji],
+        )
+        cog = ShardTracker(bot)
+        cog._notify_admins = AsyncMock()
+        cog._resolve_share_destination = lambda _clan: (destination, None)
+        clan = _clan(reminder_time_utc="08:00", emoji_name_or_id="<a:shardanim:123456789012345678>")
+        cog.store.get_clans = AsyncMock(return_value=[clan])
+        cog.store.get_sent_weekly_reminder_keys = AsyncMock(return_value=set())
+        cog.store.mark_weekly_reminder_sent = AsyncMock()
+
+        stats = await cog.process_weekly_clan_reminders(
+            now=datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc),
+            force_window=True,
+            source="test",
+        )
+
+        assert stats.sent == 1
+        assert destination.last_kwargs is not None
+        files = destination.last_kwargs.get("files")
+        assert files and len(files) == 1
+        assert files[0].filename == "shard_reminder_emoji.gif"
 
     asyncio.run(runner())
 


### PR DESCRIPTION
### Motivation
- Align shard weekly reminders with the reminder audit requirement to optionally include an emoji image attachment above the embed while keeping role pings and embed content unchanged.
- Ensure failures to resolve or download configured emoji do not fail sending reminders and produce concise warnings with `clan_key` for observability.

### Description
- Added scoped helper `_build_reminder_emoji_file` and `_resolve_reminder_emoji` in `modules/community/shard_tracker/cog.py` to resolve `EmojiNameOrId`, download image bytes, and produce a `discord.File` (`shard_reminder_emoji.gif` for animated or `shard_reminder_emoji.png` for static). 
- Updated `process_weekly_clan_reminders` to construct `send_kwargs` with `content` (role ping), `embed`, `view`, and conditionally `files=[emoji_file]` so the emoji image is sent as a message attachment above the embed (embed title/body/footer unchanged). 
- Resolution supports the following `EmojiNameOrId` forms: `<:name:id>`, `<a:name:id>`, raw ID like `123456789012345678`, and emoji name lookup via guild or bot emoji collections. 
- Added concise logs to `c1c.shards.cog`: an info when attachment is resolved (includes `clan_key`) and a warning when a populated token cannot be resolved or downloaded (includes `clan_key`), while keeping the send non-fatal.
- Files changed: `modules/community/shard_tracker/cog.py` and `tests/community/shard_tracker/test_reminders.py`.

### Testing
- Ran `pytest -q tests/community/shard_tracker/test_reminders.py` which includes tests for blank `EmojiNameOrId` (sends without file), invalid `EmojiNameOrId` (logs warning and sends without file), and valid emoji (attaches `shard_reminder_emoji.gif`); the test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4c6171088323aada4220af78c1b5)