### PR TITLE
Avoid LogRecord key collision in shard reminder emoji logging

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -1420,7 +1420,11 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         file = discord.File(io.BytesIO(raw), filename=filename)
         log.info(
             "shard reminder emoji attachment resolved",
-            extra={"clan_key": clan_key, "emoji_id": getattr(emoji, "id", None), "filename": filename},
+            extra={
+                "clan_key": clan_key,
+                "emoji_id": getattr(emoji, "id", None),
+                "emoji_attachment_filename": filename,
+            },
         )
         return file
 


### PR DESCRIPTION
### Motivation
- A `KeyError: "Attempt to overwrite 'filename' in LogRecord"` was occurring when sending shard reminders because the `extra` payload used the reserved `LogRecord` key `filename`; the log must remain but use a safe key name so reminders don't crash.

### Description
- Renamed the logging extra key `filename` to `emoji_attachment_filename` in `modules/community/shard_tracker/cog.py` while leaving the emoji attachment creation and send behavior unchanged.

### Testing
- Ran `pytest tests/community/shard_tracker/test_reminders.py -q` and the test suite for that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb58a42ff08323a06a0673dca141fb)