### PR TITLE
Revert runtime/config/logging changes from c166c17 (restore 915a2a7 behavior)

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,13 +81,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return default
 
 
-def _should_log_message_content() -> bool:
-    """Safely gate message content logging.
-
-    Default is secure: content is *not* logged unless explicitly enabled.
-    """
-
-    return _env_bool("LOG_MESSAGE_CONTENT", False)
+LOG_MESSAGE_CONTENT = _env_bool("LOG_MESSAGE_CONTENT", False)
 
 
 def _truncate_text(text: str, max_len: int = LOG_MESSAGE_CONTENT_MAX_LEN) -> str:
@@ -383,7 +377,7 @@ async def on_message(message: discord.Message):
         len(content),
         attachments_count,
     )
-    if _should_log_message_content():
+    if LOG_MESSAGE_CONTENT:
         safe_content = _safe_logged_message_content(content)
         log.info(
             "seen msg: guild=%s chan=%s msg=%s author=%s content_len=%s attachments=%s content=%r",

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import math
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -68,16 +67,11 @@ def _sheet_id() -> str:
     return sheet_id
 
 
-def _tab_name() -> tuple[str, str]:
-    env_value = (os.getenv(_RESET_REMINDER_TAB_KEY) or "").strip()
-    if env_value:
-        return env_value, f"env:{_RESET_REMINDER_TAB_KEY}"
-    cfg_value = str(cfg.get(_RESET_REMINDER_TAB_KEY) or "").strip()
-    if cfg_value:
-        return cfg_value, f"config:{_RESET_REMINDER_TAB_KEY}"
-    raise RuntimeError(
-        f"{_RESET_REMINDER_TAB_KEY} missing; set via env or milestones Config tab"
-    )
+def _tab_name() -> str:
+    tab_name = str(cfg.get(_RESET_REMINDER_TAB_KEY) or "").strip()
+    if not tab_name:
+        raise RuntimeError(f"{_RESET_REMINDER_TAB_KEY} missing in milestones Config tab")
+    return tab_name
 
 
 def _cell(row: list[Any], index: int) -> str:
@@ -120,24 +114,22 @@ def _parse_optional_int(value: object) -> int | None:
     return int(text)
 
 
-def _resolve_header_map(header: list[Any], *, tab_name: str) -> dict[str, int]:
+def _resolve_header_map(header: list[Any]) -> dict[str, int]:
     normalized = [_normalize(cell) for cell in header]
     indices = {name: idx for idx, name in enumerate(normalized) if name}
     missing = [column for column in _REQUIRED_COLUMNS if column not in indices]
     if missing:
-        raise RuntimeError(
-            f"Reset reminder tab '{tab_name}' missing required columns: {missing}"
-        )
+        raise RuntimeError(f"Reset reminder tab missing required columns: {missing}")
     return indices
 
 
 async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord]]:
-    tab_name, tab_source = _tab_name()
+    tab_name = _tab_name()
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return tab_name, {}, []
 
-    header_map = _resolve_header_map(matrix[0], tab_name=tab_name)
+    header_map = _resolve_header_map(matrix[0])
     records: list[_ResetReminderRecord] = []
 
     for row_number, row in enumerate(matrix[1:], start=2):
@@ -173,15 +165,6 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
             log.exception("invalid reset reminder row skipped", extra={"tab": tab_name, "row_number": row_number})
             continue
 
-    log.debug(
-        "loaded reset reminder rows",
-        extra={
-            "tab_name": tab_name,
-            "tab_source": tab_source,
-            "row_count": len(records),
-            "active_only": active_only,
-        },
-    )
     return tab_name, header_map, records
 
 
@@ -271,15 +254,7 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
     try:
         tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
     except Exception:
-        log.error(
-            "failed to load reset reminders",
-            exc_info=True,
-            extra={
-                "sheet_id": _sheet_id(),
-                "reset_tab_env": (os.getenv(_RESET_REMINDER_TAB_KEY) or "").strip() or "unset",
-                "reset_tab_cfg": str(cfg.get(_RESET_REMINDER_TAB_KEY) or "").strip() or "unset",
-            },
-        )
+        log.exception("failed to load reset reminders")
         return
 
     if not records:

--- a/modules/housekeeping/mirralith_overview.py
+++ b/modules/housekeeping/mirralith_overview.py
@@ -13,33 +13,11 @@ import discord
 from PIL import Image, ImageDraw, ImageFont
 
 from modules.common import runtime as runtime_helpers
-from shared.config import get_config_snapshot
 from shared.sheets import core as sheets_core
 from shared.sheets import recruitment
 from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
 
 log = logging.getLogger("c1c.housekeeping.mirralith")
-
-
-def _resolve_mirralith_channel_id() -> tuple[int | None, str, str]:
-    raw_env = (os.getenv("MIRRALITH_CHANNEL_ID") or "").strip()
-    if raw_env:
-        return _parse_channel_id(raw_env), "env:MIRRALITH_CHANNEL_ID", raw_env
-
-    snapshot = get_config_snapshot()
-    raw_cfg = str(snapshot.get("MIRRALITH_CHANNEL_ID") or "").strip()
-    if raw_cfg:
-        return _parse_channel_id(raw_cfg), "config:MIRRALITH_CHANNEL_ID", raw_cfg
-
-    return None, "unset", "unset"
-
-
-def _parse_channel_id(raw: str) -> int | None:
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return None
-    return value if value > 0 else None
 
 
 @dataclass(frozen=True)
@@ -246,17 +224,15 @@ async def upsert_labeled_message(
 async def run_mirralith_overview_job(bot: discord.Client, trigger: str = "scheduled") -> None:
     log.info("Running Mirralith overview job (trigger=%s)", trigger)
 
-    channel_id, channel_id_source, raw_channel_id = _resolve_mirralith_channel_id()
+    raw_channel_id = os.getenv("MIRRALITH_CHANNEL_ID")
+    try:
+        channel_id = int(raw_channel_id) if raw_channel_id is not None else None
+    except (TypeError, ValueError):
+        log.warning("Mirralith overview channel ID invalid; aborting")
+        return
+
     if not channel_id:
-        reason = "invalid" if raw_channel_id not in {"", "unset"} else "missing"
-        log.warning(
-            "Mirralith overview channel ID %s; aborting",
-            reason,
-            extra={
-                "channel_id_source": channel_id_source,
-                "channel_id_raw": raw_channel_id or "unset",
-            },
-        )
+        log.warning("Mirralith overview channel ID missing; aborting")
         return
 
     channel = bot.get_channel(channel_id)

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -4655,18 +4655,6 @@ class CoreOpsCog(commands.Cog):
             normalized = _normalize_snapshot_value(raw_value)
             display_value = str(redact_value(key, normalized))
             entries[key] = _EnvEntry(key=key, normalized=normalized, display=display_value)
-
-        # Backward-compatible alias for legacy env surfaces; fail-soft when absent.
-        if "WATCHDOG_MAX_DISCONNECT_SEC" not in entries:
-            legacy_key = "WATCHDOG_MAX_DISCONNECT_SEC"
-            alias_value = os.getenv(legacy_key)
-            if alias_value is None:
-                alias_value = snapshot.get("WATCHDOG_DISCONNECT_GRACE_SEC")
-            normalized = _normalize_snapshot_value(alias_value)
-            display_value = str(redact_value(legacy_key, normalized))
-            entries[legacy_key] = _EnvEntry(
-                key=legacy_key, normalized=normalized, display=display_value
-            )
         return entries
 
     def _format_key_block(
@@ -4875,7 +4863,6 @@ class CoreOpsCog(commands.Cog):
             "WATCHDOG_CHECK_SEC",
             "WATCHDOG_STALL_SEC",
             "WATCHDOG_DISCONNECT_GRACE_SEC",
-            "WATCHDOG_MAX_DISCONNECT_SEC",
             "TIMEZONE",
             "PORT",
             "LOG_LEVEL",


### PR DESCRIPTION
### Motivation
- Roll back runtime and startup regressions introduced after known-good `915a2a7` by removing the merged diffs from `c166c17`/`72caedd` while preserving commit history. 
- Ensure main branch returns to the pre-change runtime/config/logging behavior without adding new fixes.
- Keep unrelated files intact unless they were touched by the reverted commits.
- No intents, OAuth scopes, permissions, access lists, or sheet IDs were changed by this revert.

### Description
- Reverted the merge commit `c166c17` with `git revert -m 1 c166c17`, which effectively removed the diffs introduced by `72caedd` while preserving history. 
- Restored message-content logging gating in `app.py` to the prior behavior using the `LOG_MESSAGE_CONTENT` boolean and corresponding logging branches. 
- Restored reset-reminder tab lookup/validation behavior in `modules/community/reset_reminders/scheduler.py` to use the milestones Config tab name (and original header mapping signature and error phrasing). 
- Restored Mirralith overview channel lookup and related logging behavior in `modules/housekeeping/mirralith_overview.py` and reverted env-to-config/aliasing changes in `packages/c1c-coreops/src/c1c_coreops/cog.py`; the files changed by the revert are: `app.py`, `modules/community/reset_reminders/scheduler.py`, `modules/housekeeping/mirralith_overview.py`, and `packages/c1c-coreops/src/c1c_coreops/cog.py`.

### Testing
- Ran the full test suite with `pytest -q`; the test run executed but completed with multiple failing tests in areas including `community`, `onboarding`, `coreops`, and `modules` (failures were observed and reported in the test output). 
- Attempted a direct `git revert 72caedd` after the merge-revert which reported `nothing to commit`, confirming `72caedd`'s changes were already removed by reverting `c166c17`.
- No additional code fixes were added during this PR; the revert-only change preserves the repository history and aims to restore runtime/startup behavior back to the known-good state represented by `915a2a7`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c554561483238c111cbffa24908f)