### PR TITLE
Add resolve_message_target helper and improve role-map posting error handling

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 
 import discord
@@ -13,6 +12,7 @@ from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.help import build_coreops_footer
 from c1c_coreops.rbac import admin_only
 from modules.common import feature_flags, runtime as runtime_helpers
+from modules.common.discord_utils import resolve_message_target
 from modules.common.logs import channel_label
 from modules.ops import cluster_role_map, server_map
 from shared.config import get_who_we_are_channel_id
@@ -366,20 +366,36 @@ class AppAdmin(commands.Cog):
             return
 
         channel_id = get_who_we_are_channel_id()
-        target_channel, channel_error = await runtime_helpers.resolve_configured_text_channel(
-            self.bot,
-            channel_id=channel_id,
-            logger=log,
-            context="role map",
-        )
-        if channel_error:
+        try:
+            target_channel = await resolve_message_target(self.bot, channel_id)
+        except (TypeError, ValueError):
             await ctx.reply(
                 "I couldn’t determine where to post the role map. Please try again in a guild channel.",
                 mention_author=False,
             )
             await runtime_helpers.send_log_message(
                 f"📘 **Cluster role map** — cmd=whoweare • guild={guild_name} "
-                f"• status=error • reason={channel_error}"
+                "• status=error • reason=invalid_channel"
+            )
+            return
+        except PermissionError:
+            await ctx.reply(
+                "I couldn’t post the role map. Please check channel permissions and try again.",
+                mention_author=False,
+            )
+            await runtime_helpers.send_log_message(
+                f"📘 **Cluster role map** — cmd=whoweare • guild={guild_name} "
+                "• status=error • reason=forbidden_channel"
+            )
+            return
+        except RuntimeError as exc:
+            await ctx.reply(
+                "I couldn’t determine where to post the role map right now. Please try again shortly.",
+                mention_author=False,
+            )
+            await runtime_helpers.send_log_message(
+                f"📘 **Cluster role map** — cmd=whoweare • guild={guild_name} "
+                f"• status=error • reason={exc}"
             )
             return
 

--- a/modules/common/discord_utils.py
+++ b/modules/common/discord_utils.py
@@ -1,0 +1,41 @@
+"""Shared Discord channel/thread resolution helpers."""
+
+from __future__ import annotations
+
+import discord
+
+
+async def resolve_message_target(bot: discord.Client, target_id: int) -> discord.abc.Messageable:
+    """Resolve a configured message target from cache/API and ensure it can receive messages."""
+
+    target = bot.get_channel(target_id)
+    if target is None:
+        try:
+            target = await bot.fetch_channel(target_id)
+        except discord.NotFound as exc:
+            raise ValueError(f"target {target_id} was not found") from exc
+        except discord.Forbidden as exc:
+            raise PermissionError(f"missing permissions for target {target_id}") from exc
+        except discord.HTTPException as exc:
+            raise RuntimeError(f"failed to fetch target {target_id}: {exc}") from exc
+
+    if not isinstance(target, (discord.TextChannel, discord.Thread)):
+        raise TypeError(
+            f"target {target_id} is not a supported message target "
+            f"({type(target).__name__})"
+        )
+
+    if isinstance(target, discord.Thread) and target.archived:
+        try:
+            await target.edit(archived=False)
+        except discord.NotFound as exc:
+            raise ValueError(f"thread {target_id} was not found") from exc
+        except discord.Forbidden as exc:
+            raise PermissionError(f"missing permissions to unarchive thread {target_id}") from exc
+        except discord.HTTPException as exc:
+            raise RuntimeError(f"failed to unarchive thread {target_id}: {exc}") from exc
+
+    return target
+
+
+__all__ = ["resolve_message_target"]


### PR DESCRIPTION
### Motivation
- Centralize and standardize resolving configured Discord message targets and permissions for posting role maps.
- Ensure threads are unarchived when needed and provide clearer, actionable error handling when posting fails.
- Replace ad-hoc channel resolution logic with a reusable helper to reduce duplication and improve robustness.

### Description
- Add `modules/common/discord_utils.py` with `resolve_message_target(bot, target_id)` which fetches a channel, validates it is a `TextChannel` or `Thread`, and attempts to unarchive threads while converting API errors into specific exceptions.
- Update `cogs/app_admin.py` to use `resolve_message_target` when determining where to post the cluster role map and to handle the new `TypeError`, `ValueError`, `PermissionError`, and `RuntimeError` cases with distinct user replies and log messages.
- Remove the previous call to `runtime_helpers.resolve_configured_text_channel` and drop an unused `os` import in `cogs/app_admin.py`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3745a559c8323a80341f0756938e9)