### PR TITLE
Import os in app_admin to fix NameError in `!next`

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 
 import discord


### PR DESCRIPTION
### Motivation
- Prevent a runtime `NameError` when `!next` builds scheduler embeds because the module used `os.getenv(...)` but did not import `os`.

### Description
- Added `import os` to the top of `cogs/app_admin.py` without changing any logic or moving configuration handling.

Full updated import section for the file:

```python
from __future__ import annotations

import logging
import os
from datetime import datetime, timedelta, timezone

import discord
from discord.ext import commands

from c1c_coreops.helpers import help_metadata, tier
from c1c_coreops.help import build_coreops_footer
from c1c_coreops.rbac import admin_only
from modules.common import feature_flags, runtime as runtime_helpers
from modules.common.discord_utils import resolve_message_target
from modules.common.logs import channel_label
from modules.ops import cluster_role_map, server_map
from shared.config import get_who_we_are_channel_id
from shared.sheets import recruitment as recruitment_sheet
```

### Testing
- Ran `pytest -q tests/cogs/test_app_admin.py tests/housekeeping/test_next_command.py`; `tests/cogs/test_app_admin.py` passed and `tests/housekeeping/test_next_command.py` failed with an `AttributeError` referencing a stale helper name (`_build_scheduler_overview`), which is unrelated to this import fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f384c476a0832384ddeee854574aff)