### PR TITLE
Unify publish logic and add titan publish command

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -73,6 +73,104 @@ class FusionCog(commands.Cog):
             await ctx.reply(f"Couldn’t check the {tracker_label} right now. Try again in a moment.", mention_author=False)
             return
 
+    async def _publish_tracker(
+        self,
+        ctx: commands.Context,
+        *,
+        tracker_kind: str,
+        tracker_label: str,
+        prefer_draft: bool,
+    ) -> None:
+        try:
+            target = await fusion_sheets.get_publishable_fusion(
+                include_draft=True,
+                tracker_kind=tracker_kind,
+                prefer_draft=prefer_draft,
+            )
+        except Exception as exc:
+            log.exception("%s publish failed to load rows", tracker_label)
+            await fusion_logs.send_ops_alert(
+                component="command_publish",
+                summary=f"load_{tracker_label}_failed",
+                dedupe_key=f"fusion:command:publish:load_{tracker_label}",
+                error=exc,
+            )
+            await ctx.reply(f"Could not load {tracker_label} data right now.", mention_author=False)
+            return
+
+        if target is None:
+            await ctx.reply(
+                f"No {tracker_label} rows exist in the configured fusion sheet tab.",
+                mention_author=False,
+            )
+            return
+
+        missing_fields: list[str] = []
+        if target.announcement_channel_id is None:
+            missing_fields.append("announcement_channel_id")
+        if not target.fusion_name:
+            missing_fields.append("fusion_name")
+        if not target.champion:
+            missing_fields.append("champion")
+        if target.start_at_utc is None:
+            missing_fields.append("start_at_utc")
+        if target.end_at_utc is None:
+            missing_fields.append("end_at_utc")
+
+        if missing_fields:
+            await ctx.reply(
+                f"{tracker_label.title()} row is missing required fields: " + ", ".join(missing_fields),
+                mention_author=False,
+            )
+            return
+
+        channel = await resolve_announcement_channel(self.bot, target.announcement_channel_id)
+        if channel is None:
+            await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
+            return
+
+        resolution = await resolve_stored_announcement(self.bot, target)
+        if resolution.message is not None:
+            await ctx.reply(
+                f"This {tracker_label} already has an announcement post. Clear the message id or use a future republish flow.",
+                mention_author=False,
+            )
+            return
+        if resolution.had_reference and resolution.is_stale:
+            log.info(
+                "%s publish allowed despite stale announcement metadata",
+                tracker_label,
+                extra={
+                    "fusion_id": target.fusion_id,
+                    "status": target.status,
+                    "announcement_channel_id": target.announcement_channel_id,
+                    "announcement_message_id": target.announcement_message_id,
+                },
+            )
+
+        try:
+            announcement_message = await publish_fusion_announcement(self.bot, target)
+            if announcement_message is None:
+                await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
+                return
+        except Exception as exc:
+            log.exception("%s publish failed during announce send", tracker_label, extra={"fusion_id": target.fusion_id})
+            await fusion_logs.send_ops_alert(
+                component="command_publish",
+                summary="announce_send_failed",
+                dedupe_key=f"fusion:command:publish:send:{tracker_label}:{target.fusion_id}",
+                error=exc,
+                fields={"fusion_id": target.fusion_id, "tracker_kind": tracker_kind},
+            )
+            await ctx.reply("Failed to publish announcement right now.", mention_author=False)
+            return
+
+        destination = channel.mention if isinstance(channel, discord.abc.GuildChannel) else "configured channel"
+        await ctx.reply(
+            f"{tracker_label.title()} announcement published to {destination} for **{target.fusion_name}**.",
+            mention_author=False,
+        )
+
     @tier("user")
     @help_metadata(
         function_group="milestones",
@@ -95,7 +193,11 @@ class FusionCog(commands.Cog):
         access_tier="user",
         usage="!titan",
     )
-    @commands.command(name="titan", help="Titan reminder data commands.")
+    @commands.group(
+        name="titan",
+        invoke_without_command=True,
+        help="Titan reminder data commands.",
+    )
     async def titan(self, ctx: commands.Context) -> None:
         await self._tracker_entrypoint(ctx, tracker_kind="titan", tracker_label="titan")
 
@@ -171,88 +273,27 @@ class FusionCog(commands.Cog):
     @commands.guild_only()
     @admin_only()
     async def fusion_publish(self, ctx: commands.Context) -> None:
-        try:
-            target = await fusion_sheets.get_publishable_fusion(
-                include_draft=True,
-                tracker_kind="fusion",
-                prefer_draft=True,
-            )
-        except Exception as exc:
-            log.exception("fusion publish failed to load fusion rows")
-            await fusion_logs.send_ops_alert(
-                component="command_publish",
-                summary="load_fusion_failed",
-                dedupe_key="fusion:command:publish:load_fusion",
-                error=exc,
-            )
-            await ctx.reply("Could not load fusion data right now.", mention_author=False)
-            return
+        await self._publish_tracker(
+            ctx,
+            tracker_kind="fusion",
+            tracker_label="fusion",
+            prefer_draft=True,
+        )
 
-        if target is None:
-            await ctx.reply("No fusion rows exist in the configured fusion sheet tab.", mention_author=False)
-            return
-
-        missing_fields: list[str] = []
-        if target.announcement_channel_id is None:
-            missing_fields.append("announcement_channel_id")
-        if not target.fusion_name:
-            missing_fields.append("fusion_name")
-        if not target.champion:
-            missing_fields.append("champion")
-        if target.start_at_utc is None:
-            missing_fields.append("start_at_utc")
-        if target.end_at_utc is None:
-            missing_fields.append("end_at_utc")
-
-        if missing_fields:
-            await ctx.reply(
-                "Fusion row is missing required fields: " + ", ".join(missing_fields),
-                mention_author=False,
-            )
-            return
-
-        channel = await resolve_announcement_channel(self.bot, target.announcement_channel_id)
-        if channel is None:
-            await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
-            return
-
-        resolution = await resolve_stored_announcement(self.bot, target)
-        if resolution.message is not None:
-            await ctx.reply(
-                "This fusion already has an announcement post. Clear the message id or use a future republish flow.",
-                mention_author=False,
-            )
-            return
-        if resolution.had_reference and resolution.is_stale:
-            log.info(
-                "fusion publish allowed despite stale announcement metadata",
-                extra={
-                    "fusion_id": target.fusion_id,
-                    "status": target.status,
-                    "announcement_channel_id": target.announcement_channel_id,
-                    "announcement_message_id": target.announcement_message_id,
-                },
-            )
-
-        try:
-            announcement_message = await publish_fusion_announcement(self.bot, target)
-            if announcement_message is None:
-                await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
-                return
-        except Exception as exc:
-            log.exception("fusion publish failed during announce send", extra={"fusion_id": target.fusion_id})
-            await fusion_logs.send_ops_alert(
-                component="command_publish",
-                summary="announce_send_failed",
-                dedupe_key=f"fusion:command:publish:send:{target.fusion_id}",
-                error=exc,
-                fields={"fusion_id": target.fusion_id},
-            )
-            await ctx.reply("Failed to publish announcement right now.", mention_author=False)
-            return
-
-        destination = channel.mention if isinstance(channel, discord.abc.GuildChannel) else "configured channel"
-        await ctx.reply(
-            f"Fusion announcement published to {destination} for **{target.fusion_name}**.",
-            mention_author=False,
+    @tier("admin")
+    @help_metadata(
+        function_group="milestones",
+        section="community",
+        access_tier="admin",
+        usage="!titan publish",
+    )
+    @titan.command(name="publish", help="Publish titan announcement to the configured channel.")
+    @commands.guild_only()
+    @admin_only()
+    async def titan_publish(self, ctx: commands.Context) -> None:
+        await self._publish_tracker(
+            ctx,
+            tracker_kind="titan",
+            tracker_label="titan",
+            prefer_draft=True,
         )

--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -293,6 +293,42 @@ def test_fusion_publish_persists_announcement_channel_id(monkeypatch):
     asyncio.run(_run())
 
 
+def test_titan_publish_selects_titan_draft_and_creates_announcement(monkeypatch):
+    async def _run() -> None:
+        channel = FakeMessageable(123)
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=1003))
+        bot = SimpleNamespace(get_channel=lambda _channel_id: channel, fetch_channel=AsyncMock())
+        cog = FusionCog(bot)
+        ctx = SimpleNamespace(reply=AsyncMock())
+        captured_kwargs: dict[str, object] = {}
+
+        async def _fake_get_publishable(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _fusion_row(announcement_channel_id=123, announcement_message_id=None, status="draft")
+
+        update = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", _fake_get_publishable)
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+        monkeypatch.setattr(fusion_cog_module, "build_fusion_announcement_embed", lambda *_args: object())
+        monkeypatch.setattr(fusion_sheets, "update_fusion_publication", update)
+
+        await cog.titan_publish.callback(cog, ctx)
+
+        assert captured_kwargs == {
+            "include_draft": True,
+            "tracker_kind": "titan",
+            "prefer_draft": True,
+        }
+        channel.send.assert_awaited_once()
+        assert update.await_count == 1
+        ctx.reply.assert_awaited_once_with(
+            "Titan announcement published to configured channel for **Mavara**.",
+            mention_author=False,
+        )
+
+    asyncio.run(_run())
+
+
 def test_fusion_publish_blocks_duplicate_when_existing_message_resolves(monkeypatch):
     async def _run() -> None:
         channel = FakeMessageable(123)
@@ -457,3 +493,19 @@ def test_fusion_debug_event_failure_still_replies_when_internal_log_delivery_fai
         ctx.reply.assert_awaited_once_with("Fusion events are temporarily unavailable.", mention_author=False)
 
     asyncio.run(_run())
+
+
+def test_publish_commands_include_admin_gate_checks() -> None:
+    fusion_checks = [repr(check).lower() for check in FusionCog.fusion_publish.checks]
+    titan_checks = [repr(check).lower() for check in FusionCog.titan_publish.checks]
+
+    assert any("admin" in check for check in fusion_checks)
+    assert any("admin" in check for check in titan_checks)
+
+
+def test_summary_commands_do_not_include_admin_gate_checks() -> None:
+    fusion_checks = [repr(check).lower() for check in FusionCog.fusion.checks]
+    titan_checks = [repr(check).lower() for check in FusionCog.titan.checks]
+
+    assert not any("admin" in check for check in fusion_checks)
+    assert not any("admin" in check for check in titan_checks)


### PR DESCRIPTION
### Motivation
- Remove duplicated publish flow for different tracker kinds and enable reuse for `titan` in addition to `fusion`.
- Ensure both publish commands share the same validation, channel resolution, and error handling paths.
- Add coverage for the new titan publish flow and ensure admin gating is applied consistently.

### Description
- Introduce a new helper method `FusionCog._publish_tracker` that encapsulates the publish flow (load rows, validate fields, resolve channel, resolve stored announcement, send announcement, and report results).
- Refactor `fusion_publish` to call `self._publish_tracker(...)` instead of duplicating the publish logic.
- Convert `titan` from a `@commands.command` to a `@commands.group` and add `titan_publish` which also calls `self._publish_tracker(...)` with `tracker_kind="titan"`.
- Update tests in `tests/community/test_fusion_cog.py` to add `test_titan_publish_selects_titan_draft_and_creates_announcement`, `test_publish_commands_include_admin_gate_checks`, and `test_summary_commands_do_not_include_admin_gate_checks`, and adjust existing publish-related tests to the refactor.

### Testing
- Ran the community fusion cog unit tests in `tests/community/test_fusion_cog.py` (including the newly added titan publish and permission-check tests) via the project test suite; all tests passed.
- New tests `test_titan_publish_selects_titan_draft_and_creates_announcement`, `test_publish_commands_include_admin_gate_checks`, and `test_summary_commands_do_not_include_admin_gate_checks` executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38837bca083238fdabe85e5affe83)