### PR TITLE
Verify admin-only gating for fusion/titan publish commands

### DIFF
--- a/tests/community/test_fusion_cog.py
+++ b/tests/community/test_fusion_cog.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import discord
+from discord.ext import commands
 import modules.community.fusion.cog as fusion_cog_module
 from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.cog import FusionCog
@@ -503,6 +504,38 @@ def test_publish_commands_include_admin_gate_checks() -> None:
     assert any("admin" in check for check in titan_checks)
 
 
+
+
+def test_fusion_publish_denies_non_admin_users() -> None:
+    async def _run() -> None:
+        check = FusionCog.fusion_publish.checks[-1]
+        ctx = SimpleNamespace(guild=object(), author=object(), _coreops_suppress_denials=True)
+
+        try:
+            await check(ctx)
+        except commands.CheckFailure as exc:
+            assert "Admins only" in str(exc)
+            return
+
+        raise AssertionError("Expected CheckFailure for non-admin user")
+
+    asyncio.run(_run())
+
+
+def test_titan_publish_denies_non_admin_users() -> None:
+    async def _run() -> None:
+        check = FusionCog.titan_publish.checks[-1]
+        ctx = SimpleNamespace(guild=object(), author=object(), _coreops_suppress_denials=True)
+
+        try:
+            await check(ctx)
+        except commands.CheckFailure as exc:
+            assert "Admins only" in str(exc)
+            return
+
+        raise AssertionError("Expected CheckFailure for non-admin user")
+
+    asyncio.run(_run())
 def test_summary_commands_do_not_include_admin_gate_checks() -> None:
     fusion_checks = [repr(check).lower() for check in FusionCog.fusion.checks]
     titan_checks = [repr(check).lower() for check in FusionCog.titan.checks]


### PR DESCRIPTION
### Motivation
- Ensure `!fusion publish` and `!titan publish` remain admin-only so normal users cannot publish announcements and to guard against regressions in gating behavior.

### Description
- Verified `modules/community/fusion/cog.py` already protects `fusion_publish` and `titan_publish` with `@admin_only()` and marks them `@tier("admin")`, while `fusion` and `titan` entrypoints remain `@tier("user")`.
- Added two explicit tests to `tests/community/test_fusion_cog.py`: `test_fusion_publish_denies_non_admin_users` and `test_titan_publish_denies_non_admin_users`, which call the command checks and assert a `commands.CheckFailure` with the "Admins only" denial for non-admin contexts.

### Testing
- Ran `pytest -q tests/community/test_fusion_cog.py` and all tests in the file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38fca1e7883239879c5c042f59e8e)