### PR TITLE
Stagger startup sheet warmup and add 429 jitter backoff

### DIFF
--- a/shared/sheets/cache_scheduler.py
+++ b/shared/sheets/cache_scheduler.py
@@ -32,14 +32,14 @@ class _JobSpec:
 _SPEC_BY_BUCKET: Dict[str, _JobSpec] = {}
 _REGISTERED: Dict[str, Tuple[Any, asyncio.Task]] = {}
 
-STARTUP_BUCKETS: tuple[str, ...] = (
-    "clans",
-    "clan_tags",
-    "templates",
-    "onboarding_questions",
-    "reaction_roles",
-    "fusion",
-    "fusion_events",
+STARTUP_BUCKETS: tuple[tuple[str, float], ...] = (
+    ("clans", 0.0),
+    ("templates", 6.0),
+    ("clan_tags", 12.0),
+    ("onboarding_questions", 20.0),
+    ("reaction_roles", 28.0),
+    ("fusion", 40.0),
+    ("fusion_events", 52.0),
 )
 
 
@@ -279,8 +279,13 @@ async def preload_on_startup() -> None:
     """Synchronously refresh core cache buckets during startup."""
 
     ensure_cache_registration()
-    for name in STARTUP_BUCKETS:
+    last_delay = 0.0
+    for name, delay_sec in STARTUP_BUCKETS:
         bucket = _safe_bucket(name)
+        wait_sec = max(0.0, delay_sec - last_delay)
+        if wait_sec > 0:
+            await asyncio.sleep(wait_sec)
+        last_delay = max(last_delay, delay_sec)
         try:
             await cache.refresh_now(bucket, actor="startup")
         except asyncio.CancelledError:

--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import random
 from functools import lru_cache
 from typing import Any, Awaitable, Callable, Dict, Tuple, TypeVar
 
@@ -79,7 +80,7 @@ def _retry_with_backoff(
             last_exc = exc
             if attempt >= tries - 1:
                 raise
-            _sleep_with_new_loop(max(0.0, delay))
+            _sleep_with_new_loop(_next_backoff_delay(delay, multiplier=multiplier, jitter_ratio=0.25 if _is_rate_limited_error(exc) else 0.0))
             delay *= multiplier if multiplier > 1 else 1
     if last_exc is not None:  # pragma: no cover - defensive
         raise last_exc
@@ -113,11 +114,38 @@ async def _retry_with_backoff_async(
             last_exc = exc
             if attempt >= tries - 1:
                 raise
-            await asyncio.sleep(max(0.0, delay))
+            await asyncio.sleep(_next_backoff_delay(delay, multiplier=multiplier, jitter_ratio=0.25 if _is_rate_limited_error(exc) else 0.0))
             delay *= multiplier if multiplier > 1 else 1
     if last_exc is not None:  # pragma: no cover - defensive
         raise last_exc
     raise RuntimeError("_retry_with_backoff_async exhausted without executing")
+
+
+
+
+def _is_rate_limited_error(exc: Exception) -> bool:
+    """Best-effort detection for Google Sheets/API 429-style failures."""
+
+    status_code = getattr(exc, "status_code", None)
+    if status_code == 429:
+        return True
+    response = getattr(exc, "response", None)
+    if response is not None and getattr(response, "status_code", None) == 429:
+        return True
+    text = str(exc).upper()
+    return "429" in text or "RESOURCE_EXHAUSTED" in text or "READREQUESTSPERMINUTEPERUSER" in text
+
+
+def _next_backoff_delay(delay: float, *, multiplier: float, jitter_ratio: float = 0.25) -> float:
+    """Return exponential backoff delay with bounded jitter."""
+
+    capped = max(0.0, float(delay))
+    if capped <= 0:
+        return 0.0
+    jitter = capped * max(0.0, jitter_ratio)
+    low = max(0.0, capped - jitter)
+    high = capped + jitter
+    return random.uniform(low, high)
 
 
 def _sleep_with_new_loop(delay: float) -> None:


### PR DESCRIPTION
### Motivation
- Startup cache warmups were issuing several Google Sheets reads in a tight window, causing 429/RESOURCE_EXHAUSTED quota errors during frequent redeploys. 
- Reduce minute-level read bursts without removing caching or increasing poll frequency. 
- Make Sheets retry logic more resilient to 429s by applying exponential backoff with jitter.

### Description
- Stagger startup warmup by changing `STARTUP_BUCKETS` to a `(bucket, offset_seconds)` list and applying incremental sleeps in `preload_on_startup` so buckets are loaded at offsets instead of all at once. 
- Implemented a stagger plan (seconds): `clans:+0`, `templates:+6`, `clan_tags:+12`, `onboarding_questions:+20`, `reaction_roles:+28`, `fusion:+40`, `fusion_events:+52`. 
- Added rate-limit detection `_is_rate_limited_error` and `_next_backoff_delay` (with bounded jitter) to `shared/sheets/core.py`, and wired jittered exponential backoff into both `_retry_with_backoff` and `_retry_with_backoff_async`. 
- Preserved existing cache registration, caching behavior, and polling cadences; no caches removed and no polling frequency increases.

### Testing
- Compiled the modified modules with `python -m py_compile shared/sheets/core.py shared/sheets/cache_scheduler.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3908300348323bb23540ec11f4729)