### PR TITLE
Fix onboarding Sheets I/O to avoid blocking Discord event loop

### DIFF
--- a/modules/onboarding/sessions.py
+++ b/modules/onboarding/sessions.py
@@ -114,11 +114,36 @@ class Session:
         }
         sess_sheet.save(payload)
 
+    async def asave_to_sheet(self) -> None:
+        payload = {
+            "user_id": str(self.applicant_id),
+            "thread_id": str(self.thread_id),
+            "thread_name": self.thread_name or "",
+            "panel_message_id": int(self.panel_message_id or 0),
+            "step_index": int(self.step_index),
+            "answers": self.answers,
+            "completed": bool(self.completed),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "updated_at": _serialize_dt(self.updated_at),
+            "first_reminder_at": (self.first_reminder_at or self.empty_first_reminder_at).isoformat()
+            if (self.first_reminder_at or self.empty_first_reminder_at)
+            else None,
+            "warning_sent_at": (self.warning_sent_at or self.empty_warning_sent_at).isoformat()
+            if (self.warning_sent_at or self.empty_warning_sent_at)
+            else None,
+            "auto_closed_at": self.auto_closed_at.isoformat() if self.auto_closed_at else None,
+        }
+        await sess_sheet.asave(payload)
+
     @classmethod
     def load_from_sheet(cls, applicant_id: int, thread_id: int) -> Optional["Session"]:
         row = sess_sheet.load(int(applicant_id), int(thread_id))
         if not row:
             return None
+        return cls.from_sheet_row(applicant_id=applicant_id, thread_id=thread_id, row=row)
+
+    @classmethod
+    def from_sheet_row(cls, applicant_id: int, thread_id: int, row: Dict[str, Any]) -> "Session":
         panel_id = row.get("panel_message_id") or None
         session = cls(
             thread_id=int(thread_id),
@@ -210,6 +235,7 @@ async def ensure_session_for_thread(
     updated_at: datetime | None = None,
     thread_name: str | None = None,
     create_if_missing: bool = True,
+    preloaded_session_row: Dict[str, Any] | None = None,
 ) -> Session | None:
     """Load or create a session row for the given ``user_id`` and ``thread_id``.
 
@@ -226,7 +252,11 @@ async def ensure_session_for_thread(
 
     normalized_updated = _normalize_ts(updated_at)
     try:
-        existing = Session.load_from_sheet(int(user_id), int(thread_id))
+        if preloaded_session_row is not None:
+            existing = Session.from_sheet_row(user_id, thread_id, preloaded_session_row)
+        else:
+            row = await sess_sheet.aload(int(thread_id))
+            existing = Session.from_sheet_row(user_id, thread_id, row) if row else None
     except Exception:
         log.exception(
             "failed to load onboarding session", extra={"thread_id": thread_id, "user_id": user_id}
@@ -246,7 +276,7 @@ async def ensure_session_for_thread(
             updated = True
         if updated:
             try:
-                existing.save_to_sheet()
+                await existing.asave_to_sheet()
             except Exception:
                 log.exception(
                     "failed to persist onboarding session timestamp",
@@ -264,7 +294,7 @@ async def ensure_session_for_thread(
         updated_at=normalized_updated or utc_now(),
     )
     try:
-        session.save_to_sheet()
+        await session.asave_to_sheet()
     except Exception:
         log.exception(
             "failed to create onboarding session", extra={"thread_id": thread_id, "user_id": user_id}
@@ -273,4 +303,3 @@ async def ensure_session_for_thread(
 
 
 __all__ = ["Session", "SessionStore", "store", "utc_now", "ensure_session_for_thread"]
-

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -362,7 +362,7 @@ async def persist_session_for_thread(
             if session is not None and panel_message_id is not None:
                 session.panel_message_id = panel_message_id
                 try:
-                    session.save_to_sheet()
+                    await session.asave_to_sheet()
                 except Exception:
                     log.exception(
                         "failed to persist onboarding session panel id",
@@ -444,6 +444,13 @@ async def _scan_incomplete_threads(bot: commands.Bot) -> None:
 
     now = datetime.now(timezone.utc)
 
+    session_rows_by_thread_id: dict[int, dict[str, object]] = {}
+    try:
+        session_rows = await onboarding_sessions.aload_all(timeout=15.0)
+        session_rows_by_thread_id = onboarding_sessions.index_by_thread_id(session_rows)
+    except Exception:
+        log.exception("failed to load onboarding sessions for scan", exc_info=True)
+
     if feature_flags.is_enabled("welcome_dialog") and feature_flags.is_enabled("recruitment_welcome"):
         channel_id = get_welcome_channel_id()
         try:
@@ -454,7 +461,12 @@ async def _scan_incomplete_threads(bot: commands.Bot) -> None:
         if channel_int is not None:
             threads = await _collect_threads(bot, channel_int, scope_check=thread_scopes.is_welcome_parent)
             for thread in threads:
-                await _process_incomplete_thread(bot, thread, now)
+                await _process_incomplete_thread(
+                    bot,
+                    thread,
+                    now,
+                    session_row=session_rows_by_thread_id.get(int(getattr(thread, "id", 0))),
+                )
 
     if feature_flags.is_enabled("promo_enabled") and feature_flags.is_enabled("enable_promo_hook"):
         promo_channel = get_promo_channel_id()
@@ -466,7 +478,12 @@ async def _scan_incomplete_threads(bot: commands.Bot) -> None:
         if promo_channel_int is not None:
             threads = await _collect_threads(bot, promo_channel_int, scope_check=thread_scopes.is_promo_parent)
             for thread in threads:
-                await _process_promo_thread(bot, thread, now)
+                await _process_promo_thread(
+                    bot,
+                    thread,
+                    now,
+                    session_row=session_rows_by_thread_id.get(int(getattr(thread, "id", 0))),
+                )
 
 
 async def _collect_threads(
@@ -514,7 +531,7 @@ async def _resolve_target_user(thread: discord.Thread, parts: ThreadNameParts) -
     return target_id, parts.username
 
 
-def _persist_reminder_state(session: Session | None, *, action: str, timestamp: datetime) -> None:
+async def _persist_reminder_state(session: Session | None, *, action: str, timestamp: datetime) -> None:
     if session is None:
         return
 
@@ -533,7 +550,7 @@ def _persist_reminder_state(session: Session | None, *, action: str, timestamp: 
 
     session._touch(timestamp=timestamp)
     try:
-        session.save_to_sheet()
+        await session.asave_to_sheet()
     except Exception:
         log.exception(
             "failed to persist welcome reminder state",
@@ -610,7 +627,9 @@ async def _post_inactivity_log(
         log.debug("failed to post onboarding inactivity log", exc_info=True)
 
 
-async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, now: datetime) -> None:
+async def _process_incomplete_thread(
+    bot: commands.Bot, thread: discord.Thread, now: datetime, *, session_row: dict[str, object] | None = None
+) -> None:
     parsed = parse_welcome_thread_name(getattr(thread, "name", None))
     if parsed is None or parsed.state == "closed":
         return
@@ -627,6 +646,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
                 updated_at=created_at,
                 thread_name=getattr(thread, "name", ""),
                 create_if_missing=True,
+                preloaded_session_row=session_row, 
             )
         except Exception:
             log.exception(
@@ -682,7 +702,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_welcome_sheet_for_reminder(
                 phase="reminder_3h",
@@ -711,7 +731,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_welcome_sheet_for_reminder(
                 phase="reminder_3h",
@@ -742,7 +762,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_welcome_sheet_for_reminder(
                 phase="reminder_24h",
@@ -780,7 +800,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_welcome_sheet_for_reminder(
                 phase="reminder_24h",
@@ -810,7 +830,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
             "If you still need a clan later, you're welcome to open a new ticket."
         )
 
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         watcher = bot.get_cog("WelcomeTicketWatcher")
         if watcher is not None:
             context = await watcher._ensure_context(thread)
@@ -860,7 +880,7 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
             f"Please remove {mention} from the server."
         )
 
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         watcher = bot.get_cog("WelcomeTicketWatcher")
         if watcher is not None:
             context = await watcher._ensure_context(thread)
@@ -904,7 +924,9 @@ async def _process_incomplete_thread(bot: commands.Bot, thread: discord.Thread, 
         )
 
 
-async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: datetime) -> None:
+async def _process_promo_thread(
+    bot: commands.Bot, thread: discord.Thread, now: datetime, *, session_row: dict[str, object] | None = None
+) -> None:
     parsed = parse_promo_thread_name(getattr(thread, "name", None))
     if parsed is None:
         return
@@ -920,6 +942,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
                 updated_at=created_at,
                 thread_name=getattr(thread, "name", ""),
                 create_if_missing=False,
+                preloaded_session_row=session_row,
             )
         except Exception:
             log.exception(
@@ -961,7 +984,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_promo_sheet_for_reminder(
                 phase="reminder_3h",
@@ -990,7 +1013,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_promo_sheet_for_reminder(
                 phase="reminder_3h",
@@ -1021,7 +1044,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_promo_sheet_for_reminder(
                 phase="reminder_24h",
@@ -1059,7 +1082,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
                 extra={"thread_id": getattr(thread, "id", None)},
             )
             return
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         if watcher and context:
             await watcher._touch_promo_sheet_for_reminder(
                 phase="reminder_24h",
@@ -1089,7 +1112,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
             "If you still want to request a move later, feel free to open a new promo ticket anytime."
         )
 
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         watcher = bot.get_cog("PromoTicketWatcher")
         if watcher is not None:
             context = await watcher._ensure_context(thread)
@@ -1137,7 +1160,7 @@ async def _process_promo_thread(bot: commands.Bot, thread: discord.Thread, now: 
             "If you still want to request a move later, feel free to open a new promo ticket anytime."
         )
 
-        _persist_reminder_state(session, action=action, timestamp=now)
+        await _persist_reminder_state(session, action=action, timestamp=now)
         watcher = bot.get_cog("PromoTicketWatcher")
         if watcher is not None:
             context = await watcher._ensure_context(thread)

--- a/shared/sheets/onboarding_sessions.py
+++ b/shared/sheets/onboarding_sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import asyncio
 import json
 import logging
 from typing import Any, Dict, Iterable, Optional, Sequence
@@ -84,6 +85,11 @@ def load(user_id: int | None, thread_id: int) -> Optional[Dict[str, Any]]:
     }
 
 
+async def aload(thread_id: int, *, timeout: float | None = 15.0) -> Optional[Dict[str, Any]]:
+    rows = await _aload_rows(timeout=timeout)
+    return _load_from_rows(rows, thread_id=thread_id)
+
+
 def load_all() -> list[Dict[str, Any]]:
     worksheet = _sheet()
     rows = worksheet.get_all_values()
@@ -127,6 +133,11 @@ def load_all() -> list[Dict[str, Any]]:
     return sessions
 
 
+async def aload_all(*, timeout: float | None = 15.0) -> list[Dict[str, Any]]:
+    rows = await _aload_rows(timeout=timeout)
+    return _load_all_from_rows(rows)
+
+
 def save(payload: Dict[str, Any], *, allow_create: bool = True) -> bool:
     worksheet = _sheet()
     rows = worksheet.get_all_values()
@@ -164,8 +175,50 @@ def save(payload: Dict[str, Any], *, allow_create: bool = True) -> bool:
     return True
 
 
+async def asave(payload: Dict[str, Any], *, allow_create: bool = True, timeout: float | None = 15.0) -> bool:
+    worksheet = await _asheet(timeout=timeout)
+    rows = await core._retry_with_backoff_async(core.async_adapter.aworksheet_values_all, worksheet, timeout=timeout)
+    header = _validated_header(rows[0] if rows else [])
+    if header is None:
+        return False
+    header_map = _header_index_map(header)
+    target_row = _get_row_index_by_thread_id(rows[1:], header_map, payload.get("thread_id"))
+    existing: Dict[str, Any] = {}
+    if target_row is not None:
+        existing = _record_from_row(rows[target_row], header, header_map)
+    record = _merge_record(existing, payload)
+    values = build_row(record, headers=header)
+    if target_row is not None:
+        await core._retry_with_backoff_async(
+            core.async_adapter.aworksheet_values_update,
+            worksheet,
+            _range_for_row(target_row + 1, header),
+            [values],
+            timeout=timeout,
+        )
+    elif allow_create:
+        await core.async_adapter.arun(worksheet.append_row, values, timeout=timeout)
+    else:
+        log.info("🧾 onboarding session skipped • thread_id=%s • reason=missing_row", record.get("thread_id"))
+        return False
+    return True
+
+
 def get_by_thread_id(thread_id: int | str | None) -> Optional[Dict[str, Any]]:
     return load(user_id=None, thread_id=int(thread_id)) if thread_id is not None else None
+
+
+def load_from_rows(rows: Sequence[Sequence[Any]], thread_id: int | str | None) -> Optional[Dict[str, Any]]:
+    return _load_from_rows(rows, thread_id=thread_id)
+
+
+def index_by_thread_id(rows: Sequence[Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:
+    indexed: Dict[int, Dict[str, Any]] = {}
+    for row in rows:
+        thread = _safe_int(row.get("thread_id"))
+        if thread is not None:
+            indexed[thread] = row
+    return indexed
 
 
 def upsert_session(
@@ -375,3 +428,61 @@ def _column_letter(index: int) -> str:
         index, remainder = divmod(index - 1, 26)
         label = chr(65 + remainder) + label
     return label
+
+
+async def _asheet(*, timeout: float | None = 15.0):
+    sheet_id = get_onboarding_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("ONBOARDING_SHEET_ID not set")
+    tab_name = get_onboarding_sessions_tab().strip()
+    if not tab_name:
+        raise RuntimeError("ONBOARDING_SESSIONS_TAB not set in sheet/env config")
+    return await core.aget_worksheet(sheet_id, tab_name, timeout=timeout)
+
+
+async def _aload_rows(*, timeout: float | None = 15.0) -> list[list[Any]]:
+    worksheet = await _asheet(timeout=timeout)
+    return await core._retry_with_backoff_async(core.async_adapter.aworksheet_values_all, worksheet, timeout=timeout)
+
+
+def _load_from_rows(rows: Sequence[Sequence[Any]], *, thread_id: int | str | None) -> Optional[Dict[str, Any]]:
+    header = _validated_header(rows[0] if rows else [])
+    if header is None:
+        return None
+    header_map = _header_index_map(header)
+    target_row = _get_row_index_by_thread_id(rows[1:], header_map, thread_id)
+    if target_row is None:
+        return None
+    return _session_from_record(_record_from_row(rows[target_row], header, header_map))
+
+
+def _load_all_from_rows(rows: Sequence[Sequence[Any]]) -> list[Dict[str, Any]]:
+    header = _validated_header(rows[0] if rows else [])
+    if header is None:
+        return []
+    header_map = _header_index_map(header)
+    return [_session_from_record(_record_from_row(row, header, header_map)) for row in rows[1:]]
+
+
+def _session_from_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    raw_answers = record.get("answers_json") or "{}"
+    try:
+        answers = json.loads(raw_answers)
+    except Exception:
+        answers = {}
+    panel_id = _safe_int(record.get("panel_message_id"))
+    completed_token = str(record.get("completed", "")).strip().lower()
+    return {
+        "thread_name": record.get("thread_name") or "",
+        "user_id": str(record.get("user_id") or ""),
+        "thread_id": str(record.get("thread_id") or ""),
+        "panel_message_id": panel_id if panel_id not in (None, 0) else None,
+        "step_index": _safe_int(record.get("step_index"), default=0),
+        "completed": completed_token in {"true", "1", "yes", "true"},
+        "completed_at": record.get("completed_at") or None,
+        "updated_at": record.get("updated_at") or "",
+        "first_reminder_at": record.get("first_reminder_at") or "",
+        "warning_sent_at": record.get("warning_sent_at") or "",
+        "auto_closed_at": record.get("auto_closed_at") or "",
+        "answers": answers,
+    }


### PR DESCRIPTION
### Motivation
- The onboarding reminder/scan path performed synchronous gspread calls (e.g., `worksheet.get_all_values()`) directly on the Discord event loop which caused heartbeat stalls and long freezes during scans. 
- The change aims to move all blocking Sheets I/O off the event loop using the project’s existing async adapter and retry/backoff wrappers so one slow/failed Sheets call cannot block the scheduler.
- Maintain existing behavior and logging while avoiding per-thread synchronous reads and preserving retry/backoff semantics.

### Description
- Added async sheet helpers and row mappers in `shared/sheets/onboarding_sessions.py`, including `aload`, `aload_all`, `asave`, `_asheet`, `_aload_rows`, `_load_from_rows`, `_load_all_from_rows`, `index_by_thread_id` and `_session_from_record`, and wired them to the existing async adapter + backoff (`core.async_adapter`, `core._retry_with_backoff_async`).
- Updated the session model in `modules/onboarding/sessions.py` with `Session.asave_to_sheet()` and a `from_sheet_row()` factory, and made `ensure_session_for_thread()` support `preloaded_session_row` and use async sheet loads so callers can reuse a preloaded snapshot instead of issuing per-thread sync calls.
- Changed the welcome/promo scanner in `modules/onboarding/watcher_welcome.py` to preload all onboarding sessions once per scan (`await onboarding_sessions.aload_all(...)`), index them by `thread_id`, pass `session_row` into per-thread processors, and convert reminder persistence to async (`await session.asave_to_sheet()` / `await _persist_reminder_state(...)`).
- Preserved retry/backoff and timeout handling by routing async operations through `shared.sheets.core`/`async_adapter`, and improved failure handling so preload or per-thread sheet failures are logged with `exc_info=True` and do not crash or block the scan.
- No changes to gateway intents, OAuth scopes, or sheet IDs were made.

### Testing
- Compiled the modified modules with `python -m py_compile shared/sheets/onboarding_sessions.py modules/onboarding/sessions.py modules/onboarding/watcher_welcome.py` and compilation succeeded.
- Verified that async paths use the existing Sheets async adapter and backoff helpers (static inspection / smoke verification), and catch-and-log behavior is in place so one failing Sheets call will not stop the scan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f392d63bb08323b3c89c5907eb66d5)