### PR TITLE
Fix welcome panel ticket parsing for ####-Name threads

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -64,7 +64,7 @@ _AUTO_CLOSED_THREADS: set[int] = set()
 _TRIGGER_PHRASE = "awake by reacting with"
 _TICKET_EMOJI = "🎫"
 
-_TICKET_CODE_RE = re.compile(r"(W\d{4})", re.IGNORECASE)
+_TICKET_CODE_RE = re.compile(r"(W?\d{4})", re.IGNORECASE)
 _PROMO_TICKET_CODE_RE = re.compile(r"([RML]\d{4})", re.IGNORECASE)
 _PROMO_THREAD_NAME_RE = re.compile(
     r"^(?P<prefix>[RML])(?P<digits>\d{4})[-_\s]+(?P<slug>[A-Za-z0-9][A-Za-z0-9._-]*)"
@@ -85,15 +85,18 @@ def _normalize_ticket_code(ticket: str | None) -> str:
     token = (ticket or "").strip().lstrip("#")
     if not token:
         return ""
-    if not token.upper().startswith("W"):
-        token = f"W{token}"
-    prefix = token[:1].upper()
-    digits = token[1:5]
-    if len(digits) == 4 and digits.isdigit():
-        return f"{prefix}{digits}"
+
+    direct = re.fullmatch(r"(?P<prefix>[Ww]?)(?P<digits>\d{4})", token)
+    if direct:
+        digits = direct.group("digits")
+        return f"W{digits}"
+
     match = _TICKET_CODE_RE.search(token)
     if match:
-        return match.group(1).upper()
+        raw = match.group(1).upper()
+        digits = raw[1:] if raw.startswith("W") else raw
+        if len(digits) == 4 and digits.isdigit():
+            return f"W{digits}"
     return ""
 
 
@@ -117,13 +120,16 @@ def parse_welcome_thread_name(name: str | None) -> Optional[ThreadNameParts]:
     if not name:
         return None
 
-    match = _TICKET_CODE_RE.search(name)
+    normalized = (name or "").strip()
+    match = re.search(r"(?<![A-Za-z0-9])(?P<code>W?\d{4})(?!\d)", normalized, re.IGNORECASE)
     if not match:
         return None
 
-    ticket_code = _normalize_ticket_code(match.group(1))
-    prefix = name[: match.start()].strip(" -_") or None
-    suffix = name[match.end():].strip(" -_")
+    ticket_code = _normalize_ticket_code(match.group("code"))
+    if not ticket_code:
+        return None
+    prefix = normalized[: match.start()].strip(" -_") or None
+    suffix = normalized[match.end():].strip(" -_")
 
     username = suffix or ""
     clan_tag: Optional[str] = None
@@ -1662,10 +1668,10 @@ async def post_open_questions_panel(
     elif resolution.flow:
         normalized_flow = resolution.flow
 
+    parser = parse_promo_thread_name if normalized_flow.startswith("promo") else parse_welcome_thread_name
+    parsed_parts = parser(thread_name)
     if ticket_code is None:
-        parser = parse_promo_thread_name if normalized_flow.startswith("promo") else parse_welcome_thread_name
-        parts = parser(thread_name)
-        ticket_code = getattr(parts, "ticket_code", None)
+        ticket_code = getattr(parsed_parts, "ticket_code", None)
 
     parent_channel = getattr(thread, "parent", None)
     question_count, schema_version = logs.question_stats(normalized_flow)
@@ -1779,6 +1785,17 @@ async def post_open_questions_panel(
             panel_message_id,
         )
 
+    expected_patterns = "W####-Name | ####-Name | Res-W####-Name-CLAN | Closed-W####-Name-CLAN | R/M/L####-Name"
+    log.warning(
+        "failed to parse ticket context for panel post",
+        extra={
+            "reason": "ticket_not_parsed",
+            "thread_id": getattr(thread, "id", None),
+            "thread_name": thread_name,
+            "flow": normalized_flow,
+            "expected_patterns": expected_patterns,
+        },
+    )
     await _emit(result="skipped", reason="ticket_not_parsed")
     return PanelOutcome("skipped", "ticket_not_parsed", ticket_code, thread_name, _elapsed())
 
@@ -2181,7 +2198,13 @@ class WelcomeWatcher(commands.Cog):
             context = await self._ensure_context(thread)
         except Exception:
             context = None
-            log.exception("failed to resolve ticket context for panel post", extra={"thread_id": getattr(thread, "id", None)})
+            log.exception(
+                "failed to resolve ticket context for panel post",
+                extra={
+                    "thread_id": getattr(thread, "id", None),
+                    "thread_name": getattr(thread, "name", None),
+                },
+            )
         if context is not None:
             context_user_id = getattr(context, "recruit_id", None)
 

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -55,6 +55,14 @@ def test_parse_thread_name_open() -> None:
     assert parts.state == "open"
 
 
+def test_parse_thread_name_open_without_w_prefix() -> None:
+    parts = parse_welcome_thread_name("0867-Caillean")
+    assert parts is not None
+    assert parts.ticket_code == "W0867"
+    assert parts.username == "Caillean"
+    assert parts.state == "open"
+
+
 def test_parse_thread_name_reserved() -> None:
     parts = parse_welcome_thread_name("Res-W0298-Caillean AT-C1CE")
     assert parts is not None
@@ -71,6 +79,10 @@ def test_parse_thread_name_closed() -> None:
     assert parts.username == "Caillean AT"
     assert parts.clan_tag == "NONE"
     assert parts.state == "closed"
+
+
+def test_parse_thread_name_invalid() -> None:
+    assert parse_welcome_thread_name("welcome-caillean") is None
 
 
 def test_decision_reservation_same_clan() -> None:


### PR DESCRIPTION
### Motivation
- The welcome panel posting flow was skipping valid threads named like `0867-Caillean` because `parse_welcome_thread_name` only matched a leading `W` token (`W####`), causing `ticket_not_parsed` outcomes on emoji/phrase triggers. 
- The change aims to accept common thread name variants (bare `####-Name` and `W####-Name`) and normalize ticket numbers to canonical `W####` without hardcoding any user or thread identifiers. 
- Better diagnostics are needed when parsing fails to make future triage easier.

### Description
- Relaxed and improved ticket-code recognition by allowing optional `W` in the ticket regex and adding a focused search for `W?####` tokens, then normalizing to `W####` in `_normalize_ticket_code` so `0867` → `W0867`.
- Updated `parse_welcome_thread_name` to use a normalized input slice and to reject when normalization fails, preserving prefix/suffix parsing and `ThreadNameParts.state` semantics for `Res-`/`Closed-` formats.
- Changed `post_open_questions_panel` to pre-parse the thread name and use the parsed parts when `ticket_code` is not supplied, and added a clearer warning log including `thread_id`, `thread_name`, `flow`, and `expected_patterns` when parsing fails.
- Improved exception logging in `_post_panel` to include `thread_name` alongside `thread_id` for better context in fallback paths.
- Added tests to `tests/onboarding/test_welcome_reservations.py` covering parsing `0867-Caillean`, preserving existing formats, and asserting invalid names fail cleanly.

### Testing
- Ran `pytest -q tests/onboarding/test_welcome_reservations.py -k 'parse_thread_name'` and the new/modified parsing tests passed.
- Ran `pytest -q tests/onboarding/test_welcome_reservations.py tests/onboarding/test_lifecycle_logging.py` and observed one unrelated failure in `test_ticket_open_with_mention_writes_welcome_sheet` during this environment run, which appears pre-existing and not caused by the parsing changes.
- Local unit coverage for the welcome-thread parsing and reservation name tests succeeded; logging additions were exercised by existing lifecycle tests that now log richer context on parse failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3951946d8832393bf4e39b0e0923b)