### PR TITLE
Fix welcome panel ticket parsing and use reaction subject fallback

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -128,16 +128,16 @@ def parse_welcome_thread_name(name: str | None) -> Optional[ThreadNameParts]:
     ticket_code = _normalize_ticket_code(match.group("code"))
     if not ticket_code:
         return None
-    prefix = normalized[: match.start()].strip(" -_") or None
-    suffix = normalized[match.end():].strip(" -_")
 
-    username = suffix or ""
-    clan_tag: Optional[str] = None
-    if suffix:
-        parts = suffix.split("-", 1)
-        username = parts[0].strip(" -_")
-        if len(parts) > 1:
-            clan_tag = parts[1].strip(" -_") or None
+    separator_chars = " -_–—"
+    prefix = normalized[: match.start()].strip(separator_chars) or None
+    suffix = normalized[match.end():].strip(separator_chars)
+    if not suffix:
+        return None
+
+    tokens = [token.strip(separator_chars) for token in re.split(r"[-_–—]+", suffix, maxsplit=1)]
+    username = (tokens[0] if tokens else "").strip(separator_chars)
+    clan_tag = (tokens[1] if len(tokens) > 1 else "").strip(separator_chars) or None
 
     if not username:
         return None
@@ -1786,6 +1786,7 @@ async def post_open_questions_panel(
         )
 
     expected_patterns = "W####-Name | ####-Name | Res-W####-Name-CLAN | Closed-W####-Name-CLAN | R/M/L####-Name"
+    parsed_ticket_hint = _normalize_ticket_code(thread_name or "") or _normalize_promo_ticket(thread_name or "") or None
     log.warning(
         "failed to parse ticket context for panel post",
         extra={
@@ -1793,6 +1794,7 @@ async def post_open_questions_panel(
             "thread_id": getattr(thread, "id", None),
             "thread_name": thread_name,
             "flow": normalized_flow,
+            "parsed_ticket": parsed_ticket_hint,
             "expected_patterns": expected_patterns,
         },
     )
@@ -2192,6 +2194,7 @@ class WelcomeWatcher(commands.Cog):
         flow: str = "welcome",
         ticket_code: str | None = None,
         trigger_message: discord.Message | None = None,
+        subject_user_id: int | None = None,
     ) -> None:
         context_user_id: int | None = None
         try:
@@ -2215,7 +2218,7 @@ class WelcomeWatcher(commands.Cog):
             flow=flow,
             ticket_code=ticket_code,
             trigger_message=trigger_message,
-            subject_user_id=context_user_id,
+            subject_user_id=context_user_id if context_user_id is not None else subject_user_id,
         )
         self._log_panel_outcome(actor, thread, outcome, flow=flow)
 
@@ -2313,7 +2316,7 @@ class WelcomeWatcher(commands.Cog):
             await logs.send_welcome_log("warn", **context)
             return
 
-        await self._post_panel(thread, actor=actor, source="emoji")
+        await self._post_panel(thread, actor=actor, source="emoji", subject_user_id=payload.user_id)
 
 
 class _ClanSelect(discord.ui.Select):

--- a/tests/onboarding/test_lifecycle_logging.py
+++ b/tests/onboarding/test_lifecycle_logging.py
@@ -322,3 +322,34 @@ def test_completion_logging_helper(monkeypatch):
     asyncio.run(runner())
     assert recorded and recorded[0]["event"] == "complete"
     assert recorded[0]["extras"]["level_detail"] == "Late Game"
+
+
+def test_post_panel_uses_explicit_subject_user_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_lifecycle_log(**_payload):
+        return None
+
+    async def ensure_membership(_thread):
+        return True, None
+
+    async def fake_persist(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(logs, "log_onboarding_panel_lifecycle", fake_lifecycle_log)
+    monkeypatch.setattr(logs, "question_stats", lambda flow: (16, "v1"))
+    monkeypatch.setattr(watcher_welcome.thread_membership, "ensure_thread_membership", ensure_membership)
+    monkeypatch.setattr(panels, "OpenQuestionsPanelView", lambda: SimpleNamespace())
+    monkeypatch.setattr(watcher_welcome, "persist_session_for_thread", fake_persist)
+
+    watcher = watcher_welcome.WelcomeWatcher(bot=SimpleNamespace(user=SimpleNamespace(id=99999)))
+    thread = DummyThread(name="0867-Caillean")
+    actor = SimpleNamespace(display_name="Recruit", bot=False)
+
+    async def runner() -> None:
+        await watcher._post_panel(thread, actor=actor, source="emoji", subject_user_id=123456789)
+
+    asyncio.run(runner())
+
+    assert captured["user_id"] == 123456789
+    assert captured["ticket_number"] == "W0867"

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -63,6 +63,15 @@ def test_parse_thread_name_open_without_w_prefix() -> None:
     assert parts.state == "open"
 
 
+
+
+def test_parse_thread_name_open_without_w_prefix_em_dash() -> None:
+    parts = parse_welcome_thread_name("0867—Caillean")
+    assert parts is not None
+    assert parts.ticket_code == "W0867"
+    assert parts.username == "Caillean"
+    assert parts.state == "open"
+
 def test_parse_thread_name_reserved() -> None:
     parts = parse_welcome_thread_name("Res-W0298-Caillean AT-C1CE")
     assert parts is not None


### PR DESCRIPTION
### Motivation
- Welcome panel posting was skipping when thread names like `0867-Caillean` were used because the parser was brittle about separators and the reaction fallback did not forward the reacting user id into panel/session persistence.
- Improve diagnostics so parse failures include a parsed-ticket hint and expected patterns to simplify debugging.

### Description
- Relaxed and hardened `parse_welcome_thread_name` to accept additional separator variants (including en/ em dash and underscores) and to correctly normalize numeric names like `0867-Caillean` to `W0867` while preserving existing reserved/closed/promo patterns.
- Extended `WelcomeWatcher._post_panel` to accept an optional `subject_user_id` and prefer an explicit subject id when present, and updated the emoji reaction handler to pass `payload.user_id` into `_post_panel` so reaction context can be used when title parsing is imperfect.
- Added a `parsed_ticket` hint to panel post parse-failure logs alongside `thread_id`, `thread_name`, `flow`, and `expected_patterns`.
- Added/updated tests: an em-dash parsing test for numeric welcome thread names and a test asserting that an explicit `subject_user_id` passed to `_post_panel` is used for session persistence.

### Testing
- Initial targeted test run including several onboarding parsing and lifecycle tests revealed a missing signature error which was fixed in-code (the failure was `TypeError`/`NameError` before the signature and call-site were aligned). 
- After the fix, the focused tests `tests/onboarding/test_lifecycle_logging.py::test_post_panel_uses_explicit_subject_user_id`, `tests/onboarding/test_lifecycle_logging.py::test_welcome_watcher_logs_missing_ticket`, and `tests/onboarding/test_welcome_reservations.py::test_parse_thread_name_open_without_w_prefix_em_dash` were run and passed.
- Existing invalid-name behavior remains covered by `tests/onboarding/test_welcome_reservations.py::test_parse_thread_name_invalid` (still expected to fail parsing) and other onboarding tests were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39861460c832382243be750f42faf)