### PR TITLE
Fix Titan schedule event matching and improve publish error diagnostics

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -149,12 +149,25 @@ class FusionCog(commands.Cog):
             )
 
         try:
+            event_count = len(await fusion_sheets.get_fusion_events(target.fusion_id))
             announcement_message = await publish_fusion_announcement(self.bot, target)
             if announcement_message is None:
                 await ctx.reply("Configured announcement channel is not messageable.", mention_author=False)
                 return
         except Exception as exc:
-            log.exception("%s publish failed during announce send", tracker_label, extra={"fusion_id": target.fusion_id})
+            log.exception(
+                "%s publish failed during announce send",
+                tracker_label,
+                extra={
+                    "fusion_id": target.fusion_id,
+                    "tracker_kind": tracker_kind,
+                    "event_count": event_count if "event_count" in locals() else None,
+                    "target_channel_id": getattr(target, "announcement_channel_id", None),
+                    "announcement_channel_id": getattr(target, "announcement_channel_id", None),
+                    "announcement_message_id": getattr(target, "announcement_message_id", None),
+                },
+                exc_info=True,
+            )
             await fusion_logs.send_ops_alert(
                 component="command_publish",
                 summary="announce_send_failed",

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -103,6 +103,10 @@ def _normalize(row: Mapping[str, object]) -> dict[str, object]:
     return out
 
 
+def _normalize_fusion_id(value: object) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
 def _pick(row: Mapping[str, object], *keys: str) -> object:
     for key in keys:
         if key in row:
@@ -479,10 +483,12 @@ async def get_fusion_events(fusion_id: str) -> list[FusionEventRow]:
     _, events_bucket = register_cache_buckets()
     rows = await _cached_rows(events_bucket)
     target = str(fusion_id or "").strip()
+    target_norm = _normalize_fusion_id(fusion_id)
     filtered = [
         row
         for row in rows
-        if isinstance(row, FusionEventRow) and row.fusion_id == target
+        if isinstance(row, FusionEventRow)
+        and (row.fusion_id == target or _normalize_fusion_id(row.fusion_id) == target_norm)
     ]
     filtered.sort(key=lambda row: (row.start_at_utc, row.sort_order, row.event_id))
     return filtered

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -121,6 +121,34 @@ def test_get_upcoming_events_returns_only_future_events_sorted(
     assert [row.event_id for row in result] == ["future-soon", "future-later"]
 
 
+def test_get_fusion_events_matches_fusion_id_casefold_and_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = (
+        fusion.FusionEventRow(
+            fusion_id=" Anomalus_Titan_Event_2026_04 ",
+            event_id="PH_1",
+            event_name="Path Event",
+            event_type="tournament",
+            category="",
+            start_at_utc=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+            end_at_utc=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
+            reward_amount=100.0,
+            bonus=None,
+            reward_type="Titan Event Points",
+            points_needed=1000,
+            is_estimated=True,
+            sort_order=1,
+        ),
+    )
+    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=rows))
+
+    result = asyncio.run(fusion.get_fusion_events("anomalus_titan_event_2026_04"))
+
+    assert [row.event_id for row in result] == ["PH_1"]
+
+
 def test_get_active_events_returns_only_currently_active_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Titan schedules were rendering zero events because `get_fusion_events` used strict equality on `fusion_id`, so case/whitespace differences between the fusion row and event rows caused matches to be missed.
- `!titan publish` produced opaque failures without enough contextual data to diagnose send errors or empty schedules.

### Description
- Added a normalizer `_normalize_fusion_id` and updated `get_fusion_events` to accept either an exact match or a normalized match (`strip + casefold + whitespace collapse`) to tolerate formatting differences while preserving exact-match behavior first in `shared/sheets/fusion.py`.
- Enhanced publish error diagnostics in the publish flow (`_publish_tracker` in `modules/community/fusion/cog.py`) to capture `event_count`, `fusion_id`, `tracker_kind`, `target_channel_id`, `announcement_channel_id`, and `announcement_message_id`, and to log full traceback (`exc_info=True`).
- Added a regression test `test_get_fusion_events_matches_fusion_id_casefold_and_whitespace` in `tests/shared/sheets/test_fusion.py` verifying event rows load when `fusion_id` differs only by case/whitespace.
- No schema changes, no Titan-specific hardcoding, and no change to `reward_type` filtering logic.

### Testing
- Ran `pytest -q tests/shared/sheets/test_fusion.py tests/community/test_fusion_cog.py` and the targeted test suite passed (all tests covering the modified behavior succeeded).
- Added unit test `test_get_fusion_events_matches_fusion_id_casefold_and_whitespace` which passed under the test run.
- Confirmed changes were committed and only intended files were modified (`shared/sheets/fusion.py`, `modules/community/fusion/cog.py`, `tests/shared/sheets/test_fusion.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a1a95b48832396bc9d2f21ce88ec)