### PR TITLE
Welcome fallback: auto-react on bot intro with 👍 and target correct message

### DIFF
--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -1126,6 +1126,48 @@ async def locate_welcome_message(thread: discord.Thread) -> discord.Message | No
     return None
 
 
+def _is_welcome_trigger_message(
+    message: discord.Message | None,
+    *,
+    bot_user_id: int | None = None,
+) -> bool:
+    if message is None:
+        return False
+    author = getattr(message, "author", None)
+    if author is None:
+        return False
+    if bot_user_id is not None and getattr(author, "id", None) != bot_user_id:
+        return False
+    content = (getattr(message, "content", "") or "").lower()
+    return (
+        "slap a 👍 on this message" in content
+        or "awake by reacting with" in content
+        or "[#welcome:ticket]" in content
+    )
+
+
+async def locate_welcome_trigger_message(
+    thread: discord.Thread,
+    *,
+    bot_user_id: int | None = None,
+    preferred_message: discord.Message | None = None,
+) -> discord.Message | None:
+    """Locate the bot-authored welcome trigger/intro message in the thread."""
+
+    if _is_welcome_trigger_message(preferred_message, bot_user_id=bot_user_id):
+        return preferred_message
+
+    history = getattr(thread, "history", None)
+    if callable(history):
+        try:
+            async for candidate in history(limit=25, oldest_first=False):
+                if _is_welcome_trigger_message(candidate, bot_user_id=bot_user_id):
+                    return candidate
+        except Exception:
+            pass
+    return None
+
+
 def extract_target_from_message(
     message: discord.Message | None,
 ) -> tuple[int | None, int | None]:

--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -13,13 +13,14 @@ from modules.onboarding import logs, thread_membership, thread_scopes
 from modules.onboarding.controllers.welcome_controller import (
     extract_target_from_message,
     locate_welcome_message,
+    locate_welcome_trigger_message,
 )
 from modules.onboarding.ui import panels
 from modules.onboarding.welcome_flow import start_welcome_dialog
 from shared.config import get_ticket_tool_bot_id
 
 # Fallback: 🎫 on the Ticket Tool close-button message
-FALLBACK_EMOJI = "🎫"  # :ticket:
+FALLBACK_EMOJI = "👍"
 TRIGGER_TOKEN = "[#welcome:ticket]"
 PROMO_TRIGGER_MAP = {
     "<!-- trigger:promo.r -->": "promo.r",
@@ -232,6 +233,28 @@ class OnboardingReactionFallbackCog(commands.Cog):
                 target_extra.setdefault("message_id", int(payload.message_id))
             except (TypeError, ValueError):
                 pass
+        try:
+            trigger_message = await locate_welcome_trigger_message(
+                thread,
+                bot_user_id=getattr(getattr(self.bot, "user", None), "id", None),
+                preferred_message=welcome_message,
+            )
+        except Exception as exc:
+            lookup_context = _base_context(member=member, thread=thread)
+            lookup_context.update({"result": "trigger_lookup_failed", "trigger": "target_lookup"})
+            await logs.send_welcome_exception("warn", exc, **lookup_context)
+            return
+        if trigger_message is not None and int(getattr(trigger_message, "id", 0) or 0) != int(payload.message_id):
+            await _log_reject(
+                "wrong_message",
+                member=member,
+                thread=thread,
+                parent_id=getattr(thread, "parent_id", None),
+                trigger="target_gate",
+                result="wrong_message",
+                extra={**target_extra, "target_message_id": getattr(trigger_message, "id", None)},
+            )
+            return
 
         ticket_tool_id = get_ticket_tool_bot_id()
         actor_is_privileged = rbac.is_admin_member(member) or rbac.is_recruiter(member)

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -24,6 +24,7 @@ from modules.onboarding.ui import panels
 from modules.onboarding.controllers.welcome_controller import (
     extract_target_from_message,
     locate_welcome_message,
+    locate_welcome_trigger_message,
 )
 from modules.onboarding.sheet_logging import log_sheet_write
 from modules.onboarding.sessions import Session, ensure_session_for_thread
@@ -62,7 +63,7 @@ _ONBOARDING_LOG_CHANNEL_FETCHED = False
 _AUTO_CLOSED_THREADS: set[int] = set()
 
 _TRIGGER_PHRASE = "awake by reacting with"
-_TICKET_EMOJI = "🎫"
+_TICKET_EMOJI = "👍"
 _FALLBACK_AUTO_ADD_ATTEMPTS = 4
 _FALLBACK_AUTO_ADD_DELAY_SECONDS = 1.0
 
@@ -2511,8 +2512,21 @@ class WelcomeTicketWatcher(commands.Cog):
             return
 
         for attempt in range(1, _FALLBACK_AUTO_ADD_ATTEMPTS + 1):
+            preferred_target: discord.Message | None = None
+            target_source = "history_fallback"
             try:
-                target = await locate_welcome_message(thread)
+                preferred_target = await locate_welcome_message(thread)
+                target = await locate_welcome_trigger_message(
+                    thread,
+                    bot_user_id=getattr(getattr(self.bot, "user", None), "id", None),
+                    preferred_message=preferred_target,
+                )
+                if (
+                    target is not None
+                    and preferred_target is not None
+                    and getattr(target, "id", None) == getattr(preferred_target, "id", None)
+                ):
+                    target_source = "direct_message"
             except Exception:
                 log.warning(
                     "fallback_reaction_auto_add target_lookup_failed — thread=%s • attempt=%s",
@@ -2531,11 +2545,12 @@ class WelcomeTicketWatcher(commands.Cog):
                 )
             else:
                 log.info(
-                    "fallback_reaction_auto_add target — thread=%s • message_id=%s • author_id=%s • emoji=%s",
+                    "fallback_reaction_auto_add target — thread=%s • message_id=%s • author_id=%s • emoji=%s • source=%s",
                     getattr(thread, "id", None),
                     getattr(target, "id", None),
                     getattr(getattr(target, "author", None), "id", None),
                     _TICKET_EMOJI,
+                    target_source,
                 )
                 try:
                     await target.add_reaction(_TICKET_EMOJI)


### PR DESCRIPTION
### Motivation
- The auto-add fallback reacted to the thread starter/system message with the wrong emoji, causing panels not to spawn from the bot welcome intro.
- The generic welcome message locator returned the first message in the thread (often Ticket Tool/system), which is not always the bot’s intro message and therefore the wrong reaction target.

### Description
- Added `_is_welcome_trigger_message` and `locate_welcome_trigger_message` to prefer the bot-authored welcome/intro message and to search recent history when needed (`modules/onboarding/controllers/welcome_controller.py`).
- Updated the welcome watcher to prefer the resolved trigger message (or a direct candidate) when auto-adding the fallback reaction and to include `message_id`, `author_id`, `emoji`, and `source` in logs (`modules/onboarding/watcher_welcome.py`).
- Switched the fallback trigger emoji from 🎫 to 👍 in both the watcher and the reaction fallback handler so it matches the welcome text and handler acceptance (`modules/onboarding/watcher_welcome.py` and `modules/onboarding/reaction_fallback.py`).
- Tightened the reaction-fallback gating to validate that the reaction is on the resolved welcome trigger message when available, preventing Ticket Tool/system messages from triggering the panel (`modules/onboarding/reaction_fallback.py`).

### Testing
- Ran `pytest -q tests/onboarding/test_reaction_fallback.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a32294ec8323ac70f2ab73230d80)