### PR TITLE
Route role-audit housekeeping report to admin/ops destination chain

### DIFF
--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -13,6 +13,8 @@ from discord.ext import commands
 from modules.common.embeds import get_embed_colour
 from modules.common.tickets import TicketThread, fetch_ticket_threads
 from shared.config import (
+    get_log_channel_id,
+    get_logging_channel_id,
     get_admin_audit_dest_id,
     get_allowed_guild_ids,
     get_clan_role_ids,
@@ -26,6 +28,18 @@ from shared.config import (
 log = logging.getLogger("c1c.housekeeping.role_audit")
 
 ROLE_AUDIT_REASON = "Housekeeping role audit"
+
+
+def resolve_audit_destination() -> tuple[int | None, str]:
+    """Return audit destination ID with config-source label."""
+    for key, value in (
+        ("ADMIN_AUDIT_DEST_ID", get_admin_audit_dest_id()),
+        ("LOG_CHANNEL_ID", get_log_channel_id()),
+        ("LOGGING_CHANNEL_ID", get_logging_channel_id()),
+    ):
+        if value:
+            return value, key
+    return None, "unconfigured"
 
 
 @dataclass(slots=True)
@@ -290,7 +304,7 @@ async def run_role_and_visitor_audit(bot: commands.Bot) -> tuple[bool, str]:
     wanderer_role_id = get_wandering_souls_role_id()
     visitor_role_id = get_visitor_role_id()
     clan_role_ids = get_clan_role_ids()
-    dest_id = get_admin_audit_dest_id()
+    dest_id, dest_source = resolve_audit_destination()
 
     if not all((raid_role_id, wanderer_role_id, visitor_role_id, clan_role_ids, dest_id)):
         return False, "config-missing"
@@ -358,6 +372,16 @@ async def run_role_and_visitor_audit(bot: commands.Bot) -> tuple[bool, str]:
 
     if not isinstance(channel, (discord.TextChannel, discord.Thread)):
         return False, "dest-invalid"
+    log.info(
+        "role audit destination resolved",
+        extra={
+            "destination_source": "env",
+            "destination_key": dest_source,
+            "destination_id": dest_id,
+            "destination_label": getattr(channel, "name", str(dest_id)),
+            "destination_kind": type(channel).__name__,
+        },
+    )
 
     embed = _render_report(
         summary=aggregated,

--- a/modules/recruitment/reporting/daily_recruiter_update.py
+++ b/modules/recruitment/reporting/daily_recruiter_update.py
@@ -24,6 +24,7 @@ from modules.recruitment.reporting.open_ticket_report import (
     send_currently_open_tickets_report,
 )
 from modules.housekeeping.role_audit import run_role_and_visitor_audit
+from modules.housekeeping.role_audit import resolve_audit_destination
 
 log = logging.getLogger("c1c.recruitment.reporting.daily")
 
@@ -442,8 +443,11 @@ async def _log_event(
     error: str,
     user_id: Optional[int] = None,
     note: Optional[str] = None,
+    destination_source: str = "env",
+    destination_key: Optional[str] = None,
+    destination_id: Optional[int] = None,
 ) -> None:
-    dest_id = get_report_destination_id() or 0
+    dest_id = destination_id if destination_id is not None else (get_report_destination_id() or 0)
     guild_id: Optional[int] = None
     guild: Optional[discord.Guild] = None
     if dest_id:
@@ -461,6 +465,12 @@ async def _log_event(
     if note:
         reason_text = (
             f"{reason_text}; note={note}" if reason_text and reason_text != "-" else f"note={note}"
+        )
+    if destination_key:
+        reason_text = (
+            f"{reason_text}; dest_source={destination_source}; dest_key={destination_key}; dest_id={dest_id}"
+            if reason_text and reason_text != "-"
+            else f"dest_source={destination_source}; dest_key={destination_key}; dest_id={dest_id}"
         )
     ok = result.lower() == "ok"
     message = LogTemplates.report(
@@ -528,6 +538,7 @@ async def run_full_recruiter_reports(
     result = "ok" if ok else "fail"
     await _log_event(bot=bot, actor=actor, result=result, error=error, user_id=user_id)
 
+    audit_dest_id, audit_dest_key = resolve_audit_destination()
     audit_ok, audit_error = await run_role_and_visitor_audit(bot)
     audit_result = "ok" if audit_ok else "fail"
     await _log_event(
@@ -537,6 +548,8 @@ async def run_full_recruiter_reports(
         error=audit_error,
         note="role-audit",
         user_id=user_id,
+        destination_key=audit_dest_key,
+        destination_id=audit_dest_id,
     )
 
     tickets_ok, tickets_error = await send_currently_open_tickets_report(bot)


### PR DESCRIPTION
### Motivation
- The housekeeping role/visitor audit was being emitted alongside the recruiter daily report actor, causing admin-only `role-audit` messages to target the recruiters destination instead of ops/admin logging channels.
- The intent is to keep recruiter-facing reports separate from admin housekeeping reports while using existing env-configured destinations and avoiding hardcoded IDs or new env vars.

### Description
- Added `resolve_audit_destination()` to prefer `ADMIN_AUDIT_DEST_ID` and fall back to `LOG_CHANNEL_ID` then `LOGGING_CHANNEL_ID` for role-audit targets, and used it in `run_role_and_visitor_audit` (file: `modules/housekeeping/role_audit.py`).
- Emitted a structured info log when the role-audit destination is resolved containing `destination_key`, `destination_id`, `destination_label`, and `destination_kind` for better observability (file: `modules/housekeeping/role_audit.py`).
- Propagated audit destination metadata into the scheduled recruiter report log lines so scheduled runs include `dest_source`, `dest_key`, and `dest_id` when logging the `role-audit` note (file: `modules/recruitment/reporting/daily_recruiter_update.py`).
- Left recruiter posting behavior unchanged: `REPORT_RECRUITERS_DEST_ID` still controls the Daily Recruiter Update destination and both report and audit accept `discord.TextChannel` or `discord.Thread` targets (files: `modules/recruitment/reporting/destinations.py`, `modules/recruitment/reporting/daily_recruiter_update.py`).

### Testing
- Ran unit tests `pytest -q tests/housekeeping/test_role_audit.py tests/recruitment/test_daily_recruiter_update.py` which completed successfully with all tests passing.
- Existing recruiter report resolution and schedule logic remain covered by existing tests and were not changed functionally, and the added destination-resolution logic is exercised by the role-audit test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bb4212b08323a29588a1b3f3a32f)