### PR TITLE
Improve CORE_READY diagnostics for reset view registration failures

### DIFF
--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -6,6 +6,8 @@ import logging
 
 from discord.ext import commands
 
+from shared.config import cfg, get_feature_toggles
+
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
 from modules.community.shard_tracker.views import register_persistent_shard_views
 from modules.community.reset_reminders.scheduler import register_persistent_reset_views
@@ -41,7 +43,24 @@ async def on_ready(bot: commands.Bot) -> None:
         try:
             await register_persistent_reset_views(bot)
         except Exception:
-            log.exception("CORE_READY FAILURE: register_persistent_reset_views")
+            hook_name = "register_persistent_reset_views"
+            toggles = get_feature_toggles()
+            reset_feature_enabled = any(
+                bool(toggles.get(key, False))
+                for key in (
+                    "reset_reminders",
+                    "reset_reminders_enabled",
+                    "feature_reset_reminders",
+                )
+            )
+            log.exception(
+                "CORE_READY FAILURE: %s | env=%s | guild_count=%s | guild_ids=%s | reset_feature_enabled=%s",
+                hook_name,
+                str(cfg.get("ENV_NAME") or "unknown").strip() or "unknown",
+                len(getattr(bot, "guilds", []) or []),
+                [getattr(guild, "id", None) for guild in (getattr(bot, "guilds", []) or [])],
+                reset_feature_enabled,
+            )
             return
 
         # Ensure both onboarding watchers are wired


### PR DESCRIPTION
### Motivation
- Production logs showed `CORE_READY FAILURE: register_persistent_reset_views` with a null/empty exception text, hiding the real error and making diagnosis difficult.
- The change aims to capture the full traceback and useful runtime context when that hook fails, without changing startup control flow.

### Description
- Updated `modules/coreops/ready.py` to import `cfg` and `get_feature_toggles` and enhanced the `except` block around `register_persistent_reset_views` to emit full traceback via `log.exception(...)`.
- The new log entry includes `hook_name`, `ENV_NAME`, `guild_count`, `guild_ids`, and an inferred `reset_feature_enabled` flag derived from known feature toggle keys.
- Preserved existing behavior by returning from `on_ready` after logging the error and not changing functional logic.
- Only `modules/coreops/ready.py` was modified.

### Testing
- Compiled the modified file with `python -m compileall modules/coreops/ready.py` and the compilation succeeded.
- No automated unit tests were added or run for this change in the rollout; runtime verification is expected after redeploy where future failures will include full traceback and context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bb5338388323b17528e921c08388)