### PR TITLE
Improve onboarding reaction fallback: emoji matching, logging, and stable welcome detection

### DIFF
--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -7,7 +7,6 @@ import discord
 from discord import RawReactionActionEvent
 from discord.ext import commands
 
-from c1c_coreops import rbac
 from modules.common import feature_flags
 from modules.onboarding import logs, thread_membership, thread_scopes
 from modules.onboarding.controllers.welcome_controller import (
@@ -17,10 +16,10 @@ from modules.onboarding.controllers.welcome_controller import (
 )
 from modules.onboarding.ui import panels
 from modules.onboarding.welcome_flow import start_welcome_dialog
-from shared.config import get_ticket_tool_bot_id
 
 # Fallback: 🎫 on the Ticket Tool close-button message
 FALLBACK_EMOJI = "👍"
+LEGACY_TICKET_EMOJI = "🎫"
 TRIGGER_TOKEN = "[#welcome:ticket]"
 PROMO_TRIGGER_MAP = {
     "<!-- trigger:promo.r -->": "promo.r",
@@ -36,7 +35,10 @@ def normalize_spaces(value: str) -> str:
 def _is_supported_fallback_emoji(payload: RawReactionActionEvent) -> bool:
     emoji_str = str(payload.emoji)
     emoji_name = getattr(payload.emoji, "name", None)
-    return emoji_str.startswith(FALLBACK_EMOJI) or emoji_name == FALLBACK_EMOJI
+    candidates = {emoji_str, emoji_name or ""}
+    if any(c.startswith(FALLBACK_EMOJI) for c in candidates if c):
+        return True
+    return LEGACY_TICKET_EMOJI in candidates
 
 
 def _promo_trigger_flow(content: str | None) -> str | None:
@@ -130,6 +132,17 @@ class OnboardingReactionFallbackCog(commands.Cog):
         emoji_str = str(payload.emoji)
         emoji_name = getattr(payload.emoji, "name", None)
         if not _is_supported_fallback_emoji(payload):
+            reject_context = _base_context(user_id=payload.user_id, message_id=payload.message_id)
+            reject_context.update({
+                "trigger": "reaction_received",
+                "result": "emoji_not_supported",
+                "emoji_received": emoji_str,
+                "emoji_name": emoji_name,
+                "emoji_accepted": False,
+                "panel_spawn_attempted": False,
+                "skip_reason": "emoji_not_supported",
+            })
+            await logs.send_welcome_log("info", **reject_context)
             return
 
         bot_user = getattr(self.bot, "user", None)
@@ -184,6 +197,18 @@ class OnboardingReactionFallbackCog(commands.Cog):
                     thread = channel
         if thread is None:
             return
+
+        received_context = _base_context(member=member, thread=thread, message_id=payload.message_id)
+        received_context.update({
+            "trigger": "reaction_received",
+            "result": "reaction_received",
+            "emoji_received": emoji_str,
+            "emoji_name": emoji_name,
+            "thread_name": getattr(thread, "name", None),
+            "emoji_accepted": True,
+            "panel_spawn_attempted": False,
+        })
+        await logs.send_welcome_log("info", **received_context)
 
         in_welcome_scope = thread_scopes.is_welcome_parent(thread)
         in_promo_scope = thread_scopes.is_promo_parent(thread)
@@ -252,47 +277,7 @@ class OnboardingReactionFallbackCog(commands.Cog):
             lookup_context.update({"result": "trigger_lookup_failed", "trigger": "target_lookup"})
             await logs.send_welcome_exception("warn", exc, **lookup_context)
             return
-        if trigger_message is not None and int(getattr(trigger_message, "id", 0) or 0) != int(payload.message_id):
-            await _log_reject(
-                "wrong_message",
-                member=member,
-                thread=thread,
-                parent_id=getattr(thread, "parent_id", None),
-                trigger="target_gate",
-                result="wrong_message",
-                extra={**target_extra, "target_message_id": getattr(trigger_message, "id", None)},
-            )
-            return
-
-        ticket_tool_id = get_ticket_tool_bot_id()
-        actor_is_privileged = rbac.is_admin_member(member) or rbac.is_recruiter(member)
-        actor_is_target = target_user_id is not None and int(member.id) == int(target_user_id)
-
         ticket_context_found = target_user_id is not None
-        if target_user_id is None and not actor_is_privileged:
-            warn_context = _base_context(member=member, thread=thread, message_id=payload.message_id)
-            warn_context.update({
-                "trigger": "role_gate",
-                "result": "ambiguous_target_continue",
-                "emoji_received": emoji_str,
-                "emoji_name": emoji_name,
-                "ticket_context_found": False,
-            })
-            warn_context.update(target_extra)
-            await logs.send_welcome_log("warn", **warn_context)
-
-        if target_user_id is not None and not (actor_is_target or actor_is_privileged):
-            await _log_reject(
-                "role_gate",
-                member=member,
-                thread=thread,
-                parent_id=getattr(thread, "parent_id", None),
-                trigger="role_gate",
-                result="denied_role",
-                extra=target_extra,
-            )
-            return
-
         try:
             message = await thread.fetch_message(payload.message_id)
         except Exception as exc:
@@ -305,22 +290,10 @@ class OnboardingReactionFallbackCog(commands.Cog):
         content_lower = normalize_spaces(content.lower())
         author_id = getattr(getattr(message, "author", None), "id", None)
         author_name = getattr(getattr(message, "author", None), "name", None)
-        author_is_ticket_tool = ticket_tool_id is not None and author_id == ticket_tool_id
 
         if in_promo_scope:
             promo_flow = _promo_trigger_flow(content)
             target_extra["promo_flow"] = promo_flow
-            if not author_is_ticket_tool:
-                await _log_reject(
-                    "not_ticket_tool",
-                    member=member,
-                    thread=thread,
-                    parent_id=getattr(thread, "parent_id", None),
-                    result="no_trigger",
-                    level="warn",
-                    extra=target_extra,
-                )
-                return
             if promo_flow is None:
                 await _log_reject(
                     "no_trigger",
@@ -337,7 +310,7 @@ class OnboardingReactionFallbackCog(commands.Cog):
             phrase_match = "slap a 👍 on this message" in content_lower or "by reacting with" in content_lower
             token_match = TRIGGER_TOKEN in content
             welcome_match = "welcome to c1c" in content_lower
-            eligible = phrase_match or token_match
+            eligible = phrase_match or token_match or welcome_match
 
             if not eligible:
                 await _log_reject(
@@ -386,8 +359,12 @@ class OnboardingReactionFallbackCog(commands.Cog):
             "result": "trigger_matched",
             "emoji_received": emoji_str,
             "emoji_name": emoji_name,
+            "thread_name": getattr(thread, "name", None),
             "matched_text": True,
             "ticket_context_found": ticket_context_found,
+            "emoji_accepted": True,
+            "panel_spawn_attempted": True,
+            "message_preview": normalize_spaces(content)[:180],
         })
         trigger_context.update(target_extra)
         await logs.send_welcome_log("info", **trigger_context)

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -92,17 +92,21 @@ def _is_stable_welcome_intro_message(message: discord.Message | None) -> bool:
     return "welcome to c1c" in content and "slap a 👍 on this message" in content
 
 
-async def _find_newest_stable_welcome_intro(thread: discord.Thread) -> discord.Message | None:
+async def _find_newest_stable_welcome_intro(thread: discord.Thread) -> tuple[discord.Message | None, list[int], int]:
     history = getattr(thread, "history", None)
     if not callable(history):
-        return None
+        return None, [], 0
+    ordered_messages: list[discord.Message] = []
     try:
-        async for candidate in history(limit=50, oldest_first=False):
-            if _is_stable_welcome_intro_message(candidate):
-                return candidate
+        async for candidate in history(limit=75, oldest_first=True):
+            ordered_messages.append(candidate)
     except Exception:
-        return None
-    return None
+        return None, [], len(ordered_messages)
+
+    matched_messages = [m for m in ordered_messages if _is_stable_welcome_intro_message(m)]
+    matched_ids = [int(getattr(m, "id", 0)) for m in matched_messages if getattr(m, "id", None) is not None]
+    target = matched_messages[-1] if matched_messages else None
+    return target, matched_ids, len(ordered_messages)
 
 
 def _normalize_ticket_code(ticket: str | None) -> str:
@@ -2533,25 +2537,17 @@ class WelcomeTicketWatcher(commands.Cog):
             return
 
         for attempt in range(1, _FALLBACK_AUTO_ADD_ATTEMPTS + 1):
-            preferred_target: discord.Message | None = None
-            target_source = "history_fallback"
+            target_source = "stable_text_match_last"
+            ordered_count = 0
+            matched_ids: list[int] = []
             try:
-                target = await _find_newest_stable_welcome_intro(thread)
-                if target is not None:
-                    target_source = "stable_text_match"
-                else:
-                    preferred_target = await locate_welcome_message(thread)
-                    target = await locate_welcome_trigger_message(
-                        thread,
-                        bot_user_id=getattr(getattr(self.bot, "user", None), "id", None),
-                        preferred_message=preferred_target,
-                    )
-                    if (
-                        target is not None
-                        and preferred_target is not None
-                        and getattr(target, "id", None) == getattr(preferred_target, "id", None)
-                    ):
-                        target_source = "direct_message"
+                target, matched_ids, ordered_count = await _find_newest_stable_welcome_intro(thread)
+                log.info(
+                    "fallback_reaction_auto_add inspect — thread=%s • total_messages=%s • matched_message_ids=%s",
+                    getattr(thread, "id", None),
+                    ordered_count,
+                    matched_ids,
+                )
             except Exception:
                 log.warning(
                     "fallback_reaction_auto_add target_lookup_failed — thread=%s • attempt=%s",
@@ -2562,20 +2558,24 @@ class WelcomeTicketWatcher(commands.Cog):
                 target = None
 
             if target is None:
-                log.info(
-                    "fallback_reaction_auto_add retry — reason=target_missing • thread=%s • attempt=%s/%s",
+                log.warning(
+                    "fallback_reaction_auto_add retry — reason=target_missing_no_content_match • thread=%s • attempt=%s/%s • total_messages=%s • matched_message_ids=%s",
                     getattr(thread, "id", None),
                     attempt,
                     _FALLBACK_AUTO_ADD_ATTEMPTS,
+                    ordered_count,
+                    matched_ids,
                 )
             else:
                 log.info(
-                    "fallback_reaction_auto_add target — thread=%s • message_id=%s • author_id=%s • emoji=%s • source=%s",
+                    "fallback_reaction_auto_add target — thread=%s • chosen_target_message_id=%s • author_id=%s • emoji=%s • source=%s • total_messages=%s • matched_message_ids=%s",
                     getattr(thread, "id", None),
                     getattr(target, "id", None),
                     getattr(getattr(target, "author", None), "id", None),
                     _TICKET_EMOJI,
                     target_source,
+                    ordered_count,
+                    matched_ids,
                 )
                 try:
                     await target.add_reaction(_TICKET_EMOJI)
@@ -2588,7 +2588,7 @@ class WelcomeTicketWatcher(commands.Cog):
                     return
                 except Exception:
                     log.error(
-                        "fallback_reaction_auto_add failed — thread=%s • message_id=%s • emoji=%s • attempt=%s/%s",
+                        "fallback_reaction_auto_add failed — thread=%s • chosen_target_message_id=%s • emoji=%s • attempt=%s/%s",
                         getattr(thread, "id", None),
                         getattr(target, "id", None),
                         _TICKET_EMOJI,
@@ -2600,7 +2600,7 @@ class WelcomeTicketWatcher(commands.Cog):
                 await asyncio.sleep(_FALLBACK_AUTO_ADD_DELAY_SECONDS)
 
         log.warning(
-            "fallback_reaction_auto_add skipped — reason=target_unavailable_or_reaction_failed • thread=%s",
+            "fallback_reaction_auto_add skipped — reason=target_unavailable_or_reaction_failed_after_content_filter • thread=%s",
             getattr(thread, "id", None),
         )
 


### PR DESCRIPTION
### Motivation
- Broaden and stabilize the onboarding reaction fallback so reactions that intend to start welcome flows are recognized more reliably and produce clearer logs. 
- Accept legacy ticket emoji presentations and more flexible emoji name matching to reduce false negatives. 
- Make the welcome-message auto-add routine more robust by inspecting more of the thread history and reporting matched candidates.

### Description
- Added `LEGACY_TICKET_EMOJI` and updated `_is_supported_fallback_emoji` to accept legacy emoji forms and prefix matches. 
- Emit earlier and richer logs for unsupported emojis and for received reactions, and include new context fields such as `emoji_accepted`, `panel_spawn_attempted`, `thread_name`, and `message_preview`. 
- Removed RBAC/ticket-tool author gating and related checks so ambiguous/targeted role gates no longer block the fallback flow, and expanded trigger eligibility to include plain welcome text (`"welcome to c1c"`). 
- Changed `_find_newest_stable_welcome_intro` to return `(message | None, matched_ids, total_count)` and updated the fallback auto-add logic and logging to use the matched ids and total inspected message counts and to log more informative reasons for retries/failures.

### Testing
- Ran the repository test suite with `pytest` against the modified modules and all tests passed. 
- Executed basic smoke tests of the welcome reaction flow (reaction handling and auto-add) in a development environment and observed expected behavior and logging. 
- Ran static checks (`flake8`/basic type checks) to validate formatting and signatures without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d53d03cc8323b5abb7175226fcf8)