### PR TITLE
Cleanup onboarding panel after summary and skip idle reminders for closed/archived threads

### DIFF
--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -31,6 +31,7 @@ from modules.onboarding.ui.views import NextStepView
 from modules.onboarding.ui import panels
 from shared.logfmt import channel_label, user_label
 from shared.sheets.onboarding_questions import Question, schema_hash
+from shared.sheets import onboarding_sessions
 from shared.config import get_recruiter_role_ids
 
 log = logging.getLogger(__name__)
@@ -1530,7 +1531,102 @@ class BaseWelcomeController:
             allowed_mentions=allowed_mentions if mention_text else None,
         )
 
+        await self.cleanup_onboarding_panel(thread, exclude_message_id=getattr(summary_message, "id", None))
+
         return summary_message, summary_embed
+
+    async def cleanup_onboarding_panel(
+        self,
+        thread: discord.Thread | discord.TextChannel,
+        *,
+        exclude_message_id: int | None = None,
+    ) -> None:
+        thread_id = getattr(thread, "id", None)
+        panel_message_id: int | None = None
+        if thread_id is not None:
+            panel_message_id = self._panel_messages.get(int(thread_id))
+        if panel_message_id is None:
+            row = onboarding_sessions.get_by_thread_id(thread_id)
+            raw_panel_id = row.get("panel_message_id") if isinstance(row, dict) else None
+            try:
+                panel_message_id = int(raw_panel_id) if raw_panel_id else None
+            except (TypeError, ValueError):
+                panel_message_id = None
+
+        panel_message: discord.Message | None = None
+        if panel_message_id:
+            try:
+                panel_message = await thread.fetch_message(int(panel_message_id))
+            except Exception:
+                panel_message = None
+
+        if panel_message is None:
+            markers = ("ready when you are", "open questions", "restart", "resume")
+            try:
+                async for candidate in thread.history(limit=30):
+                    if exclude_message_id and getattr(candidate, "id", None) == exclude_message_id:
+                        continue
+                    author_id = getattr(getattr(candidate, "author", None), "id", None)
+                    bot_id = getattr(getattr(self, "bot", None), "user", None)
+                    bot_id = getattr(bot_id, "id", None)
+                    if bot_id is None or author_id != bot_id:
+                        continue
+                    content_text = str(getattr(candidate, "content", "") or "").casefold()
+                    matches_text = any(marker in content_text for marker in markers)
+                    view_obj = getattr(candidate, "components", None) or []
+                    matches_buttons = any(
+                        any(
+                            any(marker in str(getattr(comp, "label", "") or "").casefold() for marker in markers)
+                            for comp in getattr(row, "children", [])
+                        )
+                        for row in view_obj
+                    )
+                    if matches_text or matches_buttons:
+                        panel_message = candidate
+                        break
+            except Exception:
+                panel_message = None
+
+        if panel_message is None:
+            log.info(
+                "onboarding panel cleanup skipped • reason=summary_posted • thread_id=%s • result=not_found",
+                thread_id,
+            )
+            return
+
+        if exclude_message_id and getattr(panel_message, "id", None) == exclude_message_id:
+            log.info(
+                "onboarding panel cleanup skipped • reason=summary_posted • thread_id=%s • result=not_found",
+                thread_id,
+            )
+            return
+
+        try:
+            await panel_message.delete()
+            log.info(
+                "onboarding panel cleanup • reason=summary_posted • thread_id=%s • deleted_message_id=%s • result=deleted",
+                thread_id,
+                getattr(panel_message, "id", None),
+            )
+            panels.mark_panel_inactive_by_message(getattr(panel_message, "id", None))
+            return
+        except Exception:
+            pass
+
+        try:
+            await panel_message.edit(view=None)
+            log.info(
+                "onboarding panel cleanup • reason=summary_posted • thread_id=%s • deleted_message_id=%s • result=failed",
+                thread_id,
+                getattr(panel_message, "id", None),
+            )
+        except Exception:
+            log.warning(
+                "onboarding panel cleanup failed • reason=summary_posted • thread_id=%s • deleted_message_id=%s • result=failed",
+                thread_id,
+                getattr(panel_message, "id", None),
+                exc_info=True,
+            )
 
     def _thread_for(self, thread_id: int) -> discord.Thread | None:
         return self._threads.get(thread_id)

--- a/modules/onboarding/idle_watcher.py
+++ b/modules/onboarding/idle_watcher.py
@@ -54,6 +54,38 @@ def _format_interval(delta: timedelta) -> float:
     return delta.total_seconds()
 
 
+def _is_closed_ticket_name(thread: discord.Thread | None) -> bool:
+    if thread is None:
+        return False
+    name = str(getattr(thread, "name", "") or "")
+    return name.lower().startswith("closed-")
+
+
+def _is_thread_archived_or_locked(thread: discord.Thread | None) -> bool:
+    if thread is None:
+        return False
+    return bool(getattr(thread, "archived", False)) or bool(getattr(thread, "locked", False))
+
+
+async def has_recruitment_summary(thread: discord.Thread, *, history_limit: int = 50) -> bool:
+    markers = ("c1c • recruitment summary", "recruitment summary")
+    try:
+        async for message in thread.history(limit=history_limit):
+            content = str(getattr(message, "content", "") or "").casefold()
+            if any(marker in content for marker in markers):
+                return True
+
+            embeds = getattr(message, "embeds", []) or []
+            for embed in embeds:
+                title = str(getattr(embed, "title", "") or "").casefold()
+                description = str(getattr(embed, "description", "") or "").casefold()
+                if any(marker in title or marker in description for marker in markers):
+                    return True
+    except Exception:
+        log.warning("failed checking thread for recruitment summary", exc_info=True)
+    return False
+
+
 async def ensure_idle_watcher(bot: commands.Bot) -> None:
     global _WATCHER_TASK
 
@@ -204,6 +236,43 @@ async def _handle_row(
 
     resolution = welcome_flow.resolve_onboarding_flow(thread)
     flow = (resolution.flow or "welcome").lower()
+
+    session_status = str(row.get("status") or "").strip().lower()
+    if session_status in {"closed", "cancelled", "completed", "auto_closed"}:
+        log.info(
+            "onboarding reminder skipped • reason=closed_ticket • thread_id=%s • thread_name=%s • user_id=%s",
+            getattr(thread, "id", thread_id),
+            getattr(thread, "name", ""),
+            user_id,
+        )
+        return
+
+    if _is_closed_ticket_name(thread):
+        log.info(
+            "onboarding reminder skipped • reason=closed_ticket • thread_id=%s • thread_name=%s • user_id=%s",
+            getattr(thread, "id", thread_id),
+            getattr(thread, "name", ""),
+            user_id,
+        )
+        return
+
+    if _is_thread_archived_or_locked(thread):
+        log.info(
+            "onboarding reminder skipped • reason=thread_archived_or_locked • thread_id=%s • thread_name=%s • user_id=%s",
+            getattr(thread, "id", thread_id),
+            getattr(thread, "name", ""),
+            user_id,
+        )
+        return
+
+    if await has_recruitment_summary(thread):
+        log.info(
+            "onboarding reminder skipped • reason=recruitment_summary_exists • thread_id=%s • thread_name=%s • user_id=%s",
+            getattr(thread, "id", thread_id),
+            getattr(thread, "name", ""),
+            user_id,
+        )
+        return
 
     first_reminder_at = _parse_iso(row.get("first_reminder_at"))
     warning_sent_at = _parse_iso(row.get("warning_sent_at"))


### PR DESCRIPTION
### Motivation

- Ensure the onboarding panel UI is removed or disabled after a recruitment summary is posted so threads remain clean and avoid duplicate controls.
- Prevent idle-watcher reminders from firing for sessions that are already closed, threads that are archived/locked, or threads that already contain a recruitment summary.

### Description

- Add `cleanup_onboarding_panel` to `BaseWelcomeController` and call it after `send_summary_message` to delete or remove the view from the stored panel message and mark the panel inactive via `panels.mark_panel_inactive_by_message`.
- Look up the panel message id from the controller cache or from `shared.sheets.onboarding_sessions.get_by_thread_id` and attempt to fetch, delete, or edit the message, with logging for success/failure and an `exclude_message_id` guard.
- Add helper functions in `idle_watcher.py`: `_is_closed_ticket_name`, `_is_thread_archived_or_locked`, and `has_recruitment_summary` to detect threads that should not receive reminders.
- Short-circuit idle-watcher handling in `_handle_row` to skip reminders when session `status` is closed/completed/cancelled/auto_closed, when the thread name starts with `closed-`, when the thread is archived or locked, or when a recruitment summary is already present.

### Testing

- Ran targeted onboarding tests with `pytest tests/modules/onboarding` and all tests passed.
- Ran the full test suite with `pytest` and it completed without failures.
- Ran linting and basic type checks (`flake8`/`mypy`) and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3edb83d8c83239f45283fddaa0233)