### PR TITLE
Fix onboarding fallback RBAC import causing prod extension-load failure

### DIFF
--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -10,7 +10,8 @@ import discord
 from discord import RawReactionActionEvent
 from discord.ext import commands
 
-from modules.common import feature_flags, rbac
+from c1c_coreops import rbac
+from modules.common import feature_flags
 from shared.config import get_ticket_tool_bot_id
 from modules.onboarding import logs, thread_membership, thread_scopes
 from modules.onboarding.controllers.welcome_controller import (


### PR DESCRIPTION
### Motivation
- Production startup failed during extension load due to `ImportError` caused by `modules.common` not exporting `rbac`, which aborted onboarding extension imports. 
- The intent is a minimal fix to restore the canonical RBAC import used elsewhere so startup and extension loading succeed without changing permission behavior.

### Description
- Replaced the broken import in `modules/onboarding/reaction_fallback.py` from `from modules.common import feature_flags, rbac` to `from c1c_coreops import rbac` and `from modules.common import feature_flags` to match the repository canonical usage. 
- No other codepath, RBAC helpers, intents, OAuth scopes, or permission lists were modified.
- Verified there are no remaining `modules.common` RBAC imports left in the codebase.

### Testing
- Ran a targeted repo search for bad imports (`from modules.common import rbac` / `import modules.common.rbac`) and confirmed none remain, which succeeded. 
- Performed import-checks with the local `c1c_coreops` package in `PYTHONPATH` and placeholder env vars: importing `modules.onboarding.reaction_fallback` succeeded. 
- Performed import-check of the `modules.onboarding` package with the same environment emulation and confirmed successful import and extension discovery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47082691883239d8ee25dcd559e89)