### PR TITLE
Add diagnostics and improved difficulty/range filtering to recruitment search

### DIFF
--- a/modules/recruitment/search.py
+++ b/modules/recruitment/search.py
@@ -16,20 +16,60 @@ from shared.sheets.recruitment import (
 )
 
 from modules.recruitment import search_helpers
-from modules.recruitment.search_helpers import (
-    parse_inactives_num,
-    parse_spots_num,
-    row_matches,
-)
+from modules.recruitment.search_helpers import parse_inactives_num, parse_spots_num
+
+COL_S_CVC = 18
+COL_T_SIEGE = 19
+COL_U_STYLE = 20
 
 __all__ = [
     "fetch_roster_records",
     "filter_records",
     "normalize_records",
     "enforce_inactives_only",
+    "filter_records_with_diagnostics",
 ]
 
 log = logging.getLogger(__name__)
+
+
+def _norm(value: str | None) -> str:
+    return (value or "").strip().upper()
+
+
+def _difficulty_match(cell_value: str, wanted: str | None) -> bool:
+    if not wanted:
+        return True
+    token = _norm(wanted)
+    cell = _norm(cell_value)
+    if token in {"UNM", "ULTRA NIGHTMARE", "ULTRA-NIGHTMARE", "ULTRANIGHTMARE"}:
+        return any(k in cell for k in ("UNM", "ULTRA NIGHTMARE", "ULTRA-NIGHTMARE", "ULTRANIGHTMARE"))
+    return token in cell
+
+
+def _cell(row: Sequence[str], header_map: dict[str, int], key: str) -> str:
+    idx = header_map.get(key)
+    if idx is None or idx < 0 or idx >= len(row):
+        return ""
+    return str(row[idx] or "")
+
+
+def _flag_ok(row: Sequence[str], idx: int, expected: str | None) -> bool:
+    token = _norm(expected)
+    if token in {"", "—", "-", "ANY", "NONE", "NULL"}:
+        return True
+    if idx < 0 or idx >= len(row):
+        return False
+    return str(row[idx] or "").strip() == expected
+
+
+def _playstyle_ok(row: Sequence[str], wanted: str | None) -> bool:
+    if not wanted:
+        return True
+    if COL_U_STYLE >= len(row):
+        return False
+    return search_helpers._playstyle_ok(str(row[COL_U_STYLE] or ""), wanted)
+
 
 
 async def fetch_roster_records(*, force: bool = False) -> list[RecruitmentClanRecord]:
@@ -123,34 +163,96 @@ def filter_records(
 ) -> list[RecruitmentClanRecord]:
     """Apply sheet and roster-mode filters to ``records``."""
 
+    matches, _diag = filter_records_with_diagnostics(
+        records,
+        cb=cb,
+        hydra=hydra,
+        chimera=chimera,
+        cvc=cvc,
+        siege=siege,
+        playstyle=playstyle,
+        roster_mode=roster_mode,
+    )
+    return matches
+
+
+def filter_records_with_diagnostics(
+    records: Sequence[RecruitmentClanRecord | Sequence[str]],
+    *,
+    cb: str | None,
+    hydra: str | None,
+    chimera: str | None,
+    cvc: str | None,
+    siege: str | None,
+    playstyle: str | None,
+    roster_mode: str | None,
+) -> tuple[list[RecruitmentClanRecord], dict[str, int]]:
+    """Apply filters and return matches plus reason counts for dropped rows."""
+
     normalized = normalize_records(records)
     matches: list[RecruitmentClanRecord] = []
-    if not normalized:
-        return matches
+    diagnostics: dict[str, int] = {}
+
+    try:
+        header_map = sheet_recruitment.get_clan_header_map()
+    except Exception:
+        header_map = {}
+
+    primary_matches: list[RecruitmentClanRecord] = []
+    range_matches: list[RecruitmentClanRecord] = []
 
     for record in normalized:
         try:
-            if not row_matches(
-                record.row,
-                cb,
-                hydra,
-                chimera,
-                cvc,
-                siege,
-                playstyle,
-            ):
+            row = record.row
+
+            cb_primary_ok = _difficulty_match(_cell(row, header_map, "cb"), cb)
+            hydra_primary_ok = _difficulty_match(_cell(row, header_map, "hydra"), hydra)
+            chimera_primary_ok = _difficulty_match(_cell(row, header_map, "chimera"), chimera)
+
+            cb_range_ok = _difficulty_match(_cell(row, header_map, "cb_range"), cb)
+            hydra_range_ok = _difficulty_match(_cell(row, header_map, "hydra_range"), hydra)
+            chimera_range_ok = _difficulty_match(_cell(row, header_map, "chimera_range"), chimera)
+
+            primary_ok = cb_primary_ok and hydra_primary_ok and chimera_primary_ok
+            fallback_ok = (cb_primary_ok or cb_range_ok) and (hydra_primary_ok or hydra_range_ok) and (chimera_primary_ok or chimera_range_ok)
+
+            if not fallback_ok:
+                diagnostics["difficulty"] = diagnostics.get("difficulty", 0) + 1
+                continue
+            if not _flag_ok(row, COL_S_CVC, cvc):
+                diagnostics["cvc"] = diagnostics.get("cvc", 0) + 1
+                continue
+            if not _flag_ok(row, COL_T_SIEGE, siege):
+                diagnostics["siege"] = diagnostics.get("siege", 0) + 1
+                continue
+            if not _playstyle_ok(row, playstyle):
+                diagnostics["playstyle"] = diagnostics.get("playstyle", 0) + 1
                 continue
             if roster_mode == "open" and record.open_spots <= 0:
+                diagnostics["roster_open_spots"] = diagnostics.get("roster_open_spots", 0) + 1
                 continue
             if roster_mode == "full" and record.open_spots > 0:
+                diagnostics["roster_full_only"] = diagnostics.get("roster_full_only", 0) + 1
                 continue
             if roster_mode == "inactives" and record.inactives <= 0:
+                diagnostics["roster_inactives"] = diagnostics.get("roster_inactives", 0) + 1
                 continue
-            matches.append(record)
+
+            if primary_ok:
+                primary_matches.append(record)
+            else:
+                range_matches.append(record)
         except Exception:
+            diagnostics["exception"] = diagnostics.get("exception", 0) + 1
             continue
 
-    return matches
+    matches = list(primary_matches)
+    if len(matches) < 3:
+        matches.extend(range_matches)
+    else:
+        diagnostics["range_fallback_held"] = len(range_matches)
+
+    return matches, diagnostics
 
 
 def enforce_inactives_only(

--- a/modules/recruitment/search_helpers.py
+++ b/modules/recruitment/search_helpers.py
@@ -9,6 +9,7 @@ __all__ = [
     "parse_spots_num",
     "parse_inactives_num",
     "row_matches",
+    "evaluate_row_filters",
     "format_filters_footer",
 ]
 
@@ -91,7 +92,8 @@ def _cell_has_diff(cell_text: str, token: str | None) -> bool:
 
 
 def _cell_equals_flag(cell_text: str, expected: Optional[str]) -> bool:
-    if expected is None:
+    normalized_expected = _norm(expected or "")
+    if normalized_expected in {"", "—", "-", "ANY", "NONE", "NULL"}:
         return True
     return (cell_text or "").strip() == expected
 
@@ -188,6 +190,41 @@ def row_matches(
     )
 
 
+def evaluate_row_filters(
+    row: Sequence[str],
+    cb: Optional[str],
+    hydra: Optional[str],
+    chimera: Optional[str],
+    cvc: Optional[str],
+    siege: Optional[str],
+    playstyle: Optional[str],
+) -> tuple[bool, str]:
+    """Return ``(matches, reason)`` for debugging filter behavior."""
+
+    if len(row) <= IDX_AB:
+        return False, "short_row"
+    if _is_header_row(row):
+        return False, "header_row"
+    if not (row[COL_B_CLAN] or "").strip():
+        return False, "blank_clan"
+    roster_cell = row[COL_E_SPOTS] if len(row) > COL_E_SPOTS else ""
+    if not str(roster_cell or "").strip():
+        return False, "blank_roster"
+    if not _cell_has_diff(row[COL_P_CB], cb):
+        return False, "cb"
+    if not _cell_has_diff(row[COL_Q_HYDRA], hydra):
+        return False, "hydra"
+    if not _cell_has_diff(row[COL_R_CHIMERA], chimera):
+        return False, "chimera"
+    if not _cell_equals_flag(row[COL_S_CVC], cvc):
+        return False, "cvc"
+    if not _cell_equals_flag(row[COL_T_SIEGE], siege):
+        return False, "siege"
+    if not _playstyle_ok(row[COL_U_STYLE], playstyle):
+        return False, "playstyle"
+    return True, "ok"
+
+
 def format_filters_footer(
     cb: Optional[str],
     hydra: Optional[str],
@@ -233,4 +270,3 @@ def format_filters_footer(
         parts.append(extra_note)
 
     return " • ".join(parts)
-

--- a/modules/recruitment/views/member_panel.py
+++ b/modules/recruitment/views/member_panel.py
@@ -466,7 +466,7 @@ class MemberPanelController:
     def _filter_rows(
         self, records: Sequence[RecruitmentClanRecord], filters: MemberSearchFilters
     ) -> list[RecruitmentClanRecord]:
-        return roster_search.filter_records(
+        matches, diagnostics = roster_search.filter_records_with_diagnostics(
             records,
             cb=filters.cb,
             hydra=filters.hydra,
@@ -476,4 +476,9 @@ class MemberPanelController:
             playstyle=filters.playstyle,
             roster_mode=filters.roster_mode,
         )
-
+        if not matches:
+            log.debug(
+                "member clansearch returned no rows",
+                extra={"filters": filters.__dict__, "diagnostics": diagnostics},
+            )
+        return matches

--- a/modules/recruitment/views/member_panel_legacy.py
+++ b/modules/recruitment/views/member_panel_legacy.py
@@ -406,7 +406,7 @@ class MemberPanelControllerLegacy:
         if roster_mode in {"", "any"}:
             roster_mode = None
 
-        matches = roster_search.filter_records(
+        matches, diagnostics = roster_search.filter_records_with_diagnostics(
             rows,
             cb=state.cb,
             hydra=state.hydra,
@@ -416,6 +416,11 @@ class MemberPanelControllerLegacy:
             playstyle=state.playstyle,
             roster_mode=roster_mode,
         )
+        if not matches:
+            log.debug(
+                "member legacy clansearch returned no rows",
+                extra={"state": state.__dict__, "diagnostics": diagnostics},
+            )
 
         return roster_search.enforce_inactives_only(
             matches,

--- a/modules/recruitment/views/recruiter_panel.py
+++ b/modules/recruitment/views/recruiter_panel.py
@@ -808,7 +808,7 @@ class RecruiterPanelView(discord.ui.View):
 
             self.has_searched = True
 
-            filtered_records = roster_search.filter_records(
+            filtered_records, diagnostics = roster_search.filter_records_with_diagnostics(
                 records,
                 cb=self.cb,
                 hydra=self.hydra,
@@ -835,6 +835,21 @@ class RecruiterPanelView(discord.ui.View):
             )
 
             if not filtered_records:
+                log.debug(
+                    "recruiter clanmatch returned no rows",
+                    extra={
+                        "filters": {
+                            "cb": self.cb,
+                            "hydra": self.hydra,
+                            "chimera": self.chimera,
+                            "cvc": self.cvc,
+                            "siege": self.siege,
+                            "playstyle": self.playstyle,
+                            "roster_mode": self.roster_mode,
+                        },
+                        "diagnostics": diagnostics,
+                    },
+                )
                 self.matches = []
                 self.results_filters_text = filters_summary
                 self.results_note = None
@@ -939,5 +954,4 @@ class RecruiterPanelView(discord.ui.View):
                 await self.results_message.edit(view=self.results_view)
         if self.message:
             self.cog.unregister_panel(self.message.id)
-
 

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -68,6 +68,12 @@ def _column_aliases(*aliases: str) -> tuple[str, ...]:
 
 
 HEADER_MAP: Dict[str, tuple[str, ...]] = {
+    "cb": _column_aliases("cb", "clan boss", "clanboss"),
+    "hydra": _column_aliases("hydra", "hydra difficulty"),
+    "chimera": _column_aliases("chimera", "chimera difficulty"),
+    "cb_range": _column_aliases("cb range", "clan boss range", "clanboss range"),
+    "hydra_range": _column_aliases("hydra range", "hydra difficulty range"),
+    "chimera_range": _column_aliases("chimera range", "chimera difficulty range"),
     "open_spots": _column_aliases(
         "open spots",
         "spots",


### PR DESCRIPTION
### Motivation

- Improve visibility into why rows are dropped during recruitment searches by emitting structured diagnostics.  
- Make difficulty filtering more flexible by checking both primary and range columns and preferring primary entries when available.  
- Normalize flag/playstyle checks and register additional header aliases to make sheet header resolution more robust.

### Description

- Added helper functions in `modules/recruitment/search.py` (`_norm`, `_difficulty_match`, `_cell`, `_flag_ok`, `_playstyle_ok`) and column constants for CvC/Siege/Playstyle to evaluate cells safely.  
- Introduced `filter_records_with_diagnostics` in `modules/recruitment/search.py` which returns `(matches, diagnostics)` and implements primary vs range difficulty matching with a fallback policy that prefers primary matches and only uses range matches when fewer than three primary matches exist.  
- Kept `filter_records` as a thin wrapper over the new diagnostics variant to preserve the original API.  
- Emit debug logs with filter context and `diagnostics` when member/recruiter search panels return no rows by updating `member_panel.py`, `member_panel_legacy.py`, and `recruiter_panel.py`.  
- Added `evaluate_row_filters` to `modules/recruitment/search_helpers.py` for debug-friendly row evaluation and tightened `_cell_equals_flag` normalization to treat tokens like `ANY`, `NONE`, and `NULL` as wildcards.  
- Extended `shared/sheets/recruitment.py` header map with aliases for `cb`, `hydra`, `chimera` and their `_range` variants to improve header resolution for legacy sheets.

### Testing

- Ran the project's recruitment-related unit tests and the search helper tests; they completed and passed.  
- Exercised the recruiter and member panel search flows in the test harness to verify no-results logging and that the fallback primary/range behavior returns sensible results under filter combinations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c9eebec08323981bda27810ff7a1)