### PR TITLE
Update Role & Visitor Audit embed wording and include visitor join dates

### DIFF
--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -276,6 +276,13 @@ def _render_section(title: str, lines: Sequence[str]) -> list[str]:
     return [f"**{title}**", *content]
 
 
+def _format_joined_date(member: discord.abc.User) -> str:
+    joined_at = getattr(member, "joined_at", None)
+    if not joined_at:
+        return "unknown"
+    return joined_at.strftime("%Y-%m-%d")
+
+
 def _render_report(
     *,
     summary: AuditResult,
@@ -298,7 +305,7 @@ def _render_report(
         f"• {_format_member(member)} – {wanderer_action} `{raid_role_name}`, kept `{wanderer_role_name}` (no clan tags)"
         for member in (summary.auto_fixed_wanderers or [])
     ]
-    parts.extend(_render_section("1) Auto-fixed stray members", stray_lines + wanderer_lines))
+    parts.extend(_render_section("1) Stray members", stray_lines + wanderer_lines))
     parts.append("")
 
     manual_lines = [
@@ -313,7 +320,10 @@ def _render_report(
     )
     parts.append("")
 
-    visitor_no_ticket = [f"• {_format_member(member)} – no ticket found" for member in (summary.visitors_no_ticket or [])]
+    visitor_no_ticket = [
+        f"• {_format_member(member)} – joined {_format_joined_date(member)} – no ticket found"
+        for member in (summary.visitors_no_ticket or [])
+    ]
     parts.extend(_render_section("3) Visitors without any ticket", visitor_no_ticket))
     parts.append("")
 

--- a/tests/housekeeping/test_role_audit.py
+++ b/tests/housekeeping/test_role_audit.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from datetime import datetime, timezone
 
 from modules.housekeeping import role_audit
 
@@ -41,7 +42,7 @@ def test_classify_roles_covers_stray_and_wander_cases():
 
 
 def test_render_report_formats_all_sections():
-    member = DummyMember(id=1, name="tester", roles=[])
+    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
     clan_role = DummyRole(id=10, name="ClanTag")
     ticket = SimpleNamespace(name="W0001-test", url="https://discord.com/channels/1/2")
 
@@ -62,8 +63,21 @@ def test_render_report_formats_all_sections():
     assert isinstance(embed, role_audit.discord.Embed)
     description = embed.description or ""
 
-    assert "Auto-fixed stray members" in description
+    assert "1) Stray members" in description
     assert "Manual review" in description
     assert "Visitors without any ticket" in description
+    assert "joined 2026-04-18" in description
     assert "Visitors with only closed tickets" in description
     assert "Visitors with extra roles" in description
+
+
+def test_render_report_uses_unknown_join_date_when_missing():
+    member = DummyMember(id=1, name="tester", roles=[], joined_at=None)
+    summary = role_audit.AuditResult(checked=1, visitors_no_ticket=[member])
+
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+
+    description = embed.description or ""
+    assert "joined unknown" in description


### PR DESCRIPTION
### Motivation
- Remove wording that implies the audit auto-fixes members by renaming the stray section header to avoid communicating behavior that no longer occurs.
- Provide moderators additional context for visitors without tickets by showing each member's server join date in `YYYY-MM-DD` format.
- Preserve existing audit behavior and avoid introducing any hard-coded channel IDs, sheet tabs, or columns.

### Description
- Renamed the first audit section from `"1) Auto-fixed stray members"` to `"1) Stray members"` in `modules/housekeeping/role_audit.py`.
- Added a helper `def _format_joined_date(member: discord.abc.User) -> str` to render `member.joined_at` as `YYYY-MM-DD` or return `unknown` when unavailable.
- Updated the "Visitors without any ticket" lines to include the joined date as `• @Name — joined YYYY-MM-DD — no ticket found` using the new formatter.
- Updated tests in `tests/housekeeping/test_role_audit.py` to assert the new section title and both join-date formatting paths, while keeping the rest of the audit output unchanged.

### Testing
- Ran `pytest -q tests/housekeeping/test_role_audit.py` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6432977008323a673566254769cbc)