### PR TITLE
Add robust append API and repair pass for Welcome sheet; update watcher to use it

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -2803,9 +2803,8 @@ class WelcomeTicketWatcher(commands.Cog):
         created_at: datetime,
         user_ref: str,
     ) -> None:
-        headers = _WELCOME_HEADERS
-        created_value = created_at.isoformat()
-        updated_value = datetime.now(timezone.utc).isoformat()
+        created_value = created_at
+        updated_value = datetime.now(timezone.utc)
 
         try:
             existing = await asyncio.to_thread(
@@ -2819,35 +2818,16 @@ class WelcomeTicketWatcher(commands.Cog):
             )
             existing = None
 
+        clan_value = context.final_clan or ""
+        closed_value = ""
         if existing:
             row_values = list(existing[1])
-        else:
-            row_values = [
-                context.ticket_number,
-                context.username,
-                context.final_clan or "",
-                "",
-                getattr(thread, "name", ""),
-                str(context.recruit_id or ""),
-                str(getattr(thread, "id", 0)),
-                "",
-                "open",
-                created_value,
-                "",
-            ]
-
-        if len(row_values) < len(headers):
-            row_values.extend(["" for _ in range(len(headers) - len(row_values))])
-
-        try:
-            created_idx = headers.index("created_at")
-            updated_idx = headers.index("updated_at")
-        except ValueError:
-            return
-
-        if not row_values[created_idx]:
-            row_values[created_idx] = created_value
-        row_values[updated_idx] = updated_value
+            clan_idx = onboarding_sheets.WELCOME_CLAN_TAG_INDEX
+            closed_idx = onboarding_sheets.WELCOME_DATE_CLOSED_INDEX
+            if clan_idx < len(row_values) and not clan_value:
+                clan_value = str(row_values[clan_idx] or "").strip()
+            if closed_idx < len(row_values):
+                closed_value = str(row_values[closed_idx] or "").strip()
 
         try:
             await log_sheet_write(
@@ -2858,7 +2838,18 @@ class WelcomeTicketWatcher(commands.Cog):
                 thread=thread,
                 user=user_ref,
                 write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_welcome, row_values, headers
+                    onboarding_sheets.append_welcome_ticket_row,
+                    context.ticket_number,
+                    context.username,
+                    clan_value,
+                    closed_value,
+                    thread_name=getattr(thread, "name", ""),
+                    user_id=context.recruit_id,
+                    thread_id=int(getattr(thread, "id", 0)),
+                    panel_message_id=context.prompt_message_id,
+                    status="open",
+                    created_at=created_value,
+                    updated_at=updated_value,
                 ),
             )
         except Exception:
@@ -3064,9 +3055,19 @@ class WelcomeTicketWatcher(commands.Cog):
 
         row_values: List[str] | None = row_info[1] if row_info else None
         if not row_values:
-            row_values = [context.ticket_number, context.username, "", ""]
             try:
-                await asyncio.to_thread(onboarding_sheets.upsert_welcome, row_values, _WELCOME_HEADERS)
+                await asyncio.to_thread(
+                    onboarding_sheets.append_welcome_ticket_row,
+                    context.ticket_number,
+                    context.username,
+                    "",
+                    "",
+                    thread_name=getattr(thread, "name", ""),
+                    user_id=context.recruit_id,
+                    thread_id=int(getattr(thread, "id", 0)),
+                    panel_message_id=context.prompt_message_id,
+                    status="open",
+                )
             except Exception:
                 log.exception(
                     "failed to insert onboarding row during manual close",
@@ -3280,7 +3281,6 @@ class WelcomeTicketWatcher(commands.Cog):
         )
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-        row = [context.ticket_number, context.username, final_tag, timestamp]
 
         try:
             result = await log_sheet_write(
@@ -3291,7 +3291,17 @@ class WelcomeTicketWatcher(commands.Cog):
                 thread=thread,
                 user=context.username,
                 write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_welcome, row, _WELCOME_HEADERS
+                    onboarding_sheets.append_welcome_ticket_row,
+                    context.ticket_number,
+                    context.username,
+                    final_tag,
+                    timestamp,
+                    thread_name=getattr(thread, "name", ""),
+                    user_id=context.recruit_id,
+                    thread_id=int(getattr(thread, "id", 0)),
+                    panel_message_id=context.prompt_message_id,
+                    status="closed",
+                    updated_at=datetime.now(timezone.utc),
                 ),
             )
         except Exception:

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1661,6 +1661,17 @@ async def _send_runtime(message: str) -> None:
         log.warning("failed to send welcome watcher log message", exc_info=True)
 
 
+async def _send_welcome_repair_visibility() -> None:
+    try:
+        message = onboarding_sheets.consume_welcome_repair_alert()
+    except Exception:
+        log.debug("failed to consume welcome repair alert", exc_info=True)
+        return
+    if not message:
+        return
+    await _send_runtime(message)
+
+
 def _channel_readable_label(bot: commands.Bot, channel_id: int | None) -> str:
     if channel_id is None:
         return "#unknown"
@@ -2785,6 +2796,7 @@ class WelcomeTicketWatcher(commands.Cog):
                 context.username,
                 result,
             )
+            await _send_welcome_repair_visibility()
         except Exception as exc:
             log.error(
                 "❌ welcome_ticket_open — ticket=%s • user=%s • result=error • reason=%s",
@@ -2852,6 +2864,7 @@ class WelcomeTicketWatcher(commands.Cog):
                     updated_at=updated_value,
                 ),
             )
+            await _send_welcome_repair_visibility()
         except Exception:
             log.debug(
                 "welcome reminder: sheet touch failed",
@@ -3076,6 +3089,7 @@ class WelcomeTicketWatcher(commands.Cog):
                 row_values = None
             else:
                 context.row_created_during_close = True
+                await _send_welcome_repair_visibility()
                 log.warning(
                     "⚠️ welcome_close_manual — ticket=%s • user=%s • reason=onboarding_row_missing_manual_close • action=row_inserted_no_reconcile",
                     context.ticket_number,
@@ -3304,6 +3318,7 @@ class WelcomeTicketWatcher(commands.Cog):
                     updated_at=datetime.now(timezone.utc),
                 ),
             )
+            await _send_welcome_repair_visibility()
         except Exception:
             log.exception(
                 "❌ welcome_close — ticket=%s • user=%s • final=%s • result=error • reason=sheet_write",

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -23,6 +23,8 @@ _CONFIG_CACHE_TS: float = 0.0
 _CLAN_TAGS: List[str] | None = None
 _CLAN_TAG_TS: float = 0.0
 _WELCOME_REPAIR_LAST_RUN: float = 0.0
+_WELCOME_REPAIR_ALERT_LAST_TS: float = 0.0
+_WELCOME_REPAIR_ALERT_PENDING: str | None = None
 
 
 log = logging.getLogger(__name__)
@@ -356,6 +358,28 @@ def repair_welcome_rows(ws) -> dict[str, int]:
     return {"repaired": repaired, "flagged": flagged, "scanned": scanned}
 
 
+def _queue_welcome_repair_alert(summary: dict[str, int]) -> None:
+    global _WELCOME_REPAIR_ALERT_LAST_TS, _WELCOME_REPAIR_ALERT_PENDING
+    flagged = int(summary.get("flagged", 0) or 0)
+    if flagged <= 0:
+        return
+    repaired = int(summary.get("repaired", 0) or 0)
+    now_ts = time.time()
+    if (now_ts - _WELCOME_REPAIR_ALERT_LAST_TS) < 3600:
+        return
+    _WELCOME_REPAIR_ALERT_LAST_TS = now_ts
+    _WELCOME_REPAIR_ALERT_PENDING = (
+        f"Welcome ticket repair: {repaired} repaired, {flagged} flagged for review"
+    )
+
+
+def consume_welcome_repair_alert() -> str | None:
+    global _WELCOME_REPAIR_ALERT_PENDING
+    message = _WELCOME_REPAIR_ALERT_PENDING
+    _WELCOME_REPAIR_ALERT_PENDING = None
+    return message
+
+
 def _match_row(
     headers: Sequence[str],
     row: Sequence[str],
@@ -475,8 +499,9 @@ def append_welcome_ticket_row(
     if (now_ts - _WELCOME_REPAIR_LAST_RUN) > 3600:
         summary = repair_welcome_rows(ws)
         _WELCOME_REPAIR_LAST_RUN = now_ts
+        _queue_welcome_repair_alert(summary)
         if summary.get("repaired") or summary.get("flagged"):
-            log.warning("welcome row repair pass summary • %s", summary)
+            log.warning("welcome row repair pass summary", extra={"summary": summary})
     normalized_header = [_normalize_header_name(col) for col in header]
     ticket_value = _fmt_ticket(ticket)
     if not ticket_value:

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from datetime import datetime, timezone
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
@@ -21,6 +22,7 @@ _CONFIG_CACHE_TS: float = 0.0
 
 _CLAN_TAGS: List[str] | None = None
 _CLAN_TAG_TS: float = 0.0
+_WELCOME_REPAIR_LAST_RUN: float = 0.0
 
 
 log = logging.getLogger(__name__)
@@ -61,6 +63,8 @@ PROMO_HEADERS: List[str] = [
 WELCOME_TICKET_INDEX = 0
 WELCOME_CLAN_TAG_INDEX = 2
 WELCOME_DATE_CLOSED_INDEX = 3
+_DISCORD_ID_RE = re.compile(r"^\d{15,22}$")
+_WELCOME_TICKET_RE = re.compile(r"^[A-Z]+\d{2,}$")
 
 
 def _sheet_id() -> str:
@@ -264,6 +268,94 @@ def _normalize_header_name(name: str) -> str:
     return "".join(ch for ch in str(name or "").lower() if ch.isalnum())
 
 
+def _is_isoish(value: str) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def _is_discord_id(value: str) -> bool:
+    return bool(_DISCORD_ID_RE.match(str(value or "").strip()))
+
+
+def _looks_like_ticket(value: str) -> bool:
+    return bool(_WELCOME_TICKET_RE.match(_fmt_ticket(value)))
+
+
+def repair_welcome_rows(ws) -> dict[str, int]:
+    header = _ensure_headers(ws, WELCOME_HEADERS)
+    norm = [_normalize_header_name(col) for col in header]
+    idx = {name: pos for pos, name in enumerate(norm)}
+    required = {"ticketnumber", "username"}
+    if not required.issubset(idx):
+        return {"repaired": 0, "flagged": 0, "scanned": 0}
+
+    values = core.call_with_backoff(ws.get_all_values)
+    repaired = 0
+    flagged = 0
+    scanned = 0
+    for row_number, row in enumerate(values[1:], start=2):
+        scanned += 1
+        row_values = list(row) + [""] * (len(header) - len(row))
+        ticket = row_values[idx["ticketnumber"]].strip()
+        username = row_values[idx["username"]].strip()
+        user_id_idx = idx.get("userid")
+        thread_id_idx = idx.get("threadid")
+        status_idx = idx.get("status")
+        created_idx = idx.get("createdat")
+        updated_idx = idx.get("updatedat")
+
+        user_id = row_values[user_id_idx].strip() if user_id_idx is not None else ""
+        thread_id = row_values[thread_id_idx].strip() if thread_id_idx is not None else ""
+
+        changed = False
+        if user_id_idx is not None and not _is_discord_id(user_id):
+            candidate = thread_id if _is_discord_id(thread_id) else ""
+            if candidate:
+                row_values[user_id_idx] = candidate
+                if thread_id_idx is not None:
+                    row_values[thread_id_idx] = ""
+                changed = True
+            elif _is_isoish(user_id):
+                row_values[user_id_idx] = ""
+                changed = True
+
+        if thread_id_idx is not None and not _is_discord_id(row_values[thread_id_idx]):
+            if _is_isoish(row_values[thread_id_idx]) or "-" in row_values[thread_id_idx]:
+                row_values[thread_id_idx] = ""
+                changed = True
+
+        invalid = (not _looks_like_ticket(ticket)) or (not username)
+        if invalid and status_idx is not None:
+            status_value = str(row_values[status_idx] or "").strip().lower()
+            if status_value not in {"invalid", "needs_review"}:
+                row_values[status_idx] = "needs_review"
+                changed = True
+            flagged += 1
+        elif status_idx is not None and str(row_values[status_idx] or "").strip().lower() == "needs_review":
+            # keep explicit invalid marker untouched
+            pass
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if changed and updated_idx is not None:
+            row_values[updated_idx] = now_iso
+        if created_idx is not None and not str(row_values[created_idx] or "").strip():
+            row_values[created_idx] = now_iso
+            changed = True
+
+        if changed:
+            end_col = _col_to_a1(len(header) - 1)
+            core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row_values[: len(header)]])
+            repaired += 1
+
+    return {"repaired": repaired, "flagged": flagged, "scanned": scanned}
+
+
 def _match_row(
     headers: Sequence[str],
     row: Sequence[str],
@@ -375,19 +467,73 @@ def append_welcome_ticket_row(
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
 ) -> str:
+    global _WELCOME_REPAIR_LAST_RUN
     sheet_id, tab = _resolve_onboarding_and_welcome_tab()
     ws = core.get_worksheet(sheet_id, tab)
     header = _ensure_headers(ws, WELCOME_HEADERS)
+    now_ts = time.time()
+    if (now_ts - _WELCOME_REPAIR_LAST_RUN) > 3600:
+        summary = repair_welcome_rows(ws)
+        _WELCOME_REPAIR_LAST_RUN = now_ts
+        if summary.get("repaired") or summary.get("flagged"):
+            log.warning("welcome row repair pass summary • %s", summary)
+    normalized_header = [_normalize_header_name(col) for col in header]
     ticket_value = _fmt_ticket(ticket)
+    if not ticket_value:
+        raise ValueError("ticket value is required for welcome ticket writes")
+    if not _looks_like_ticket(ticket_value):
+        raise ValueError(f"ticket value has unexpected format: {ticket_value}")
+    if not str(username or "").strip():
+        raise ValueError("username is required for welcome ticket writes")
+
+    existing_match = None
+    try:
+        keys, search_values = _ticket_key_columns(header, ticket_value, thread_id)
+        values = core.call_with_backoff(ws.get_all_values)
+        for row in values[1:]:
+            if _match_row(header, row, keys, search_values):
+                existing_match = list(row)
+                break
+    except Exception:
+        existing_match = None
+
     created, updated = _normalize_ticket_timestamps(created_at, updated_at)
+    if existing_match and created_at is None:
+        try:
+            created_idx = normalized_header.index("createdat")
+        except ValueError:
+            created_idx = -1
+        if created_idx >= 0 and created_idx < len(existing_match):
+            existing_created = str(existing_match[created_idx] or "").strip()
+            if existing_created:
+                try:
+                    created = datetime.fromisoformat(existing_created.replace("Z", "+00:00"))
+                except ValueError:
+                    pass
+
+    clan_text = str(clan_tag or "").strip()
+    closed_text = str(date_closed or "").strip()
+    if existing_match:
+        try:
+            clan_idx = normalized_header.index("clantag")
+            if not clan_text and clan_idx < len(existing_match):
+                clan_text = str(existing_match[clan_idx] or "").strip()
+        except ValueError:
+            pass
+        try:
+            closed_idx = normalized_header.index("dateclosed")
+            if not closed_text and closed_idx < len(existing_match):
+                closed_text = str(existing_match[closed_idx] or "").strip()
+        except ValueError:
+            pass
 
     value_map: dict[str, str] = {
         "ticket": ticket_value,
         "ticketnumber": ticket_value,
         "ticketid": ticket_value,
         "username": str(username or "").strip(),
-        "clantag": str(clan_tag or "").strip(),
-        "dateclosed": str(date_closed or "").strip(),
+        "clantag": clan_text,
+        "dateclosed": closed_text,
         "threadname": str(thread_name or "").strip(),
         "userid": str(user_id) if user_id is not None else "",
         "threadid": str(thread_id) if thread_id is not None else "",


### PR DESCRIPTION
### Motivation
- Replace ad-hoc row upserts with a safer, validated append/update path for Welcome tickets and proactively repair malformed rows. 
- Ensure the watcher writes consistent typed timestamps and preserves existing clan/date_closed values when touching or closing tickets.

### Description
- Introduces `append_welcome_ticket_row` in `shared/sheets/onboarding.py` which validates inputs, normalizes timestamps with `_normalize_ticket_timestamps`, finds matching rows, preserves existing `clantag`/`dateclosed` when appropriate, and delegates to the existing `_upsert` logic. 
- Adds sheet-health helpers and heuristics including `_is_isoish`, `_is_discord_id`, `_looks_like_ticket`, regex constants, and a `repair_welcome_rows` pass that flags or fixes common issues (misplaced discord ids, iso timestamps in id fields, missing created timestamps) and runs at most once per hour during writes. 
- Updates watcher code in `modules/onboarding/watcher_welcome.py` to call `append_welcome_ticket_row` instead of the old `upsert_welcome` and to pass `created_at`/`updated_at` as `datetime` objects while preserving/deriving `clan` and `date_closed` values from existing rows when touching or closing tickets. 
- Adds stronger input checks in the append path to reject empty or malformed `ticket`/`username` values and logs repair summaries when fixes are applied. 

### Testing
- Ran the automated test suite with `pytest` against the modified modules and sheets helpers, and the test run completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1139aa74832399728ceecf2078be)