### PR TITLE
Support `fragment` fusion_type in fusion publish flow

### DIFF
--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -107,6 +107,10 @@ def _normalize_fusion_id(value: object) -> str:
     return " ".join(str(value or "").strip().casefold().split())
 
 
+def _normalize_fusion_type(value: object) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
 def _pick(row: Mapping[str, object], *keys: str) -> object:
     for key in keys:
         if key in row:
@@ -350,7 +354,7 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
                     fusion_name=str(row.get("fusion_name") or "").strip(),
                     champion=str(row.get("champion") or "").strip(),
                     champion_image_url=str(row.get("champion_image_url") or "").strip(),
-                    fusion_type=str(row.get("fusion_type") or "").strip(),
+                    fusion_type=_normalize_fusion_type(row.get("fusion_type")),
                     fusion_structure=str(row.get("fusion_structure") or "").strip(),
                     reward_type=str(row.get("reward_type") or "").strip(),
                     needed=_parse_int(_pick(row, "fusion.needed", "needed")),
@@ -866,7 +870,10 @@ async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:
     return ended
 
 def _tracker_kind(row: FusionRow) -> str:
-    return "titan" if str(row.fusion_type or "").strip().casefold() == "titan" else "fusion"
+    normalized = _normalize_fusion_type(row.fusion_type)
+    if normalized in {"titan", "titan_event", "titan event"}:
+        return "titan"
+    return "fusion"
 
 
 async def get_publishable_fusion(

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -314,3 +314,89 @@ def test_transition_fusion_to_ended_is_noop_when_already_ended(
     assert changed is False
     worksheet.update.assert_not_awaited()
     fusion.cache.refresh_now.assert_not_awaited()
+
+
+def _fusion_row(*, fusion_id: str, fusion_type: str, status: str) -> fusion.FusionRow:
+    return fusion.FusionRow(
+        fusion_id=fusion_id,
+        fusion_name=fusion_id,
+        champion="Champ",
+        champion_image_url="",
+        fusion_type=fusion_type,
+        fusion_structure="",
+        reward_type="fragments",
+        needed=100,
+        available=0,
+        start_at_utc=dt.datetime(2026, 5, 1, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        announcement_channel_id=None,
+        opt_in_role_id=None,
+        announcement_message_id=None,
+        published_at=None,
+        last_announcement_refresh_at=None,
+        last_announcement_status_hash="",
+        status=status,
+    )
+
+
+def test_get_publishable_fusion_includes_fragment_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = (
+        _fusion_row(fusion_id="hybrid-active", fusion_type="hybrid", status="active"),
+        _fusion_row(fusion_id="fragment-draft", fusion_type="fragment", status="draft"),
+    )
+    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=rows))
+
+    result = asyncio.run(
+        fusion.get_publishable_fusion(include_draft=True, tracker_kind="fusion", prefer_draft=True)
+    )
+
+    assert result is not None
+    assert result.fusion_id == "fragment-draft"
+
+
+@pytest.mark.parametrize(
+    ("fusion_type", "expected"),
+    [
+        ("hybrid", "fusion"),
+        ("fragment", "fusion"),
+        ("fusion", "fusion"),
+        ("traditional", "fusion"),
+        ("titan", "titan"),
+        ("titan_event", "titan"),
+        ("titan event", "titan"),
+    ],
+)
+def test_tracker_kind_maps_supported_fusion_types(fusion_type: str, expected: str) -> None:
+    row = _fusion_row(fusion_id="f-1", fusion_type=fusion_type, status="draft")
+    assert fusion._tracker_kind(row) == expected
+
+
+def test_load_fusions_normalizes_fragment_fusion_type_case(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
+        return [
+            {
+                "fusion_id": "fragment-case",
+                "fusion_name": "Mashiro",
+                "champion": "Mashiro",
+                "champion_image_url": "",
+                "fusion_type": "FRAGMENT",
+                "reward_type": "fragments",
+                "needed": "100",
+                "available": "0",
+                "start_at_utc": "2026-05-01T00:00:00Z",
+                "end_at_utc": "2026-05-20T00:00:00Z",
+                "status": "draft",
+            }
+        ]
+
+    monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+
+    rows = asyncio.run(fusion._load_fusions())
+
+    assert len(rows) == 1
+    assert rows[0].fusion_type == "fragment"


### PR DESCRIPTION
### Motivation
- Rows with `fusion_type="fragment"` were being ignored by the publish selection path, so fragment fusions were not flowing through the normal fusion announcement/reminder/progress pipeline.
- The intention is to ensure fragment entries behave like normal fusions (not titan events) without adding a new tracker kind and while preserving config-driven sheet handling.

### Description
- Add a `_normalize_fusion_type` helper and use it when loading rows so fusion types are canonicalized case/whitespace-insensitively (e.g., `FRAGMENT` → `fragment`).
- Update `_tracker_kind` to inspect the normalized fusion type and map `{"titan", "titan_event", "titan event"}` to `"titan"` while treating all other supported forms (including `hybrid`, `fragment`, `fusion`, `traditional`) as `"fusion"`.
- Do not introduce any new tracker kind and keep the existing fusion pipeline (`announcement`, `events`, `reminders`, `progress`) unchanged.
- Add unit tests in `tests/shared/sheets/test_fusion.py` that verify fragment drafts are selected by `get_publishable_fusion(...)`, the tracker-kind mappings for aliases, and normalization of uppercase `FRAGMENT`.

### Testing
- Ran `pytest -q tests/shared/sheets/test_fusion.py` and the suite passed (`...................  [100%]`).
- The change is limited to `shared/sheets/fusion.py` and tests in `tests/shared/sheets/test_fusion.py`, and all modified tests succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccfa2280c832388558841011be3c4)