### PR TITLE
Improve diagnostics for fusion row parsing and welcome ticket repair failures

### DIFF
--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -100,6 +100,25 @@ class FusionCog(commands.Cog):
             return
 
         if target is None:
+            parse_errors = fusion_sheets.get_last_fusion_parse_errors()
+            kind_parse_errors = {
+                fusion_id: field
+                for fusion_id, field in parse_errors.items()
+                if tracker_kind in {"fusion", "titan"} and tracker_kind in fusion_id.casefold()
+            }
+            if parse_errors and not kind_parse_errors:
+                kind_parse_errors = parse_errors
+            if kind_parse_errors:
+                log.warning(
+                    "%s publish found fusion parse errors in source rows",
+                    tracker_label,
+                    extra={"parse_errors": kind_parse_errors},
+                )
+                await ctx.reply(
+                    f"{tracker_label.title()} row exists but could not be parsed; check logs.",
+                    mention_author=False,
+                )
+                return
             await ctx.reply(
                 f"No {tracker_label} rows exist in the configured fusion sheet tab.",
                 mention_author=False,

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -23,6 +23,7 @@ _CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))
 
 _FUSION_BUCKET = "fusion"
 _FUSION_EVENTS_BUCKET = "fusion_events"
+_LAST_FUSION_PARSE_ERRORS: dict[str, str] = {}
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
 _PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "done_bonus", "skipped"}
@@ -345,50 +346,100 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
     tab_name = _resolve_tab_name("FUSION_TAB")
     rows = await afetch_records(_sheet_id(), tab_name)
     parsed: list[FusionRow] = []
+    parse_errors: dict[str, str] = {}
     for raw in rows or []:
         row = _normalize(raw)
+        fusion_id = str(row.get("fusion_id") or "").strip()
+        fusion_name = str(row.get("fusion_name") or "").strip()
+        status = str(row.get("status") or "").strip().lower()
+        fusion_type_raw = row.get("fusion_type")
+        raw_keys = sorted([str(key) for key in row.keys()]) if isinstance(row, dict) else []
         try:
+            champion = str(row.get("champion") or "").strip()
+            champion_image_url = str(row.get("champion_image_url") or "").strip()
+            fusion_type = _normalize_fusion_type(fusion_type_raw)
+            fusion_structure = str(row.get("fusion_structure") or "").strip()
+            reward_type = str(row.get("reward_type") or "").strip()
+            needed = _parse_int(_pick(row, "fusion.needed", "needed"))
+            available = _parse_int(_pick(row, "fusion.available", "available"))
+            start_at_utc = _parse_iso_utc(row.get("start_at_utc"))
+            end_at_utc = _parse_iso_utc(row.get("end_at_utc"))
+            announcement_channel_id = _parse_discord_id(row.get("announcement_channel_id"))
+            opt_in_role_id = _parse_discord_id(row.get("opt_in_role_id"))
+            announcement_message_id = _parse_discord_id(row.get("announcement_message_id"))
+            published_at = _parse_iso_utc_optional(row.get("published_at"))
+            last_announcement_refresh_at = _parse_iso_utc_optional(row.get("last_announcement_refresh_at"))
+            last_announcement_status_hash = str(row.get("last_announcement_status_hash") or "").strip()
             parsed.append(
                 FusionRow(
-                    fusion_id=str(row.get("fusion_id") or "").strip(),
-                    fusion_name=str(row.get("fusion_name") or "").strip(),
-                    champion=str(row.get("champion") or "").strip(),
-                    champion_image_url=str(row.get("champion_image_url") or "").strip(),
-                    fusion_type=_normalize_fusion_type(row.get("fusion_type")),
-                    fusion_structure=str(row.get("fusion_structure") or "").strip(),
-                    reward_type=str(row.get("reward_type") or "").strip(),
-                    needed=_parse_int(_pick(row, "fusion.needed", "needed")),
-                    available=_parse_int(_pick(row, "fusion.available", "available")),
-                    start_at_utc=_parse_iso_utc(row.get("start_at_utc")),
-                    end_at_utc=_parse_iso_utc(row.get("end_at_utc")),
-                    announcement_channel_id=_parse_discord_id(
-                        row.get("announcement_channel_id")
-                    ),
-                    opt_in_role_id=_parse_discord_id(row.get("opt_in_role_id")),
-                    announcement_message_id=_parse_discord_id(
-                        row.get("announcement_message_id")
-                    ),
-                    published_at=_parse_iso_utc_optional(row.get("published_at")),
-                    last_announcement_refresh_at=_parse_iso_utc_optional(
-                        row.get("last_announcement_refresh_at")
-                    ),
-                    last_announcement_status_hash=str(
-                        row.get("last_announcement_status_hash") or ""
-                    ).strip(),
-                    status=str(row.get("status") or "").strip().lower(),
+                    fusion_id=fusion_id,
+                    fusion_name=fusion_name,
+                    champion=champion,
+                    champion_image_url=champion_image_url,
+                    fusion_type=fusion_type,
+                    fusion_structure=fusion_structure,
+                    reward_type=reward_type,
+                    needed=needed,
+                    available=available,
+                    start_at_utc=start_at_utc,
+                    end_at_utc=end_at_utc,
+                    announcement_channel_id=announcement_channel_id,
+                    opt_in_role_id=opt_in_role_id,
+                    announcement_message_id=announcement_message_id,
+                    published_at=published_at,
+                    last_announcement_refresh_at=last_announcement_refresh_at,
+                    last_announcement_status_hash=last_announcement_status_hash,
+                    status=status,
                 )
             )
-        except Exception:
+        except Exception as exc:
+            failed_field = "unknown"
+            for field_name, parser in (
+                ("fusion_type", lambda: _normalize_fusion_type(fusion_type_raw)),
+                ("needed", lambda: _parse_int(_pick(row, "fusion.needed", "needed"))),
+                ("available", lambda: _parse_int(_pick(row, "fusion.available", "available"))),
+                ("start_at_utc", lambda: _parse_iso_utc(row.get("start_at_utc"))),
+                ("end_at_utc", lambda: _parse_iso_utc(row.get("end_at_utc"))),
+                ("announcement_channel_id", lambda: _parse_discord_id(row.get("announcement_channel_id"))),
+                ("opt_in_role_id", lambda: _parse_discord_id(row.get("opt_in_role_id"))),
+                ("announcement_message_id", lambda: _parse_discord_id(row.get("announcement_message_id"))),
+                ("published_at", lambda: _parse_iso_utc_optional(row.get("published_at"))),
+                ("last_announcement_refresh_at", lambda: _parse_iso_utc_optional(row.get("last_announcement_refresh_at"))),
+            ):
+                try:
+                    parser()
+                except Exception:
+                    failed_field = field_name
+                    break
             log.warning(
                 "fusion row skipped due to parse error",
                 extra={
-                    "fusion_id": str(row.get("fusion_id") or "").strip(),
-                    "fusion_name": str(row.get("fusion_name") or "").strip(),
-                    "status": str(row.get("status") or "").strip(),
+                    "fusion_id": fusion_id,
+                    "fusion_name": fusion_name,
+                    "status": status,
+                    "fusion_type": str(fusion_type_raw or "").strip(),
+                    "failed_field": failed_field,
+                    "tab": tab_name,
+                    "row_keys": raw_keys,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
                 },
                 exc_info=True,
             )
+            if status == "draft":
+                log.info(
+                    "draft fusion row skipped because it could not be parsed",
+                    extra={"fusion_id": fusion_id, "fusion_name": fusion_name, "failed_field": failed_field},
+                )
+            if fusion_id:
+                parse_errors[fusion_id] = failed_field
+    global _LAST_FUSION_PARSE_ERRORS
+    _LAST_FUSION_PARSE_ERRORS = parse_errors
     return tuple(parsed)
+
+
+def get_last_fusion_parse_errors() -> dict[str, str]:
+    return dict(_LAST_FUSION_PARSE_ERRORS)
 
 
 async def _load_fusion_events() -> tuple[FusionEventRow, ...]:
@@ -1046,6 +1097,7 @@ __all__ = [
     "derive_event_status",
     "get_valid_event_timing",
     "get_publishable_fusion",
+    "get_last_fusion_parse_errors",
     "get_fusion_events",
     "get_sent_reminder_keys",
     "reminder_dedupe_backend_metadata",

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -489,7 +489,20 @@ def run_welcome_ticket_repair_pass(*, min_interval_sec: float = 3600) -> dict[st
 
     sheet_id, tab = _resolve_onboarding_and_welcome_tab()
     ws = core.get_worksheet(sheet_id, tab)
-    summary = repair_welcome_rows(ws)
+    scanned_rows = -1
+    try:
+        raw_values = core.call_with_backoff(ws.get_all_values)
+        scanned_rows = max(0, len(raw_values) - 1)
+    except Exception:
+        scanned_rows = -1
+    try:
+        summary = repair_welcome_rows(ws)
+    except Exception:
+        log.exception(
+            "welcome ticket repair failed with exception",
+            extra={"tab_name": tab, "sheet_id": sheet_id, "row_count": scanned_rows},
+        )
+        raise
     _WELCOME_REPAIR_LAST_RUN = now_ts
     _queue_welcome_repair_alert(summary)
     return summary


### PR DESCRIPTION
### Motivation
- Surface hidden parse/repair exceptions so operators get actionable diagnostics instead of silent skips or generic failure messages.
- Ensure fusion rows (including drafts) report which field failed and include traceback/context so problematic rows like `Mashiro_2026_05` can be triaged quickly.
- Make welcome ticket repair failures log full tracebacks and worksheet context so repair runs are debuggable.

### Description
- Restructured `_load_fusions` in `shared/sheets/fusion.py` to parse major fields in explicit per-field steps before constructing `FusionRow`, and added per-row failure isolation to detect the `failed_field` when parsing fails.
- Enhanced fusion parse-failure logging to call `log.warning(..., exc_info=True)` and include `fusion_id`, `fusion_name`, `status`, `fusion_type`, `failed_field`, `tab`, `row_keys`, `error_type`, and `error_message` in `extra` for clear diagnostics.
- Track the most recent parse failures in-memory via `get_last_fusion_parse_errors()` so callers can detect parse-broken source rows and avoid silently reporting "no rows" when rows exist but failed to parse.
- In `modules/community/fusion/cog.py` publish flow, consult `get_last_fusion_parse_errors()` and return an admin-facing message `"<Tracker> row exists but could not be parsed; check logs."` when parse-broken rows are detected, and write a warning with parse-error details.
- In `shared/sheets/onboarding.py`, wrap `repair_welcome_rows` with a try/except that uses `log.exception(...)` and includes resolved `tab_name`, `sheet_id`, and detected `row_count` in `extra`, then re-raises to ensure tracebacks are emitted and visible.

### Testing
- Ran compilation check with `python -m compileall shared/sheets/fusion.py shared/sheets/onboarding.py modules/community/fusion/cog.py modules/onboarding/watcher_welcome.py`, which completed successfully.
- Verified the repository state and that the modified modules import/compile without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd2140a24832391fe2dbd91d475a2)