### PR TITLE
Support `needed_total` alias when parsing fusion rows

### DIFF
--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -360,7 +360,7 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
             fusion_type = _normalize_fusion_type(fusion_type_raw)
             fusion_structure = str(row.get("fusion_structure") or "").strip()
             reward_type = str(row.get("reward_type") or "").strip()
-            needed = _parse_int(_pick(row, "fusion.needed", "needed"))
+            needed = _parse_int(_pick(row, "needed_total", "needed", "fusion.needed"))
             available = _parse_int(_pick(row, "fusion.available", "available"))
             start_at_utc = _parse_iso_utc(row.get("start_at_utc"))
             end_at_utc = _parse_iso_utc(row.get("end_at_utc"))
@@ -396,7 +396,7 @@ async def _load_fusions() -> tuple[FusionRow, ...]:
             failed_field = "unknown"
             for field_name, parser in (
                 ("fusion_type", lambda: _normalize_fusion_type(fusion_type_raw)),
-                ("needed", lambda: _parse_int(_pick(row, "fusion.needed", "needed"))),
+                ("needed", lambda: _parse_int(_pick(row, "needed_total", "needed", "fusion.needed"))),
                 ("available", lambda: _parse_int(_pick(row, "fusion.available", "available"))),
                 ("start_at_utc", lambda: _parse_iso_utc(row.get("start_at_utc"))),
                 ("end_at_utc", lambda: _parse_iso_utc(row.get("end_at_utc"))),

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -40,6 +40,38 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
     assert rows[0].start_at_utc == dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc)
 
 
+
+
+def test_load_fusions_reads_needed_total_alias_for_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
+        return [
+            {
+                "fusion_id": "f-frag",
+                "fusion_name": "Mashiro",
+                "champion": "Mashiro",
+                "champion_image_url": "https://cdn.discordapp.com/mashiro.png",
+                "fusion_type": "fragment",
+                "fusion_structure": "",
+                "reward_type": "fragment",
+                "needed_total": "100",
+                "available": "135",
+                "start_at_utc": "2026-04-08T00:00:00Z",
+                "end_at_utc": "2026-04-22T00:00:00Z",
+                "status": "active",
+            }
+        ]
+
+    monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+
+    rows = asyncio.run(fusion._load_fusions())
+
+    assert len(rows) == 1
+    assert rows[0].fusion_type == "fragment"
+    assert rows[0].needed == 100
+    assert rows[0].available == 135
+
 def _event(
     *,
     event_id: str,


### PR DESCRIPTION
### Motivation
- Fragment fusion sheet rows sometimes use the header `needed_total` instead of `needed` or `fusion.needed`, causing parsed `needed` to be 0 and announcements to show `Target: 0 fragment needed / X available`.
- The parser must accept header aliases and avoid hard-coded column indexes so existing hybrid/titan rows continue to parse correctly.

### Description
- Update fusion row parsing in `shared/sheets/fusion.py` so `needed` is resolved from the alias chain `needed_total`, `needed`, then `fusion.needed` using `_pick`.
- Keep `available` parsing unchanged and continue to support both `fusion.available` and `available`.
- Update the parse-error probing logic to use the same `needed_total` alias chain for accurate diagnostics.
- Add a regression test `test_load_fusions_reads_needed_total_alias_for_fragment` in `tests/shared/sheets/test_fusion.py` that verifies a `fragment` row with `needed_total=100` and `available=135` parses to `needed==100` and `available==135`.

### Testing
- Ran the targeted fusion sheet tests with `pytest -q tests/shared/sheets/test_fusion.py -k "needed_total_alias_for_fragment or reads_fusion_prefixed_needed or tracker_kind_maps_supported_fusion_types or load_fusions_normalizes_fragment_fusion_type_case"` and they all passed (`.......... [100%]`).
- The new regression test verifies Mashiro-style fragment rows parse `needed` from `needed_total` and existing tests confirm hybrid/titan rows remain correct.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd57e0be48323b733cb1ecf649287)