### PR TITLE
Refine fusion announcement embed milestone layout

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -117,10 +117,15 @@ def _build_fusion_embed(
     event_days = [event.start_at_utc.astimezone(dt.timezone.utc).date() for event in sorted_events]
 
     reward_unit = str(fusion.reward_type or "").strip() or "rewards"
+    fusion_type = str(fusion.fusion_type or "").strip().casefold()
+    if fusion_type == "fragment":
+        goal_line = f"Goal: Collect 100 fragments to summon {fusion.champion}"
+    else:
+        goal_line = f"Goal: Earn {fusion.needed:g} {reward_unit} for {fusion.champion}"
+
     summary_lines = [
         f"Type: {_humanize_type(fusion.fusion_type)}",
-        f"Runs: {_format_dt_utc(fusion.start_at_utc)} -> {_format_dt_utc(fusion.end_at_utc)}",
-        "",
+        goal_line,
         f"Target: {fusion.needed:g} {reward_unit} needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
     ]
@@ -130,11 +135,11 @@ def _build_fusion_embed(
     milestones_lines = [
         f"First start: {_format_day_label(min(event_days))}" if event_days else "First start: TBA",
         f"Last start: {_format_day_label(max(event_days))}" if event_days else "Last start: TBA",
+        f"End: {_format_dt_utc(fusion.end_at_utc)}",
     ]
     if has_bonus:
         bonus_events = [event.event_name for event in sorted_events if event.bonus is not None and event.bonus > 0]
-        prefix = "Bonus event" if len(bonus_events) == 1 else "Bonus events"
-        milestones_lines.append(f"{prefix}: {', '.join(bonus_events)}")
+        milestones_lines.append(f"Bonus Events: {', '.join(bonus_events)}")
 
     embed = discord.Embed(
         title=f"Fusion: {fusion.fusion_name}",

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -56,7 +56,9 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
 
     embed = build_fusion_announcement_embed(_fusion(), list(reversed(events)))
 
+    assert "Goal: Earn 400 fragments for Mavara" in (embed.description or "")
     assert "Target: 400 fragments needed / 450 available" in (embed.description or "")
+    assert "Runs:" not in (embed.description or "")
     assert embed.fields[0].name == "Key Milestones"
     assert embed.fields[1].name == "Schedule Status"
     assert len(embed.fields) >= 4
@@ -97,5 +99,17 @@ def test_build_fusion_embed_uses_dynamic_reward_labels_for_titan() -> None:
 
     embed = build_fusion_announcement_embed(titan, [event])
 
+    assert "Goal: Earn 1750 points for Mavara" in (embed.description or "")
     assert "Target: 1750 points needed / 2000 available" in (embed.description or "")
     assert "for 25 points (+50 bonus points)" in embed.fields[-1].value
+
+
+def test_build_fusion_embed_fragment_goal_and_end_in_milestones() -> None:
+    fragment = replace(_fusion(), fusion_type="fragment", needed=100, available=78)
+    event = _event(9, 1)
+
+    embed = build_fusion_announcement_embed(fragment, [event])
+
+    assert "Goal: Collect 100 fragments to summon Mavara" in (embed.description or "")
+    milestones = embed.fields[0].value or ""
+    assert "End: 2026-04-22 00:00 UTC" in milestones


### PR DESCRIPTION
### Motivation
- Reduce duplicated date information and visual noise in fusion announcement embeds by removing the redundant `Runs: start -> end` line and consolidating dates under a single `Key Milestones` field.
- Ensure fragment, hybrid, and titan fusion types show an appropriate, concise `Goal` line while keeping `Target`, `Bonus Events`, and `Schedule Status` visible.

### Description
- Removed the `Runs: _format_dt_utc(start) -> _format_dt_utc(end)` line from the embed description and replaced it with a type-aware `Goal` line (fragment vs non-fragment) in `modules/community/fusion/rendering.py`.
- Added `End: <fusion.end_at_utc>` to the `Key Milestones` field and moved `First start` and `Last start` there so all date information appears only once in `Key Milestones`.
- Simplified bonus output to a single line `Bonus Events: ...` inside `Key Milestones` when bonus events are present, leaving `Schedule Status` logic unchanged.
- Updated tests in `tests/community/test_fusion_rendering.py` to assert the new `Goal` wording, absence of `Runs:`, presence of `Target`, and that the `End` value appears in `Key Milestones`, and added a fragment-specific test case.

### Testing
- Ran `pytest -q tests/community/test_fusion_rendering.py` and the test suite passed (all tests succeeded).
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd8538ff88323923025f1666b7d24)