### PR TITLE
Add startup summary message, simplify onboarding reaction/member handling, and tidy server_map logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -235,6 +235,71 @@ async def _enforce_guild_allow_list(
     return True
 
 
+
+
+def _channel_readable(bot_client: commands.Bot, channel_id: int | None) -> str:
+    if not channel_id:
+        return "not configured"
+    channel = bot_client.get_channel(channel_id)
+    if channel is not None:
+        return onboarding_channel_path(channel)
+    return f"<#{channel_id}>"
+
+
+def _fmt_next(jobs: list[object], job_name: str) -> str:
+    for job in jobs:
+        if getattr(job, "name", None) == job_name:
+            next_run = getattr(job, "next_run", None)
+            if next_run is None:
+                return "pending"
+            try:
+                return next_run.astimezone(dt.timezone.utc).replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
+            except Exception:
+                return "pending"
+    return "not scheduled"
+
+
+def _read_watchdog_values(runtime_obj: Runtime) -> tuple[int, int, int]:
+    return (
+        int(getattr(runtime_obj, "_watchdog_check_sec", 300)),
+        int(getattr(runtime_obj, "_watchdog_stall_sec", 1200)),
+        int(getattr(runtime_obj, "_watchdog_disconnect_grace_sec", 6000)),
+    )
+
+
+def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[object], watchdog: tuple[int, int, int]) -> str:
+    toggles = shared_config.features
+    cache_buckets = ["clans", "fusion", "fusion_events", "onboarding_questions", "reaction_roles"]
+    cache_lines = []
+    for name in cache_buckets:
+        snap = cache_telemetry.get_snapshot(name)
+        status = "ok" if (snap.last_result or "").lower() in {"ok", "success"} else (snap.last_result or "pending")
+        rows = snap.item_count if snap.item_count is not None else "?"
+        cache_lines.append(f"• {name}: {status}, {rows} rows")
+
+    interval_s, stall_s, grace_s = watchdog
+    lines = [
+        "✅ Woadkeeper startup complete",
+        "",
+        "Watchers",
+        f"• Welcome: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_welcome_channel_id())}",
+        f"• Promo: {'enabled' if toggles.promo_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_promo_channel_id())}",
+        "",
+        "Cache",
+        *cache_lines,
+        "",
+        "Schedulers",
+        f"• clans: next {_fmt_next(jobs, 'cache_refresh:clans')}",
+        f"• templates: next {_fmt_next(jobs, 'cache_refresh:templates')}",
+        f"• cleanup: next {_fmt_next(jobs, 'cleanup_watcher')}",
+        f"• mirralith_overview: next {_fmt_next(jobs, 'mirralith_overview')}",
+        "",
+        "Watchdog",
+        f"• interval {interval_s}s",
+        f"• stall {stall_s}s",
+        f"• disconnect grace {grace_s}s",
+    ]
+    return "\n".join(lines)
 @bot.event
 async def on_ready():
     hb.note_ready()
@@ -254,7 +319,7 @@ async def on_ready():
         )
     bot._c1c_started_mono = _STARTED_MONO
 
-    if not await _enforce_guild_allow_list(log_when_empty=True):
+    if not await _enforce_guild_allow_list(log_when_empty=True, log_success=False):
         return
 
     try:
@@ -277,19 +342,7 @@ async def on_ready():
         log.exception("READY FAILURE: ensure_scheduler_started")
 
     try:
-        started, interval, stall, grace = runtime.watchdog(delay_sec=5.0)
-        if started:
-            async def announce() -> None:
-                await asyncio.sleep(5.0)
-                await runtime.send_log_message(
-                    LogTemplates.watchdog(
-                        interval_s=interval,
-                        stall_s=stall,
-                        disconnect_grace_s=grace,
-                    )
-                )
-
-            runtime.scheduler.spawn(announce(), name="watchdog_announce")
+        runtime.watchdog(delay_sec=5.0)
 
         if not hasattr(bot, "_cron_summary_task"):
             async def _daily_summary_loop() -> None:
@@ -312,6 +365,13 @@ async def on_ready():
 
         await keepalive.ensure_started(bot)
         runtime.schedule_startup_preload()
+        watchdog_values = _read_watchdog_values(runtime)
+        summary = _build_startup_summary_message(
+            bot_client=bot,
+            jobs=runtime.scheduler.jobs,
+            watchdog=watchdog_values,
+        )
+        await runtime.send_log_message(summary)
     except Exception:
         log.warning("non-critical ready task failed", exc_info=True)
 

--- a/modules/onboarding/logs.py
+++ b/modules/onboarding/logs.py
@@ -678,11 +678,8 @@ def _render_payload(payload: Mapping[str, Any]) -> str | None:
         detail_items: list[str] = []
         detail_fields = [
             ("view", ("view_tag", "view")),
-            ("custom_id", ("custom_id",)),
             ("view_id", ("view_id",)),
-            ("app_perms_text", ("app_perms_text", "app_permissions")),
             ("missing", ("missing",)),
-            ("trigger", ("trigger",)),
             ("source", ("source",)),
             ("reason", ("reason",)),
             ("schema", ("schema",)),
@@ -700,9 +697,6 @@ def _render_payload(payload: Mapping[str, Any]) -> str | None:
                 continue
             detail_items.append(f"{name}={_stringify(value)}")
 
-        permissions_snapshot = payload.get("app_permissions_snapshot")
-        if permissions_snapshot:
-            detail_items.append(f"app_perms_flags={_stringify(permissions_snapshot)}")
 
         extra_details = payload.get("details")
         if isinstance(extra_details, Mapping):

--- a/modules/onboarding/reaction_fallback.py
+++ b/modules/onboarding/reaction_fallback.py
@@ -182,30 +182,7 @@ class OnboardingReactionFallbackCog(commands.Cog):
         if guild is None:
             return
 
-        member: Optional[discord.Member] = payload.member
-        if member is None:
-            member = guild.get_member(payload.user_id)
-        if member is None:
-            try:
-                member = await guild.fetch_member(payload.user_id)
-            except Exception as exc:
-                context = _base_context(user_id=payload.user_id)
-                context.update({"result": "member_fetch_failed", "trigger": "member_lookup"})
-                await logs.send_welcome_exception("warn", exc, **context)
-                return
-
-        if not isinstance(member, discord.Member):
-            context = _base_context(user_id=payload.user_id)
-            context.update({"result": "member_type", "trigger": "member_lookup"})
-            await logs.send_welcome_log("warn", **context)
-            return
-
-        if getattr(member, "bot", False):
-            context = _base_context(member=member, user_id=payload.user_id)
-            context.update({"result": "bot_member", "trigger": "member_lookup"})
-            await logs.send_welcome_log("info", **context)
-            return
-
+        member: Optional[discord.Member] = None
         thread: Optional[discord.Thread] = guild.get_thread(payload.channel_id)
         if thread is None:
             channel = self.bot.get_channel(payload.channel_id)
@@ -227,6 +204,24 @@ class OnboardingReactionFallbackCog(commands.Cog):
         in_welcome_scope = thread_scopes.is_welcome_parent(thread)
         in_promo_scope = thread_scopes.is_promo_parent(thread)
         if not (in_welcome_scope or in_promo_scope):
+            return
+
+        member = payload.member
+        if member is None:
+            member = guild.get_member(payload.user_id)
+        if member is None:
+            try:
+                member = await guild.fetch_member(payload.user_id)
+            except Exception:
+                log.debug("onboarding_reaction_member_lookup_failed", exc_info=True)
+                return
+
+        if not isinstance(member, discord.Member):
+            log.debug("onboarding_reaction_member_not_member", extra={"user_id": payload.user_id})
+            return
+
+        if getattr(member, "bot", False):
+            log.debug("onboarding_reaction_ignored_bot_member", extra={"user_id": payload.user_id})
             return
 
         if not _is_supported_fallback_emoji(payload):

--- a/modules/ops/server_map.py
+++ b/modules/ops/server_map.py
@@ -357,11 +357,6 @@ async def refresh_server_map(
     requested_label = requested_channel or "config"
     target_label = channel_label(guild, channel_id)
 
-    await runtime_helpers.send_log_message(
-        "📘 Server map — "
-        f"cmd={cmd_label} • guild={guild_name} "
-        f"• channel_fallback={target_label} • requested_channel={requested_label}"
-    )
 
     try:
         state = await server_map_state.fetch_state()
@@ -377,8 +372,7 @@ async def refresh_server_map(
     now = dt.datetime.now(dt.timezone.utc)
 
     if not force and not should_refresh(last_run, refresh_days, now=now):
-        message = _format_skip("interval_not_elapsed", last_run_raw)
-        await runtime_helpers.send_log_message(message)
+        log.debug("server map skipped: interval not elapsed", extra={"last_run": last_run_raw, "actor": actor})
         return ServerMapResult(
             status="skipped",
             reason="interval_not_elapsed",
@@ -419,7 +413,7 @@ async def refresh_server_map(
         len(category_blacklist),
         len(channel_blacklist),
     )
-    await runtime_helpers.send_log_message(config_debug)
+    log.debug(config_debug)
 
     bodies, stats = build_map_messages(
         guild,
@@ -474,11 +468,6 @@ async def refresh_server_map(
         except discord.HTTPException:
             log.debug("failed to delete old server map message", exc_info=True)
 
-    if cleaned:
-        await runtime_helpers.send_log_message(
-            f"📘 Server map — cmd={cmd_label} • guild={guild_name} • cleaned_messages={cleaned}"
-        )
-
     if updated_messages:
         primary = updated_messages[0]
         try:
@@ -499,15 +488,11 @@ async def refresh_server_map(
         return ServerMapResult(status="error", reason="state_update_failed")
 
     await runtime_helpers.send_log_message(
-        "📘 Server map — "
-        f"cmd={cmd_label} • guild={guild_name} "
-        f"• categories={stats.categories} "
-        f"• channels={stats.channels} "
-        f"• uncategorized={stats.uncategorized} "
-        f"• messages={len(updated_messages)} "
-        f"• cat_blacklist_ids={len(category_blacklist)} "
-        f"• chan_blacklist_ids={len(channel_blacklist)} "
-        f"• target_channel={target_label}"
+        "✅ Server map updated — "
+        f"cmd={cmd_label} • guild={guild_name} • target={target_label} "
+        f"• categories={stats.categories} • channels={stats.channels} • uncategorized={stats.uncategorized} "
+        f"• messages={len(updated_messages)}"
+        + (f" • cleaned={cleaned}" if cleaned else "")
     )
 
     return ServerMapResult(


### PR DESCRIPTION
### Motivation
- Provide a concise startup summary with scheduler and cache telemetry to surface runtime state after the bot becomes ready.
- Simplify and harden onboarding reaction handling and logging to avoid noisy external log writes and to use internal debug logs for transient failures.
- Reduce and clarify `server_map` logging by removing duplicate/verbose runtime log messages and producing a single clear success message.

### Description
- Added helper functions in `app.py`: `_channel_readable`, `_fmt_next`, `_read_watchdog_values`, and `_build_startup_summary_message` and send a composed startup summary after schedulers/startup tasks complete using `runtime.send_log_message`.
- Changed the guild allowlist call in `on_ready` to suppress success logging by calling `_enforce_guild_allow_list(..., log_success=False)` and updated watchdog startup flow to call `runtime.watchdog` and emit the startup summary using scheduler job introspection.
- Simplified member lookup and error handling in `modules/onboarding/reaction_fallback.py` to rely on debug logs and early returns instead of sending structured welcome logs for transient lookup failures.
- Trimmed and reorganized payload detail fields and removed a permissions snapshot line in `modules/onboarding/logs.py` to reduce redundant detail output.
- Cleaned up `modules/ops/server_map.py` logging by replacing several `runtime_helpers.send_log_message` calls with standard `log.debug`/`log.info` calls, skipping intermediate send messages, and formatting the final success message as `✅ Server map updated — ...` with an optional cleaned count.

### Testing
- Ran the project test suite with `pytest -q`, and the tests completed successfully.
- Exercised the bot startup flow in a local/dev environment to verify the startup summary message is composed and sent without raising exceptions.
- Ran static checks/linter (project configured checks) and fixed issues reported, with no remaining errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bbf4d1b48323817bb032ca9c42f4)