### PR TITLE
Improve startup summary resilience and restore structured Welcome/Promo admin logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,37 +268,60 @@ def _read_watchdog_values(runtime_obj: Runtime) -> tuple[int, int, int]:
 
 
 def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[object], watchdog: tuple[int, int, int]) -> str:
-    toggles = shared_config.features
-    cache_buckets = ["clans", "fusion", "fusion_events", "onboarding_questions", "reaction_roles"]
-    cache_lines = []
-    for name in cache_buckets:
-        snap = cache_telemetry.get_snapshot(name)
-        status = "ok" if (snap.last_result or "").lower() in {"ok", "success"} else (snap.last_result or "pending")
-        rows = snap.item_count if snap.item_count is not None else "?"
-        cache_lines.append(f"• {name}: {status}, {rows} rows")
+    lines = ["✅ Woadkeeper startup complete", ""]
 
-    interval_s, stall_s, grace_s = watchdog
-    lines = [
-        "✅ Woadkeeper startup complete",
-        "",
-        "Watchers",
-        f"• Welcome: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_welcome_channel_id())}",
-        f"• Promo: {'enabled' if toggles.promo_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_promo_channel_id())}",
-        "",
-        "Cache",
-        *cache_lines,
-        "",
-        "Schedulers",
-        f"• clans: next {_fmt_next(jobs, 'cache_refresh:clans')}",
-        f"• templates: next {_fmt_next(jobs, 'cache_refresh:templates')}",
-        f"• cleanup: next {_fmt_next(jobs, 'cleanup_watcher')}",
-        f"• mirralith_overview: next {_fmt_next(jobs, 'mirralith_overview')}",
-        "",
-        "Watchdog",
-        f"• interval {interval_s}s",
-        f"• stall {stall_s}s",
-        f"• disconnect grace {grace_s}s",
-    ]
+    try:
+        toggles = shared_config.features
+        watcher_lines = [
+            "Watchers",
+            f"• Welcome: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_welcome_channel_id())}",
+            f"• Promo: {'enabled' if toggles.promo_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_promo_channel_id())}",
+        ]
+        lines.extend(watcher_lines)
+    except Exception:
+        log.exception("startup summary watchers section unavailable", exc_info=True)
+        lines.extend(["Watchers", "• unavailable"])
+
+    try:
+        cache_buckets = ["clans", "fusion", "fusion_events", "onboarding_questions", "reaction_roles"]
+        cache_lines = []
+        for name in cache_buckets:
+            snap = cache_telemetry.get_snapshot(name)
+            status = "ok" if (snap.last_result or "").lower() in {"ok", "success"} else (snap.last_result or "pending")
+            rows = snap.item_count if snap.item_count is not None else "?"
+            cache_lines.append(f"• {name}: {status}, {rows} rows")
+        lines.extend(["", "Cache", *cache_lines])
+    except Exception:
+        log.exception("startup summary cache section unavailable", exc_info=True)
+        lines.extend(["", "Cache", "• unavailable"])
+
+    try:
+        scheduler_lines = [
+            "Schedulers",
+            f"• clans: next {_fmt_next(jobs, 'cache_refresh:clans')}",
+            f"• templates: next {_fmt_next(jobs, 'cache_refresh:templates')}",
+            f"• cleanup: next {_fmt_next(jobs, 'cleanup_watcher')}",
+            f"• mirralith_overview: next {_fmt_next(jobs, 'mirralith_overview')}",
+        ]
+        lines.extend(["", *scheduler_lines])
+    except Exception:
+        log.exception("startup summary scheduler section unavailable", exc_info=True)
+        lines.extend(["", "Schedulers", "• unavailable"])
+
+    try:
+        interval_s, stall_s, grace_s = watchdog
+        lines.extend(
+            [
+                "",
+                "Watchdog",
+                f"• interval {interval_s}s",
+                f"• stall {stall_s}s",
+                f"• disconnect grace {grace_s}s",
+            ]
+        )
+    except Exception:
+        log.exception("startup summary watchdog section unavailable", exc_info=True)
+        lines.extend(["", "Watchdog", "• unavailable"])
     return "\n".join(lines)
 @bot.event
 async def on_ready():
@@ -380,7 +403,7 @@ async def on_ready():
         )
         await runtime.send_log_message(summary, bypass_startup_suppression=True)
     except Exception:
-        log.exception("startup summary failed")
+        log.exception("startup summary failed", exc_info=True)
 
 
 @bot.event

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -319,9 +319,6 @@ def _is_suppressed_startup_admin_message(message: str) -> bool:
             "scope=startup",
             "watchdog started",
             "watchdog loop started",
-            "watcher enabled",
-            "welcome watcher",
-            "promo watcher",
             "scheduler interval",
             "scheduler intervals",
         )

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -46,6 +46,11 @@ _PROMO_TRIGGER_MAP: Dict[str, str] = {
     "<!-- trigger:promo.m -->": "promo.m",
     "<!-- trigger:promo.l -->": "promo.l",
 }
+_PROMO_TRIGGER_LABELS: Dict[str, str] = {
+    "promo.r": "Returning player",
+    "promo.m": "Player move request",
+    "promo.l": "Clan lead move request",
+}
 
 
 async def _send_runtime(message: str) -> None:
@@ -1008,7 +1013,7 @@ class PromoTicketWatcher(commands.Cog):
             return
 
         label = _channel_readable_label(self.bot, channel_id_int)
-        line = log_lifecycle(
+        log_lifecycle(
             log,
             "promo",
             "enabled",
@@ -1018,8 +1023,23 @@ class PromoTicketWatcher(commands.Cog):
             channel_id=channel_id_int,
             triggers=len(_PROMO_TRIGGER_MAP),
         )
-        if line:
-            asyncio.create_task(_send_runtime(line))
+        trigger_lines = [f"• {label}" for label in _PROMO_TRIGGER_LABELS.values()]
+        message = "\n".join(
+            [
+                "✅ Promo watcher",
+                "",
+                "Status:",
+                "• enabled",
+                "",
+                "Channel:",
+                f"• <#{channel_id_int}>",
+                f"• path: {label}",
+                "",
+                "Triggers:",
+                *trigger_lines,
+            ]
+        )
+        asyncio.create_task(_send_runtime(message))
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -2023,7 +2023,7 @@ class WelcomeWatcher(commands.Cog):
 
         if self._onb_registered:
             label = _channel_readable_label(self.bot, self.channel_id)
-            line = log_lifecycle(
+            log_lifecycle(
                 log,
                 "welcome",
                 "enabled",
@@ -2032,8 +2032,19 @@ class WelcomeWatcher(commands.Cog):
                 channel=label,
                 channel_id=self.channel_id,
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
+            message = "\n".join(
+                [
+                    "✅ Welcome watcher",
+                    "",
+                    "Status:",
+                    "• enabled",
+                    "",
+                    "Channel:",
+                    f"• <#{self.channel_id}>",
+                    f"• path: {label}",
+                ]
+            )
+            asyncio.create_task(_send_runtime(message))
         else:
             reason = self._onb_reg_error or "unknown"
             line = log_lifecycle(


### PR DESCRIPTION
### Motivation
- The startup summary builder could crash and leave `startup summary failed` with no useful traceback, reducing observability during boot.
- Welcome/Promo watcher startup announcements were being suppressed or emitted as raw debug lines and need to appear in Discord admin logs in a human-friendly, structured form.
- Scheduler output formatting was already acceptable and should be preserved while keeping noisy debug lines suppressed.

### Description
- Hardened `_build_startup_summary_message` by wrapping the `Watchers`, `Cache`, `Schedulers`, and `Watchdog` sections in independent `try/except` blocks so a failing section is rendered as `• unavailable` instead of aborting the whole summary. (`app.py`) 
- Updated startup failure logging to include full traceback details via `log.exception(..., exc_info=True)` to surface errors when the summary assembly fails. (`app.py`) 
- Restored admin-facing, structured Discord messages for Promo and Welcome watchers by composing multi-line, human-readable messages (status, channel mention + path, triggers for promo) while preserving internal structured lifecycle logs with raw IDs/counts. (`modules/onboarding/watcher_promo.py`, `modules/onboarding/watcher_welcome.py`) 
- Added a small map of human-readable promo trigger labels and used it to render trigger names in the admin message, and narrowed the startup-suppression token list so welcome/promo watcher messages are no longer filtered out. (`modules/onboarding/watcher_promo.py`, `modules/common/runtime.py`) 

### Testing
- Ran `python -m py_compile app.py modules/onboarding/watcher_promo.py modules/onboarding/watcher_welcome.py modules/common/runtime.py` and compilation succeeded. 
- Verified the modified modules load without syntax errors via the repository sanity checks performed in the rollout (compile pass succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a6b7dc148323a05fbe82d758bc92)