### PR TITLE
Unify startup summary and remove duplicate scheduler announcement

### DIFF
--- a/app.py
+++ b/app.py
@@ -274,25 +274,25 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
         toggles = shared_config.features
         watcher_lines = [
             "Watchers",
-            f"• Welcome: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_welcome_channel_id())}",
-            f"• Promo: {'enabled' if toggles.promo_watcher_enabled else 'disabled'} — {_channel_readable(bot_client, get_promo_channel_id())}",
+            f"• Promo watcher: {'enabled' if toggles.promo_watcher_enabled else 'disabled'}",
+            f"• Welcome watcher: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'}",
         ]
         lines.extend(watcher_lines)
     except Exception:
-        log.exception("startup summary watchers section unavailable", exc_info=True)
+        log.exception("startup summary watchers section unavailable")
         lines.extend(["Watchers", "• unavailable"])
 
     try:
-        cache_buckets = ["clans", "fusion", "fusion_events", "onboarding_questions", "reaction_roles"]
+        cache_buckets = ["clans", "templates", "clan_tags", "onboarding_questions"]
         cache_lines = []
         for name in cache_buckets:
             snap = cache_telemetry.get_snapshot(name)
             status = "ok" if (snap.last_result or "").lower() in {"ok", "success"} else (snap.last_result or "pending")
             rows = snap.item_count if snap.item_count is not None else "?"
-            cache_lines.append(f"• {name}: {status}, {rows} rows")
+            cache_lines.append(f"• {name}: {status} ({rows})")
         lines.extend(["", "Cache", *cache_lines])
     except Exception:
-        log.exception("startup summary cache section unavailable", exc_info=True)
+        log.exception("startup summary cache section unavailable")
         lines.extend(["", "Cache", "• unavailable"])
 
     try:
@@ -305,7 +305,7 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
         ]
         lines.extend(["", *scheduler_lines])
     except Exception:
-        log.exception("startup summary scheduler section unavailable", exc_info=True)
+        log.exception("startup summary scheduler section unavailable")
         lines.extend(["", "Schedulers", "• unavailable"])
 
     try:
@@ -320,7 +320,7 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
             ]
         )
     except Exception:
-        log.exception("startup summary watchdog section unavailable", exc_info=True)
+        log.exception("startup summary watchdog section unavailable")
         lines.extend(["", "Watchdog", "• unavailable"])
     return "\n".join(lines)
 @bot.event

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1527,7 +1527,6 @@ class Runtime:
 
     async def _register_ready_schedulers_inner(self) -> None:
         from shared.sheets.cache_scheduler import (
-            emit_schedule_log,
             ensure_cache_registration,
             preload_on_startup,
             register_refresh_job,
@@ -1551,7 +1550,6 @@ class Runtime:
             ("onboarding_questions", timedelta(days=7), "7d"),
         )
         successes: list[tuple[Any, Any]] = []
-        failure: tuple[str, BaseException] | None = None
         for bucket, interval, cadence in cache_specs:
             spec, job = register_refresh_job(
                 self,
@@ -1625,10 +1623,6 @@ class Runtime:
         else:
             log.info("housekeeping keepalive disabled via feature toggle")
 
-        self.scheduler.spawn(
-            emit_schedule_log(self, successes, failure),
-            name="cache_refresh_schedule_log",
-        )
         server_map_module.schedule_server_map_job(self)
         schedule_leagues_jobs(self)
         schedule_fusion_jobs(self)


### PR DESCRIPTION
### Motivation
- There were duplicate/conflicting startup reports: a consolidated `✅ Woadkeeper startup complete` summary plus a legacy standalone scheduler announcement, causing multiple Discord messages and partial/missing data in the consolidated summary. 
- The goal is to make the consolidated summary the single canonical startup report and ensure its sections populate reliably.

### Description
- Stop emitting the separate scheduler startup Discord message by removing the `emit_schedule_log(...)` spawn during scheduler registration in `modules/common/runtime.py`. 
- Update the consolidated summary builder in `app.py` to render watcher lines as `• Promo watcher: ...` and `• Welcome watcher: ...` to match the requested canonical wording. 
- Restrict the Cache section to the canonical startup buckets `clans`, `templates`, `clan_tags`, and `onboarding_questions`, and change formatting to `status (count)` for compact output. 
- Preserve per-section fallback rendering (`• unavailable`) and use `log.exception(...)` so failures are logged with traceback to Python logs (no silent swallow).

### Testing
- Ran `pytest -q tests/shared/test_runtime_startup_retry.py tests/shared/test_runtime_scheduler.py`; most scheduler-related tests executed but `tests/shared/test_runtime_startup_retry.py` produced 2 failures. 
- The failing tests are in the startup-retry suite and surfaced `_RetryableLoginError` under the test harness (observed as `startup failed (DEV MODE - NO RETRY)`), which is unrelated to the startup-summary formatting and the removed scheduler announcement. 
- Changes were committed and the modified files are `app.py` and `modules/common/runtime.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a8f4ceb883239a4947f077bfb6ae)