### PR TITLE
Tighten consolidated startup summary and make startup log suppression temporary

### DIFF
--- a/app.py
+++ b/app.py
@@ -240,10 +240,11 @@ async def _enforce_guild_allow_list(
 def _channel_readable(bot_client: commands.Bot, channel_id: int | None) -> str:
     if not channel_id:
         return "not configured"
+    mention = f"<#{channel_id}>"
     channel = bot_client.get_channel(channel_id)
-    if channel is not None:
-        return onboarding_channel_path(channel)
-    return f"<#{channel_id}>"
+    if channel is None:
+        return mention
+    return f"{mention} ({onboarding_channel_path(channel)})"
 
 
 def _fmt_next(jobs: list[object], job_name: str) -> str:
@@ -272,10 +273,12 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
 
     try:
         toggles = shared_config.features
+        promo_label = _channel_readable(bot_client, cfg_int("PROMO_CHANNEL_ID", 0) or None)
+        welcome_label = _channel_readable(bot_client, cfg_int("WELCOME_CHANNEL_ID", 0) or None)
         watcher_lines = [
             "Watchers",
-            f"• Promo watcher: {'enabled' if toggles.promo_watcher_enabled else 'disabled'}",
-            f"• Welcome watcher: {'enabled' if toggles.welcome_watcher_enabled else 'disabled'}",
+            f"• Promo watcher: {('enabled' if toggles.promo_watcher_enabled else 'disabled')} — {promo_label}",
+            f"• Welcome watcher: {('enabled' if toggles.welcome_watcher_enabled else 'disabled')} — {welcome_label}",
         ]
         lines.extend(watcher_lines)
     except Exception:
@@ -283,7 +286,7 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
         lines.extend(["Watchers", "• unavailable"])
 
     try:
-        cache_buckets = ["clans", "templates", "clan_tags", "onboarding_questions"]
+        cache_buckets = ["clan_tags", "clans", "fusion", "fusion_events", "leagues", "onboarding_questions", "reaction_roles", "templates"]
         cache_lines = []
         for name in cache_buckets:
             snap = cache_telemetry.get_snapshot(name)
@@ -296,13 +299,33 @@ def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[objec
         lines.extend(["", "Cache", "• unavailable"])
 
     try:
-        scheduler_lines = [
-            "Schedulers",
-            f"• clans: next {_fmt_next(jobs, 'cache_refresh:clans')}",
-            f"• templates: next {_fmt_next(jobs, 'cache_refresh:templates')}",
-            f"• cleanup: next {_fmt_next(jobs, 'cleanup_watcher')}",
-            f"• mirralith_overview: next {_fmt_next(jobs, 'mirralith_overview')}",
+        scheduled_names = [
+            ("clans", "cache_refresh:clans"),
+            ("templates", "cache_refresh:templates"),
+            ("clan_tags", "cache_refresh:clan_tags"),
+            ("onboarding_questions", "cache_refresh:onboarding_questions"),
+            ("cleanup", "cleanup_watcher"),
+            ("mirralith_overview", "mirralith_overview"),
+            ("housekeeping_keepalive", "housekeeping_keepalive"),
+            ("shard_weekly_reminders", "shard_weekly_reminders"),
         ]
+        scheduler_lines = ["Schedulers"]
+        for label, job_name in scheduled_names:
+            next_value = _fmt_next(jobs, job_name)
+            if next_value != "not scheduled":
+                scheduler_lines.append(f"• {label}: next {next_value}")
+
+        for job in jobs:
+            name = str(getattr(job, "name", "") or "")
+            if not name:
+                continue
+            if name.startswith("fusion_") and name not in {n for _, n in scheduled_names}:
+                scheduler_lines.append(f"• {name}: next {_fmt_next(jobs, name)}")
+            if name.startswith("reset_reminder") or name == "reset_reminders":
+                scheduler_lines.append(f"• {name}: next {_fmt_next(jobs, name)}")
+
+        if len(scheduler_lines) == 1:
+            scheduler_lines.append("• none scheduled")
         lines.extend(["", *scheduler_lines])
     except Exception:
         log.exception("startup summary scheduler section unavailable")
@@ -347,63 +370,64 @@ async def on_ready():
 
     runtime.suppress_startup_admin_logs = True
     try:
-        runtime.startup_diag_mark(feature_init_started=True)
-        await core_ready.on_ready(bot)
-    except Exception:
-        log.exception("READY FAILURE: core_ready.on_ready")
-        await _shutdown("ready_lifecycle_failure:core_ready")
-        return
+        try:
+            runtime.startup_diag_mark(feature_init_started=True)
+            await core_ready.on_ready(bot)
+        except Exception:
+            log.exception("READY FAILURE: core_ready.on_ready")
+            await _shutdown("ready_lifecycle_failure:core_ready")
+            return
 
-    try:
-        runtime.startup_diag_mark(scheduler_start_reached=True)
-        await runtime.register_ready_schedulers()
-    except Exception:
-        log.exception("READY FAILURE: runtime.register_ready_schedulers")
+        try:
+            runtime.startup_diag_mark(scheduler_start_reached=True)
+            await runtime.register_ready_schedulers()
+        except Exception:
+            log.exception("READY FAILURE: runtime.register_ready_schedulers")
 
-    try:
-        await ensure_scheduler_started(bot)
-    except Exception:
-        log.exception("READY FAILURE: ensure_scheduler_started")
+        try:
+            await ensure_scheduler_started(bot)
+        except Exception:
+            log.exception("READY FAILURE: ensure_scheduler_started")
 
-    try:
-        runtime.watchdog(delay_sec=5.0)
+        try:
+            runtime.watchdog(delay_sec=5.0)
 
-        if not hasattr(bot, "_cron_summary_task"):
-            async def _daily_summary_loop() -> None:
-                while True:
-                    now = dt.datetime.now(dt.timezone.utc)
-                    target = now.replace(hour=0, minute=5, second=0, microsecond=0)
-                    if now >= target:
-                        target = target + dt.timedelta(days=1)
-                    await asyncio.sleep((target - now).total_seconds())
-                    try:
-                        await emit_daily_summary(CRON_JOB_NAMES)
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        log.warning("[cron] summary_failed", exc_info=True)
+            if not hasattr(bot, "_cron_summary_task"):
+                async def _daily_summary_loop() -> None:
+                    while True:
+                        now = dt.datetime.now(dt.timezone.utc)
+                        target = now.replace(hour=0, minute=5, second=0, microsecond=0)
+                        if now >= target:
+                            target = target + dt.timedelta(days=1)
+                        await asyncio.sleep((target - now).total_seconds())
+                        try:
+                            await emit_daily_summary(CRON_JOB_NAMES)
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            log.warning("[cron] summary_failed", exc_info=True)
 
-            runtime.scheduler.spawn(_daily_summary_loop(), name="cron_daily_summary")
-            bot._cron_summary_task = True
-            log.info("[cron] summary scheduler started (00:05Z)")
+                runtime.scheduler.spawn(_daily_summary_loop(), name="cron_daily_summary")
+                bot._cron_summary_task = True
+                log.info("[cron] summary scheduler started (00:05Z)")
 
-        await keepalive.ensure_started(bot)
-        runtime.schedule_startup_preload()
-    except Exception:
-        log.warning("non-critical ready task failed", exc_info=True)
+            await keepalive.ensure_started(bot)
+            runtime.schedule_startup_preload()
+        except Exception:
+            log.warning("non-critical ready task failed", exc_info=True)
+
+        try:
+            watchdog_values = _read_watchdog_values(runtime)
+            summary = _build_startup_summary_message(
+                bot_client=bot,
+                jobs=runtime.scheduler.jobs,
+                watchdog=watchdog_values,
+            )
+            await runtime.send_log_message(summary, bypass_startup_suppression=True)
+        except Exception:
+            log.exception("startup summary failed", exc_info=True)
     finally:
         runtime.suppress_startup_admin_logs = False
-
-    try:
-        watchdog_values = _read_watchdog_values(runtime)
-        summary = _build_startup_summary_message(
-            bot_client=bot,
-            jobs=runtime.scheduler.jobs,
-            watchdog=watchdog_values,
-        )
-        await runtime.send_log_message(summary, bypass_startup_suppression=True)
-    except Exception:
-        log.exception("startup summary failed", exc_info=True)
 
 
 @bot.event


### PR DESCRIPTION
### Motivation
- Restore and improve operational detail in the single consolidated startup summary after the duplicate standalone scheduler log was removed.
- Ensure watcher/channel info, cache preload buckets, and scheduler job visibility are present so operators have useful context in one message.
- Prevent noisy startup logs from being permanently suppressed by making suppression temporary and fail-safe.

### Description
- Updated `_channel_readable` to render a mention plus human-readable `#CATEGORY › channel` path when the channel is resolvable and to safely fall back to the mention when not.
- Expanded the startup `Cache` section to include the full set of preload buckets: `clan_tags`, `clans`, `fusion`, `fusion_events`, `leagues`, `onboarding_questions`, `reaction_roles`, and `templates`.
- Expanded the startup `Schedulers` section to iterate a canonical set of scheduled names and dynamically include additional jobs such as `fusion_*` and `reset_reminder*` when present, omitting entries that are not scheduled.
- Wrapped the noisy startup wiring and summary emission in a `try/finally` so `runtime.suppress_startup_admin_logs` is set to `True` only during noisy startup emitters and is always reset to `False` afterwards, and used `bypass_startup_suppression=True` when sending the final summary.
- Kept existing failure hardening so any section generation failure renders that section as `unavailable` and logs the traceback with `log.exception`.

### Testing
- Ran `python -m py_compile app.py` which succeeded (only a pre-existing `SyntaxWarning` outside these changes was reported).
- Verified the intended change set was committed and contains only the targeted `app.py` edits by inspecting the diff before commit.
- No automated runtime integration tests were run in this change; the edits are constrained to startup summary rendering and suppression logic in `app.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cb8f9ca4832392283fff978df396)