### PR TITLE
Support partial progress tracking and sharing (partial_amount)

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -435,12 +435,14 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             },
         )
         try:
+            partial_amount = view.partial_by_event.get(event.event_id) if status == "in_progress" else None
             await fusion_sheets.upsert_user_event_progress(
                 view.fusion_id,
                 str(view.user_id),
                 event.event_id,
                 status,
                 now,
+                partial_amount=partial_amount,
             )
         except Exception as exc:
             context = {
@@ -461,6 +463,8 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             return
 
         view.progress_by_event[event.event_id] = status
+        if status != "in_progress":
+            view.partial_by_event.pop(event.event_id, None)
         view.selected_event_id = event.event_id
         view.last_update = (event.event_name, status)
         view.refresh_items()
@@ -480,12 +484,14 @@ class FusionProgressShareModeView(discord.ui.View):
         target: fusion_sheets.FusionRow,
         events: Sequence[fusion_sheets.FusionEventRow],
         progress_by_event: Mapping[str, str],
+        partial_by_event: Mapping[str, float] | None = None,
     ) -> None:
         super().__init__(timeout=300)
         self.user_id = int(user_id)
         self.target = target
         self.events = list(events)
         self.progress_by_event = dict(progress_by_event)
+        self.partial_by_event = dict(partial_by_event or {})
 
     async def _handle_share(self, interaction: discord.Interaction, *, mode: Literal["summary", "detailed"]) -> None:
         if interaction.user.id != self.user_id:
@@ -504,6 +510,7 @@ class FusionProgressShareModeView(discord.ui.View):
             target=self.target,
             events=self.events,
             progress_by_event=self.progress_by_event,
+            partial_by_event=self.partial_by_event,
             user_display_name=interaction.user.display_name,
             mode=mode,
         )
@@ -591,6 +598,7 @@ class _FusionProgressShareButton(discord.ui.Button):
             target=view.target,
             events=view.events,
             progress_by_event=view.progress_by_event,
+            partial_by_event=view.partial_by_event,
         )
         if interaction.response.is_done():
             await interaction.followup.send(

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -71,6 +71,7 @@ def build_share_snapshot(
     *,
     events: Sequence[fusion_sheets.FusionEventRow],
     progress_by_event: Mapping[str, str],
+    partial_by_event: Mapping[str, float] | None = None,
     now: dt.datetime | None = None,
 ) -> ProgressShareSnapshot:
     current_time = now or dt.datetime.now(dt.timezone.utc)
@@ -81,7 +82,12 @@ def build_share_snapshot(
     partial_map = partial_by_event or {}
 
     for event in events:
-        status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=current_time)
+        status = _effective_display_status(
+            event=event,
+            progress_by_event=progress_by_event,
+            partial_by_event=partial_by_event,
+            now=current_time,
+        )
         if status == "done_bonus":
             display_status_by_event[event.event_id] = status
             counts["done"] += 1
@@ -131,10 +137,15 @@ def build_progress_share_embed(
     target: fusion_sheets.FusionRow,
     events: Sequence[fusion_sheets.FusionEventRow],
     progress_by_event: Mapping[str, str],
+    partial_by_event: Mapping[str, float] | None = None,
     user_display_name: str,
     mode: ShareMode,
 ) -> discord.Embed:
-    snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event)
+    snapshot = build_share_snapshot(
+        events=events,
+        progress_by_event=progress_by_event,
+        partial_by_event=partial_by_event,
+    )
     overall_progress_line = _build_overall_progress_line(target=target, snapshot=snapshot)
 
     embed = discord.Embed(

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -39,7 +39,7 @@ _FUSION_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "event_id": ("event_id", "event key", "eventkey"),
     "milestone_key": ("milestone_key", "milestone", "milestone key"),
     "status": ("status",),
-    "partial_amount": ("partial_amount", "partial progress", "partial", "earned_amount", "progress_amount"),
+    "partial_amount": ("partial_amount",),
     "updated_at_utc": ("updated_at_utc", "updated at utc", "updatedat", "updated_at"),
 }
 
@@ -282,6 +282,47 @@ def _resolve_progress_header_indices(
         )
         for field in required_fields
     }
+
+
+def _find_optional_progress_column_index(*, header: list[str], field: str) -> int:
+    aliases = _FUSION_PROGRESS_COLUMN_ALIASES.get(field, (field,))
+    for alias in aliases:
+        normalized = alias.strip().lower()
+        if normalized and normalized in header:
+            return header.index(normalized)
+    return -1
+
+
+async def _ensure_optional_progress_header(
+    *,
+    worksheet: Any,
+    tab_name: str,
+    matrix: list[list[object]],
+    header: list[str],
+    field: str,
+    before_field: str | None = None,
+) -> tuple[list[list[object]], list[str]]:
+    if _find_optional_progress_column_index(header=header, field=field) >= 0:
+        return matrix, header
+    if field != "partial_amount":
+        return matrix, header
+
+    insert_at = len(header) + 1
+    if before_field:
+        before_idx = _find_optional_progress_column_index(header=header, field=before_field)
+        if before_idx >= 0:
+            insert_at = before_idx + 1
+
+    await acall_with_backoff(
+        worksheet.insert_cols,
+        values=[[field]],
+        col=insert_at,
+    )
+    refreshed = await afetch_values(_sheet_id(), tab_name)
+    if not refreshed:
+        return matrix, header
+    refreshed_header = [str(cell or "").strip().lower() for cell in refreshed[0]]
+    return refreshed, refreshed_header
 
 def _parse_iso_utc(value: object) -> dt.datetime:
     raw = str(value or "").strip()
@@ -848,12 +889,7 @@ async def get_user_event_progress(fusion_id: str, user_id: str) -> dict[str, str
     event_idx = index_by_field["event_id"]
     milestone_idx = index_by_field["milestone_key"]
     status_idx = index_by_field["status"]
-    partial_idx = _resolve_header_index(
-        tab_name=tab_name,
-        header=header,
-        field="partial_amount",
-        aliases_by_field=_FUSION_PROGRESS_COLUMN_ALIASES,
-    ) if any(alias in header for alias in _FUSION_PROGRESS_COLUMN_ALIASES["partial_amount"]) else -1
+    partial_idx = _find_optional_progress_column_index(header=header, field="partial_amount")
     target_fusion = str(fusion_id or "").strip()
     target_user = str(user_id or "").strip()
 
@@ -916,12 +952,7 @@ async def upsert_user_event_progress(
     milestone_idx = index_by_field["milestone_key"]
     status_idx = index_by_field["status"]
     updated_idx = index_by_field["updated_at_utc"]
-    partial_idx = _resolve_header_index(
-        tab_name=tab_name,
-        header=header,
-        field="partial_amount",
-        aliases_by_field=_FUSION_PROGRESS_COLUMN_ALIASES,
-    ) if any(alias in header for alias in _FUSION_PROGRESS_COLUMN_ALIASES["partial_amount"]) else -1
+    partial_idx = _find_optional_progress_column_index(header=header, field="partial_amount")
     target_fusion = str(fusion_id or "").strip()
     target_user = str(user_id or "").strip()
     target_event = str(event_id or "").strip()
@@ -929,6 +960,27 @@ async def upsert_user_event_progress(
     timestamp = updated_at.astimezone(dt.timezone.utc).isoformat()
 
     worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    if partial_idx < 0:
+        matrix, header = await _ensure_optional_progress_header(
+            worksheet=worksheet,
+            tab_name=tab_name,
+            matrix=matrix,
+            header=header,
+            field="partial_amount",
+            before_field="updated_at_utc",
+        )
+        index_by_field = _resolve_progress_header_indices(
+            tab_name=tab_name,
+            header=header,
+            include_updated_at=True,
+        )
+        fusion_idx = index_by_field["fusion_id"]
+        user_idx = index_by_field["user_id"]
+        event_idx = index_by_field["event_id"]
+        milestone_idx = index_by_field["milestone_key"]
+        status_idx = index_by_field["status"]
+        updated_idx = index_by_field["updated_at_utc"]
+        partial_idx = _find_optional_progress_column_index(header=header, field="partial_amount")
     for row_idx, row in enumerate(matrix[1:], start=2):
         row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
         row_user = str(row[user_idx] if user_idx < len(row) else "").strip()


### PR DESCRIPTION
### Motivation
- Add support for recording and sharing partial/in-progress amounts for fusion event progress and ensure the sheets backend can read/write an optional `partial_amount` column.

### Description
- Thread `partial_by_event` through the UI and share flows by passing partial values from `FusionProgressPanelView` into `FusionProgressShareModeView`, `_FusionProgressShareButton`, and `_FusionProgressStatusSelect`, and include `partial_amount` when saving an "in_progress" status.
- Update `progress_share.py` to accept `partial_by_event` in `build_share_snapshot` and `_effective_display_status`, and include partials in `completed_reward_total` and in-progress totals used for share text.
- Add `_find_optional_progress_column_index` and `_ensure_optional_progress_header` helpers in `shared/sheets/fusion.py` to locate or insert the optional `partial_amount` column, and update `get_user_event_progress` and `upsert_user_event_progress` to read/write the `partial_amount` column when present (inserting the header if missing on write).
- Simplify `_FUSION_PROGRESS_COLUMN_ALIASES` entry for `partial_amount` to rely on the canonical name and centralize detection/creation logic.

### Testing
- Ran the fusion module and sheets unit tests with `pytest tests/modules/community/fusion -q` and `pytest tests/shared/sheets -q`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ca0936f883238b972a518a064e83)