### PR TITLE
Tighten startup watcher logging and welcome repair classification

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1945,7 +1945,7 @@ class WelcomeWatcher(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
-        log.warning("welcomewatcher.on_ready fired")
+        log.debug("welcomewatcher.on_ready fired")
         # Guard against firing multiple times on reconnects
         if self._announced:
             return
@@ -1962,8 +1962,6 @@ class WelcomeWatcher(commands.Cog):
                 result="disabled",
                 reason="missing_channel_id",
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         try:
@@ -1980,8 +1978,6 @@ class WelcomeWatcher(commands.Cog):
                 reason="invalid_channel_id",
                 channel_id=channel_id,
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         self.channel_id = channel_id_int
@@ -1996,8 +1992,6 @@ class WelcomeWatcher(commands.Cog):
                 result="disabled",
                 reason="feature_welcome_dialog_off",
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         if not feature_flags.is_enabled("recruitment_welcome"):
@@ -2010,8 +2004,6 @@ class WelcomeWatcher(commands.Cog):
                 result="disabled",
                 reason="feature_recruitment_welcome_off",
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         self._register_persistent_view()
@@ -2032,19 +2024,7 @@ class WelcomeWatcher(commands.Cog):
                 channel=label,
                 channel_id=self.channel_id,
             )
-            message = "\n".join(
-                [
-                    "✅ Welcome watcher",
-                    "",
-                    "Status:",
-                    "• enabled",
-                    "",
-                    "Channel:",
-                    f"• <#{self.channel_id}>",
-                    f"• path: {label}",
-                ]
-            )
-            asyncio.create_task(_send_runtime(message))
+            log.debug("welcome watcher ready", extra={"channel_id": self.channel_id, "channel": label})
         else:
             reason = self._onb_reg_error or "unknown"
             line = log_lifecycle(
@@ -2057,12 +2037,11 @@ class WelcomeWatcher(commands.Cog):
                 channel_id=self.channel_id,
                 reason=reason,
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
+            log.warning("welcome watcher registration failed", extra={"reason": reason, "channel_id": self.channel_id})
 
 
     async def _run_startup_welcome_ticket_repair(self) -> None:
-        log.warning("welcome ticket repair started")
+        log.debug("welcome ticket repair started")
         try:
             summary = await asyncio.to_thread(
                 onboarding_sheets.run_welcome_ticket_repair_pass,
@@ -2074,7 +2053,14 @@ class WelcomeWatcher(commands.Cog):
 
         repaired = int(summary.get("repaired", 0) or 0)
         flagged = int(summary.get("flagged", 0) or 0)
-        log.warning("welcome ticket repair complete: %s repaired, %s flagged", repaired, flagged)
+        log.info("welcome ticket repair complete", extra={
+            "repaired": repaired,
+            "flagged": flagged,
+            "legacy_rows": int(summary.get("legacy_rows", 0) or 0),
+            "welcome_rows": int(summary.get("welcome_rows", 0) or 0),
+            "reservation_rows": int(summary.get("reservation_rows", 0) or 0),
+            "malformed_rows": int(summary.get("malformed_rows", 0) or 0),
+        })
 
     def _register_persistent_view(self) -> None:
         registration = panels.register_persistent_views(self.bot)

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -301,6 +301,10 @@ def repair_welcome_rows(ws) -> dict[str, int]:
     repaired = 0
     flagged = 0
     scanned = 0
+    legacy_rows = 0
+    welcome_rows = 0
+    reservation_rows = 0
+    malformed_rows = 0
     for row_number, row in enumerate(values[1:], start=2):
         scanned += 1
         row_values = list(row) + [""] * (len(header) - len(row))
@@ -332,7 +336,23 @@ def repair_welcome_rows(ws) -> dict[str, int]:
                 row_values[thread_id_idx] = ""
                 changed = True
 
-        invalid = (not _looks_like_ticket(ticket)) or (not username)
+        ticket_like = _looks_like_ticket(ticket)
+        has_username = bool(username)
+        has_user_or_thread_id = _is_discord_id(user_id) or _is_discord_id(thread_id)
+        status_value = str(row_values[status_idx] or "").strip().lower() if status_idx is not None else ""
+        is_reservation = status_value in {"reserved", "reservation", "queued", "pending"}
+        looks_like_current_welcome = ticket_like and has_username
+
+        if is_reservation:
+            reservation_rows += 1
+        elif looks_like_current_welcome:
+            welcome_rows += 1
+        elif not ticket_like and not has_user_or_thread_id and status_value in {"", "completed", "closed", "archived", "done"}:
+            legacy_rows += 1
+        else:
+            malformed_rows += 1
+
+        invalid = looks_like_current_welcome and not has_user_or_thread_id
         if invalid and status_idx is not None:
             status_value = str(row_values[status_idx] or "").strip().lower()
             if status_value not in {"invalid", "needs_review"}:
@@ -355,7 +375,7 @@ def repair_welcome_rows(ws) -> dict[str, int]:
             core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row_values[: len(header)]])
             repaired += 1
 
-    return {"repaired": repaired, "flagged": flagged, "scanned": scanned}
+    return {"repaired": repaired, "flagged": flagged, "scanned": scanned, "legacy_rows": legacy_rows, "welcome_rows": welcome_rows, "reservation_rows": reservation_rows, "malformed_rows": malformed_rows}
 
 
 def _queue_welcome_repair_alert(summary: dict[str, int]) -> None:


### PR DESCRIPTION
### Motivation
- Reduce noisy, duplicated startup/admin Discord posts and keep a single consolidated startup summary. 
- Demote non-actionable lifecycle messages so Python logs remain structured without spamming production logs. 
- Fix over-broad welcome-ticket repair flagging that was marking large numbers of legacy rows as invalid. 

### Description
- Demoted noisy lifecycle logs in `modules/onboarding/watcher_welcome.py` (`welcomewatcher.on_ready fired` and repair start) from `warning` to `debug` and kept actionable failures at `warning`/`error` levels. 
- Removed per-watcher Discord runtime sends from `WelcomeWatcher.on_ready` (removed `asyncio.create_task(_send_runtime(...))` calls) so only the consolidated startup summary is expected to be posted. 
- Replaced the per-watcher “ready” Discord message with a structured Python debug log including readable channel info. 
- Tightened `repair_welcome_rows` in `shared/sheets/onboarding.py` to classify rows into `legacy`, `welcome`, `reservation`, and `malformed` buckets, and only mark rows as `needs_review` when they look like current welcome-ticket rows but lack valid Discord IDs; the function now returns those category counts. 
- Welcome repair completion now emits an `info` log with `repaired`, `flagged`, and the new category counts to improve observability. 

### Testing
- Ran a lightweight static check with `python -m py_compile modules/onboarding/watcher_welcome.py shared/sheets/onboarding.py modules/common/runtime.py`, which completed successfully. 
- No behavioral unit tests were changed; runtime/integ validation should be observed in staging to confirm the single consolidated startup summary and reduced production log noise.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cd49388083239ce07b188339b8f0)