### PR TITLE
Refine partial-fragment UX and show per-event partials in detailed shares

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -57,6 +57,16 @@ _STATUS_INDEX_TO_CANONICAL = {
 _EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
 
 
+def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, status: str | None) -> bool:
+    if event is None:
+        return False
+    return (
+        status == "in_progress"
+        and event.reward_amount > 0
+        and str(event.reward_type or "").strip().lower() == "fragment"
+    )
+
+
 def _effective_display_status(
     *,
     event: fusion_sheets.FusionEventRow,
@@ -301,8 +311,8 @@ def _build_progress_summary_embed(
                 value=(
                     f"{icon} {selected.event_name}\n{_event_reward_label(selected)}"
                     + (
-                        f"\nPartial logged: {float((partial_by_event or {}).get(selected.event_id, 0.0)):g}"
-                        if current == "in_progress"
+                        f"\nPartial logged: {float((partial_by_event or {}).get(selected.event_id, 0.0)):g} / {selected.reward_amount:g} fragments"
+                        if _supports_partial_fragments(selected, status=current)
                         else ""
                     )
                 ),
@@ -616,7 +626,7 @@ class _FusionProgressShareButton(discord.ui.Button):
 
 class _FusionProgressUpdateButton(discord.ui.Button):
     def __init__(self) -> None:
-        super().__init__(label="Update Progress", style=discord.ButtonStyle.primary, custom_id=_FUSION_PROGRESS_UPDATE_CUSTOM_ID, row=2)
+        super().__init__(label="Log Partial Fragments", style=discord.ButtonStyle.primary, custom_id=_FUSION_PROGRESS_UPDATE_CUSTOM_ID, row=2)
 
     async def callback(self, interaction: discord.Interaction) -> None:
         view = self.view
@@ -626,17 +636,15 @@ class _FusionProgressUpdateButton(discord.ui.Button):
         if event is None:
             await _send_ephemeral(interaction, "Choose an event first.")
             return
-        if view.progress_by_event.get(event.event_id) != "in_progress":
-            await _send_ephemeral(interaction, "Set this event to In Progress before logging partials.")
-            return
-        if event.reward_amount <= 0:
-            await _send_ephemeral(interaction, "This event has no reward amount to log partial progress.")
+        status = view.progress_by_event.get(event.event_id, "not_started")
+        if not _supports_partial_fragments(event, status=status):
+            await _send_ephemeral(interaction, "Partial fragments can only be logged for in-progress fragment events with a reward amount.")
             return
         await interaction.response.send_modal(_FusionProgressModal(view=view, event=event))
 
 
-class _FusionProgressModal(discord.ui.Modal, title="Update Partial Progress"):
-    partial_amount = discord.ui.TextInput(label="Amount earned so far", placeholder="0", required=True)
+class _FusionProgressModal(discord.ui.Modal, title="Log Partial Fragments"):
+    partial_amount = discord.ui.TextInput(label="Fragments earned so far", placeholder="0", required=True)
 
     def __init__(self, *, view: "FusionProgressPanelView", event: fusion_sheets.FusionEventRow) -> None:
         super().__init__()
@@ -715,7 +723,8 @@ class FusionProgressPanelView(discord.ui.View):
             if selected_status == "done_bonus" and selected_event is not None and not _event_has_bonus(selected_event):
                 selected_status = "done"
         self.add_item(_FusionProgressStatusSelect(selected_status, selected_event=selected_event))
-        self.add_item(_FusionProgressUpdateButton())
+        if _supports_partial_fragments(selected_event, status=selected_status):
+            self.add_item(_FusionProgressUpdateButton())
         if selected_event is not None and selected_event.milestones:
             self.add_item(_FusionProgressMarkAllButton())
         self.add_item(_FusionProgressShareButton())

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -166,7 +166,15 @@ def build_progress_share_embed(
             status = snapshot.display_status_by_event.get(event.event_id, "not_started")
             icon = _STATUS_ICONS.get(status, _STATUS_ICONS["not_started"])
             label = _STATUS_LABELS.get(status, "Not Started")
-            detail_lines.append(f"{icon} {event.event_name}: {label}")
+            line = f"{icon} {event.event_name}: {label}"
+            if (
+                status == "in_progress"
+                and event.reward_amount > 0
+                and str(event.reward_type or "").strip().lower() == "fragment"
+            ):
+                partial_amount = max(0.0, float((partial_by_event or {}).get(event.event_id, 0.0)))
+                line += f" — {partial_amount:g} / {event.reward_amount:g} fragments"
+            detail_lines.append(line)
         embed.add_field(name="Event Breakdown", value="\n".join(detail_lines)[:1024] or "No events available.", inline=False)
 
     embed.set_footer(text=f"Share Mode: {mode.title()}")


### PR DESCRIPTION
### Motivation
- The existing "Update Progress" action was unclear about logging earned fragments and was shown in contexts where partials weren’t applicable.  
- Public shares included partials in the total but didn’t show which in-progress events contributed those partials.  

### Description
- Added `_supports_partial_fragments(event, *, status)` to centralize eligibility (selected event exists, status is `in_progress`, `reward_amount > 0`, and `reward_type == 'fragment'`).  
- Updated interactive copy to be explicit: button label `Log Partial Fragments`, modal title `Log Partial Fragments`, and input label `Fragments earned so far` (placeholder unchanged).  
- Only render the partial-log button when `_supports_partial_fragments(...)` is true and keep a runtime guard that responds with a friendly ephemeral error if the interaction is somehow triggered for an unsupported event.  
- Private progress embed now displays selected-event partials as `Partial logged: X / reward_amount fragments` only when the event supports partial fragments.  
- Public detailed share embed now appends per-event partial progress for eligible in-progress fragment events as `— X / reward_amount fragments`, while summary mode and sheet structure remain unchanged.  

### Testing
- Ran `python -m py_compile modules/community/fusion/opt_in_view.py modules/community/fusion/progress_share.py shared/sheets/fusion.py` and compilation succeeded.  
- Verified that changes are limited to view/rendering logic and do not modify sheet layout, tab names, or column assumptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d2b091c48323a5d263bef0b600f3)