### PR TITLE
Disallow partial fragment logging for non-stepped events and adjust progress embed formatting

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -64,6 +64,7 @@ def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, s
         status == "in_progress"
         and event.reward_amount > 0
         and str(event.reward_type or "").strip().lower() == "fragment"
+        and bool(event.milestones)
     )
 
 
@@ -280,7 +281,7 @@ def _build_progress_summary_embed(
     reward_unit = str(target.reward_type or "").strip() or "rewards"
 
     embed = discord.Embed(
-        title=f"My Progress — {target.fusion_name}",
+        title=f"My Progress: {target.fusion_name}",
         description="Private tracker for your fusion progress.",
         color=discord.Color.blurple(),
     )
@@ -652,6 +653,12 @@ class _FusionProgressModal(discord.ui.Modal, title="Log Partial Fragments"):
         self.event = event
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
+        if not self.event.milestones:
+            await _send_ephemeral(
+                interaction,
+                "This event doesn’t support stepped progress yet, so partial fragments can’t be logged.",
+            )
+            return
         try:
             amount = float(str(self.partial_amount.value).strip())
         except ValueError:

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -149,7 +149,7 @@ def build_progress_share_embed(
     overall_progress_line = _build_overall_progress_line(target=target, snapshot=snapshot)
 
     embed = discord.Embed(
-        title=f"Progress Share — {target.fusion_name}",
+        title=f"Progress Share: {target.fusion_name}",
         color=discord.Color.blurple(),
     )
     embed.add_field(name="User", value=user_display_name, inline=False)
@@ -173,7 +173,7 @@ def build_progress_share_embed(
                 and str(event.reward_type or "").strip().lower() == "fragment"
             ):
                 partial_amount = max(0.0, float((partial_by_event or {}).get(event.event_id, 0.0)))
-                line += f" — {partial_amount:g} / {event.reward_amount:g} fragments"
+                line += f" ({partial_amount:g} / {event.reward_amount:g} fragments)"
             detail_lines.append(line)
         embed.add_field(name="Event Breakdown", value="\n".join(detail_lines)[:1024] or "No events available.", inline=False)
 


### PR DESCRIPTION
### Motivation

- Prevent users from logging partial fragments for events that do not support stepped/milestone progress to avoid inconsistent state.
- Provide clearer messaging when partial logging is not allowed by surfacing an explicit modal error.
- Make progress embed titles and fragment count formatting more consistent and readable.

### Description

- Require `event.milestones` in `_supports_partial_fragments` by adding `and bool(event.milestones)` to the predicate. 
- Add a guard in `_FusionProgressModal.on_submit` that returns an ephemeral message when `self.event.milestones` is falsy so partial fragments cannot be submitted for non-stepped events. 
- Change embed titles in ` _build_progress_summary_embed` and `build_progress_share_embed` from `—` to `:` (e.g. `My Progress: {target.fusion_name}`).
- Adjust detailed fragment display in `progress_share.py` to show partial counts inside parentheses instead of using an em dash (e.g. `(x / y fragments)`).

### Testing

- Ran the project's unit test suite with `pytest` for the community fusion module, and the tests completed successfully. 
- Ran code style checks (`flake8`) and static checks without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d550fc048323bfa0590f023b2552)