### PR TITLE
Show fragment progress suffix only when partial_amount > 0

### DIFF
--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -167,12 +167,13 @@ def build_progress_share_embed(
             icon = _STATUS_ICONS.get(status, _STATUS_ICONS["not_started"])
             label = _STATUS_LABELS.get(status, "Not Started")
             line = f"{icon} {event.event_name}: {label}"
+            partial_amount = max(0.0, float((partial_by_event or {}).get(event.event_id, 0.0)))
             if (
                 status == "in_progress"
                 and event.reward_amount > 0
+                and partial_amount > 0
                 and str(event.reward_type or "").strip().lower() == "fragment"
             ):
-                partial_amount = max(0.0, float((partial_by_event or {}).get(event.event_id, 0.0)))
                 line += f" ({partial_amount:g} / {event.reward_amount:g} fragments)"
             detail_lines.append(line)
         embed.add_field(name="Event Breakdown", value="\n".join(detail_lines)[:1024] or "No events available.", inline=False)


### PR DESCRIPTION
### Motivation
- Prevent noisy detailed progress lines that display `(0 / X fragments)` for in-progress fragment events with no logged partial progress by only appending the fragment suffix when there is actual partial progress.

### Description
- Update `modules/community/fusion/progress_share.py` to compute `partial_amount` and only add the `(<partial> / <total> fragments)` suffix when `partial_amount > 0`, preserving the existing status and reward-type checks.

### Testing
- Ran `python -m py_compile modules/community/fusion/progress_share.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d7e222fc83238f89501e7a8143e9)