### PR TITLE
Fix startup logging flow and welcome repair classification

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1302,7 +1302,7 @@ class Runtime:
             }
             if len(extra_info["feature_keys"]) == 1:
                 extra_info["feature_key"] = extra_info["feature_keys"][0]
-            log.info(
+            log.debug(
                 "feature module loaded",
                 extra=extra_info,
             )
@@ -1382,7 +1382,7 @@ class Runtime:
                 raise
             else:
                 human_log.human(
-                    "info",
+                    "debug",
                     "feature module loaded",
                     feature_module=ext,
                     feature_key="always_on",
@@ -1402,7 +1402,7 @@ class Runtime:
                 continue
             else:
                 human_log.human(
-                    "info",
+                    "debug",
                     "feature module loaded",
                     feature_module=ext,
                     feature_key="community",
@@ -1526,11 +1526,7 @@ class Runtime:
             _startup_phase_log("scheduler registration", "ok")
 
     async def _register_ready_schedulers_inner(self) -> None:
-        from shared.sheets.cache_scheduler import (
-            ensure_cache_registration,
-            preload_on_startup,
-            register_refresh_job,
-        )
+        from shared.sheets.cache_scheduler import ensure_cache_registration, register_refresh_job
         from modules.housekeeping import cleanup as housekeeping_cleanup
         from modules.housekeeping import keepalive as housekeeping_keepalive
         from modules.housekeeping import mirralith_overview as housekeeping_mirralith
@@ -1542,7 +1538,8 @@ class Runtime:
 
         toggles = shared_config.features
         ensure_cache_registration()
-        await preload_on_startup()
+        # Keep startup registration fast; long-running cache preload happens in
+        # the background startup preloader task.
         cache_specs = (
             ("clans", timedelta(hours=3), "3h"),
             ("templates", timedelta(days=7), "7d"),

--- a/modules/onboarding/ui/panels.py
+++ b/modules/onboarding/ui/panels.py
@@ -343,7 +343,8 @@ def register_persistent_views(bot: discord.Client) -> dict[str, Any]:
                 fields["duplicate_registration"] = True
                 if stacksite:
                     fields["stacksite"] = stacksite
-            diag.log_event_sync("info", "persistent_view_registered", **fields)
+            event_level = "debug" if not duplicate else "warning"
+            diag.log_event_sync(event_level, "persistent_view_registered", **fields)
 
     duration_ms = int((time.perf_counter() - started) * 1000)
     buttons, text_inputs, selects = _component_counts(view)

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -341,16 +341,23 @@ def repair_welcome_rows(ws) -> dict[str, int]:
         has_user_or_thread_id = _is_discord_id(user_id) or _is_discord_id(thread_id)
         status_value = str(row_values[status_idx] or "").strip().lower() if status_idx is not None else ""
         is_reservation = status_value in {"reserved", "reservation", "queued", "pending"}
+        has_welcome_shape = ticket_like or has_username or has_user_or_thread_id
         looks_like_current_welcome = ticket_like and has_username
 
         if is_reservation:
             reservation_rows += 1
         elif looks_like_current_welcome:
             welcome_rows += 1
-        elif not ticket_like and not has_user_or_thread_id and status_value in {"", "completed", "closed", "archived", "done"}:
+        elif not has_welcome_shape and status_value in {"", "completed", "closed", "archived", "done"}:
             legacy_rows += 1
         else:
-            malformed_rows += 1
+            # Legacy rows often carry partial data (username-only or stale IDs)
+            # that should not be counted as malformed unless they appear to be
+            # welcome-shaped records with inconsistent required fields.
+            if has_welcome_shape and not looks_like_current_welcome and not is_reservation:
+                malformed_rows += 1
+            else:
+                legacy_rows += 1
 
         invalid = looks_like_current_welcome and not has_user_or_thread_id
         if invalid and status_idx is not None:
@@ -388,8 +395,14 @@ def _queue_welcome_repair_alert(summary: dict[str, int]) -> None:
     if (now_ts - _WELCOME_REPAIR_ALERT_LAST_TS) < 3600:
         return
     _WELCOME_REPAIR_ALERT_LAST_TS = now_ts
+    legacy_rows = int(summary.get("legacy_rows", 0) or 0)
+    welcome_rows = int(summary.get("welcome_rows", 0) or 0)
+    reservation_rows = int(summary.get("reservation_rows", 0) or 0)
+    malformed_rows = int(summary.get("malformed_rows", 0) or 0)
     _WELCOME_REPAIR_ALERT_PENDING = (
-        f"Welcome ticket repair: {repaired} repaired, {flagged} flagged for review"
+        "Welcome ticket repair: "
+        f"{repaired} repaired, {flagged} flagged for review "
+        f"(welcome={welcome_rows}, reservations={reservation_rows}, legacy={legacy_rows}, malformed={malformed_rows})"
     )
 
 


### PR DESCRIPTION
### Motivation
- Ensure the consolidated startup summary posts once and quickly after core ready/watchers/scheduler are wired without waiting for long cache preloads. 
- Reduce noisy/duplicate admin Discord and Python logs during startup so only the summary and genuine warnings/errors are posted. 
- Prevent the welcome-ticket repair pass from treating large numbers of legacy/historical rows as malformed so alerts reflect true issues.

### Description
- Stop blocking scheduler registration on a synchronous cache preload by removing the `preload_on_startup` call from `Runtime._register_ready_schedulers_inner` and rely on the existing background startup preloader task; keep cache registration but make preload background (`modules/common/runtime.py`).
- Demote routine startup lifecycle telemetry to debug to avoid prod spam by changing `log.info`/`human_log.human("info")` for routine feature-module loads to debug-level (`modules/common/runtime.py`).
- Demote non-duplicate persistent view registration telemetry to debug while keeping duplicate-registration warnings elevated by switching the diag event level in `register_persistent_views` (`modules/onboarding/ui/panels.py`).
- Tighten welcome-sheet repair classification to distinguish legacy/historical rows from current welcome-shaped rows and only flag genuinely invalid welcome rows, and expand the queued alert to include category counts (`shared/sheets/onboarding.py`).

### Testing
- Ran `pytest -q tests/coreops/test_ready.py tests/onboarding/test_watcher_welcome_sessions.py` and both test modules passed. 
- Verified the changed call sites and log level adjustments compile and the welcome repair alert now includes categorized counts (unit tests covering welcome watcher behavior ran green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d8d2770083238149b782df4cebfd)