### PR TITLE
Count partial fragments for stepped events and retain partials on Done

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -61,7 +61,7 @@ def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, s
     if event is None:
         return False
     return (
-        status == "in_progress"
+        status in {"in_progress", "done", "done_bonus"}
         and event.reward_amount > 0
         and str(event.reward_type or "").strip().lower() == "fragment"
         and bool(event.milestones)
@@ -307,13 +307,14 @@ def _build_progress_summary_embed(
         if selected is not None:
             current = snapshot.display_status_by_event.get(selected.event_id, "not_started")
             icon = _STATUS_ICONS.get(current, _STATUS_ICONS["not_started"])
+            partial_amount = max(0.0, float((partial_by_event or {}).get(selected.event_id, 0.0)))
             embed.add_field(
                 name="Selected Event",
                 value=(
                     f"{icon} {selected.event_name}\n{_event_reward_label(selected)}"
                     + (
-                        f"\nPartial logged: {float((partial_by_event or {}).get(selected.event_id, 0.0)):g} / {selected.reward_amount:g} fragments"
-                        if _supports_partial_fragments(selected, status=current)
+                        f"\nPartial logged: {partial_amount:g} / {selected.reward_amount:g} fragments"
+                        if _supports_partial_fragments(selected, status=current) and partial_amount > 0
                         else ""
                     )
                 ),
@@ -446,7 +447,9 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             },
         )
         try:
-            partial_amount = view.partial_by_event.get(event.event_id) if status == "in_progress" else None
+            partial_amount = view.partial_by_event.get(event.event_id)
+            if status in {"not_started", "skipped"}:
+                partial_amount = None
             await fusion_sheets.upsert_user_event_progress(
                 view.fusion_id,
                 str(view.user_id),
@@ -474,7 +477,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
             return
 
         view.progress_by_event[event.event_id] = status
-        if status != "in_progress":
+        if status in {"not_started", "skipped"}:
             view.partial_by_event.pop(event.event_id, None)
         view.selected_event_id = event.event_id
         view.last_update = (event.event_name, status)

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -33,6 +33,14 @@ _STATUS_ICONS = {
 _ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "done_bonus", "skipped"})
 
 
+def _is_stepped_fragment_event(event: fusion_sheets.FusionEventRow) -> bool:
+    return (
+        event.reward_amount > 0
+        and str(event.reward_type or "").strip().lower() == "fragment"
+        and bool(event.milestones)
+    )
+
+
 @dataclass(slots=True)
 class ProgressShareSnapshot:
     counts: dict[str, int]
@@ -88,19 +96,26 @@ def build_share_snapshot(
             partial_by_event=partial_by_event,
             now=current_time,
         )
+        partial_amount = max(0.0, float(partial_map.get(event.event_id, 0.0)))
         if status == "done_bonus":
             display_status_by_event[event.event_id] = status
             counts["done"] += 1
-            completed_reward_total += event.reward_amount + _event_bonus_amount(event)
+            done_base = event.reward_amount
+            if _is_stepped_fragment_event(event) and partial_amount > 0:
+                done_base = partial_amount
+            completed_reward_total += done_base + _event_bonus_amount(event)
             continue
         if status not in counts:
             status = "not_started"
         display_status_by_event[event.event_id] = status
         counts[status] += 1
         if status == "done":
-            completed_reward_total += event.reward_amount
+            if _is_stepped_fragment_event(event) and partial_amount > 0:
+                completed_reward_total += partial_amount
+            else:
+                completed_reward_total += event.reward_amount
         elif status == "in_progress":
-            in_progress_partial_total += max(0.0, float(partial_map.get(event.event_id, 0.0)))
+            in_progress_partial_total += partial_amount
 
     return ProgressShareSnapshot(
         counts=counts,
@@ -168,12 +183,7 @@ def build_progress_share_embed(
             label = _STATUS_LABELS.get(status, "Not Started")
             line = f"{icon} {event.event_name}: {label}"
             partial_amount = max(0.0, float((partial_by_event or {}).get(event.event_id, 0.0)))
-            if (
-                status == "in_progress"
-                and event.reward_amount > 0
-                and partial_amount > 0
-                and str(event.reward_type or "").strip().lower() == "fragment"
-            ):
+            if status in {"in_progress", "done", "done_bonus"} and partial_amount > 0 and _is_stepped_fragment_event(event):
                 line += f" ({partial_amount:g} / {event.reward_amount:g} fragments)"
             detail_lines.append(line)
         embed.add_field(name="Event Breakdown", value="\n".join(detail_lines)[:1024] or "No events available.", inline=False)


### PR DESCRIPTION
### Motivation
- Stepped fragment events with milestones should allow users to mark an event Done without automatically crediting the full event reward when they only completed some steps.  
- Preserve user-entered `partial_amount` when transitioning to `Done`/`Done + Bonus` so Done can mean “I’m finished with what I earned” rather than “I earned the whole reward”.

### Description
- Allow partial fragment support to be displayed/logged for statuses `In Progress`, `Done`, and `Done + Bonus` by expanding the partial-support check. (changed `modules/community/fusion/opt_in_view.py`)
- Preserve `partial_amount` when saving status transitions to `Done`/`Done + Bonus`, only clearing partials when changing to `Not Started` or `Skipped`, and persist the value to the sheet when appropriate. (changed `modules/community/fusion/opt_in_view.py`)
- Adjust public progress aggregation so stepped milestone fragment events use `partial_amount` (when > 0) for `Done` and `Done + Bonus`, otherwise fall back to full `reward_amount` for backward compatibility, and continue counting partials for `In Progress`. (changed `modules/community/fusion/progress_share.py`)
- Show partial suffix `(x / total fragments)` in detailed public shares and the private selected-event panel for stepped fragment events when `partial_amount > 0`. (changed `modules/community/fusion/progress_share.py` and `modules/community/fusion/opt_in_view.py`)
- No sheet schema changes and no hard-coded tab names or column indices were introduced; files modified: `modules/community/fusion/opt_in_view.py`, `modules/community/fusion/progress_share.py`.
- Manual test notes: stepped event `In Progress` with partial `15` counts `15`; changing that event to `Done` still counts `15`; non-stepped event `Done` counts full reward; `Skipped`/`Not Started` clears or ignores partials.

### Testing
- Ran `python -m py_compile modules/community/fusion/opt_in_view.py modules/community/fusion/progress_share.py shared/sheets/fusion.py`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e94b5aa88323ab9871377f0b4b42)