### PR TITLE
Show strategic progress and track skipped rewards in fusion progress embeds

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -278,7 +278,18 @@ def _build_progress_summary_embed(
     last_update: tuple[str, str] | None = None,
 ) -> discord.Embed:
     snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event, partial_by_event=partial_by_event)
-    reward_unit = str(target.reward_type or "").strip() or "rewards"
+    raw_reward_type = str(target.reward_type or "").strip()
+    lowered_reward_type = raw_reward_type.lower()
+    if lowered_reward_type in {"fragment", "fragments"}:
+        reward_label = "Fragment"
+    elif raw_reward_type:
+        reward_label = raw_reward_type.title()
+    else:
+        reward_label = "Reward"
+    acquired = snapshot.completed_reward_total
+    skipped = snapshot.skipped_reward_total
+    still_needed = max(float(target.needed) - acquired, 0.0)
+    still_needed_line = "Fusion ready" if still_needed <= 0 else f"{still_needed:g} still needed"
 
     embed = discord.Embed(
         title=f"My Progress: {target.fusion_name}",
@@ -297,8 +308,13 @@ def _build_progress_summary_embed(
         inline=False,
     )
     embed.add_field(
-        name=reward_unit.title(),
-        value=f"{snapshot.completed_reward_total:g} / {target.available:g} {reward_unit} earned",
+        name=f"{reward_label} Progress",
+        value=(
+            f"{acquired:g} acquired\n"
+            f"{skipped:g} skipped\n"
+            f"{still_needed_line}\n\n"
+            f"{target.needed:g} / {target.available:g} required"
+        ),
         inline=False,
     )
 

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -47,6 +47,7 @@ class ProgressShareSnapshot:
     display_status_by_event: dict[str, str]
     completed_reward_total: float
     in_progress_partial_total: float
+    skipped_reward_total: float
 
 
 def _event_bonus_amount(event: fusion_sheets.FusionEventRow) -> float:
@@ -87,9 +88,11 @@ def build_share_snapshot(
     display_status_by_event: dict[str, str] = {}
     completed_reward_total = 0.0
     in_progress_partial_total = 0.0
+    skipped_reward_total = 0.0
     partial_map = partial_by_event or {}
 
     for event in events:
+        raw_status = str(progress_by_event.get(event.event_id, "not_started") or "").strip().lower()
         status = _effective_display_status(
             event=event,
             progress_by_event=progress_by_event,
@@ -116,12 +119,17 @@ def build_share_snapshot(
                 completed_reward_total += event.reward_amount
         elif status == "in_progress":
             in_progress_partial_total += partial_amount
+        elif status in {"skipped", "missed"}:
+            skipped_reward_total += event.reward_amount
+            if raw_status == "done_bonus":
+                skipped_reward_total += _event_bonus_amount(event)
 
     return ProgressShareSnapshot(
         counts=counts,
         display_status_by_event=display_status_by_event,
         completed_reward_total=completed_reward_total + in_progress_partial_total,
         in_progress_partial_total=in_progress_partial_total,
+        skipped_reward_total=skipped_reward_total,
     )
 
 
@@ -144,6 +152,21 @@ def _build_summary_block(*, snapshot: ProgressShareSnapshot, overall_progress_li
         f"⚠️ Missed: {snapshot.counts['missed']}\n"
         f"⬜ Not Started: {snapshot.counts['not_started']}\n"
         f"{overall_progress_line}"
+    )
+
+
+def _build_strategic_progress_block(*, target: fusion_sheets.FusionRow, snapshot: ProgressShareSnapshot) -> str:
+    reward_type = str(target.reward_type or "").strip().title() or "Reward"
+    acquired = snapshot.completed_reward_total
+    skipped = snapshot.skipped_reward_total
+    to_go = max(float(target.needed) - acquired, 0.0)
+    to_go_line = "Fusion ready" if to_go <= 0 else f"{to_go:g} to go"
+    return (
+        f"{reward_type} Progress\n"
+        f"{acquired:g} acquired\n"
+        f"{skipped:g} skipped\n"
+        f"{to_go_line}\n\n"
+        f"{target.needed:g} / {target.available:g} needed"
     )
 
 
@@ -171,6 +194,11 @@ def build_progress_share_embed(
     embed.add_field(
         name="Summary",
         value=_build_summary_block(snapshot=snapshot, overall_progress_line=overall_progress_line),
+        inline=False,
+    )
+    embed.add_field(
+        name="Strategic Progress",
+        value=_build_strategic_progress_block(target=target, snapshot=snapshot),
         inline=False,
     )
 


### PR DESCRIPTION
### Motivation

- Improve the fusion progress embeds to give a clearer strategic view of what’s acquired, skipped, and still needed to finish a fusion.  
- Normalize reward type labeling (e.g. fragments vs generic rewards) for clearer field titles.  
- Count skipped/missed event rewards so users can plan around items they intentionally skipped or missed.

### Description

- Update `_build_progress_summary_embed` in `opt_in_view.py` to normalize reward labels, compute acquired/skipped/still-needed, and replace the old summary line with a multi-line `Reward Progress` block.  
- Add `skipped_reward_total` to `ProgressShareSnapshot` and compute it in `build_share_snapshot` in `progress_share.py`, including handling of raw status and adding event bonus when `raw_status == "done_bonus"`.  
- Add helper `_build_strategic_progress_block` and include a new "Strategic Progress" field in `build_progress_share_embed` to present acquired, skipped, and remaining requirements.  
- Minor logic cleanup: derive `raw_status` in the snapshot builder and ensure fragment/partial handling is preserved when totaling rewards.

### Testing

- Ran the repository's fusion-related unit tests and integration checks; all tests passed.  
- Ran project type checks and linters on the modified modules with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0225fc746883239969ef0ce2645797)