### PR TITLE
Refine fusion progress embed formatting for compact Discord rendering

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -289,7 +289,7 @@ def _build_progress_summary_embed(
     acquired = snapshot.completed_reward_total
     skipped = snapshot.skipped_reward_total
     still_needed = max(float(target.needed) - acquired, 0.0)
-    still_needed_line = "Fusion ready" if still_needed <= 0 else f"{still_needed:g} still needed"
+    still_needed_line = "Fusion ready" if still_needed <= 0 else f"{still_needed:g} to go"
 
     embed = discord.Embed(
         title=f"My Progress: {target.fusion_name}",
@@ -308,12 +308,13 @@ def _build_progress_summary_embed(
         inline=False,
     )
     embed.add_field(
-        name=f"{reward_label} Progress",
+        name="\u200b",
         value=(
+            f"**{reward_label} Progress**\n"
             f"{acquired:g} acquired\n"
             f"{skipped:g} skipped\n"
             f"{still_needed_line}\n\n"
-            f"{target.needed:g} / {target.available:g} required"
+            f"{target.needed:g} / {target.available:g} needed"
         ),
         inline=False,
     )

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -162,7 +162,7 @@ def _build_strategic_progress_block(*, target: fusion_sheets.FusionRow, snapshot
     to_go = max(float(target.needed) - acquired, 0.0)
     to_go_line = "Fusion ready" if to_go <= 0 else f"{to_go:g} to go"
     return (
-        f"{reward_type} Progress\n"
+        f"**{reward_type} Progress**\n"
         f"{acquired:g} acquired\n"
         f"{skipped:g} skipped\n"
         f"{to_go_line}\n\n"
@@ -197,7 +197,7 @@ def build_progress_share_embed(
         inline=False,
     )
     embed.add_field(
-        name="Strategic Progress",
+        name="\u200b",
         value=_build_strategic_progress_block(target=target, snapshot=snapshot),
         inline=False,
     )

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -417,10 +417,10 @@ def test_reward_totals_and_selected_event_labels_are_data_driven():
         selected_event_id="e_done_bonus",
     )
 
-    fragments_field = next(field for field in embed.fields if field.name == "Fragments")
+    progress_field = next(field for field in embed.fields if field.name == "\u200b")
     summary_field = next(field for field in embed.fields if field.name == "Summary")
     selected_field = next(field for field in embed.fields if field.name == "Selected Event")
-    assert fragments_field.value == "80 / 450 fragments earned"
+    assert "80 acquired" in progress_field.value
     assert "✅ Done: 2" in summary_field.value
     assert "25 + 50 bonus fragments" in selected_field.value
 
@@ -433,8 +433,8 @@ def test_done_on_bonus_event_counts_base_only():
         progress_by_event={"e_bonus": "done"},
         selected_event_id="e_bonus",
     )
-    fragments_field = next(field for field in embed.fields if field.name == "Fragments")
-    assert fragments_field.value == "25 / 450 fragments earned"
+    progress_field = next(field for field in embed.fields if field.name == "\u200b")
+    assert "25 acquired" in progress_field.value
 
 
 def test_my_progress_uses_tracker_reward_type_for_titan():
@@ -447,12 +447,27 @@ def test_my_progress_uses_tracker_reward_type_for_titan():
         selected_event_id="e_points",
     )
 
-    points_field = next(field for field in embed.fields if field.name == "Points")
+    points_field = next(field for field in embed.fields if field.name == "\u200b")
     selected_field = next(field for field in embed.fields if field.name == "Selected Event")
-    assert points_field.value == "75 / 1750 points earned"
+    assert "**Points Progress**" in points_field.value
+    assert "75 acquired" in points_field.value
     assert "25 + 50 bonus points" in selected_field.value
 
 
+
+
+def test_progress_summary_field_uses_inline_heading_and_needed_copy():
+    embed = opt_in_view._build_progress_summary_embed(
+        target=replace(_fusion_row(opt_in_role_id=777), needed=100, available=115, reward_type="fragments"),
+        events=[replace(_event_row("e_done", event_name="Done"), reward_amount=35.0), replace(_event_row("e_skipped", event_name="Skipped"), reward_amount=5.0)],
+        progress_by_event={"e_done": "done", "e_skipped": "skipped"},
+    )
+
+    progress_field = next(field for field in embed.fields if field.name == "\u200b")
+    assert progress_field.value.startswith("**Fragment Progress**\n35 acquired\n5 skipped\n65 to go")
+    assert "100 / 115 needed" in progress_field.value
+    assert "still needed" not in progress_field.value
+    assert "required" not in progress_field.value
 def test_status_options_include_done_bonus_only_when_event_has_bonus():
     bonus_event = replace(_event_row("e_bonus"), bonus=10.0)
     plain_event = _event_row("e_plain")

--- a/tests/community/test_fusion_progress_share.py
+++ b/tests/community/test_fusion_progress_share.py
@@ -58,6 +58,8 @@ def test_build_progress_share_embed_summary_mode_has_generic_summary_block():
     summary_field = next(field for field in embed.fields if field.name == "Summary")
     assert "✅ Done: 1" in summary_field.value
     assert "Progress: 5 / 450 fragments" in summary_field.value
+    strategic_field = next(field for field in embed.fields if field.name == "\u200b")
+    assert "**Fragments Progress**" in strategic_field.value
     assert all(field.name != "Event Breakdown" for field in embed.fields)
 
 
@@ -87,4 +89,6 @@ def test_build_progress_share_embed_uses_dynamic_reward_unit():
     )
 
     summary_field = next(field for field in embed.fields if field.name == "Summary")
+    strategic_field = next(field for field in embed.fields if field.name == "\u200b")
     assert "Progress: 25 / 1750 points" in summary_field.value
+    assert "**Points Progress**" in strategic_field.value


### PR DESCRIPTION
### Motivation
- Discord renders duplicate headings and extra spacing for the fusion progress blocks, making the share and private-progress embeds noisy. 
- The goal is a single visible progress heading inside the field value with compact wording and preserved progress logic.

### Description
- Use a zero-width field name (`"\u200b"`) for the progress field in `modules/community/fusion/opt_in_view.py` and `modules/community/fusion/progress_share.py` and move the visible heading into the field value as `**<Reward Label> Progress**`.
- Change the copy `"still needed"` → `"to go"` and `"required"` → `"needed"` for consistent, compact phrasing while keeping all calculations and progress logic unchanged.
- Keep snapshot/share/partial behavior and selected-event rendering intact and remove the old visible `"Strategic Progress"`/`"Fragment Progress"` field-name usage in favor of the zero-width name.
- Update tests in `tests/community/` to assert the zero-width field name and inline heading behavior and to reflect the wording changes.

### Testing
- Ran the targeted unit tests `tests/community/test_fusion_progress_share.py::test_build_progress_share_embed_summary_mode_has_generic_summary_block`, `tests/community/test_fusion_progress_share.py::test_build_progress_share_embed_uses_dynamic_reward_unit`, and `tests/community/test_fusion_opt_in_view.py::test_progress_summary_field_uses_inline_heading_and_needed_copy`, and they all passed.
- Iterated on failing assertions from broader test runs until the updated tests for the progress field and share embed reflected the new formatting and passed.
- No full-suite run was performed in this change; only the focused fusion progress/share tests were validated automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022f4bd3e48323b243ec8a2fe0415b)