### PR TITLE
Add feature toggle, dedupe alerts and in-process lock to reset reminders; improve robustness and tests

### DIFF
--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import math
+import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -10,9 +11,12 @@ import discord
 from discord.ext import commands
 
 from modules.common.embeds import get_embed_colour
+from modules.common import feature_flags
+from modules.common import runtime as rt
 from modules.community.reset_reminders.models import ResetReminder
 from modules.community.reset_reminders.views import ResetReminderView
 from shared.config import cfg, get_milestones_sheet_id
+from shared.dedupe import EventDeduper
 from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
 
 if TYPE_CHECKING:
@@ -21,6 +25,9 @@ if TYPE_CHECKING:
 log = logging.getLogger("c1c.community.reset_reminders.scheduler")
 
 _RESET_REMINDER_TAB_KEY = "RESET_REMINDER_TAB"
+_FEATURE_TOGGLE_KEY = "reset_reminders"
+_INVALID_ROW_ALERT_DEDUPER = EventDeduper(window_s=900.0, max_keys=128)
+_PROCESS_LOCK = asyncio.Lock()
 _REQUIRED_COLUMNS: tuple[str, ...] = (
     "reset_id",
     "label",
@@ -45,6 +52,10 @@ _REQUIRED_COLUMNS: tuple[str, ...] = (
 class _ResetReminderRecord:
     row_number: int
     reminder: ResetReminder
+
+
+def _is_feature_enabled() -> bool:
+    return feature_flags.is_enabled(_FEATURE_TOGGLE_KEY)
 
 
 def _normalize(value: Any) -> str:
@@ -131,6 +142,7 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
 
     header_map = _resolve_header_map(matrix[0])
     records: list[_ResetReminderRecord] = []
+    invalid_rows: list[dict[str, Any]] = []
 
     for row_number, row in enumerate(matrix[1:], start=2):
         try:
@@ -161,9 +173,42 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                 last_message_id=_parse_optional_int(_cell(row, header_map["last_message_id"])),
             )
             records.append(_ResetReminderRecord(row_number=row_number, reminder=reminder))
-        except Exception:
+        except Exception as exc:
+            reason = type(exc).__name__
+            invalid_rows.append(
+                {
+                    "row_number": row_number,
+                    "reset_id": _cell(row, header_map.get("reset_id", -1)),
+                    "reason": reason,
+                }
+            )
             log.exception("invalid reset reminder row skipped", extra={"tab": tab_name, "row_number": row_number})
             continue
+
+    valid_active_count = len(records) if active_only else sum(1 for r in records if r.reminder.status.lower() == "active")
+    log.info(
+        "reset reminder rows loaded",
+        extra={
+            "tab": tab_name,
+            "active_only": active_only,
+            "valid_active_rows": valid_active_count,
+            "invalid_rows": len(invalid_rows),
+            "invalid_row_details": invalid_rows,
+        },
+    )
+    if active_only and invalid_rows:
+        detail = ", ".join(
+            f"row={entry['row_number']} reset_id={entry.get('reset_id') or '-'} reason={entry.get('reason') or '-'}"
+            for entry in invalid_rows
+        )
+        dedupe_key = f"reset_reminders:invalid_active_rows:{tab_name}:{len(invalid_rows)}:{detail[:120]}"
+        if _INVALID_ROW_ALERT_DEDUPER.should_emit(dedupe_key):
+            try:
+                await rt.send_log_message(
+                    f"⚠️ Reset reminders — invalid active rows skipped • tab={tab_name} • count={len(invalid_rows)} • {detail}"
+                )
+            except Exception:
+                log.warning("failed to send reset reminder invalid-row ops alert", exc_info=True)
 
     return tab_name, header_map, records
 
@@ -184,6 +229,9 @@ def _next_reset(reference_date_utc: dt.datetime, cycle_days: int, now_utc: dt.da
 
 
 async def register_persistent_reset_views(bot: commands.Bot) -> None:
+    if not _is_feature_enabled():
+        log.info("reset reminders disabled via feature toggle; skipping persistent view registration")
+        return
     _, _, records = await _load_reset_reminder_records(active_only=True)
     for record in records:
         reminder = record.reminder
@@ -242,107 +290,119 @@ async def _update_row_after_send(
 
 
 async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None = None) -> None:
-    is_closed = getattr(bot, "is_closed", None)
-    is_ready = getattr(bot, "is_ready", None)
-    if callable(is_closed) and is_closed():
+    if not _is_feature_enabled():
+        log.debug("reset reminders disabled via feature toggle; skipping scheduler tick")
         return
-    if callable(is_ready) and not is_ready():
+    if _PROCESS_LOCK.locked():
+        log.info("reset reminder processing already running; skipping overlapping tick")
         return
+    # In-process lock prevents duplicate sends from overlapping scheduler ticks in one process.
+    # Multi-instance deployments sharing the same sheet still need a stronger cross-process guard.
+    async with _PROCESS_LOCK:
+        is_closed = getattr(bot, "is_closed", None)
+        is_ready = getattr(bot, "is_ready", None)
+        if callable(is_closed) and is_closed():
+            return
+        if callable(is_ready) and not is_ready():
+            return
 
-    now_utc = _utc_now(now)
-
-    try:
-        tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
-    except Exception:
-        log.exception("failed to load reset reminders")
-        return
-
-    if not records:
-        return
-
-    for record in records:
-        reminder = record.reminder
-
-        if reminder.cycle_days <= 0:
-            log.warning("reset reminder skipped; cycle_days must be > 0", extra={"reset_id": reminder.reset_id})
-            continue
-
-        if reminder.reference_date_utc > now_utc:
-            continue
-
-        if reminder.role_id <= 0 or reminder.channel_id <= 0:
-            log.warning(
-                "reset reminder skipped; missing role/channel",
-                extra={"reset_id": reminder.reset_id, "role_id": reminder.role_id, "channel_id": reminder.channel_id},
-            )
-            continue
+        now_utc = _utc_now(now)
 
         try:
-            next_reset = _next_reset(reminder.reference_date_utc, reminder.cycle_days, now_utc)
+            tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
         except Exception:
-            log.exception("reset reminder skipped; failed to compute cycle", extra={"reset_id": reminder.reset_id})
-            continue
+            log.exception("failed to load reset reminders")
+            return
 
-        trigger_time = next_reset - dt.timedelta(minutes=reminder.lead_minutes)
-        if now_utc < trigger_time:
-            continue
+        if not records:
+            return
 
-        if reminder.last_sent_for_reset_utc == next_reset:
-            continue
+        for record in records:
+            reminder = record.reminder
 
-        target = await _resolve_target_channel(bot, reminder)
-        if target is None:
-            log.warning("reset reminder skipped; target channel not found", extra={"reset_id": reminder.reset_id})
-            continue
+            if reminder.cycle_days <= 0:
+                log.warning("reset reminder skipped; cycle_days must be > 0", extra={"reset_id": reminder.reset_id})
+                continue
 
-        if reminder.last_message_id:
-            try:
-                old_message = await target.fetch_message(reminder.last_message_id)
-                await old_message.delete()
-            except Exception:
-                log.debug(
-                    "failed to delete old reset reminder",
-                    extra={"reset_id": reminder.reset_id, "last_message_id": reminder.last_message_id},
+            if reminder.reference_date_utc > now_utc:
+                continue
+
+            if reminder.role_id <= 0 or reminder.channel_id <= 0:
+                log.warning(
+                    "reset reminder skipped; missing role/channel",
+                    extra={"reset_id": reminder.reset_id, "role_id": reminder.role_id, "channel_id": reminder.channel_id},
                 )
+                continue
 
-        embed = discord.Embed(
-            title=reminder.embed_title or reminder.label,
-            description=reminder.embed_description,
-            color=get_embed_colour("community"),
-            timestamp=next_reset,
-        )
-        if reminder.embed_footer:
-            embed.set_footer(text=reminder.embed_footer)
+            try:
+                next_reset = _next_reset(reminder.reference_date_utc, reminder.cycle_days, now_utc)
+            except Exception:
+                log.exception("reset reminder skipped; failed to compute cycle", extra={"reset_id": reminder.reset_id})
+                continue
 
-        view = ResetReminderView(
-            role_id=reminder.role_id,
-            label_opt_in=reminder.button_label_opt_in,
-            label_opt_out=reminder.button_label_opt_out,
-        )
+            trigger_time = next_reset - dt.timedelta(minutes=reminder.lead_minutes)
+            if now_utc < trigger_time:
+                continue
 
-        try:
-            message = await target.send(
-                content=f"<@&{reminder.role_id}>",
-                embed=embed,
-                view=view,
+            if reminder.last_sent_for_reset_utc == next_reset:
+                continue
+
+            target = await _resolve_target_channel(bot, reminder)
+            if target is None:
+                log.warning("reset reminder skipped; target channel not found", extra={"reset_id": reminder.reset_id})
+                continue
+
+            if reminder.last_message_id:
+                try:
+                    old_message = await target.fetch_message(reminder.last_message_id)
+                    await old_message.delete()
+                except Exception:
+                    log.debug(
+                        "failed to delete old reset reminder",
+                        extra={"reset_id": reminder.reset_id, "last_message_id": reminder.last_message_id},
+                    )
+
+            embed = discord.Embed(
+                title=reminder.embed_title or reminder.label,
+                description=reminder.embed_description,
+                color=get_embed_colour("community"),
+                timestamp=next_reset,
             )
-        except Exception:
-            log.exception("reset reminder send failed", extra={"reset_id": reminder.reset_id})
-            continue
+            if reminder.embed_footer:
+                embed.set_footer(text=reminder.embed_footer)
 
-        try:
-            await _update_row_after_send(
-                tab_name=tab_name,
-                header_map=header_map,
-                row_number=record.row_number,
-                next_reset=next_reset,
-                message_id=message.id,
+            view = ResetReminderView(
+                role_id=reminder.role_id,
+                label_opt_in=reminder.button_label_opt_in,
+                label_opt_out=reminder.button_label_opt_out,
             )
-        except Exception:
-            log.exception("reset reminder sheet update failed", extra={"reset_id": reminder.reset_id})
+
+            try:
+                message = await target.send(
+                    content=f"<@&{reminder.role_id}>",
+                    embed=embed,
+                    view=view,
+                )
+            except Exception:
+                log.exception("reset reminder send failed", extra={"reset_id": reminder.reset_id})
+                continue
+
+            try:
+                await _update_row_after_send(
+                    tab_name=tab_name,
+                    header_map=header_map,
+                    row_number=record.row_number,
+                    next_reset=next_reset,
+                    message_id=message.id,
+                )
+            except Exception:
+                log.exception("reset reminder sheet update failed", extra={"reset_id": reminder.reset_id})
 
 
 def schedule_reset_reminder_jobs(runtime: "Runtime") -> None:
+    if not _is_feature_enabled():
+        log.info("reset reminders disabled via feature toggle; scheduler job not registered")
+        return
     if any(getattr(job, "name", None) == "reset_reminders" for job in runtime.scheduler.jobs):
         log.info("reset reminder scheduler already registered; skipping duplicate job")
         return

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -61,13 +61,32 @@ class _DummyBot:
         assert channel_id == 123
         return self._channel
 
+    def add_view(self, _view):
+        return None
 
-def test_schedule_reset_jobs_is_idempotent() -> None:
+
+def test_schedule_reset_jobs_is_idempotent(monkeypatch) -> None:
     runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
 
     scheduler.schedule_reset_reminder_jobs(runtime)
     scheduler.schedule_reset_reminder_jobs(runtime)
 
+    assert len(runtime.scheduler.jobs) == 1
+    assert runtime.scheduler.jobs[0].name == "reset_reminders"
+
+
+def test_schedule_reset_jobs_not_registered_when_disabled(monkeypatch) -> None:
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: False)
+    scheduler.schedule_reset_reminder_jobs(runtime)
+    assert runtime.scheduler.jobs == []
+
+
+def test_schedule_reset_jobs_registered_when_enabled(monkeypatch) -> None:
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    scheduler.schedule_reset_reminder_jobs(runtime)
     assert len(runtime.scheduler.jobs) == 1
     assert runtime.scheduler.jobs[0].name == "reset_reminders"
 
@@ -103,6 +122,7 @@ def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> Non
 
     monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
     monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
 
     channel = _DummyChannel()
 
@@ -119,3 +139,155 @@ def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> Non
     assert channel.sent[0]["content"] == "<@&999>"
     assert len(updates) == 1
     assert updates[0]["row_number"] == 7
+
+
+def test_process_reset_reminder_dedupes_by_last_sent(monkeypatch) -> None:
+    now = dt.datetime(2026, 5, 22, 23, 30, tzinfo=dt.timezone.utc)
+    next_reset = dt.datetime(2026, 5, 23, 0, 0, tzinfo=dt.timezone.utc)
+    reminder = scheduler.ResetReminder(
+        reset_id="grim_forest",
+        label="Grim Forest",
+        status="active",
+        reference_date_utc=dt.datetime(2026, 3, 24, 0, 0, tzinfo=dt.timezone.utc),
+        cycle_days=30,
+        lead_minutes=60,
+        role_id=999,
+        channel_id=123,
+        thread_id=None,
+        embed_title="",
+        embed_description="Reset incoming",
+        embed_footer="footer",
+        button_label_opt_in="Opt in",
+        button_label_opt_out="Opt out",
+        last_sent_for_reset_utc=next_reset,
+        last_message_id=111,
+    )
+    record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    channel = _DummyChannel()
+    updates = []
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(scheduler, "_next_reset", lambda *_args: next_reset)
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record])))
+    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: updates.append(kwargs))
+    bot = _DummyBot(channel)
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+    assert channel.sent == []
+    assert updates == []
+
+
+def test_process_reset_reminder_delete_failure_does_not_block_send(monkeypatch) -> None:
+    now = dt.datetime(2026, 5, 22, 23, 30, tzinfo=dt.timezone.utc)
+
+    class _FailDeleteMessage(_DummyMessage):
+        async def delete(self) -> None:
+            raise RuntimeError("delete failed")
+
+    class _DeleteFailChannel(_DummyChannel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.last_message = _FailDeleteMessage(111)
+
+    reminder = scheduler.ResetReminder(
+        reset_id="cursed_city",
+        label="Cursed City",
+        status="active",
+        reference_date_utc=dt.datetime(2026, 3, 24, 0, 0, tzinfo=dt.timezone.utc),
+        cycle_days=30,
+        lead_minutes=60,
+        role_id=999,
+        channel_id=123,
+        thread_id=None,
+        embed_title="",
+        embed_description="Reset incoming",
+        embed_footer="footer",
+        button_label_opt_in="Opt in",
+        button_label_opt_out="Opt out",
+        last_sent_for_reset_utc=None,
+        last_message_id=111,
+    )
+    record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    updates = []
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record])))
+    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: updates.append(kwargs))
+    channel = _DeleteFailChannel()
+    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    bot = _DummyBot(channel)
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+    assert len(channel.sent) == 1
+    assert len(updates) == 1
+
+
+def test_invalid_rows_skipped_without_crash(monkeypatch) -> None:
+    async def _fetch_values(_sheet_id, _tab):
+        return [
+            ["reset_id", "label", "status", "reference_date_utc", "cycle_days", "lead_minutes", "role_id", "channel_id", "thread_id", "embed_title", "embed_description", "embed_footer", "button_label_opt_in", "button_label_opt_out", "last_sent_for_reset_utc", "last_message_id"],
+            ["doom", "Doom", "active", "not-a-date", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", ""],
+            ["grim", "Grim", "active", "2026-01-01T00:00:00Z", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", ""],
+        ]
+
+    monkeypatch.setattr(scheduler, "afetch_values", _fetch_values)
+    monkeypatch.setattr(scheduler, "_tab_name", lambda: "ResetTab")
+    monkeypatch.setattr(scheduler, "_sheet_id", lambda: "sheet")
+    tab, header, records = asyncio.run(scheduler._load_reset_reminder_records(active_only=True))
+    assert tab == "ResetTab"
+    assert "reset_id" in header
+    assert len(records) == 1
+
+
+def test_register_persistent_views_disabled(monkeypatch) -> None:
+    class _Bot:
+        def __init__(self):
+            self.views = []
+
+        def add_view(self, view):
+            self.views.append(view)
+
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: False)
+    bot = _Bot()
+    asyncio.run(scheduler.register_persistent_reset_views(bot))
+    assert bot.views == []
+
+
+def test_register_persistent_views_active_rows(monkeypatch) -> None:
+    class _Bot:
+        def __init__(self):
+            self.views = []
+
+        def add_view(self, view):
+            self.views.append(view)
+
+    reminder = scheduler.ResetReminder(
+        reset_id="doom_tower",
+        label="Doom Tower",
+        status="active",
+        reference_date_utc=dt.datetime(2026, 3, 24, 0, 0, tzinfo=dt.timezone.utc),
+        cycle_days=30,
+        lead_minutes=60,
+        role_id=999,
+        channel_id=123,
+        thread_id=None,
+        embed_title="",
+        embed_description="Reset incoming",
+        embed_footer="footer",
+        button_label_opt_in="Opt in",
+        button_label_opt_out="Opt out",
+        last_sent_for_reset_utc=None,
+        last_message_id=None,
+    )
+    record = scheduler._ResetReminderRecord(row_number=2, reminder=reminder)
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(
+        scheduler,
+        "_load_reset_reminder_records",
+        lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"reset_id": 0}, [record])),
+    )
+
+    bot = _Bot()
+    asyncio.run(scheduler.register_persistent_reset_views(bot))
+    assert len(bot.views) == 1
+    view = bot.views[0]
+    assert view.timeout is None
+    custom_ids = [child.custom_id for child in view.children]
+    assert custom_ids == ["reset_reminder:999:in", "reset_reminder:999:out"]


### PR DESCRIPTION
### Motivation

- Allow safe opt-out of reset reminders via a feature flag to disable scheduling and view registration at runtime.
- Prevent duplicate sends from overlapping scheduler ticks in a single process and reduce noisy ops by deduping invalid-row alerts.
- Improve resiliency and observability when loading rows, deleting old messages, sending reminders, and updating the sheet.

### Description

- Introduce `_is_feature_enabled()` and gate `register_persistent_reset_views`, `schedule_reset_reminder_jobs`, and `process_reset_reminders` behind the `reset_reminders` feature flag using `modules.common.feature_flags`.
- Add an in-process `asyncio.Lock` `_PROCESS_LOCK` to avoid overlapping scheduler ticks and early-return when a tick is already running.
- Enhance `_load_reset_reminder_records` to collect and log invalid rows, send a deduped ops alert via `runtime.send_log_message`, and attach an `EventDeduper` to avoid repeat alerts.
- Rework `process_reset_reminders` flow to reload records inside the processing lock, compute `next_reset` per record, handle deletion failures gracefully, and add stronger logging around failures and skipped rows.
- Avoid registering duplicate scheduler jobs and skip job registration when the feature is disabled.
- Update tests in `tests/community/test_reset_reminder_scheduler.py` to cover feature-flag behavior, de-duplication by `last_sent_for_reset_utc`, deletion-failure resilience, invalid row skipping, and persistent view registration.

### Testing

- Ran the updated `tests/community/test_reset_reminder_scheduler.py` suite under `pytest`, including new tests `test_schedule_reset_jobs_is_idempotent`, `test_schedule_reset_jobs_not_registered_when_disabled`, `test_schedule_reset_jobs_registered_when_enabled`, `test_process_reset_reminder_sends_once_and_updates_sheet`, `test_process_reset_reminder_dedupes_by_last_sent`, `test_process_reset_reminder_delete_failure_does_not_block_send`, `test_invalid_rows_skipped_without_crash`, `test_register_persistent_views_disabled`, and `test_register_persistent_views_active_rows`.
- All tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0225e5fe188323802e8ef2c9046f85)