### PR TITLE
Refactor startup Discord admin logging into isolated startup summary system

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ from c1c_coreops.rbac import (
 )
 from c1c_coreops.cron_summary import emit_daily_summary
 from modules.recruitment.reporting.daily_recruiter_update import ensure_scheduler_started
+from modules.ops.startup_summary import render_startup_summary
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -219,7 +220,7 @@ async def _enforce_guild_allow_list(
             return False
 
     if log_success:
-        log.info(
+        log.debug(
             "Guild allow-list verified",
             extra={
                 "allowed": allowed_sorted,
@@ -237,115 +238,6 @@ async def _enforce_guild_allow_list(
 
 
 
-def _channel_readable(bot_client: commands.Bot, channel_id: int | None) -> str:
-    if not channel_id:
-        return "not configured"
-    mention = f"<#{channel_id}>"
-    channel = bot_client.get_channel(channel_id)
-    if channel is None:
-        return mention
-    return f"{mention} ({onboarding_channel_path(channel)})"
-
-
-def _fmt_next(jobs: list[object], job_name: str) -> str:
-    for job in jobs:
-        if getattr(job, "name", None) == job_name:
-            next_run = getattr(job, "next_run", None)
-            if next_run is None:
-                return "pending"
-            try:
-                return next_run.astimezone(dt.timezone.utc).replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
-            except Exception:
-                return "pending"
-    return "not scheduled"
-
-
-def _read_watchdog_values(runtime_obj: Runtime) -> tuple[int, int, int]:
-    return (
-        int(getattr(runtime_obj, "_watchdog_check_sec", 300)),
-        int(getattr(runtime_obj, "_watchdog_stall_sec", 1200)),
-        int(getattr(runtime_obj, "_watchdog_disconnect_grace_sec", 6000)),
-    )
-
-
-def _build_startup_summary_message(*, bot_client: commands.Bot, jobs: list[object], watchdog: tuple[int, int, int]) -> str:
-    lines = ["✅ Woadkeeper startup complete", ""]
-
-    try:
-        toggles = shared_config.features
-        promo_label = _channel_readable(bot_client, cfg_int("PROMO_CHANNEL_ID", 0) or None)
-        welcome_label = _channel_readable(bot_client, cfg_int("WELCOME_CHANNEL_ID", 0) or None)
-        watcher_lines = [
-            "Watchers",
-            f"• Promo watcher: {('enabled' if toggles.promo_watcher_enabled else 'disabled')} — {promo_label}",
-            f"• Welcome watcher: {('enabled' if toggles.welcome_watcher_enabled else 'disabled')} — {welcome_label}",
-        ]
-        lines.extend(watcher_lines)
-    except Exception:
-        log.exception("startup summary watchers section unavailable")
-        lines.extend(["Watchers", "• unavailable"])
-
-    try:
-        cache_buckets = ["clan_tags", "clans", "fusion", "fusion_events", "leagues", "onboarding_questions", "reaction_roles", "templates"]
-        cache_lines = []
-        for name in cache_buckets:
-            snap = cache_telemetry.get_snapshot(name)
-            status = "ok" if (snap.last_result or "").lower() in {"ok", "success"} else (snap.last_result or "pending")
-            rows = snap.item_count if snap.item_count is not None else "?"
-            cache_lines.append(f"• {name}: {status} ({rows})")
-        lines.extend(["", "Cache", *cache_lines])
-    except Exception:
-        log.exception("startup summary cache section unavailable")
-        lines.extend(["", "Cache", "• unavailable"])
-
-    try:
-        scheduled_names = [
-            ("clans", "cache_refresh:clans"),
-            ("templates", "cache_refresh:templates"),
-            ("clan_tags", "cache_refresh:clan_tags"),
-            ("onboarding_questions", "cache_refresh:onboarding_questions"),
-            ("cleanup", "cleanup_watcher"),
-            ("mirralith_overview", "mirralith_overview"),
-            ("housekeeping_keepalive", "housekeeping_keepalive"),
-            ("shard_weekly_reminders", "shard_weekly_reminders"),
-        ]
-        scheduler_lines = ["Schedulers"]
-        for label, job_name in scheduled_names:
-            next_value = _fmt_next(jobs, job_name)
-            if next_value != "not scheduled":
-                scheduler_lines.append(f"• {label}: next {next_value}")
-
-        for job in jobs:
-            name = str(getattr(job, "name", "") or "")
-            if not name:
-                continue
-            if name.startswith("fusion_") and name not in {n for _, n in scheduled_names}:
-                scheduler_lines.append(f"• {name}: next {_fmt_next(jobs, name)}")
-            if name.startswith("reset_reminder") or name == "reset_reminders":
-                scheduler_lines.append(f"• {name}: next {_fmt_next(jobs, name)}")
-
-        if len(scheduler_lines) == 1:
-            scheduler_lines.append("• none scheduled")
-        lines.extend(["", *scheduler_lines])
-    except Exception:
-        log.exception("startup summary scheduler section unavailable")
-        lines.extend(["", "Schedulers", "• unavailable"])
-
-    try:
-        interval_s, stall_s, grace_s = watchdog
-        lines.extend(
-            [
-                "",
-                "Watchdog",
-                f"• interval {interval_s}s",
-                f"• stall {stall_s}s",
-                f"• disconnect grace {grace_s}s",
-            ]
-        )
-    except Exception:
-        log.exception("startup summary watchdog section unavailable")
-        lines.extend(["", "Watchdog", "• unavailable"])
-    return "\n".join(lines)
 @bot.event
 async def on_ready():
     hb.note_ready()
@@ -368,66 +260,61 @@ async def on_ready():
     if not await _enforce_guild_allow_list(log_when_empty=True, log_success=False):
         return
 
-    runtime.suppress_startup_admin_logs = True
     try:
-        try:
-            runtime.startup_diag_mark(feature_init_started=True)
-            await core_ready.on_ready(bot)
-        except Exception:
-            log.exception("READY FAILURE: core_ready.on_ready")
-            await _shutdown("ready_lifecycle_failure:core_ready")
-            return
+        runtime.startup_diag_mark(feature_init_started=True)
+        await core_ready.on_ready(bot)
+    except Exception:
+        log.exception("READY FAILURE: core_ready.on_ready")
+        await _shutdown("ready_lifecycle_failure:core_ready")
+        return
 
-        try:
-            runtime.startup_diag_mark(scheduler_start_reached=True)
-            await runtime.register_ready_schedulers()
-        except Exception:
-            log.exception("READY FAILURE: runtime.register_ready_schedulers")
+    try:
+        runtime.startup_diag_mark(scheduler_start_reached=True)
+        await runtime.register_ready_schedulers()
+    except Exception:
+        log.exception("READY FAILURE: runtime.register_ready_schedulers")
 
-        try:
-            await ensure_scheduler_started(bot)
-        except Exception:
-            log.exception("READY FAILURE: ensure_scheduler_started")
+    try:
+        await ensure_scheduler_started(bot)
+    except Exception:
+        log.exception("READY FAILURE: ensure_scheduler_started")
 
-        try:
-            runtime.watchdog(delay_sec=5.0)
+    try:
+        runtime.watchdog(delay_sec=5.0)
 
-            if not hasattr(bot, "_cron_summary_task"):
-                async def _daily_summary_loop() -> None:
-                    while True:
-                        now = dt.datetime.now(dt.timezone.utc)
-                        target = now.replace(hour=0, minute=5, second=0, microsecond=0)
-                        if now >= target:
-                            target = target + dt.timedelta(days=1)
-                        await asyncio.sleep((target - now).total_seconds())
-                        try:
-                            await emit_daily_summary(CRON_JOB_NAMES)
-                        except asyncio.CancelledError:
-                            raise
-                        except Exception:
-                            log.warning("[cron] summary_failed", exc_info=True)
+        if not hasattr(bot, "_cron_summary_task"):
+            async def _daily_summary_loop() -> None:
+                while True:
+                    now = dt.datetime.now(dt.timezone.utc)
+                    target = now.replace(hour=0, minute=5, second=0, microsecond=0)
+                    if now >= target:
+                        target = target + dt.timedelta(days=1)
+                    await asyncio.sleep((target - now).total_seconds())
+                    try:
+                        await emit_daily_summary(CRON_JOB_NAMES)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        log.warning("[cron] summary_failed", exc_info=True)
 
-                runtime.scheduler.spawn(_daily_summary_loop(), name="cron_daily_summary")
-                bot._cron_summary_task = True
-                log.info("[cron] summary scheduler started (00:05Z)")
+            runtime.scheduler.spawn(_daily_summary_loop(), name="cron_daily_summary")
+            bot._cron_summary_task = True
+            log.info("[cron] summary scheduler started (00:05Z)")
 
-            await keepalive.ensure_started(bot)
-            runtime.schedule_startup_preload()
-        except Exception:
-            log.warning("non-critical ready task failed", exc_info=True)
+        await keepalive.ensure_started(bot)
+        runtime.schedule_startup_preload()
+    except Exception:
+        log.warning("non-critical ready task failed", exc_info=True)
 
-        try:
-            watchdog_values = _read_watchdog_values(runtime)
-            summary = _build_startup_summary_message(
-                bot_client=bot,
-                jobs=runtime.scheduler.jobs,
-                watchdog=watchdog_values,
-            )
-            await runtime.send_log_message(summary, bypass_startup_suppression=True)
-        except Exception:
-            log.exception("startup summary failed", exc_info=True)
-    finally:
-        runtime.suppress_startup_admin_logs = False
+    try:
+        summary = render_startup_summary(
+            bot_client=bot,
+            runtime=runtime,
+            jobs=runtime.scheduler.jobs,
+        )
+        await runtime.send_log_message(summary)
+    except Exception:
+        log.exception("startup summary failed", exc_info=True)
 
 
 @bot.event
@@ -493,13 +380,13 @@ async def on_message(message: discord.Message):
     )
     if LOG_MESSAGE_CONTENT:
         safe_content = _safe_logged_message_content(content)
-        log.info(
+        log.debug(
             "seen msg: guild=%s chan=%s msg=%s author=%s content_len=%s attachments=%s content=%r",
             *base_fields,
             safe_content,
         )
     else:
-        log.info(
+        log.debug(
             "seen msg: guild=%s chan=%s msg=%s author=%s content_len=%s attachments=%s",
             *base_fields,
         )

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -267,15 +267,6 @@ async def _startup_preload(bot: commands.Bot | None = None) -> None:
         log.info("Cache preloader completed with no rows")
         return
 
-    deduper = refresh_deduper()
-    bucket_names_for_key = [res.name or name for res, name in zip(refresh_results, bucket_names)]
-    key = refresh_dedupe_key("startup", None, bucket_names_for_key)
-    if refresh_results and deduper.should_emit(key):
-        buckets_for_message = refresh_bucket_results(refresh_results)
-        await send_log_message(
-            format_refresh_message("startup", buckets_for_message, total_s=total_ms / 1000.0)
-        )
-
     log.info("Cache preloader completed")
 
 
@@ -309,33 +300,14 @@ def schedule_startup_preload(bot: commands.Bot | None = None) -> None:
     )
 
 
-def _is_suppressed_startup_admin_message(message: str) -> bool:
-    text = str(message or "").strip().lower()
-    if not text:
-        return False
-    return any(
-        token in text
-        for token in (
-            "scope=startup",
-            "watchdog started",
-            "watchdog loop started",
-            "scheduler interval",
-            "scheduler intervals",
-        )
-    )
-
-
-async def send_log_message(message: str, *, bypass_startup_suppression: bool = False) -> None:
+async def send_log_message(message: str) -> None:
     """Proxy to the active runtime's log channel helper, if available."""
 
     runtime = get_active_runtime()
     if runtime is None:
         return
     try:
-        if bypass_startup_suppression:
-            await runtime.send_log_message(message, bypass_startup_suppression=True)
-        else:
-            await runtime.send_log_message(message)
+        await runtime.send_log_message(message)
     except Exception:
         log.warning("failed to send log message (non-fatal)", exc_info=True)
 
@@ -952,7 +924,6 @@ class Runtime:
         self._startup_scheduler_registered = False
         self._startup_scheduler_lock = asyncio.Lock()
         self._startup_diag: dict[str, Any] = {}
-        self.suppress_startup_admin_logs: bool = False
         set_active_runtime(self)
 
     def _reset_startup_diag(self, *, attempt: int) -> None:
@@ -1070,15 +1041,9 @@ class Runtime:
         await self.shutdown_webserver()
 
     async def send_log_message(
-        self, message: str, *, bypass_startup_suppression: bool = False
+        self, message: str
     ) -> None:
         try:
-            if (
-                self.suppress_startup_admin_logs
-                and not bypass_startup_suppression
-                and _is_suppressed_startup_admin_message(message)
-            ):
-                return
             channel_id = get_log_channel_id()
             if not channel_id:
                 return

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -960,8 +960,6 @@ class PromoTicketWatcher(commands.Cog):
                 channel=None,
                 channel_id=None,
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         try:
@@ -978,8 +976,6 @@ class PromoTicketWatcher(commands.Cog):
                 reason="invalid_promo_channel",
                 channel_id=channel_id,
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         self.channel_id = channel_id_int
@@ -994,8 +990,6 @@ class PromoTicketWatcher(commands.Cog):
                 result="disabled",
                 reason="feature_promo_enabled_off",
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         if not feature_flags.is_enabled("enable_promo_hook"):
@@ -1008,8 +1002,6 @@ class PromoTicketWatcher(commands.Cog):
                 result="disabled",
                 reason="feature_enable_promo_hook_off",
             )
-            if line:
-                asyncio.create_task(_send_runtime(line))
             return
 
         label = _channel_readable_label(self.bot, channel_id_int)

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -2106,7 +2106,7 @@ class WelcomeWatcher(commands.Cog):
         if isinstance(duration_ms, int):
             payload["duration"] = f"{duration_ms}ms"
         if duplicate:
-            payload["duplicate_registration"] = True
+            log.debug("welcome watcher persistent view duplicate registration", extra={"view": view_name})
         if error is not None:
             payload["reason"] = f"{error.__class__.__name__}: {error}"
 

--- a/modules/ops/startup_summary.py
+++ b/modules/ops/startup_summary.py
@@ -1,0 +1,114 @@
+"""Discord admin startup summary renderer."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Iterable
+
+from discord.ext import commands
+
+from modules.common.runtime import Runtime
+from modules.onboarding.watcher_welcome import _channel_readable_label
+from shared.cache import telemetry as cache_telemetry
+from shared.config import cfg_int
+from shared.sheet_config import shared_config
+
+log = logging.getLogger("c1c.ops.startup_summary")
+
+_CACHE_BUCKETS = ["clan_tags", "clans", "fusion", "fusion_events", "leagues", "onboarding_questions", "reaction_roles", "templates"]
+_SCHEDULER_MAP = {
+    "clans": "cache_refresh:clans",
+    "templates": "cache_refresh:templates",
+    "clan_tags": "cache_refresh:clan_tags",
+    "onboarding_questions": "cache_refresh:onboarding_questions",
+    "cleanup": "cleanup_watcher",
+    "housekeeping_keepalive": "housekeeping_keepalive",
+    "mirralith_overview": "mirralith_overview",
+    "shard_weekly_reminders": "shard_weekly_reminders",
+    "fusion_reminders": "fusion_reminders",
+    "reset_reminders": "reset_reminders",
+}
+
+def _channel_line(bot_client: commands.Bot, channel_id: int | None) -> str:
+    if not channel_id:
+        return "not configured"
+    mention = f"<#{channel_id}>"
+    try:
+        channel = bot_client.get_channel(int(channel_id))
+    except Exception:
+        channel = None
+    if channel is None:
+        return mention
+    try:
+        return f"{mention} ({_channel_readable_label(bot_client, channel_id).lstrip('#')})"
+    except Exception:
+        return mention
+
+def _fmt_next(jobs: Iterable[object], name: str) -> str:
+    for job in jobs:
+        if getattr(job, 'name', None) != name:
+            continue
+        next_run = getattr(job, 'next_run', None)
+        if next_run is None:
+            return 'pending'
+        try:
+            return next_run.astimezone(dt.timezone.utc).replace(second=0, microsecond=0).strftime('%Y-%m-%d %H:%M UTC')
+        except Exception:
+            return 'pending'
+    return 'not scheduled'
+
+def render_startup_summary(*, bot_client: commands.Bot, runtime: Runtime, jobs: list[object]) -> str:
+    lines = ["✅ Woadkeeper startup complete", ""]
+
+    try:
+        toggles = shared_config.features
+        watchers = [
+            "Watchers",
+            f"• Promo watcher: {'enabled' if bool(getattr(toggles,'promo_watcher_enabled',False)) else 'disabled'} — {_channel_line(bot_client, cfg_int('PROMO_CHANNEL_ID', 0) or None)}",
+            f"• Welcome watcher: {'enabled' if bool(getattr(toggles,'welcome_watcher_enabled',False)) else 'disabled'} — {_channel_line(bot_client, cfg_int('WELCOME_CHANNEL_ID', 0) or None)}",
+        ]
+        lines.extend(watchers)
+    except Exception:
+        log.exception('startup summary watchers section unavailable')
+        lines.extend(["Watchers", "• unavailable"])
+
+    try:
+        cache_lines=["Cache"]
+        for bucket in _CACHE_BUCKETS:
+            try:
+                snap = cache_telemetry.get_snapshot(bucket)
+                raw = str((getattr(snap,'last_result',None) or 'pending')).lower()
+                status = raw if raw in {'ok','pending','stale','error'} else ('ok' if raw in {'success','retry_ok'} else 'pending')
+                count = getattr(snap,'item_count',None)
+                cache_lines.append(f"• {bucket}: {status} ({count if count is not None else '?'})")
+            except Exception:
+                log.exception('startup summary cache item unavailable', extra={'bucket':bucket})
+                cache_lines.append(f"• {bucket}: pending (?)")
+        lines.extend(["",*cache_lines])
+    except Exception:
+        log.exception('startup summary cache section unavailable')
+        lines.extend(["", "Cache", "• unavailable"])
+
+    try:
+        scheduler_lines=["Schedulers"]
+        for label, job_name in _SCHEDULER_MAP.items():
+            next_val = _fmt_next(jobs, job_name)
+            if next_val == 'not scheduled':
+                scheduler_lines.append(f"• {label}: not scheduled")
+            else:
+                scheduler_lines.append(f"• {label}: next {next_val}")
+        lines.extend(["",*scheduler_lines])
+    except Exception:
+        log.exception('startup summary scheduler section unavailable')
+        lines.extend(["", "Schedulers", "• unavailable"])
+
+    try:
+        interval = int(getattr(runtime, '_watchdog_check_sec', 300))
+        stall = int(getattr(runtime, '_watchdog_stall_sec', 1200))
+        grace = int(getattr(runtime, '_watchdog_disconnect_grace_sec', 6000))
+        lines.extend(["", "Watchdog", f"• interval {interval}s", f"• stall {stall}s", f"• disconnect grace {grace}s"])
+    except Exception:
+        log.exception('startup summary watchdog section unavailable')
+        lines.extend(["", "Watchdog", "• unavailable"])
+
+    return "\n".join(lines)


### PR DESCRIPTION
### Motivation
- The existing startup admin logging was layered and brittle, producing multiple overlapping Discord admin messages (watchers, cache refresh, schedulers, watchdog) and relying on a global suppression flag.
- Multiple code paths emitted startup success state separately which caused inconsistent admin UX and racey behavior.
- The goal is a single, isolated startup summary renderer that does not depend on lifecycle/debug emitters or suppression semantics.

### Description
- Added a dedicated renderer `render_startup_summary` in `modules/ops/startup_summary.py` that builds four guarded sections (`Watchers`, `Cache`, `Schedulers`, `Watchdog`) with per-item fallbacks and safe attribute access.
- Replaced the inline startup formatter in `app.py` with a call to `render_startup_summary(...)` so the app emits exactly one startup summary message after core wiring (core ready, scheduler registration, watchdog, preload scheduling). 
- Removed startup-only refresh-summary emission and the related dedupe/send path from the cache startup preload, and simplified `modules/common/runtime.send_log_message` to stop using the global startup-suppression filtering logic.
- Stopped emitting promo-watcher startup success/disabled lines to the startup Discord stream by removing the startup `send_log_message` calls in `modules/onboarding/watcher_promo.py`, and demoted noisy lifecycle/duplicate registration and message-observation logs to debug in `modules/onboarding/watcher_welcome.py` and `app.py` respectively.

### Testing
- Ran byte-compile on the modified files with `python -m py_compile app.py modules/ops/startup_summary.py modules/common/runtime.py modules/onboarding/watcher_promo.py modules/onboarding/watcher_welcome.py` and the compilation completed successfully (one harmless `SyntaxWarning` in `app.py` observed during iteration). 
- Ran `python -m py_compile modules/onboarding/watcher_promo.py` independently and it compiled successfully.
- Verified that startup summary construction, cache-preload path removal of startup emission, suppression-flag removal, and log-level demotions were applied across the stated files via static inspection and compilation checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0239f642608323820b56be97905aee)