### PR TITLE
Enhance Role & Visitor Audit output with detected-issues and action sections

### DIFF
--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -52,6 +52,10 @@ class AuditResult:
     visitors_closed_only: list[tuple[discord.Member, list[TicketThread]]] | None = None
     visitors_extra_roles: list[tuple[discord.Member, list[discord.Role], list[TicketThread]]] | None = None
     proposed_role_mutations: list[tuple[discord.Member, list[discord.Role], list[discord.Role]]] | None = None
+    action_roles_removed: list[str] | None = None
+    action_roles_added: list[str] | None = None
+    action_users_kicked: list[str] | None = None
+    action_failed_or_skipped: list[str] | None = None
 
 
 def _member_roles(member: discord.Member) -> set[int]:
@@ -113,11 +117,11 @@ async def _apply_role_changes(
     dry_run: bool = True,
     remove: Sequence[discord.Role] = (),
     add: Sequence[discord.Role] = (),
-) -> bool:
+) -> tuple[bool, str | None]:
     actor_normalized = (actor or "").strip().lower()
     scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
     if dry_run or actor_normalized in scheduled_actors:
-        return True
+        return True, None
     before_roles = [getattr(role, "name", str(getattr(role, "id", "unknown"))) for role in getattr(member, "roles", [])]
     try:
         if remove:
@@ -129,14 +133,14 @@ async def _apply_role_changes(
             "role audit skipped member — missing permissions",
             extra={"member_id": getattr(member, "id", None)},
         )
-        return False
+        return False, "missing permission"
     except discord.HTTPException as exc:
         log.warning(
             "role audit member update failed",
             exc_info=True,
             extra={"member_id": getattr(member, "id", None), "error": str(exc)},
         )
-        return False
+        return False, str(exc)
     after_roles = [getattr(role, "name", str(getattr(role, "id", "unknown"))) for role in getattr(member, "roles", [])]
     log.info(
         "role audit mutation applied",
@@ -152,7 +156,7 @@ async def _apply_role_changes(
             "success": True,
         },
     )
-    return True
+    return True, None
 
 
 async def _audit_guild(
@@ -211,6 +215,10 @@ async def _audit_guild(
         visitors_closed_only=[],
         visitors_extra_roles=[],
         proposed_role_mutations=[],
+        action_roles_removed=[],
+        action_roles_added=[],
+        action_users_kicked=[],
+        action_failed_or_skipped=[],
     )
 
     for member in members:
@@ -224,7 +232,7 @@ async def _audit_guild(
         )
         if classification == "stray":
             result.proposed_role_mutations.append((member, [raid_role], [wanderer_role]))
-            changed = await _apply_role_changes(
+            changed, error = await _apply_role_changes(
                 member,
                 actor=actor,
                 dry_run=dry_run,
@@ -233,11 +241,22 @@ async def _audit_guild(
             )
             if changed:
                 result.auto_fixed_strays.append(member)
+                if not dry_run:
+                    result.action_roles_removed.append(
+                        f"• {_format_member(member)} – removed `{raid_role_name}`"
+                    )
+                    result.action_roles_added.append(
+                        f"• {_format_member(member)} – added `{wanderer_role_name}`"
+                    )
+            elif error:
+                result.action_failed_or_skipped.append(
+                    f"• {_format_member(member)} – could not update roles: {error}"
+                )
             continue
 
         if classification == "drop_raid":
             result.proposed_role_mutations.append((member, [raid_role], []))
-            changed = await _apply_role_changes(
+            changed, error = await _apply_role_changes(
                 member,
                 actor=actor,
                 dry_run=dry_run,
@@ -245,6 +264,14 @@ async def _audit_guild(
             )
             if changed:
                 result.auto_fixed_wanderers.append(member)
+                if not dry_run:
+                    result.action_roles_removed.append(
+                        f"• {_format_member(member)} – removed `{raid_role_name}`"
+                    )
+            elif error:
+                result.action_failed_or_skipped.append(
+                    f"• {_format_member(member)} – could not remove `{raid_role_name}`: {error}"
+                )
             continue
 
         if classification == "wander_with_clan":
@@ -272,8 +299,7 @@ async def _audit_guild(
 
 
 def _render_section(title: str, lines: Sequence[str]) -> list[str]:
-    content = lines or ["• None"]
-    return [f"**{title}**", *content]
+    return [f"**{title}**", *lines]
 
 
 def _format_joined_date(member: discord.abc.User) -> str:
@@ -305,40 +331,63 @@ def _render_report(
         f"• {_format_member(member)} – {wanderer_action} `{raid_role_name}`, kept `{wanderer_role_name}` (no clan tags)"
         for member in (summary.auto_fixed_wanderers or [])
     ]
-    parts.extend(_render_section("1) Stray members", stray_lines + wanderer_lines))
-    parts.append("")
+    detected_sections: list[tuple[str, list[str]]] = []
+    action_sections: list[tuple[str, list[str]]] = []
+    if stray_lines or wanderer_lines:
+        detected_sections.append(("1) Stray members", stray_lines + wanderer_lines))
 
     manual_lines = [
         f"• {_format_member(member)} – Has `{wanderer_role_name}` and clan tags: {_format_roles(clan_roles)}"
         for member, clan_roles in (summary.wanderers_with_clans or [])
     ]
-    parts.extend(
-        _render_section(
-            "2) Manual review – Wandering Souls with clan tags",
-            manual_lines,
-        )
-    )
-    parts.append("")
+    if manual_lines:
+        detected_sections.append(("2) Manual review – Wandering Souls with clan tags", manual_lines))
 
     visitor_no_ticket = [
         f"• {_format_member(member)} – joined {_format_joined_date(member)} – no ticket found"
         for member in (summary.visitors_no_ticket or [])
     ]
-    parts.extend(_render_section("3) Visitors without any ticket", visitor_no_ticket))
-    parts.append("")
+    if visitor_no_ticket:
+        detected_sections.append(("3) Visitors without any ticket", visitor_no_ticket))
 
     visitor_closed_only = [
         f"• {_format_member(member)} – Tickets: {_format_ticket_links(tickets)}"
         for member, tickets in (summary.visitors_closed_only or [])
     ]
-    parts.extend(_render_section("4) Visitors with only closed tickets", visitor_closed_only))
-    parts.append("")
+    if visitor_closed_only:
+        detected_sections.append(("4) Visitors with only closed tickets", visitor_closed_only))
 
     visitor_extra_roles = [
         f"• {_format_member(member)} – Roles: {_format_roles(roles)} – Tickets: {_format_ticket_links(tickets)}"
         for member, roles, tickets in (summary.visitors_extra_roles or [])
     ]
-    parts.extend(_render_section("5) Visitors with extra roles", visitor_extra_roles))
+    if visitor_extra_roles:
+        detected_sections.append(("5) Visitors with extra roles", visitor_extra_roles))
+
+    if summary.action_roles_removed:
+        action_sections.append(("6) Roles removed", summary.action_roles_removed))
+    if summary.action_roles_added:
+        action_sections.append(("7) Roles added", summary.action_roles_added))
+    if summary.action_users_kicked:
+        action_sections.append(("8) Users kicked", summary.action_users_kicked))
+    if summary.action_failed_or_skipped:
+        action_sections.append(("9) Failed / skipped actions", summary.action_failed_or_skipped))
+
+    if detected_sections:
+        parts.extend(["━━━━━━━━━━━━", "DETECTED ISSUES", "━━━━━━━━━━━━", ""])
+        for idx, (title, lines) in enumerate(detected_sections):
+            parts.extend(_render_section(title, lines))
+            if idx < len(detected_sections) - 1:
+                parts.append("")
+
+    if action_sections:
+        if parts:
+            parts.append("")
+        parts.extend(["━━━━━━━━━━━━", "ACTIONS PERFORMED", "━━━━━━━━━━━━", ""])
+        for idx, (title, lines) in enumerate(action_sections):
+            parts.extend(_render_section(title, lines))
+            if idx < len(action_sections) - 1:
+                parts.append("")
 
     embed = discord.Embed(
         title="🧹 Role & Visitor Audit",
@@ -386,6 +435,10 @@ async def run_role_and_visitor_audit(
         visitors_closed_only=[],
         visitors_extra_roles=[],
         proposed_role_mutations=[],
+        action_roles_removed=[],
+        action_roles_added=[],
+        action_users_kicked=[],
+        action_failed_or_skipped=[],
     )
 
     for guild in target_guilds:
@@ -419,6 +472,10 @@ async def run_role_and_visitor_audit(
         aggregated.visitors_closed_only.extend(result.visitors_closed_only or [])
         aggregated.visitors_extra_roles.extend(result.visitors_extra_roles or [])
         aggregated.proposed_role_mutations.extend(result.proposed_role_mutations or [])
+        aggregated.action_roles_removed.extend(result.action_roles_removed or [])
+        aggregated.action_roles_added.extend(result.action_roles_added or [])
+        aggregated.action_users_kicked.extend(result.action_users_kicked or [])
+        aggregated.action_failed_or_skipped.extend(result.action_failed_or_skipped or [])
 
     if aggregated.checked == 0:
         return False, "no-members"
@@ -514,6 +571,10 @@ async def preview_role_audit_mutations(
         visitors_closed_only=[],
         visitors_extra_roles=[],
         proposed_role_mutations=[],
+        action_roles_removed=[],
+        action_roles_added=[],
+        action_users_kicked=[],
+        action_failed_or_skipped=[],
     )
     for guild in target_guilds:
         result = await _audit_guild(

--- a/tests/housekeeping/test_role_audit.py
+++ b/tests/housekeeping/test_role_audit.py
@@ -63,12 +63,15 @@ def test_render_report_formats_all_sections():
     assert isinstance(embed, role_audit.discord.Embed)
     description = embed.description or ""
 
+    assert "DETECTED ISSUES" in description
     assert "1) Stray members" in description
     assert "Manual review" in description
     assert "Visitors without any ticket" in description
     assert "joined 2026-04-18" in description
     assert "Visitors with only closed tickets" in description
     assert "Visitors with extra roles" in description
+    assert "ACTIONS PERFORMED" not in description
+    assert "• None" not in description
 
 
 def test_render_report_uses_unknown_join_date_when_missing():
@@ -81,3 +84,47 @@ def test_render_report_uses_unknown_join_date_when_missing():
 
     description = embed.description or ""
     assert "joined unknown" in description
+
+
+def test_render_report_apply_mode_includes_actions_and_failures():
+    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    summary = role_audit.AuditResult(
+        checked=2,
+        auto_fixed_strays=[member],
+        action_roles_removed=["• <@1> – removed `Raid`"],
+        action_roles_added=["• <@1> – added `Wandering Souls`"],
+        action_users_kicked=["• <@1> – kicked: visitor expired / no valid ticket"],
+        action_failed_or_skipped=["• <@1> – could not kick: missing permission"],
+    )
+    embed = role_audit._render_report(
+        summary=summary,
+        raid_role_name="Raid",
+        wanderer_role_name="Wandering Souls",
+        dry_run=False,
+    )
+    description = embed.description or ""
+    assert "ACTIONS PERFORMED" in description
+    assert "6) Roles removed" in description
+    assert "7) Roles added" in description
+    assert "8) Users kicked" in description
+    assert "9) Failed / skipped actions" in description
+    assert "removed `Raid`" in description
+    assert "added `Wandering Souls`" in description
+    assert "kicked:" in description
+
+
+def test_render_report_dry_run_wording_and_footer():
+    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    summary = role_audit.AuditResult(checked=9, auto_fixed_strays=[member], auto_fixed_wanderers=[member])
+    embed = role_audit._render_report(
+        summary=summary,
+        raid_role_name="raid",
+        wanderer_role_name="Wandering Souls",
+        dry_run=True,
+    )
+    description = embed.description or ""
+    assert "Would remove" in description
+    assert "would add" in description
+    assert embed.footer.text is not None
+    assert "Date:" in embed.footer.text
+    assert "Checked: 9 members" in embed.footer.text


### PR DESCRIPTION
### Motivation
- Make the admin housekeeping audit output clearer by separating findings from actual apply-mode outcomes into `DETECTED ISSUES` and `ACTIONS PERFORMED` blocks.
- Preserve existing detection logic and categories while ensuring empty sections are omitted instead of rendering `• None` lines.
- Capture and report results and failures of role mutations performed during apply/fix runs so operators can see what the bot actually did.
- Keep dry-run wording distinct from apply-mode wording and avoid changing config or adding new env/sheet migrations.

### Description
- Added action accumulators to `AuditResult` (`action_roles_removed`, `action_roles_added`, `action_users_kicked`, `action_failed_or_skipped`) to store apply/fix outcomes across guilds.
- Changed `_apply_role_changes` to return `(success, error)` and surface failure reasons like `missing permission` or HTTP error strings without aborting the audit loop.
- Updated `_audit_guild` to append action lines on successful mutations and to record failures into `action_failed_or_skipped`; existing detection lists are preserved and `proposed_role_mutations` remains available.
- Reworked report rendering: removed the `• None` fallback, introduced `DETECTED ISSUES` and `ACTIONS PERFORMED` sections built from non-empty subsections, and kept dry-run vs apply wording in detection lines and action summaries.
- Propagated the new action accumulators through multi-guild aggregation and updated `preview_role_audit_mutations` to initialize the new fields.
- Updated tests in `tests/housekeeping/test_role_audit.py` to assert omission of empty sections, presence of detected sections, distinct dry-run wording, apply-mode action sections, failures reporting, and preserved footer formatting.

### Testing
- Ran `pytest -q tests/housekeeping/test_role_audit.py` and all tests passed.
- Added assertions that empty sections are omitted and that `ACTIONS PERFORMED` appears only when action entries exist, and these assertions succeeded under CI test run.
- Verified dry-run wording uses `Would remove`/`would add` and apply-mode reports use `removed`/`added`/`kicked` via unit tests that passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023a55d75c832391fb0085394dc67b)