### PR TITLE
Fix startup_summary startup crash from missing shared.sheet_config import

### DIFF
--- a/modules/ops/startup_summary.py
+++ b/modules/ops/startup_summary.py
@@ -11,7 +11,7 @@ from modules.common.runtime import Runtime
 from modules.onboarding.watcher_welcome import _channel_readable_label
 from shared.cache import telemetry as cache_telemetry
 from shared.config import get_promo_channel_id, get_welcome_channel_id
-from shared.sheet_config import shared_config
+from modules.common import feature_flags
 
 log = logging.getLogger("c1c.ops.startup_summary")
 
@@ -67,11 +67,18 @@ def render_startup_summary(*, bot_client: commands.Bot, runtime: Runtime, jobs: 
     lines = ["✅ Woadkeeper startup complete", ""]
 
     try:
-        toggles = shared_config.features
+        try:
+            promo_enabled = feature_flags.is_enabled("promo_enabled") and feature_flags.is_enabled("enable_promo_hook")
+            welcome_enabled = feature_flags.is_enabled("recruitment_welcome") and feature_flags.is_enabled("welcome_dialog")
+            promo_status = "enabled" if promo_enabled else "disabled"
+            welcome_status = "enabled" if welcome_enabled else "disabled"
+        except Exception:
+            promo_status = "configured" if _safe_channel_id(get_promo_channel_id()) else "not configured"
+            welcome_status = "configured" if _safe_channel_id(get_welcome_channel_id()) else "not configured"
         watchers = [
             "Watchers",
-            f"• Promo watcher: {'enabled' if bool(getattr(toggles,'promo_watcher_enabled',False)) else 'disabled'} — {_channel_line(bot_client, _safe_channel_id(get_promo_channel_id()))}",
-            f"• Welcome watcher: {'enabled' if bool(getattr(toggles,'welcome_watcher_enabled',False)) else 'disabled'} — {_channel_line(bot_client, _safe_channel_id(get_welcome_channel_id()))}",
+            f"• Promo watcher: {promo_status} — {_channel_line(bot_client, _safe_channel_id(get_promo_channel_id()))}",
+            f"• Welcome watcher: {welcome_status} — {_channel_line(bot_client, _safe_channel_id(get_welcome_channel_id()))}",
         ]
         lines.extend(watchers)
     except Exception:


### PR DESCRIPTION
### Motivation
- Resolve a production startup crash caused by importing a nonexistent module (`shared.sheet_config`).
- Ensure the startup summary reports watcher status using the same helpers the watcher modules use so the summary reflects real, available checks.

### Description
- Removed the invalid `from shared.sheet_config import shared_config` import from `modules/ops/startup_summary.py` and imported `modules.common.feature_flags` instead.
- Replaced the previous toggle access with a pair of checks that match watcher modules: promo uses `feature_flags.is_enabled("promo_enabled") and feature_flags.is_enabled("enable_promo_hook")` and welcome uses `feature_flags.is_enabled("recruitment_welcome") and feature_flags.is_enabled("welcome_dialog")`.
- Added a non-blocking fallback so if feature-flag lookup fails the summary renders watcher status as `configured` when a channel ID exists or `not configured` when missing.
- Preserved existing channel mention / readable-label rendering and kept the startup summary resilient to exceptions.

### Testing
- Ran `python -m py_compile app.py modules/ops/startup_summary.py` which succeeded (compile completed; an unrelated `SyntaxWarning` in `app.py` was emitted but did not prevent compilation).
- Confirmed the `shared.sheet_config` import was removed and the startup summary no longer depends on the nonexistent module by recompiling the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0242f2b0a88323a462b245cc2efe36)