### PR TITLE
Add clanrole management cog (remove command + cleanup) and unit tests

### DIFF
--- a/cogs/clanrole_management.py
+++ b/cogs/clanrole_management.py
@@ -1,0 +1,171 @@
+"""Clan role management commands for staff/admin role cleanup flows."""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from shared import config
+
+log = logging.getLogger(__name__)
+
+
+def is_authorized_clan_role_manager(member: discord.Member) -> bool:
+    if member.guild_permissions.administrator:
+        return True
+    allowed_role_ids = (
+        config.get_admin_role_ids()
+        | config.get_staff_role_ids()
+        | config.get_lead_role_ids()
+        | config.get_recruiter_role_ids()
+        | config.get_clan_lead_ids()
+    )
+    return bool({r.id for r in member.roles} & allowed_role_ids)
+
+
+def get_member_clan_roles(member: discord.Member, clan_role_ids: set[int]) -> list[discord.Role]:
+    return [role for role in member.roles if role.id in clan_role_ids]
+
+
+class ClanRoleRemoveSelect(discord.ui.Select):
+    def __init__(self, parent: "ClanRoleRemoveView", roles: list[discord.Role]) -> None:
+        super().__init__(
+            placeholder="Select clan role to remove",
+            min_values=1,
+            max_values=1,
+            options=[discord.SelectOption(label=r.name, value=str(r.id)) for r in roles],
+        )
+        self.parent_view = parent
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self.parent_view.handle_selection(interaction, int(self.values[0]))
+
+
+class ClanRoleRemoveView(discord.ui.View):
+    def __init__(self, cog: "ClanRoleManagementCog", ctx: commands.Context, target: discord.Member, roles: list[discord.Role]) -> None:
+        super().__init__(timeout=60)
+        self.cog = cog
+        self.ctx = ctx
+        self.target = target
+        self.message: discord.Message | None = None
+        self.add_item(ClanRoleRemoveSelect(self, roles))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user and interaction.user.id == self.ctx.author.id:
+            return True
+        await interaction.response.send_message("⚠️ Only the original command invoker can choose a role.", ephemeral=True)
+        return False
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(content="Timed out — no clan role changes were made.", view=self)
+            except Exception:
+                log.debug("failed to disable clanrole remove view on timeout", exc_info=True)
+
+    async def handle_selection(self, interaction: discord.Interaction, role_id: int) -> None:
+        selected = next((role for role in self.target.roles if role.id == role_id), None)
+        if selected is None:
+            await interaction.response.send_message("⚠️ Selected role is no longer on that member. No changes made.", ephemeral=True)
+            return
+        summary = await self.cog.apply_clan_removal_cleanup(self.ctx, self.target, selected)
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(content=summary, view=self)
+        self.stop()
+
+
+class ClanRoleManagementCog(commands.Cog):
+    @tier("user")
+    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
+    @commands.group(name="clanrole", invoke_without_command=True)
+    async def clanrole(self, ctx: commands.Context) -> None:
+        await ctx.reply("Usage: `!clanrole remove @member`", mention_author=False)
+
+    @tier("user")
+    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
+    @clanrole.command(name="remove", help="Remove a member from a clan role and run Raid/Wandering Souls cleanup.")
+    async def clanrole_remove(self, ctx: commands.Context, member: discord.Member | None = None) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.reply("⚠️ This command can only be used in a server.", mention_author=False)
+            return
+        if member is None:
+            await ctx.reply("Usage: `!clanrole remove @member`", mention_author=False)
+            return
+        if not is_authorized_clan_role_manager(ctx.author):
+            await ctx.reply("⚠️ You do not have permission to remove clan roles.", mention_author=False)
+            return
+
+        clan_roles = get_member_clan_roles(member, config.get_clan_role_ids())
+        if not clan_roles:
+            await ctx.reply(f"{member.mention} has no configured clan role to remove.", mention_author=False)
+            return
+        if len(clan_roles) > 1:
+            view = ClanRoleRemoveView(self, ctx, member, clan_roles)
+            msg = await ctx.reply(f"{ctx.author.mention} choose exactly one clan role to remove from {member.mention}.", view=view, mention_author=False)
+            view.message = msg
+            return
+
+        await ctx.reply(await self.apply_clan_removal_cleanup(ctx, member, clan_roles[0]), mention_author=False)
+
+    async def apply_clan_removal_cleanup(self, ctx: commands.Context, member: discord.Member, clan_role: discord.Role) -> str:
+        reason = f"Clan removal cleanup requested by {ctx.author}"
+        try:
+            await member.remove_roles(clan_role, reason=reason)
+            log.info("removed clan role", extra={"member_id": member.id, "role_id": clan_role.id, "actor_id": ctx.author.id})
+        except (discord.Forbidden, discord.HTTPException):
+            log.exception("failed role mutation")
+            return f"❌ Failed to remove {clan_role.mention} from {member.mention} due to role hierarchy or permissions."
+
+        success = [f"Removed {clan_role.mention} from {member.mention}."]
+        failures: list[str] = []
+        remaining_clan_roles = [
+            role for role in member.roles if role.id in config.get_clan_role_ids() and role.id != clan_role.id
+        ]
+        if remaining_clan_roles:
+            log.info("skipped Raid because another clan role remains", extra={"member_id": member.id, "actor_id": ctx.author.id})
+            return " ".join(success + ["Raid kept because another clan role remains."])
+
+        raid_role_id = config.get_raid_role_id()
+        raid_role = member.guild.get_role(raid_role_id or 0)
+        if raid_role_id and raid_role is None:
+            failures.append("Configured Raid role could not be found")
+        elif raid_role and raid_role in member.roles:
+            try:
+                await member.remove_roles(raid_role, reason=reason)
+                success.append("Removed Raid")
+                log.info("removed Raid", extra={"member_id": member.id, "actor_id": ctx.author.id})
+            except (discord.Forbidden, discord.HTTPException):
+                failures.append("Failed to remove Raid")
+                log.exception("failed role mutation")
+        elif raid_role:
+            success.append("Raid was already absent")
+
+        wanderer_role_id = config.get_wandering_souls_role_id()
+        wanderer_role = member.guild.get_role(wanderer_role_id or 0)
+        if wanderer_role_id and wanderer_role is None:
+            failures.append("Configured Wandering Souls role could not be found")
+        elif wanderer_role and wanderer_role not in member.roles:
+            try:
+                await member.add_roles(wanderer_role, reason=reason)
+                success.append("Added Wandering Souls")
+                log.info("added Wandering Souls", extra={"member_id": member.id, "actor_id": ctx.author.id})
+            except (discord.Forbidden, discord.HTTPException):
+                failures.append("Failed to add Wandering Souls")
+                log.exception("failed role mutation")
+        elif wanderer_role:
+            success.append("Wandering Souls was already present")
+
+        msg = "; ".join(success) + "."
+        if failures:
+            msg += f" ⚠️ {'; '.join(failures)}."
+        return msg
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ClanRoleManagementCog())

--- a/packages/c1c-coreops/src/c1c_coreops/cop.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cop.py
@@ -18,6 +18,7 @@ from cogs.recruitment_clan_profile import ClanProfileCog
 from cogs.recruitment_member import RecruitmentMember
 from cogs.recruitment_recruiter import RecruiterPanelCog
 from cogs.recruitment_welcome import WelcomeBridge
+from cogs.clanrole_management import ClanRoleManagementCog
 from modules.ops.permissions_ui import PermissionsUICog
 from shared.testing.environment import apply_required_test_environment
 
@@ -190,6 +191,7 @@ async def _setup_help_bot() -> commands.Bot:
     await bot.add_cog(WelcomeBridge(bot))
     await bot.add_cog(RecruitmentMember(bot))
     await bot.add_cog(ClanProfileCog(bot))
+    await bot.add_cog(ClanRoleManagementCog())
     return bot
 
 

--- a/tests/recruitment/test_clan_remove_command.py
+++ b/tests/recruitment/test_clan_remove_command.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import asyncio
+import pytest
+
+from cogs.clanrole_management import ClanRoleManagementCog, ClanRoleRemoveView, get_member_clan_roles, is_authorized_clan_role_manager
+
+
+class DummyRole:
+    def __init__(self, rid: int, name: str):
+        self.id = rid
+        self.name = name
+        self.mention = f"@{name}"
+
+
+class DummyMember:
+    def __init__(self, mid: int, roles: list[DummyRole], guild, admin: bool = False):
+        self.id = mid
+        self.roles = roles
+        self.guild = guild
+        self.mention = f"<@{mid}>"
+        self.guild_permissions = SimpleNamespace(administrator=admin)
+        self.remove_roles = AsyncMock(side_effect=self._remove)
+        self.add_roles = AsyncMock(side_effect=self._add)
+
+    async def _remove(self, role, reason=None):
+        if role in self.roles:
+            self.roles.remove(role)
+
+    async def _add(self, role, reason=None):
+        if role not in self.roles:
+            self.roles.append(role)
+
+
+@pytest.fixture
+def roles():
+    return {
+        "clan1": DummyRole(1, "ClanOne"),
+        "clan2": DummyRole(2, "ClanTwo"),
+        "raid": DummyRole(3, "Raid"),
+        "wander": DummyRole(4, "Wandering Souls"),
+        "mgr": DummyRole(10, "Manager"),
+    }
+
+
+def _ctx(author):
+    return SimpleNamespace(author=author, guild=SimpleNamespace(id=1), reply=AsyncMock())
+
+
+def test_authorized_by_admin(roles, monkeypatch):
+    member = DummyMember(10, [roles["clan1"]], SimpleNamespace(), admin=True)
+    assert is_authorized_clan_role_manager(member)
+
+
+def test_authorized_by_clan_lead_ids(roles, monkeypatch):
+    monkeypatch.setattr("cogs.clanrole_management.config.get_admin_role_ids", lambda: set())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_staff_role_ids", lambda: set())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_lead_role_ids", lambda: set())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_recruiter_role_ids", lambda: set())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_lead_ids", lambda: {10})
+    member = DummyMember(10, [roles["mgr"]], SimpleNamespace(), admin=False)
+    assert is_authorized_clan_role_manager(member)
+
+
+def test_get_member_clan_roles(roles):
+    member = DummyMember(10, [roles["clan1"], roles["raid"]], SimpleNamespace())
+    found = get_member_clan_roles(member, {1, 2})
+    assert [r.id for r in found] == [1]
+
+
+def test_cleanup_removes_raid_adds_wander(roles, monkeypatch):
+    guild = SimpleNamespace(get_role=lambda rid: {3: roles["raid"], 4: roles["wander"]}.get(rid))
+    member = DummyMember(42, [roles["clan1"], roles["raid"]], guild)
+    author = DummyMember(1, [roles["mgr"]], guild)
+    ctx = _ctx(author)
+    cog = ClanRoleManagementCog()
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    monkeypatch.setattr("cogs.clanrole_management.config.get_raid_role_id", lambda: 3)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_wandering_souls_role_id", lambda: 4)
+    msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
+    assert "Removed Raid" in msg and "Added Wandering Souls" in msg
+
+
+def test_cleanup_keeps_raid_if_other_clan(roles, monkeypatch):
+    guild = SimpleNamespace(get_role=lambda rid: {3: roles["raid"], 4: roles["wander"]}.get(rid))
+    member = DummyMember(42, [roles["clan1"], roles["clan2"], roles["raid"]], guild)
+    ctx = _ctx(DummyMember(1, [roles["mgr"]], guild))
+    cog = ClanRoleManagementCog()
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    monkeypatch.setattr("cogs.clanrole_management.config.get_raid_role_id", lambda: 3)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_wandering_souls_role_id", lambda: 4)
+    msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
+    assert "Raid kept because another clan role remains" in msg
+
+
+def test_cleanup_missing_raid_existing_wander(roles, monkeypatch):
+    guild = SimpleNamespace(get_role=lambda rid: {3: roles["raid"], 4: roles["wander"]}.get(rid))
+    member = DummyMember(42, [roles["clan1"], roles["wander"]], guild)
+    ctx = _ctx(DummyMember(1, [roles["mgr"]], guild))
+    cog = ClanRoleManagementCog()
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    monkeypatch.setattr("cogs.clanrole_management.config.get_raid_role_id", lambda: 3)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_wandering_souls_role_id", lambda: 4)
+    msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
+    assert "Raid was already absent" in msg and "already present" in msg
+
+
+def test_multiple_roles_view_restricts_invoker(roles):
+    cog = ClanRoleManagementCog()
+    guild = SimpleNamespace()
+    author = DummyMember(1, [roles["mgr"]], guild)
+    target = DummyMember(2, [roles["clan1"], roles["clan2"]], guild)
+    view = ClanRoleRemoveView(cog, _ctx(author), target, [roles["clan1"], roles["clan2"]])
+    interaction = SimpleNamespace(user=SimpleNamespace(id=99), response=SimpleNamespace(send_message=AsyncMock()))
+    ok = asyncio.run(view.interaction_check(interaction))
+    assert ok is False
+
+
+def test_remaining_clan_detection_excludes_removed_role_without_cache_refresh(roles, monkeypatch):
+    guild = SimpleNamespace(get_role=lambda rid: {3: roles["raid"], 4: roles["wander"]}.get(rid))
+    member = DummyMember(42, [roles["clan1"], roles["raid"]], guild)
+    # Simulate stale cache: remove_roles does not mutate member.roles
+    member.remove_roles = AsyncMock(return_value=None)
+    ctx = _ctx(DummyMember(1, [roles["mgr"]], guild))
+    cog = ClanRoleManagementCog()
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    monkeypatch.setattr("cogs.clanrole_management.config.get_raid_role_id", lambda: 3)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_wandering_souls_role_id", lambda: 4)
+    msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
+    assert "Raid kept because another clan role remains" not in msg
+
+
+def test_view_timeout_handles_missing_message(roles):
+    view = ClanRoleRemoveView(ClanRoleManagementCog(), _ctx(DummyMember(1, [roles["mgr"]], SimpleNamespace())), DummyMember(2, [roles["clan1"]], SimpleNamespace()), [roles["clan1"]])
+    view.message = SimpleNamespace(edit=AsyncMock(side_effect=RuntimeError("gone")))
+    asyncio.run(view.on_timeout())
+
+
+def test_handle_selection_stops_view(roles):
+    cog = ClanRoleManagementCog()
+    cog.apply_clan_removal_cleanup = AsyncMock(return_value="ok")
+    author = DummyMember(1, [roles["mgr"]], SimpleNamespace())
+    target = DummyMember(2, [roles["clan1"]], SimpleNamespace())
+    view = ClanRoleRemoveView(cog, _ctx(author), target, [roles["clan1"]])
+    interaction = SimpleNamespace(response=SimpleNamespace(edit_message=AsyncMock()))
+    called = {"stop": False}
+    original_stop = view.stop
+    def _stop():
+        called["stop"] = True
+        original_stop()
+    view.stop = _stop
+    asyncio.run(view.handle_selection(interaction, 1))
+    assert called["stop"] is True
+
+
+def test_missing_configured_roles_reported(roles, monkeypatch):
+    guild = SimpleNamespace(get_role=lambda rid: None)
+    member = DummyMember(42, [roles["clan1"]], guild)
+    ctx = _ctx(DummyMember(1, [roles["mgr"]], guild))
+    cog = ClanRoleManagementCog()
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    monkeypatch.setattr("cogs.clanrole_management.config.get_raid_role_id", lambda: 3)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_wandering_souls_role_id", lambda: 4)
+    msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
+    assert "Configured Raid role could not be found" in msg
+    assert "Configured Wandering Souls role could not be found" in msg


### PR DESCRIPTION
### Motivation

- Provide a staff/admin tool to remove a member from a clan role and perform the associated cleanup flows (Raid removal and Wandering Souls assignment).
- Centralize permission checks for clan role managers and expose an interactive selection UI when a member has multiple clan roles.

### Description

- Added `cogs/clanrole_management.py` implementing `ClanRoleManagementCog` with a `!clanrole remove` command, permission helper `is_authorized_clan_role_manager`, member helper `get_member_clan_roles`, an interactive `ClanRoleRemoveView`/`ClanRoleRemoveSelect` flow, and `apply_clan_removal_cleanup` which handles removing the clan role and adjusting Raid/Wandering Souls roles.
- Registered the new cog in the help/setup helper by importing and adding `ClanRoleManagementCog` in `packages/c1c-coreops/src/c1c_coreops/cop.py`.
- Added comprehensive unit tests in `tests/recruitment/test_clan_remove_command.py` covering permission checks, clan-role discovery, cleanup behaviors (remove Raid, add Wandering Souls, handle remaining clans), view interaction restrictions/timeouts, and reporting for missing configured roles.

### Testing

- Ran the new unit tests with `pytest tests/recruitment/test_clan_remove_command.py` and they passed.
- The tests exercise `apply_clan_removal_cleanup`, `ClanRoleRemoveView` behavior, and the helper functions, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023bf6d9f083239bb67cc3b488c20d)