### PR TITLE
Load clanrole_management cog at startup and add command registration tests

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1285,6 +1285,11 @@ class Runtime:
             log.info("modules: clan_profile enabled")
         else:
             log.info("modules: clan_profile disabled")
+
+        from cogs import clanrole_management
+
+        await clanrole_management.setup(self.bot)
+        log.info("modules: clanrole_management enabled")
         await _load_feature_module(
             "cogs.recruitment_welcome", ("recruitment_welcome",)
         )

--- a/tests/recruitment/test_clan_remove_command.py
+++ b/tests/recruitment/test_clan_remove_command.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock
 import discord
 import asyncio
 import pytest
+from discord.ext import commands
 
-from cogs.clanrole_management import ClanRoleManagementCog, ClanRoleRemoveView, get_member_clan_roles, is_authorized_clan_role_manager
+from cogs import recruitment_clan_profile
+from cogs.clanrole_management import ClanRoleManagementCog, ClanRoleRemoveView, get_member_clan_roles, is_authorized_clan_role_manager, setup
 
 
 class DummyRole:
@@ -168,3 +170,32 @@ def test_missing_configured_roles_reported(roles, monkeypatch):
     msg = asyncio.run(cog.apply_clan_removal_cleanup(ctx, member, roles["clan1"]))
     assert "Configured Raid role could not be found" in msg
     assert "Configured Wandering Souls role could not be found" in msg
+
+
+def test_setup_registers_clanrole_commands():
+    async def _run():
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        try:
+            await setup(bot)
+            command = bot.get_command("clanrole")
+            assert command is not None
+            assert command.name == "clanrole"
+            assert command.get_command("remove") is not None
+        finally:
+            await bot.close()
+
+    asyncio.run(_run())
+
+
+def test_clan_command_unchanged_after_clanrole_setup():
+    async def _run():
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        try:
+            await recruitment_clan_profile.setup(bot)
+            await setup(bot)
+            assert bot.get_command("clan") is not None
+            assert bot.get_command("clanrole") is not None
+        finally:
+            await bot.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Ensure the `clanrole_management` cog is initialized during bot startup so its commands and behavior are available at runtime.
- Verify that registering the `clanrole` command group does not interfere with the existing `clan` command provided by `recruitment_clan_profile`.

### Description
- Added an unconditional import and `await clanrole_management.setup(self.bot)` call in `Runtime` startup and logged its enablement in `modules/common/runtime.py`.
- Updated `tests/recruitment/test_clan_remove_command.py` to import `recruitment_clan_profile` and the `setup` helper from `cogs.clanrole_management`.
- Added `test_setup_registers_clanrole_commands` to assert that `setup(bot)` registers the `clanrole` command group and its `remove` subcommand on a `commands.Bot` instance.
- Added `test_clan_command_unchanged_after_clanrole_setup` to assert that running `recruitment_clan_profile.setup(bot)` and then `clanrole_management.setup(bot)` leaves the `clan` command in place alongside `clanrole`.

### Testing
- Ran the modified recruitment test file with `pytest tests/recruitment/test_clan_remove_command.py` and the new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02de7d643c8323bdfc8cd40a68742d)