### PR TITLE
Support text/member queries and add target-selection UI for `clanrole remove`

### DIFF
--- a/cogs/clanrole_management.py
+++ b/cogs/clanrole_management.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 import discord
 from discord.ext import commands
@@ -80,38 +81,135 @@ class ClanRoleRemoveView(discord.ui.View):
         self.stop()
 
 
+class ClanRoleTargetSelect(discord.ui.Select):
+    def __init__(self, parent: "ClanRoleTargetView", members: list[discord.Member]) -> None:
+        options: list[discord.SelectOption] = []
+        for member in members[:25]:
+            display_label = member.display_name
+            username = member.name
+            label = display_label if display_label == username else f"{display_label} ({username})"
+            options.append(discord.SelectOption(label=label[:100], value=str(member.id)))
+        super().__init__(placeholder="Select target member", min_values=1, max_values=1, options=options)
+        self.parent_view = parent
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self.parent_view.handle_selection(interaction, int(self.values[0]))
+
+
+class ClanRoleTargetView(discord.ui.View):
+    def __init__(self, cog: "ClanRoleManagementCog", ctx: commands.Context, members: list[discord.Member]) -> None:
+        super().__init__(timeout=60)
+        self.cog = cog
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+        self.add_item(ClanRoleTargetSelect(self, members))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user and interaction.user.id == self.ctx.author.id:
+            return True
+        await interaction.response.send_message("⚠️ Only the original command invoker can choose a member.", ephemeral=True)
+        return False
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(content="Timed out — no clan role changes were made.", view=self)
+            except Exception:
+                log.debug("failed to disable clanrole target view on timeout", exc_info=True)
+
+    async def handle_selection(self, interaction: discord.Interaction, member_id: int) -> None:
+        member = self.ctx.guild.get_member(member_id) if self.ctx.guild else None
+        if member is None:
+            await interaction.response.send_message("⚠️ That member is no longer available in this server. No changes made.", ephemeral=True)
+            return
+        summary, view = await self.cog.build_clanrole_remove_response(self.ctx, member)
+        for child in self.children:
+            child.disabled = True
+        if view is not None:
+            if isinstance(view, ClanRoleRemoveView):
+                view.message = interaction.message
+            await interaction.response.edit_message(content=summary, view=view)
+        else:
+            await interaction.response.edit_message(content=summary, view=self)
+        self.stop()
+
+
 class ClanRoleManagementCog(commands.Cog):
     @tier("user")
     @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
     @commands.group(name="clanrole", invoke_without_command=True)
     async def clanrole(self, ctx: commands.Context) -> None:
-        await ctx.reply("Usage: `!clanrole remove @member`", mention_author=False)
+        await ctx.reply("Usage: `!clanrole remove <member query>`", mention_author=False)
 
     @tier("user")
     @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
     @clanrole.command(name="remove", help="Remove a member from a clan role and run Raid/Wandering Souls cleanup.")
-    async def clanrole_remove(self, ctx: commands.Context, member: discord.Member | None = None) -> None:
+    async def clanrole_remove(self, ctx: commands.Context, *, member_query: str | None = None) -> None:
         if ctx.guild is None or not isinstance(ctx.author, discord.Member):
             await ctx.reply("⚠️ This command can only be used in a server.", mention_author=False)
             return
-        if member is None:
-            await ctx.reply("Usage: `!clanrole remove @member`", mention_author=False)
+        if not member_query:
+            await ctx.reply("Usage: `!clanrole remove <member query>`", mention_author=False)
             return
         if not is_authorized_clan_role_manager(ctx.author):
             await ctx.reply("⚠️ You do not have permission to remove clan roles.", mention_author=False)
             return
-
-        clan_roles = get_member_clan_roles(member, config.get_clan_role_ids())
-        if not clan_roles:
-            await ctx.reply(f"{member.mention} has no configured clan role to remove.", mention_author=False)
+        members = await self.resolve_member_query(ctx, member_query)
+        if not members:
+            await ctx.reply("⚠️ No matching member found. Try mention, ID, or exact name.", mention_author=False)
             return
-        if len(clan_roles) > 1:
-            view = ClanRoleRemoveView(self, ctx, member, clan_roles)
-            msg = await ctx.reply(f"{ctx.author.mention} choose exactly one clan role to remove from {member.mention}.", view=view, mention_author=False)
+        if len(members) > 1:
+            view = ClanRoleTargetView(self, ctx, members)
+            msg = await ctx.reply(f"{ctx.author.mention} multiple members matched `{member_query}`. Choose the target member.", view=view, mention_author=False)
             view.message = msg
             return
+        await self.process_clanrole_remove(ctx, members[0])
 
-        await ctx.reply(await self.apply_clan_removal_cleanup(ctx, member, clan_roles[0]), mention_author=False)
+    async def resolve_member_query(self, ctx: commands.Context, raw_query: str) -> list[discord.Member]:
+        query = raw_query.strip()
+        mention_match = re.fullmatch(r"<@!?(\d+)>", query)
+        id_text = mention_match.group(1) if mention_match else (query if query.isdigit() else None)
+        if id_text:
+            member_id = int(id_text)
+            cached = ctx.guild.get_member(member_id)
+            if cached:
+                return [cached]
+            try:
+                fetched = await ctx.guild.fetch_member(member_id)
+                return [fetched]
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                return []
+
+        normalized = query.casefold()
+        exact: list[discord.Member] = []
+        starts_with: list[discord.Member] = []
+        for member in ctx.guild.members:
+            fields = [member.display_name, member.name]
+            if getattr(member, "global_name", None):
+                fields.append(member.global_name)
+            normalized_fields = [field.casefold() for field in fields if field]
+            if any(field == normalized for field in normalized_fields):
+                exact.append(member)
+            elif any(field.startswith(normalized) for field in normalized_fields):
+                starts_with.append(member)
+        return exact if exact else starts_with
+
+    async def build_clanrole_remove_response(self, ctx: commands.Context, member: discord.Member) -> tuple[str, discord.ui.View | None]:
+        clan_roles = get_member_clan_roles(member, config.get_clan_role_ids())
+        if not clan_roles:
+            return (f"{member.mention} has no configured clan role to remove.", None)
+        if len(clan_roles) > 1:
+            return (f"{ctx.author.mention} choose exactly one clan role to remove from {member.mention}.", ClanRoleRemoveView(self, ctx, member, clan_roles))
+
+        return (await self.apply_clan_removal_cleanup(ctx, member, clan_roles[0]), None)
+
+    async def process_clanrole_remove(self, ctx: commands.Context, member: discord.Member) -> None:
+        content, view = await self.build_clanrole_remove_response(ctx, member)
+        msg = await ctx.reply(content, view=view, mention_author=False)
+        if isinstance(view, ClanRoleRemoveView):
+            view.message = msg
 
     async def apply_clan_removal_cleanup(self, ctx: commands.Context, member: discord.Member, clan_role: discord.Role) -> str:
         reason = f"Clan removal cleanup requested by {ctx.author}"

--- a/tests/recruitment/test_clan_remove_command.py
+++ b/tests/recruitment/test_clan_remove_command.py
@@ -9,7 +9,7 @@ import pytest
 from discord.ext import commands
 
 from cogs import recruitment_clan_profile
-from cogs.clanrole_management import ClanRoleManagementCog, ClanRoleRemoveView, get_member_clan_roles, is_authorized_clan_role_manager, setup
+from cogs.clanrole_management import ClanRoleManagementCog, ClanRoleRemoveView, ClanRoleTargetView, get_member_clan_roles, is_authorized_clan_role_manager, setup
 
 
 class DummyRole:
@@ -20,11 +20,14 @@ class DummyRole:
 
 
 class DummyMember:
-    def __init__(self, mid: int, roles: list[DummyRole], guild, admin: bool = False):
+    def __init__(self, mid: int, roles: list[DummyRole], guild, admin: bool = False, *, display_name: str | None = None, name: str | None = None, global_name: str | None = None):
         self.id = mid
         self.roles = roles
         self.guild = guild
         self.mention = f"<@{mid}>"
+        self.display_name = display_name or f"display-{mid}"
+        self.name = name or f"user-{mid}"
+        self.global_name = global_name
         self.guild_permissions = SimpleNamespace(administrator=admin)
         self.remove_roles = AsyncMock(side_effect=self._remove)
         self.add_roles = AsyncMock(side_effect=self._add)
@@ -120,6 +123,141 @@ def test_multiple_roles_view_restricts_invoker(roles):
     interaction = SimpleNamespace(user=SimpleNamespace(id=99), response=SimpleNamespace(send_message=AsyncMock()))
     ok = asyncio.run(view.interaction_check(interaction))
     assert ok is False
+
+
+def test_target_view_restricts_invoker(roles):
+    cog = ClanRoleManagementCog()
+    guild = SimpleNamespace()
+    author = DummyMember(1, [roles["mgr"]], guild)
+    target = DummyMember(2, [roles["clan1"]], guild)
+    view = ClanRoleTargetView(cog, _ctx(author), [target])
+    interaction = SimpleNamespace(user=SimpleNamespace(id=99), response=SimpleNamespace(send_message=AsyncMock()))
+    ok = asyncio.run(view.interaction_check(interaction))
+    assert ok is False
+
+
+def test_resolve_member_query_exact_name_preferred_over_startswith(roles):
+    guild = SimpleNamespace(
+        members=[
+            DummyMember(1, [], None, display_name="Smurfette", name="smurfette"),
+            DummyMember(2, [], None, display_name="Smurf", name="smurf"),
+        ],
+        get_member=lambda mid: None,
+        fetch_member=AsyncMock(),
+    )
+    for member in guild.members:
+        member.guild = guild
+    ctx = SimpleNamespace(guild=guild)
+    found = asyncio.run(ClanRoleManagementCog().resolve_member_query(ctx, "smurf"))
+    assert [m.id for m in found] == [2]
+
+
+def test_resolve_member_query_exact_username(roles):
+    target = DummyMember(2, [], None, display_name="Foo", name="Caillean")
+    guild = SimpleNamespace(members=[target], get_member=lambda mid: None, fetch_member=AsyncMock())
+    target.guild = guild
+    found = asyncio.run(ClanRoleManagementCog().resolve_member_query(SimpleNamespace(guild=guild), "caillean"))
+    assert [m.id for m in found] == [2]
+
+
+def test_resolve_member_query_exact_global_name(roles):
+    target = DummyMember(2, [], None, display_name="Foo", name="bar", global_name="Smurf")
+    guild = SimpleNamespace(members=[target], get_member=lambda mid: None, fetch_member=AsyncMock())
+    target.guild = guild
+    found = asyncio.run(ClanRoleManagementCog().resolve_member_query(SimpleNamespace(guild=guild), "smurf"))
+    assert [m.id for m in found] == [2]
+
+
+def test_resolve_member_query_startswith_unique(roles):
+    target = DummyMember(2, [], None, display_name="Smurfy", name="bar")
+    guild = SimpleNamespace(members=[target], get_member=lambda mid: None, fetch_member=AsyncMock())
+    target.guild = guild
+    found = asyncio.run(ClanRoleManagementCog().resolve_member_query(SimpleNamespace(guild=guild), "smu"))
+    assert [m.id for m in found] == [2]
+
+
+def test_resolve_member_query_mention_and_id(roles):
+    target = DummyMember(42, [], None)
+    guild = SimpleNamespace(
+        members=[target],
+        get_member=lambda mid: target if mid == 42 else None,
+        fetch_member=AsyncMock(return_value=None),
+    )
+    target.guild = guild
+    cog = ClanRoleManagementCog()
+    assert [m.id for m in asyncio.run(cog.resolve_member_query(SimpleNamespace(guild=guild), "<@42>"))] == [42]
+    assert [m.id for m in asyncio.run(cog.resolve_member_query(SimpleNamespace(guild=guild), "42"))] == [42]
+
+
+def test_clanrole_remove_no_match_warning(roles, monkeypatch):
+    guild = SimpleNamespace(members=[], get_member=lambda _: None, fetch_member=AsyncMock())
+    author = DummyMember(1, [roles["mgr"]], guild)
+    ctx = SimpleNamespace(author=author, guild=guild, reply=AsyncMock())
+    monkeypatch.setattr("cogs.clanrole_management.is_authorized_clan_role_manager", lambda _: True)
+    asyncio.run(ClanRoleManagementCog().clanrole_remove.callback(ClanRoleManagementCog(), ctx, member_query="nobody"))
+    assert "No matching member found" in ctx.reply.await_args.kwargs["content"] if "content" in ctx.reply.await_args.kwargs else ctx.reply.await_args.args[0]
+
+
+def test_multiple_matches_shows_target_dropdown_and_no_mutation(roles, monkeypatch):
+    guild = SimpleNamespace(get_member=lambda _: None, fetch_member=AsyncMock())
+    t1 = DummyMember(2, [roles["clan1"]], guild, display_name="smurf-one", name="smurfone")
+    t2 = DummyMember(3, [roles["clan1"]], guild, display_name="smurf-two", name="smurftwo")
+    guild.members = [t1, t2]
+    author = DummyMember(1, [roles["mgr"]], guild)
+    ctx = SimpleNamespace(author=author, guild=guild, reply=AsyncMock())
+    monkeypatch.setattr("cogs.clanrole_management.is_authorized_clan_role_manager", lambda _: True)
+    cog = ClanRoleManagementCog()
+    asyncio.run(cog.clanrole_remove.callback(cog, ctx, member_query="smurf"))
+    assert ctx.reply.await_count == 1
+    assert t1.remove_roles.await_count == 0 and t2.remove_roles.await_count == 0
+
+
+def test_existing_multiclan_dropdown_after_text_resolution(roles, monkeypatch):
+    guild = SimpleNamespace(get_member=lambda _: None, fetch_member=AsyncMock())
+    target = DummyMember(2, [roles["clan1"], roles["clan2"]], guild, display_name="Caillean", name="caillean")
+    guild.members = [target]
+    author = DummyMember(1, [roles["mgr"]], guild)
+    ctx = SimpleNamespace(author=author, guild=guild, reply=AsyncMock())
+    monkeypatch.setattr("cogs.clanrole_management.is_authorized_clan_role_manager", lambda _: True)
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    cog = ClanRoleManagementCog()
+    asyncio.run(cog.clanrole_remove.callback(cog, ctx, member_query="Caillean"))
+    assert ctx.reply.await_count == 1
+    assert target.remove_roles.await_count == 0
+
+
+def test_target_selection_with_multiclan_edits_interaction_without_ctx_reply(roles, monkeypatch):
+    guild = SimpleNamespace()
+    author = DummyMember(1, [roles["mgr"]], guild)
+    target = DummyMember(2, [roles["clan1"], roles["clan2"]], guild, display_name="Caillean", name="caillean")
+    guild.get_member = lambda mid: target if mid == 2 else None
+    guild.members = [target]
+    ctx = SimpleNamespace(author=author, guild=guild, reply=AsyncMock())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    cog = ClanRoleManagementCog()
+    view = ClanRoleTargetView(cog, ctx, [target])
+    interaction = SimpleNamespace(message=SimpleNamespace(id=101), response=SimpleNamespace(edit_message=AsyncMock()))
+    asyncio.run(view.handle_selection(interaction, 2))
+    assert ctx.reply.await_count == 0
+    assert interaction.response.edit_message.await_count == 1
+
+
+def test_target_selection_multiclan_sets_remove_view_message_reference(roles, monkeypatch):
+    guild = SimpleNamespace()
+    author = DummyMember(1, [roles["mgr"]], guild)
+    target = DummyMember(2, [roles["clan1"], roles["clan2"]], guild, display_name="Caillean", name="caillean")
+    guild.get_member = lambda mid: target if mid == 2 else None
+    guild.members = [target]
+    ctx = SimpleNamespace(author=author, guild=guild, reply=AsyncMock())
+    monkeypatch.setattr("cogs.clanrole_management.config.get_clan_role_ids", lambda: {1, 2})
+    cog = ClanRoleManagementCog()
+    view = ClanRoleTargetView(cog, ctx, [target])
+    interaction_message = SimpleNamespace(id=999)
+    interaction = SimpleNamespace(message=interaction_message, response=SimpleNamespace(edit_message=AsyncMock()))
+    asyncio.run(view.handle_selection(interaction, 2))
+    passed_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(passed_view, ClanRoleRemoveView)
+    assert passed_view.message is interaction_message
 
 
 def test_remaining_clan_detection_excludes_removed_role_without_cache_refresh(roles, monkeypatch):


### PR DESCRIPTION
### Motivation

- Improve flexibility of the `clanrole remove` flow so staff can target members by mention, ID, username/display name/global name, or partial name instead of requiring a resolved `discord.Member` argument.

### Description

- Change `clanrole remove` to accept a freeform `member_query: str` and update usage messages accordingly.
- Add `resolve_member_query` to parse mentions/IDs and perform exact or starts-with matching across `display_name`, `name`, and `global_name`, preferring exact matches over starts-with.
- Introduce `ClanRoleTargetSelect` and `ClanRoleTargetView` UI components to present a dropdown when a text query yields multiple candidate members, and wire that into the existing multi-clan selection flow via `build_clanrole_remove_response` and `process_clanrole_remove` helpers.
- Minor cleanup: import `re`, refactor response building to return `(content, view)` so interaction edits can be performed without duplicating ctx replies.

### Testing

- Updated and added unit tests in `tests/recruitment/test_clan_remove_command.py` covering query resolution, mention/ID handling, exact vs starts-with matching, target view interaction restrictions, and integration of the target dropdown with the multi-clan removal flow; these tests were executed and passed.
- Existing cleanup logic tests (raid/wandering souls behavior and view timeout/selection handling) were re-run as part of the test module and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f04e6884832394b5919af7928320)