### PR TITLE
Add configurable grouped fusion reminders and reminder settings sheet

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import logging
 import os
 import time
@@ -18,7 +19,6 @@ from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.reminders")
 
-_PRESTART_HOURS = max(1, int(os.getenv("FUSION_PRESTART_REMINDER_HOURS", "6")))
 _LOOKBACK_MINUTES = max(5, int(os.getenv("FUSION_REMINDER_LOOKBACK_MIN", "30")))
 _DEDUP_TIMEOUT_BACKOFF_SEC = max(60, int(os.getenv("FUSION_REMINDER_DEDUPE_BACKOFF_SEC", "300")))
 _DEDUP_TIMEOUT_SEC = max(1.0, float(os.getenv("FUSION_REMINDER_DEDUPE_TIMEOUT_SEC", "10")))
@@ -51,6 +51,7 @@ def _build_reminder_embed(
     reward_unit: str,
 ) -> discord.Embed:
     jump_link = f"[Open Fusion Overview]({jump_url})"
+    prestart_hours = max(1, int(os.getenv("FUSION_PRESTART_REMINDER_HOURS", "6")))
     if reminder_type == "start":
         title = "Fusion Reminder"
         description = (
@@ -60,7 +61,7 @@ def _build_reminder_embed(
         )
     else:
         title = f"⏳ {event_name} starts soon"
-        description = f"Starts in {_PRESTART_HOURS}h. Plan accordingly."
+        description = f"Starts in {prestart_hours}h. Plan accordingly."
 
     embed = discord.Embed(
         title=title,
@@ -71,6 +72,60 @@ def _build_reminder_embed(
     if reminder_type != "start":
         embed.add_field(name="Fusion", value=jump_link, inline=False)
     return embed
+
+
+def _build_grouped_embed(
+    *,
+    jump_url: str,
+    live_events: list[fusion_sheets.FusionEventRow],
+    starting_soon_events: list[fusion_sheets.FusionEventRow],
+    upcoming_events: list[fusion_sheets.FusionEventRow],
+    ending_events: list[fusion_sheets.FusionEventRow],
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="Fusion Reminder",
+        description=f"🔗 [Open Fusion Overview]({jump_url})",
+        color=discord.Color.blurple(),
+    )
+    if live_events:
+        embed.add_field(
+            name="Live now",
+            value="\n".join(f"• {event.event_name}" for event in live_events[:10]),
+            inline=False,
+        )
+    if starting_soon_events:
+        embed.add_field(
+            name="Starting soon",
+            value="\n".join(f"• {event.event_name}" for event in starting_soon_events[:10]),
+            inline=False,
+        )
+    if upcoming_events:
+        embed.add_field(
+            name="Upcoming / planning",
+            value="\n".join(f"• {event.event_name}" for event in upcoming_events[:10]),
+            inline=False,
+        )
+    if ending_events:
+        embed.add_field(
+            name="Ending soon",
+            value="\n".join(f"• {event.event_name}" for event in ending_events[:10]),
+            inline=False,
+        )
+    return embed
+
+
+def _grouped_event_bucket_key(
+    *,
+    live_events: list[fusion_sheets.FusionEventRow],
+    starting_soon_events: list[fusion_sheets.FusionEventRow],
+    ending_events: list[fusion_sheets.FusionEventRow],
+) -> str:
+    tokens: list[str] = []
+    tokens.extend(f"live:{event.event_id}" for event in sorted(live_events, key=lambda e: e.event_id))
+    tokens.extend(f"starting_soon:{event.event_id}" for event in sorted(starting_soon_events, key=lambda e: e.event_id))
+    tokens.extend(f"ending:{event.event_id}" for event in sorted(ending_events, key=lambda e: e.event_id))
+    digest = hashlib.sha1("|".join(tokens).encode("utf-8")).hexdigest()[:12] if tokens else "empty"
+    return f"grouped:{digest}"
 
 
 async def process_fusion_reminders(
@@ -196,14 +251,73 @@ async def process_fusion_reminders(
         )
         return
 
+    settings = await fusion_sheets.get_fusion_reminder_settings()
+    if settings.group_events:
+        live_events: list[fusion_sheets.FusionEventRow] = []
+        starting_soon_events: list[fusion_sheets.FusionEventRow] = []
+        upcoming_events: list[fusion_sheets.FusionEventRow] = []
+        ending_events: list[fusion_sheets.FusionEventRow] = []
+        for event in events:
+            timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_reminders")
+            if timing is None:
+                continue
+            start_at, end_at = timing
+            if settings.include_start_events and start_at <= reference and (end_at is None or reference < end_at):
+                live_events.append(event)
+            if settings.include_upcoming_events:
+                start_due_at = start_at - dt.timedelta(minutes=settings.start_offset_minutes)
+                upcoming_horizon = reference + dt.timedelta(days=settings.upcoming_window_days)
+                if start_due_at <= reference < start_at:
+                    starting_soon_events.append(event)
+                elif reference < start_at <= upcoming_horizon:
+                    upcoming_events.append(event)
+            if settings.include_ending_events and end_at is not None:
+                if reference <= end_at <= reference + dt.timedelta(hours=settings.end_lookahead_hours):
+                    ending_events.append(event)
+        due_trigger_events = bool(live_events or starting_soon_events or ending_events)
+        if due_trigger_events:
+            reminder_type = "grouped"
+            group_event_key = _grouped_event_bucket_key(
+                live_events=live_events,
+                starting_soon_events=starting_soon_events,
+                ending_events=ending_events,
+            )
+            group_key = (group_event_key, reminder_type)
+            if group_key not in sent_keys:
+                announcement_message = await ensure_fusion_announcement(bot, target)
+                if announcement_message is not None:
+                    embed = _build_grouped_embed(
+                        jump_url=announcement_message.jump_url,
+                        live_events=live_events,
+                        starting_soon_events=starting_soon_events,
+                        upcoming_events=upcoming_events,
+                        ending_events=ending_events,
+                    )
+                    mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
+                    await announcement_message.channel.send(
+                        content=mention_content,
+                        embed=embed,
+                        view=build_fusion_opt_in_view(target),
+                    )
+                    if durable_dedupe_available:
+                        await fusion_sheets.mark_reminder_sent(
+                            target.fusion_id,
+                            event_id=group_event_key,
+                            reminder_type=reminder_type,
+                            sent_at=reference,
+                        )
+                    sent_keys.add(group_key)
+        return
+
     for event in events:
         timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_reminders")
         if timing is None:
             continue
         start_at, _ = timing
+        prestart_hours = max(1, int(os.getenv("FUSION_PRESTART_REMINDER_HOURS", "6")))
 
         triggers: list[tuple[str, dt.datetime]] = [
-            ("prestart_6h", start_at - dt.timedelta(hours=_PRESTART_HOURS)),
+            ("prestart_6h", start_at - dt.timedelta(hours=prestart_hours)),
             ("start", start_at),
         ]
 

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -26,6 +26,7 @@ _FUSION_EVENTS_BUCKET = "fusion_events"
 _LAST_FUSION_PARSE_ERRORS: dict[str, str] = {}
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
+_FUSION_REMINDER_SETTINGS_TAB_KEY = "FUSION_REMINDER_SETTINGS_TAB"
 _PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "done_bonus", "skipped"}
 _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "fusion_id": ("fusion_id",),
@@ -98,6 +99,17 @@ class FusionUserEventProgressRow:
     milestone_key: str
     status: str
     updated_at: dt.datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FusionReminderSettings:
+    start_offset_minutes: int = 360
+    end_lookahead_hours: int = 24
+    upcoming_window_days: int = 2
+    group_events: bool = False
+    include_start_events: bool = True
+    include_ending_events: bool = False
+    include_upcoming_events: bool = False
 
 
 def _resolve_tab_name(key: str) -> str:
@@ -201,6 +213,13 @@ def _parse_milestones(value: object, *, fusion_id: str, event_id: str) -> tuple[
 def _parse_bool(value: object) -> bool:
     text = str(value or "").strip().lower()
     return text in {"1", "true", "yes", "y"}
+
+
+def _parse_nonnegative_int(value: object, default: int) -> int:
+    parsed = _parse_int_optional(value)
+    if parsed is None or parsed < 0:
+        return default
+    return parsed
 
 
 def _parse_discord_id(value: object) -> int | None:
@@ -734,6 +753,27 @@ async def get_active_events(
     return [item[1] for item in active]
 
 
+async def get_fusion_reminder_settings() -> FusionReminderSettings:
+    tab_name = _resolve_tab_name(_FUSION_REMINDER_SETTINGS_TAB_KEY)
+    rows = await afetch_records(_sheet_id(), tab_name)
+    parsed: dict[str, object] = {}
+    for raw in rows or []:
+        row = _normalize(raw)
+        key = str(_pick(row, "key", "setting", "name") or "").strip().lower()
+        value = _pick(row, "value", "setting_value")
+        if key:
+            parsed[key] = value
+    return FusionReminderSettings(
+        start_offset_minutes=_parse_nonnegative_int(parsed.get("start_offset_minutes"), 360),
+        end_lookahead_hours=_parse_nonnegative_int(parsed.get("end_lookahead_hours"), 24),
+        upcoming_window_days=_parse_nonnegative_int(parsed.get("upcoming_window_days"), 2),
+        group_events=_parse_bool(parsed.get("group_events")),
+        include_start_events=_parse_bool(parsed.get("include_start_events", True)),
+        include_ending_events=_parse_bool(parsed.get("include_ending_events")),
+        include_upcoming_events=_parse_bool(parsed.get("include_upcoming_events")),
+    )
+
+
 def get_valid_event_timing(
     event: FusionEventRow,
     *,
@@ -1213,6 +1253,7 @@ __all__ = [
     "FusionEventRow",
     "FusionRow",
     "FusionUserEventProgressRow",
+    "FusionReminderSettings",
     "get_active_fusion",
     "get_ended_fusions",
     "get_published_fusions",
@@ -1226,6 +1267,7 @@ __all__ = [
     "reminder_dedupe_backend_metadata",
     "get_user_event_progress",
     "get_upcoming_events",
+    "get_fusion_reminder_settings",
     "mark_reminder_sent",
     "upsert_user_event_progress",
     "update_fusion_publication",

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -61,6 +61,18 @@ class _DummyAnnouncementMessage:
         self.channel = channel
 
 
+def _settings(**overrides):
+    return fusion_sheets.FusionReminderSettings(
+        start_offset_minutes=overrides.get("start_offset_minutes", 360),
+        end_lookahead_hours=overrides.get("end_lookahead_hours", 24),
+        upcoming_window_days=overrides.get("upcoming_window_days", 2),
+        group_events=overrides.get("group_events", False),
+        include_start_events=overrides.get("include_start_events", True),
+        include_ending_events=overrides.get("include_ending_events", False),
+        include_upcoming_events=overrides.get("include_upcoming_events", False),
+    )
+
+
 def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
     now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
     event = _event(event_id="e-start", start_at=now)
@@ -80,6 +92,7 @@ def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (now, now + dt.timedelta(hours=1)))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
     monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
 
@@ -119,6 +132,7 @@ def test_prestart_reminder_fires_once(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (event_start, event_start + dt.timedelta(hours=1)))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
     monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
 
@@ -153,6 +167,7 @@ def test_invalid_events_skipped_and_no_role_mention_when_absent(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", _timing)
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
     monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
 
@@ -175,9 +190,302 @@ def test_announcement_self_heals_before_sending(monkeypatch):
     monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (now, now + dt.timedelta(hours=1)))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", ensure)
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
 
     ensure.assert_awaited_once()
     assert channel.sent
+
+
+def test_group_events_true_sends_single_grouped_message(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    e1 = _event(event_id="a", start_at=now)
+    e2 = _event(event_id="b", start_at=now + dt.timedelta(hours=4))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[e1, e2]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    mark_sent = AsyncMock()
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", mark_sent)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 1
+    assert channel.sent[0]["embed"].fields[0].name == "Live now"
+    assert mark_sent.await_count == 1
+
+
+def test_grouped_upcoming_toggle(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    e = _event(event_id="future", start_at=now + dt.timedelta(days=1))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    common = [
+        ("get_publishable_fusion", AsyncMock(return_value=_fusion_row())),
+        ("get_fusion_events", AsyncMock(return_value=[e])),
+        ("get_sent_reminder_keys", AsyncMock(return_value=set())),
+        ("mark_reminder_sent", AsyncMock()),
+    ]
+    for name, fn in common:
+        monkeypatch.setattr(fusion_sheets, name, fn)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=False)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 0
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 0
+
+
+def test_grouped_dedupe_allows_new_window_when_event_set_changes(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    live = _event(event_id="live", start_at=now - dt.timedelta(minutes=1))
+    upcoming = _event(event_id="upcoming", start_at=now + dt.timedelta(hours=1))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    sent: set[tuple[str, str]] = set()
+
+    async def _get_sent_keys(_fusion_id: str):
+        return set(sent)
+
+    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
+        sent.add((event_id, reminder_type))
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[live]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(hours=1)))
+    assert len(channel.sent) == 1
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[live, upcoming]))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(hours=2)))
+    assert len(channel.sent) == 2
+
+
+def test_grouped_boundary_start_is_live_not_upcoming(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="boundary", start_at=now)
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    names = [field.name for field in channel.sent[0]["embed"].fields]
+    assert "Live now" in names
+    assert "Starting soon" not in names
+
+
+def test_grouped_state_change_upcoming_to_live_resends(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="flip", start_at=now + dt.timedelta(minutes=1))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    sent: set[tuple[str, str]] = set()
+
+    async def _get_sent_keys(_fusion_id: str):
+        return set(sent)
+
+    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
+        sent.add((event_id, reminder_type))
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(minutes=2)))
+    assert len(channel.sent) == 2
+
+
+def test_grouped_hash_stable_for_row_order(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    e1 = _event(event_id="a", start_at=now - dt.timedelta(minutes=1))
+    e2 = _event(event_id="b", start_at=now + dt.timedelta(hours=1))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    sent: set[tuple[str, str]] = set()
+
+    async def _get_sent_keys(_fusion_id: str):
+        return set(sent)
+
+    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
+        sent.add((event_id, reminder_type))
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[e1, e2]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[e2, e1]))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(minutes=1)))
+    assert len(channel.sent) == 1
+
+
+def test_grouped_planning_only_does_not_trigger_send(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    planning = _event(event_id="plan", start_at=now + dt.timedelta(hours=10))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[planning]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_fusion_reminder_settings",
+        AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True, start_offset_minutes=120, upcoming_window_days=1)),
+    )
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 0
+
+
+def test_grouped_start_offset_triggers_when_inside_window(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    soon = _event(event_id="soon", start_at=now + dt.timedelta(minutes=90))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[soon]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_fusion_reminder_settings",
+        AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True, start_offset_minutes=120, upcoming_window_days=1)),
+    )
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 1
+    names = [field.name for field in channel.sent[0]["embed"].fields]
+    assert "Starting soon" in names
+    assert "Upcoming / planning" not in names
+
+
+def test_grouped_live_event_triggers_send(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    live = _event(event_id="live-only", start_at=now - dt.timedelta(minutes=10))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[live]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=True, include_start_events=True)))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 1
+
+
+def test_grouped_ending_soon_triggers_send(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    ending = fusion_sheets.FusionEventRow(
+        fusion_id="f-1",
+        event_id="ending",
+        event_name="Event ending",
+        event_type="tournament",
+        category="arena",
+        start_at_utc=now - dt.timedelta(hours=1),
+        end_at_utc=now + dt.timedelta(minutes=30),
+        reward_amount=100.0,
+        bonus=None,
+        reward_type="fragments",
+        points_needed=1000,
+        is_estimated=False,
+        sort_order=1,
+    )
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[ending]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_fusion_reminder_settings",
+        AsyncMock(return_value=_settings(group_events=True, include_start_events=False, include_ending_events=True, end_lookahead_hours=1)),
+    )
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 1
+    names = [field.name for field in channel.sent[0]["embed"].fields]
+    assert "Ending soon" in names
+
+
+def test_grouped_include_upcoming_false_excludes_planning_context(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    due = _event(event_id="due", start_at=now - dt.timedelta(minutes=5))
+    future = _event(event_id="future", start_at=now + dt.timedelta(hours=10))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[due, future]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_fusion_reminder_settings",
+        AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=False, start_offset_minutes=60)),
+    )
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    assert len(channel.sent) == 1
+    names = [field.name for field in channel.sent[0]["embed"].fields]
+    assert "Upcoming / planning" not in names
+
+
+def test_grouped_planning_only_changes_do_not_resend(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    due = _event(event_id="due", start_at=now + dt.timedelta(minutes=20))
+    plan_a = _event(event_id="plan-a", start_at=now + dt.timedelta(hours=10))
+    plan_b = _event(event_id="plan-b", start_at=now + dt.timedelta(hours=11))
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    sent: set[tuple[str, str]] = set()
+
+    async def _get_sent_keys(_fusion_id: str):
+        return set(sent)
+
+    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
+        sent.add((event_id, reminder_type))
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[due, plan_a]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_fusion_reminder_settings",
+        AsyncMock(return_value=_settings(group_events=True, include_upcoming_events=True, start_offset_minutes=60, upcoming_window_days=1)),
+    )
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[due, plan_b]))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(minutes=1)))
+    assert len(channel.sent) == 1

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -131,3 +131,28 @@ def test_get_sent_reminder_keys_does_not_require_sent_at_header(monkeypatch: pyt
     sent = asyncio.run(fusion_sheets.get_sent_reminder_keys("f-1"))
 
     assert sent == {("e-1", "start")}
+
+
+def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.MonkeyPatch):
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings",
+        },
+    )
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_records(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "FusionReminderSettings"
+        return [
+            {"key": "group_events", "value": "TRUE"},
+            {"key": "upcoming_window_days", "value": "3"},
+            {"key": "include_upcoming_events", "value": "TRUE"},
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_records", _afetch_records)
+    settings = asyncio.run(fusion_sheets.get_fusion_reminder_settings())
+    assert settings.group_events is True
+    assert settings.upcoming_window_days == 3
+    assert settings.include_upcoming_events is True


### PR DESCRIPTION
### Motivation

- Provide a configurable way to group multiple fusion events into a single reminder message and make reminder behaviour configurable from Sheets.
- Allow per-deployment tuning of the prestart offset via env and make grouping/offsets controllable via a new reminder settings sheet.

### Description

- Added a `FusionReminderSettings` dataclass and `get_fusion_reminder_settings()` in `shared/sheets/fusion.py` to read reminder configuration from the configured sheet tab via `FUSION_REMINDER_SETTINGS_TAB` (key `_FUSION_REMINDER_SETTINGS_TAB_KEY`).
- Implemented grouped reminder logic in `modules/community/fusion/reminders.py` including `_build_grouped_embed()` to render grouped reminders and `_grouped_event_bucket_key()` which computes a stable hash key (via `hashlib.sha1`) for deduplication; the grouped flow reads settings via `get_fusion_reminder_settings()` and sends a single announcement when enabled.
- Replaced the module-level `_PRESTART_HOURS` usage with an on-demand env lookup (`FUSION_PRESTART_REMINDER_HOURS`) so `prestart_hours` is evaluated where reminders are built and triggered.
- Exported the new `FusionReminderSettings` and `get_fusion_reminder_settings` in the module `__all__` and added small helpers (`_parse_nonnegative_int`) and parsing wiring for sheet records.

### Testing

- Ran unit tests in `tests/community/test_fusion_reminders.py` which exercise single-event reminders as well as multiple new grouped reminder behaviors and all assertions passed.
- Ran schema/read tests in `tests/shared/sheets/test_fusion_reminder_schema.py` that validate reading of the reminder settings sheet and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f2f967808323a97e4a140f21ab9d)