### PR TITLE
Clean up fusion summary wording and event row markers

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -30,7 +30,10 @@ def _humanize_type(value: str) -> str:
     if not text:
         return "Unknown"
     normalized = text.replace("_", " ").replace("-", " ")
-    return " ".join(token.capitalize() for token in normalized.split())
+    humanized = " ".join(token.capitalize() for token in normalized.split())
+    if str(value or "").strip().casefold() == "fragment":
+        return "Fragment Fusion"
+    return humanized
 
 
 def _status_icon(status: str) -> str:
@@ -47,7 +50,7 @@ def _format_event_line(event: FusionEventRow, *, status: str) -> str:
     reward_unit = str(event.reward_type or "").strip() or "rewards"
     bonus_text = f" (+{event.bonus:g} bonus {reward_unit})" if has_bonus else ""
     return (
-        f"{_status_icon(status)} {event.event_name} — "
+        f"{_status_icon(status)} {event.event_name} • "
         f"{points_text} for {event.reward_amount:g} {reward_unit}{bonus_text}"
     )
 
@@ -119,7 +122,7 @@ def _build_fusion_embed(
     reward_unit = str(fusion.reward_type or "").strip() or "rewards"
     fusion_type = str(fusion.fusion_type or "").strip().casefold()
     if fusion_type == "fragment":
-        goal_line = f"Goal: Collect 100 fragments to summon {fusion.champion}"
+        goal_line = f"Goal: {fusion.needed:g} fragments needed to summon {fusion.champion}"
     else:
         goal_line = f"Goal: Earn {fusion.needed:g} {reward_unit} for {fusion.champion}"
 
@@ -129,8 +132,6 @@ def _build_fusion_embed(
         f"Target: {fusion.needed:g} {reward_unit} needed / {fusion.available:g} available",
         f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
     ]
-    if fusion.fusion_structure.strip():
-        summary_lines.insert(1, fusion.fusion_structure.strip())
 
     milestones_lines = [
         f"First start: {_format_day_label(min(event_days))}" if event_days else "First start: TBA",
@@ -192,7 +193,7 @@ def _build_fusion_embed(
         if len(embed.fields) >= _EMBED_MAX_FIELDS:
             break
         lines = [
-            f"• {_format_event_line(event, status=status_by_event_id[event.event_id])}"
+            _format_event_line(event, status=status_by_event_id[event.event_id])
             for event in grouped_events[day]
         ]
         embed.add_field(

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -532,7 +532,7 @@ def test_share_mode_summary_posts_to_fusion_announcement_channel(monkeypatch):
 
         channel.send.assert_awaited_once()
         embed = channel.send.await_args.kwargs["embed"]
-        assert embed.title == "Progress Share — Mavara"
+        assert embed.title == "Progress Share: Mavara"
         summary_field = next(field for field in embed.fields if field.name == "Summary")
         assert "✅ Done: 1" in summary_field.value
 

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -102,6 +102,7 @@ def test_build_fusion_embed_uses_dynamic_reward_labels_for_titan() -> None:
     assert "Goal: Earn 1750 points for Mavara" in (embed.description or "")
     assert "Target: 1750 points needed / 2000 available" in (embed.description or "")
     assert "for 25 points (+50 bonus points)" in embed.fields[-1].value
+    assert "—" not in embed.fields[-1].value
 
 
 def test_build_fusion_embed_fragment_goal_and_end_in_milestones() -> None:
@@ -110,6 +111,29 @@ def test_build_fusion_embed_fragment_goal_and_end_in_milestones() -> None:
 
     embed = build_fusion_announcement_embed(fragment, [event])
 
-    assert "Goal: Collect 100 fragments to summon Mavara" in (embed.description or "")
+    description = embed.description or ""
+    assert "Type: Fragment Fusion" in description
+    assert "Goal: 100 fragments needed to summon Mavara" in description
+    assert "get 100 fragments -> fuse the Champion" not in description
+    assert "—" not in description
     milestones = embed.fields[0].value or ""
     assert "End: 2026-04-22 00:00 UTC" in milestones
+
+
+def test_build_fusion_embed_event_rows_start_with_status_emoji_not_bullet() -> None:
+    events = [_event(9, 1), _event(9, 2)]
+
+    embed = build_fusion_announcement_embed(_fusion(), events, now=dt.datetime(2026, 4, 9, 10, tzinfo=dt.timezone.utc))
+
+    day_field = next(field for field in embed.fields if field.name == "Thu, Apr 9")
+    lines = (day_field.value or "").splitlines()
+    assert lines
+    for line in lines:
+        assert not line.startswith("• 🏁")
+        assert not line.startswith("• 🔥")
+        assert not line.startswith("• ⏳")
+        assert not line.startswith("• ✅")
+        assert line.startswith(("🏁 ", "🔥 ", "⏳ "))
+        assert "Event" in line
+        assert "—" not in line
+


### PR DESCRIPTION
### Motivation
- Make the fusion announcement summary less repetitive and visually cleaner by removing duplicated objective text and removing unnecessary list bullets and em dashes from event rows.
- Preserve all data and logic (fragment/points math, progress/status/event ordering, opt-in behavior, sheet schema) while only changing user-facing text/format.

### Description
- Render fragment fusions with a special type label so the summary now contains `Type: Fragment Fusion` and the fragment goal uses `Goal: <needed> fragments needed to summon <champion>`. (changed `_humanize_type` and fragment `goal_line` in `modules/community/fusion/rendering.py`).
- Remove the injected `fusion_structure` line from the summary block to avoid duplicated objective wording. (removed the insertion of `fusion.fusion_structure` into summary lines in `modules/community/fusion/rendering.py`).
- Replace em dashes with a middle dot in event lines and stop prefixing event rows with a leading bullet so event rows now render as `<status_emoji> <event_name> • <points/reward detail>` instead of `• <status_emoji> <event_name> — <detail>`. (updated `_format_event_line` and the per-day line construction in `modules/community/fusion/rendering.py`).
- Tests updated/added to reflect new wording and formatting in `tests/community/test_fusion_rendering.py` and `tests/community/test_fusion_opt_in_view.py`.

### Testing
- Ran `pytest -q tests/community/test_fusion_rendering.py tests/community/test_fusion_announcements.py tests/community/test_fusion_opt_in_view.py` and all tests passed (`34 passed`).
- Updated/added focused assertions to confirm the new text and formatting, including checks that the summary contains `Type: Fragment Fusion`, the fragment goal reads `Goal: 100 fragments needed to summon <champion>`, the legacy duplicate phrase is absent, event rows start with the status emoji (not `• `), and no em dash appears in the changed text paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04247247348323b4512cdfe50071bb)