### PR TITLE
Move C1CLeague mention out of embed and update league announcement formatting

### DIFF
--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -365,7 +365,10 @@ class LeaguesCog(commands.Cog):
 
         reaction_roles_attached: int | None = None
         try:
-            announcement_message = await announcement_channel.send(embed=announcement_embed)
+            announcement_message = await announcement_channel.send(
+                content=self._league_role_mention(),
+                embed=announcement_embed,
+            )
         except Exception as exc:
             log.exception("leagues announcement failed")
             await self._post_status(
@@ -511,34 +514,35 @@ class LeaguesCog(commands.Cog):
 
         return discord.File(fp=io.BytesIO(png_bytes), filename=filename)
 
+    def _league_role_mention(self) -> str:
+        role_id = self._parse_int_env("C1C_LEAGUE_ROLE_ID")
+        return f"<@&{role_id}>" if role_id else "@C1CLeague"
+
     def _build_announcement(
         self, bundles: Iterable[LeagueBundle], jump_links: Mapping[str, str]
     ) -> str:
         jump_map = {bundle.slug: jump_links[bundle.slug] for bundle in bundles}
-        role_id = self._parse_int_env("C1C_LEAGUE_ROLE_ID")
-        mention = f"<@&{role_id}>" if role_id else "@C1CLeague"
         return "\n".join(
             [
-                f"📊 Shifting Echoes from the {mention} …",
+                "# Shifting Echoes from the C1CLeague …",
                 "",
                 "The climb never truly stops. Each week, new names rise, old banners hold the line, and some records quietly fall in the dust behind you.",
                 "",
-                "🦅 Legendary League  ",
+                "🦅 **Legendary League**  ",
                 "The gates never close for long. New contenders keep pushing the limits, and the old guard keeps proving why they’re still on top.",
                 "",
-                "🌟 Rising Stars League  ",
+                "🌟 **Rising Stars League**  ",
                 "Not every victory is shouted from rooftops. Some of you are carving your place into the stone one quiet, relentless step at a time.",
                 "",
-                "⚡ Stormforged League  ",
+                "⚡ **Stormforged League**  ",
                 "Where clans clash, storms crackle, and every key, banner and fight adds another spark to the scoreboard.",
                 "",
                 "Want to see what stirred the rankings this time?",
                 "",
-                f"🔹 Legendary League – [Jump to this week’s update]({jump_map['legendary']})  ",
-                f"🔹 Rising Stars League – [Jump to this week’s update]({jump_map['rising']})  ",
-                f"🔹 Stormforged League – [Jump to this week’s update]({jump_map['storm']})",
+                f"🔹 **Legendary League** – [Jump to this week’s update]({jump_map['legendary']})  ",
+                f"🔹 **Rising Stars League** – [Jump to this week’s update]({jump_map['rising']})  ",
+                f"🔹 **Stormforged League** – [Jump to this week’s update]({jump_map['storm']})",
                 "",
-                mention,
             ]
         )
 

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from modules.community.leagues.cog import LeaguesCog
+from modules.community.leagues.config import LeagueBundle, LeagueSpec
+
+
+def _bundle(slug: str, name: str) -> LeagueBundle:
+    spec = LeagueSpec(key=f"{slug}_h", slug=slug, kind="header", index=None, sheet_name="Tab", cell_range="A1:B2")
+    return LeagueBundle(slug=slug, display_name=name, header=spec, boards=[spec])
+
+
+def test_build_announcement_uses_plain_title_and_bold_league_names() -> None:
+    cog = LeaguesCog(SimpleNamespace())
+    bundles = [
+        _bundle("legendary", "Legendary League"),
+        _bundle("rising", "Rising Stars League"),
+        _bundle("storm", "Stormforged League"),
+    ]
+    text = cog._build_announcement(
+        bundles,
+        {
+            "legendary": "https://discord.test/legendary",
+            "rising": "https://discord.test/rising",
+            "storm": "https://discord.test/storm",
+        },
+    )
+
+    assert "# Shifting Echoes from the C1CLeague …" in text
+    assert "@C1CLeague" not in text
+    assert "🦅 **Legendary League**" in text
+    assert "🌟 **Rising Stars League**" in text
+    assert "⚡ **Stormforged League**" in text
+    assert "🔹 **Legendary League** – [Jump to this week’s update](https://discord.test/legendary)" in text
+
+
+def test_league_role_mention_prefers_role_id(monkeypatch) -> None:
+    cog = LeaguesCog(SimpleNamespace())
+    monkeypatch.setenv("C1C_LEAGUE_ROLE_ID", "12345")
+    assert cog._league_role_mention() == "<@&12345>"


### PR DESCRIPTION
### Motivation
- Discord role mentions sent inside embed text do not reliably trigger pings, so the mention must be moved to message content while keeping the embed clean. 
- Update the announcement title and league name styling to match the requested visual format without changing posting or subscription logic.

### Description
- Send the role mention in the message `content` when posting the weekly announcement by calling `announcement_channel.send(content=self._league_role_mention(), embed=announcement_embed)`. (modified `modules/community/leagues/cog.py`)
- Add helper `def _league_role_mention(self) -> str` to resolve `C1C_LEAGUE_ROLE_ID` or fall back to the literal `@C1CLeague`. (added in `modules/community/leagues/cog.py`)
- Replace the embed lead line with the exact literal `# Shifting Echoes from the C1CLeague …` (no `@` mention) and preserve the ellipsis. (changed in `modules/community/leagues/cog.py`)
- Make all league names bold in both section headers and the jump-link summary (e.g. `🦅 **Legendary League**` and `🔹 **Legendary League** – [Jump …]`). (changed in `modules/community/leagues/cog.py`)
- Remove the duplicate role mention from the embed body and add focused rendering tests in `tests/community/test_leagues_rendering.py` that validate the title/formatting and the mention helper.
- No changes were made to announcement flow, reaction-role wiring, role subscription behavior, intents, or environment variable names.

### Testing
- Added `tests/community/test_leagues_rendering.py` with two unit tests validating the embed text and `C1C_LEAGUE_ROLE_ID` resolution. 
- Ran the focused test suite with `pytest -q tests/community/test_leagues_rendering.py` which completed successfully: `2 passed`.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0459c792ac8323a249add0828afe50)