### PR TITLE
Normalize onboarding completion (treat completed_at as authoritative)

### DIFF
--- a/modules/onboarding/idle_watcher.py
+++ b/modules/onboarding/idle_watcher.py
@@ -112,7 +112,7 @@ async def _ticket_needs_onboarding_reminder(row: dict, thread: discord.Thread) -
         return False
     if _is_thread_archived_or_locked(thread):
         return False
-    if row.get("completed"):
+    if row.get("completed") or row.get("completed_at"):
         return False
 
     durable_summary_keys = (
@@ -253,7 +253,7 @@ async def _handle_row(
     if not user_id or not thread_id:
         return
 
-    if row.get("completed"):
+    if row.get("completed") or row.get("completed_at"):
         return
     if row.get("auto_closed_at"):
         return

--- a/modules/onboarding/sessions.py
+++ b/modules/onboarding/sessions.py
@@ -165,6 +165,8 @@ class Session:
                 session.completed_at = datetime.fromisoformat(normalized)
             except Exception:
                 session.completed_at = None
+        if session.completed_at is not None and not session.completed:
+            session.completed = True
         reminder_token = row.get("first_reminder_at")
         reminder_at = _parse_iso(reminder_token) if reminder_token else None
         if reminder_at:

--- a/shared/sheets/onboarding_sessions.py
+++ b/shared/sheets/onboarding_sessions.py
@@ -67,8 +67,8 @@ def load(user_id: int | None, thread_id: int) -> Optional[Dict[str, Any]]:
 
     panel_id = _safe_int(record.get("panel_message_id"))
     completed_token = str(record.get("completed", "")).strip().lower()
-    completed = completed_token in {"true", "1", "yes", "true"}
     completed_at = record.get("completed_at") or None
+    completed = completed_token in {"true", "1", "yes", "true"} or bool(completed_at)
     return {
         "thread_name": record.get("thread_name") or "",
         "user_id": str(record.get("user_id") or ""),
@@ -110,8 +110,8 @@ def load_all() -> list[Dict[str, Any]]:
 
         panel_id = _safe_int(record.get("panel_message_id"))
         completed_token = str(record.get("completed", "")).strip().lower()
-        completed = completed_token in {"true", "1", "yes", "true"}
         completed_at = record.get("completed_at") or None
+        completed = completed_token in {"true", "1", "yes", "true"} or bool(completed_at)
 
         sessions.append(
             {
@@ -329,14 +329,19 @@ def _record_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(completed_value, str):
         completed_value = completed_value.strip().lower() in {"true", "1", "yes"}
 
+    completed_at_value = payload.get("completed_at") or ""
+    completed_flag = bool(completed_value)
+    if completed_at_value and not completed_flag:
+        completed_flag = True
+
     return {
         "thread_name": str(payload.get("thread_name") or ""),
         "user_id": str(payload.get("user_id") or ""),
         "thread_id": str(payload.get("thread_id") or ""),
         "panel_message_id": _safe_int(payload.get("panel_message_id"), default="") or "",
         "step_index": _safe_int(payload.get("step_index"), default=0) or 0,
-        "completed": bool(completed_value),
-        "completed_at": payload.get("completed_at") or "",
+        "completed": completed_flag,
+        "completed_at": completed_at_value,
         "answers_json": answers_json,
         "answers": answers or {},
         "updated_at": updated_at,
@@ -472,14 +477,16 @@ def _session_from_record(record: Dict[str, Any]) -> Dict[str, Any]:
         answers = {}
     panel_id = _safe_int(record.get("panel_message_id"))
     completed_token = str(record.get("completed", "")).strip().lower()
+    completed_at = record.get("completed_at") or None
+    completed = completed_token in {"true", "1", "yes", "true"} or bool(completed_at)
     return {
         "thread_name": record.get("thread_name") or "",
         "user_id": str(record.get("user_id") or ""),
         "thread_id": str(record.get("thread_id") or ""),
         "panel_message_id": panel_id if panel_id not in (None, 0) else None,
         "step_index": _safe_int(record.get("step_index"), default=0),
-        "completed": completed_token in {"true", "1", "yes", "true"},
-        "completed_at": record.get("completed_at") or None,
+        "completed": completed,
+        "completed_at": completed_at,
         "updated_at": record.get("updated_at") or "",
         "first_reminder_at": record.get("first_reminder_at") or "",
         "warning_sent_at": record.get("warning_sent_at") or "",

--- a/tests/onboarding/test_idle_watcher.py
+++ b/tests/onboarding/test_idle_watcher.py
@@ -27,6 +27,12 @@ class _DummyThread:
         if locked is not None:
             self.locked = locked
 
+    def history(self, *, limit=50):
+        async def _iter():
+            if False:
+                yield None
+        return _iter()
+
 
 class _DummyBot:
     def __init__(self, threads: dict[int, _DummyThread]):
@@ -40,6 +46,9 @@ class _DummyBot:
 
     async def fetch_channel(self, thread_id: int):
         return self._threads.get(thread_id)
+
+    def get_cog(self, _name: str):
+        return None
 
 
 def _fixed_now() -> datetime:
@@ -101,6 +110,34 @@ def test_idle_watcher_posts_first_reminder(monkeypatch):
     assert thread.sent
     assert "open questions" in thread.sent[0].lower()
     assert saves and saves[0].get("first_reminder_at")
+
+
+def test_idle_watcher_skips_when_completed_at_present(monkeypatch):
+    thread = _DummyThread(999)
+    bot = _DummyBot({999: thread})
+    saves: list[dict] = []
+
+    async def _resolve(_bot, _tid):
+        return thread
+
+    monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "load_all",
+        lambda: [_row(8.0, completed=False, completed_at="2025-01-01T10:00:00+00:00")],
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "update_existing",
+        lambda thread_id, payload: saves.append(payload),
+    )
+    monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
+    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+
+    asyncio.run(idle_watcher.run_idle_scan(bot, now=_fixed_now()))
+
+    assert thread.sent == []
+    assert saves == []
 
 
 def test_idle_watcher_posts_warning(monkeypatch):
@@ -206,3 +243,27 @@ def test_idle_watcher_autoclose_promo(monkeypatch):
     assert thread.sent and "promo ticket" in thread.sent[-1].lower()
     assert "remove the user" not in thread.sent[-1]
     assert saves and saves[0].get("auto_closed_at")
+
+
+def test_idle_watcher_skips_closed_ticket(monkeypatch):
+    thread = _DummyThread(999, name="Closed-W1234-user-NONE")
+    bot = _DummyBot({999: thread})
+    saves: list[dict] = []
+
+    async def _resolve(_bot, _tid):
+        return thread
+
+    monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
+    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(6.0)])
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "update_existing",
+        lambda thread_id, payload: saves.append(payload),
+    )
+    monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
+    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+
+    asyncio.run(idle_watcher.run_idle_scan(bot, now=_fixed_now()))
+
+    assert thread.sent == []
+    assert saves == []

--- a/tests/shared/sheets/test_onboarding_sessions.py
+++ b/tests/shared/sheets/test_onboarding_sessions.py
@@ -91,3 +91,22 @@ def test_thread_id_matching_uses_strings(monkeypatch, headers):
     assert len(sheet.appended) == 1
     record = sheet_module._record_from_row(sheet.appended[0], headers, sheet_module._header_index_map(headers))
     assert record["thread_id"] == payload["thread_id"]
+
+
+def test_completed_at_normalizes_completed_true_in_load(monkeypatch, headers):
+    payload = {
+        "thread_id": "555",
+        "thread_name": "W0555-user",
+        "user_id": "111",
+        "completed": False,
+        "completed_at": "2025-12-06T00:00:00Z",
+        "updated_at": "2025-12-06T00:00:00Z",
+    }
+    sheet = _RecordingSheet([headers, _row(payload, headers)])
+    monkeypatch.setattr(sheet_module, "_sheet", lambda: sheet)
+
+    loaded = sheet_module.load(user_id=111, thread_id=555)
+
+    assert loaded is not None
+    assert loaded["completed"] is True
+    assert loaded["completed_at"] == "2025-12-06T00:00:00Z"


### PR DESCRIPTION
### Motivation
- Reminder jobs were pinging tickets where `completed_at` was populated but `completed` was still false because completion checks only inspected the boolean `completed` field.
- Persisted rows and some paths set `completed_at` without reliably setting `completed=True`, causing false reminders for welcome/promo tickets.

### Description
- Normalize read/write paths so a non-empty `completed_at` implies `completed=True` in `shared/sheets/onboarding_sessions.py` when loading, saving, and when building payload rows. 
- Gate reminder logic in `modules/onboarding/idle_watcher.py` to skip tickets if either `completed` is true or `completed_at` is present. 
- Self-heal in-memory session hydration in `modules/onboarding/sessions.py` by flipping `completed` to true when a `completed_at` timestamp is present. 
- Added regression tests to `tests/shared/sheets/test_onboarding_sessions.py` and `tests/onboarding/test_idle_watcher.py` to cover normalization, reminder skipping when `completed_at` exists, and closed-ticket suppression; no sheet schema changes were introduced.

### Testing
- Ran: `pytest -q tests/shared/sheets/test_onboarding_sessions.py tests/onboarding/test_idle_watcher.py tests/onboarding/test_summary_v1.py` and all targeted tests passed. 
- New/updated tests include `test_completed_at_normalizes_completed_true_in_load`, `test_idle_watcher_skips_when_completed_at_present`, and closed-ticket reminder suppression tests, and they succeeded during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046ab96ea883238c456e478dfeaf03)