### PR TITLE
Log open-spot decision details and mark welcome repair alerts as metadata repair

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -601,6 +601,14 @@ class PromoTicketWatcher(commands.Cog):
             context.username,
             result,
         )
+        source = "promo"
+        log.info(
+            "promo_open_spots_reconcile — ticket=%s • user=%s • clan=%s • source=%s • result=skipped • reason=no_promo_open_spots_reconcile_currently",
+            context.ticket_number,
+            context.username,
+            context.clan_tag or "-",
+            source,
+        )
         try:
             onboarding_sessions.mark_completed(getattr(thread, "id", 0))
         except Exception:

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1654,6 +1654,49 @@ async def _log_clan_math_event(
             "failed to send clan math log",
             extra={"ticket": context.ticket_number, "result": normalized_result},
         )
+
+
+def _decision_visibility_line(
+    *,
+    final_tag: str,
+    previous_final: str | None,
+    reservation_row: reservations_sheets.ReservationRow | None,
+    reservation_label: str,
+    consume_open_spot: bool,
+    final_is_real: bool,
+    open_deltas: Dict[str, int],
+) -> str:
+    previous_display = (previous_final or "").strip().upper() or "-"
+    reservation_state = (
+        f"matched_row={reservation_row.row_number}({reservation_label or 'unknown'})"
+        if reservation_row is not None
+        else "none"
+    )
+    if open_deltas:
+        delta_bits = ", ".join(f"{tag}:{delta:+d}" for tag, delta in sorted(open_deltas.items()))
+        return (
+            "decision: "
+            f"final_tag={final_tag or '-'} • previous_final={previous_display} • "
+            f"reservation={reservation_state} • consume_open_spot={consume_open_spot} • "
+            f"final_is_real={final_is_real} • decision_result=applied_open_delta • deltas={delta_bits}"
+        )
+
+    skip_reason = "unknown_noop"
+    if not final_is_real and final_tag and final_tag != _NO_PLACEMENT_TAG:
+        skip_reason = "non_real_final_tag"
+    elif reservation_row is not None and reservation_label in {"same", "cancelled"}:
+        skip_reason = "reservation_consumed_or_matched"
+    elif not consume_open_spot and previous_display == (final_tag or "").strip().upper():
+        skip_reason = "already_finalized_same_tag"
+    elif not consume_open_spot:
+        skip_reason = "consume_open_spot_false"
+
+    return (
+        "decision: "
+        f"final_tag={final_tag or '-'} • previous_final={previous_display} • "
+        f"reservation={reservation_state} • consume_open_spot={consume_open_spot} • "
+        f"final_is_real={final_is_real} • decision_result=skipped_open_delta • skip_reason={skip_reason}"
+    )
 async def _send_runtime(message: str) -> None:
     try:
         await rt.send_log_message(message)
@@ -3359,6 +3402,8 @@ class WelcomeTicketWatcher(commands.Cog):
         row_targets: "OrderedDict[str, str]" = OrderedDict()
         before_snapshots: Dict[str, _ClanMathRowSnapshot] = {}
         column_map: Dict[str, int] | None = None
+        final_is_real = False
+        decision_open_deltas: Dict[str, int] = {}
 
         if not row_missing:
             final_entry = (
@@ -3400,6 +3445,7 @@ class WelcomeTicketWatcher(commands.Cog):
                 previous_final=previous_final,
             )
             reservation_label = decision.label
+            decision_open_deltas = dict(decision.open_deltas)
 
             target_tags = _clan_tags_for_logging(
                 final_tag,
@@ -3462,6 +3508,17 @@ class WelcomeTicketWatcher(commands.Cog):
                 row_change_lines = _build_clan_math_row_lines(
                     row_targets, before_snapshots, after_snapshots
                 )
+
+        decision_line = _decision_visibility_line(
+            final_tag=final_tag,
+            previous_final=previous_final,
+            reservation_row=reservation_row,
+            reservation_label=reservation_label,
+            consume_open_spot=consume_open_spot,
+            final_is_real=final_is_real,
+            open_deltas=decision_open_deltas,
+        )
+        row_change_lines = [decision_line, *row_change_lines]
 
         final_display = final_tag if final_tag else _NO_PLACEMENT_TAG
         confirmation = (

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -472,9 +472,9 @@ def _queue_welcome_repair_alert(summary: dict[str, int]) -> None:
     reservation_rows = int(summary.get("reservation_rows", 0) or 0)
     malformed_rows = int(summary.get("malformed_rows", 0) or 0)
     _WELCOME_REPAIR_ALERT_PENDING = (
-        "Welcome ticket repair: "
+        "Welcome ticket metadata repair: "
         f"{repaired} repaired, {flagged} flagged for review "
-        f"(welcome={welcome_rows}, reservations={reservation_rows}, legacy={legacy_rows}, malformed={malformed_rows})"
+        f"(welcome={welcome_rows}, reservations={reservation_rows}, legacy={legacy_rows}, malformed={malformed_rows}, open_spots_repair=not_performed)"
     )
 
 

--- a/tests/onboarding/test_onboarding_repair_logic.py
+++ b/tests/onboarding/test_onboarding_repair_logic.py
@@ -63,3 +63,22 @@ def test_legacy_rows_not_flagged(monkeypatch):
     ws, summary = _run(values, monkeypatch)
     assert summary["flagged"] == 0
     assert ws.updated == []
+
+
+def test_repair_alert_mentions_open_spots_not_performed():
+    onboarding._WELCOME_REPAIR_ALERT_LAST_TS = 0
+    onboarding._WELCOME_REPAIR_ALERT_PENDING = None
+    onboarding._queue_welcome_repair_alert(
+        {
+            "repaired": 0,
+            "flagged": 1,
+            "welcome_rows": 1,
+            "reservation_rows": 0,
+            "legacy_rows": 0,
+            "malformed_rows": 0,
+        }
+    )
+    message = onboarding.consume_welcome_repair_alert()
+    assert message is not None
+    assert "metadata repair" in message
+    assert "open_spots_repair=not_performed" in message

--- a/tests/onboarding/test_open_spot_visibility_logging.py
+++ b/tests/onboarding/test_open_spot_visibility_logging.py
@@ -1,0 +1,123 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+
+from modules.onboarding.watcher_welcome import WelcomeTicketWatcher, TicketContext, _NO_PLACEMENT_TAG
+from modules.onboarding.watcher_promo import PromoTicketWatcher, PromoTicketContext
+from shared.sheets import onboarding as onboarding_sheets
+
+
+class DummyThread:
+    def __init__(self):
+        self.id = 1
+        self.name = "W0001-user"
+        self.guild = SimpleNamespace(get_channel=lambda *_: None, guilds=[])
+        self.messages = []
+
+    async def send(self, content=None, **kwargs):
+        self.messages.append((content, kwargs))
+        return SimpleNamespace(id=111)
+
+    async def edit(self, **kwargs):
+        return None
+
+
+class DummyBot:
+    user = SimpleNamespace(id=123)
+
+
+def test_welcome_same_tag_logs_idempotent_reason(monkeypatch):
+    async def run():
+        bot = commands.Bot(command_prefix='!', intents=discord.Intents.none())
+        watcher = WelcomeTicketWatcher(bot)
+        watcher._clan_tags = ["C1CE", _NO_PLACEMENT_TAG]
+        watcher._clan_tag_set = set(watcher._clan_tags)
+        ctx = TicketContext(thread_id=1, ticket_number='W1', username='u', recruit_id=1, recruit_display='u')
+        ctx.state = 'awaiting_clan'
+        logs = []
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.log_sheet_write', lambda **kwargs: asyncio.sleep(0, result='updated'))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row', lambda _t: (2, ['W1','u','','','','','','','','','','']) )
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.onboarding_sheets.WELCOME_CLAN_TAG_INDEX', 2)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row', lambda tag: (10, ['','','C1CE','','4'] + ['']*30) if tag=='C1CE' else None)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.reservations_sheets.find_active_reservations_for_recruit', lambda *a,**k: asyncio.sleep(0, result=[]))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.availability.adjust_manual_open_spots', lambda *a,**k: asyncio.sleep(0, result=4))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.availability.recompute_clan_availability', lambda *a,**k: asyncio.sleep(0, result=None))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map', lambda: {'open_spots':4})
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.rt.send_log_message', lambda m: logs.append(m) or asyncio.sleep(0))
+        await watcher._finalize_clan_tag(DummyThread(), ctx, 'C1CE', actor=None, source='s', prompt_message=None, view=None)
+        await bot.close()
+        assert any('decision:' in m for m in logs)
+    asyncio.run(run())
+
+
+def test_welcome_first_time_applies_delta(monkeypatch):
+    async def run():
+        bot = commands.Bot(command_prefix='!', intents=discord.Intents.none())
+        watcher = WelcomeTicketWatcher(bot)
+        watcher._clan_tags = ["C1CE", _NO_PLACEMENT_TAG]
+        watcher._clan_tag_set = set(watcher._clan_tags)
+        ctx = TicketContext(thread_id=1, ticket_number='W2', username='u', recruit_id=1, recruit_display='u')
+        ctx.state = 'awaiting_clan'
+        logs = []
+        deltas = []
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.log_sheet_write', lambda **kwargs: asyncio.sleep(0, result='updated'))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row', lambda _t: None)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row', lambda tag: (10, ['','','C1CE','','4'] + ['']*30) if tag=='C1CE' else None)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.reservations_sheets.find_active_reservations_for_recruit', lambda *a,**k: asyncio.sleep(0, result=[]))
+        async def fake_adjust(tag, delta):
+            deltas.append((tag, delta))
+            return 3
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.availability.adjust_manual_open_spots', fake_adjust)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.availability.recompute_clan_availability', lambda *a,**k: asyncio.sleep(0, result=None))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map', lambda: {'open_spots':4})
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.rt.send_log_message', lambda m: logs.append(m) or asyncio.sleep(0))
+        await watcher._finalize_clan_tag(DummyThread(), ctx, 'C1CE', actor=None, source='s', prompt_message=None, view=None)
+        await bot.close()
+        assert ('C1CE', -1) in deltas
+        assert any('decision_result=applied_open_delta' in m for m in logs)
+    asyncio.run(run())
+
+
+def test_welcome_non_real_logs_skip_reason(monkeypatch):
+    async def run():
+        bot = commands.Bot(command_prefix='!', intents=discord.Intents.none())
+        watcher = WelcomeTicketWatcher(bot)
+        watcher._clan_tags = ["C1CZ", _NO_PLACEMENT_TAG]
+        watcher._clan_tag_set = set(watcher._clan_tags)
+        ctx = TicketContext(thread_id=1, ticket_number='W3', username='u', recruit_id=1, recruit_display='u')
+        ctx.state = 'awaiting_clan'
+        logs = []
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.log_sheet_write', lambda **kwargs: asyncio.sleep(0, result='updated'))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row', lambda _t: None)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row', lambda _tag: None)
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.reservations_sheets.find_active_reservations_for_recruit', lambda *a,**k: asyncio.sleep(0, result=[]))
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map', lambda: {'open_spots':4})
+        monkeypatch.setattr('modules.onboarding.watcher_welcome.rt.send_log_message', lambda m: logs.append(m) or asyncio.sleep(0))
+        await watcher._finalize_clan_tag(DummyThread(), ctx, 'C1CZ', actor=None, source='s', prompt_message=None, view=None)
+        await bot.close()
+        assert any('skip_reason=non_real_final_tag' in m for m in logs)
+    asyncio.run(run())
+
+
+def test_repair_alert_mentions_not_performed():
+    onboarding_sheets._queue_welcome_repair_alert({'repaired':0,'flagged':1,'legacy_rows':0,'welcome_rows':1,'reservation_rows':0,'malformed_rows':0})
+    msg = onboarding_sheets.consume_welcome_repair_alert()
+    assert 'open_spots_repair=not_performed' in (msg or '')
+
+
+def test_promo_logs_no_reconcile(monkeypatch, caplog):
+    monkeypatch.setattr('modules.common.feature_flags.is_enabled', lambda *_: True)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.get_promo_channel_id', lambda: 1)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.get_ticket_tool_bot_id', lambda: 1)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.thread_scopes.is_promo_parent', lambda *_: True)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sheets.upsert_promo', lambda *_: 'updated')
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sessions.mark_completed', lambda *_: True)
+    watcher = PromoTicketWatcher(bot=DummyBot())
+    ctx = PromoTicketContext(thread_id=1,ticket_number='R1',username='u',promo_type='Returning',thread_created='x',year='2026',month='Jan',state='awaiting_clan')
+    watcher._load_clan_tags = lambda : asyncio.sleep(0, result=['C1CE'])
+    caplog.set_level(logging.INFO)
+    asyncio.run(watcher._finalize_clan_tag(DummyThread(), ctx, 'C1CE', actor=None, prompt_message=None, view=None))
+    assert 'reason=no_promo_open_spots_reconcile_currently' in caplog.text

--- a/tests/onboarding/test_promo_close_clan_prompt.py
+++ b/tests/onboarding/test_promo_close_clan_prompt.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -165,6 +166,27 @@ def test_finalize_never_enters_awaiting_details(monkeypatch):
         )
     )
     assert ctx.state == "closed"
+
+
+def test_promo_close_logs_open_spots_reconcile_skipped(monkeypatch, caplog):
+    watcher = _setup_watcher(monkeypatch)
+    ctx = _context(state="awaiting_clan")
+    monkeypatch.setattr("modules.onboarding.watcher_promo.onboarding_sheets.upsert_promo", lambda *_: "updated")
+    watcher._load_clan_tags = AsyncMock(return_value=["C1CE"])
+    thread = DummyThread(10, "closed-R1111-user")
+    thread.edit = AsyncMock()
+    with caplog.at_level(logging.INFO):
+        asyncio.run(
+            watcher._finalize_clan_tag(
+                thread,
+                ctx,
+                "C1CE",
+                actor=None,
+                prompt_message=None,
+                view=None,
+            )
+        )
+    assert "reason=no_promo_open_spots_reconcile_currently" in caplog.text
 
 
 def test_duplicate_close_signal_ignored_after_closed(monkeypatch):

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -1304,6 +1304,7 @@ def test_finalize_posts_clan_math_log(monkeypatch) -> None:
     assert "source=ticket_tool" in message
     assert "reservation=none" in message
     assert "result=ok" in message
+    assert "decision_result=applied_open_delta" in message
     assert "- C1CE row 12" in message
     assert "open_spots: 3 → 2" in message
     assert "AF: 3 → 2" in message
@@ -1413,6 +1414,7 @@ def test_finalize_error_pings_admins(monkeypatch) -> None:
     message = log_messages[-1]
     assert "result=error" in message
     assert "reason=partial_actions" in message
+    assert "decision_result=applied_open_delta" in message
     assert "<@&111>" in message and "<@&222>" in message
     assert "open_spots: 4 → 4" in message
 
@@ -1539,10 +1541,72 @@ def test_finalize_manual_path_logs_source(monkeypatch) -> None:
     assert "source=manual_fallback" in message
     assert f"reservation=row{reservation.row_number}(same)" in message
     assert "result=ok" in message
+    assert "decision_result=skipped_open_delta" in message
+    assert "skip_reason=reservation_consumed_or_matched" in message
     assert "- C1CE row 9" in message
     assert "open_spots: 2 → 2" in message
     assert adjustments == []
     assert "<@&" not in message
+
+
+def test_finalize_non_real_tag_logs_skip_reason(monkeypatch) -> None:
+    async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.onboarding_sheets.upsert_welcome",
+        lambda *_args, **_kwargs: "updated",
+    )
+
+    async def fake_find_reservations(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return []
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.reservations_sheets.find_active_reservations_for_recruit",
+        fake_find_reservations,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row",
+        lambda _tag: None,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: {"open_spots": 4},
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.get_admin_role_ids", lambda: set()
+    )
+
+    log_messages: list[str] = []
+
+    async def fake_send_log(message: str) -> None:
+        log_messages.append(message)
+
+    monkeypatch.setattr("modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log)
+
+    async def runner() -> None:
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        watcher = WelcomeTicketWatcher(bot)
+        watcher._clan_tags = ["C1CZ", _NO_PLACEMENT_TAG]
+        watcher._clan_tag_set = set(watcher._clan_tags)
+        context = TicketContext(
+            thread_id=1,
+            ticket_number="W7777",
+            username="Tester",
+            recruit_id=12,
+            recruit_display="Tester",
+        )
+        context.state = "awaiting_clan"
+        await watcher._finalize_clan_tag(_DummyThread(), context, "C1CZ", actor=None, source="select", prompt_message=None, view=None)
+        await bot.close()
+
+    asyncio.run(runner())
+    assert log_messages
+    message = log_messages[-1]
+    assert "decision_result=skipped_open_delta" in message
+    assert "skip_reason=non_real_final_tag" in message
+    assert "open_spots" not in message or "open_spots: " not in message
 
 def test_manual_close_missing_row_prompts(monkeypatch, caplog) -> None:
     inserted_rows: list[list[str]] = []


### PR DESCRIPTION
### Motivation
- Improve observability around open-spot adjustments when finalizing clan tags so operators can see whether open-spot deltas were applied or why they were skipped. 
- Surface when welcome-repair alerts do not include open-spot reconciliation to avoid confusion about what was repaired. 

### Description
- Add a new helper ` _decision_visibility_line` to format a single-line visibility record describing `final_tag`, previous final, reservation info, whether `consume_open_spot` was used, whether the final is a real clan, and either the applied `open_deltas` or a `skip_reason` for no-op cases. 
- Integrate decision visibility into welcome flow by tracking `final_is_real` and `decision_open_deltas` and prepending the decision line to `row_change_lines` in `WelcomeTicketWatcher._finalize_clan_tag`. 
- Emit an informational log in `PromoTicketWatcher._finalize_clan_tag` when promo open-spot reconcile is intentionally skipped with reason `no_promo_open_spots_reconcile_currently`. 
- Update onboarding sheets alert text in `shared/sheets/onboarding.py` to rename the alert to "Welcome ticket metadata repair" and include `open_spots_repair=not_performed` in the pending message. 
- Add and update unit tests to assert the new logging and alert text in various welcome/promo scenarios and to validate decision visibility formatting (`tests/onboarding/test_open_spot_visibility_logging.py` plus adjustments to existing onboarding tests). 

### Testing
- Ran onboarding unit tests including the new `tests/onboarding/test_open_spot_visibility_logging.py` and updated assertions in existing tests; all tests passed. 
- Exercised `WelcomeTicketWatcher._finalize_clan_tag` and `PromoTicketWatcher._finalize_clan_tag` behavior in unit tests to verify decision logging and promo skip logging succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c3e0b54c8323823679890b08a029)