### PR TITLE
Fix open_spots delta application to use resolved header column

### DIFF
--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -28,8 +28,10 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
 
     sheet_row, row = entry
     header_map = recruitment.get_clan_header_map()
-    open_index = header_map.get("open_spots", recruitment.FALLBACK_OPEN_SPOTS_INDEX)
-    current = _parse_manual_open_spots(row)
+    open_index = header_map.get("open_spots")
+    if open_index is None:
+        raise ValueError("clan header missing required open_spots column")
+    current = _parse_manual_open_spots(row, open_index=open_index)
     new_value = max(current + delta, 0)
 
     updated_row = list(row)
@@ -117,10 +119,10 @@ async def recompute_clan_availability(
     )
 
 
-def _parse_manual_open_spots(row: Sequence[str]) -> int:
-    if len(row) <= 4:
+def _parse_manual_open_spots(row: Sequence[str], *, open_index: int = 4) -> int:
+    if open_index < 0 or len(row) <= open_index:
         return 0
-    return _to_int(row[4])
+    return _to_int(row[open_index])
 
 
 def _format_reservation_summary(count: int, names: Sequence[str]) -> str:

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -138,3 +138,58 @@ def test_recompute_clan_availability_zero_reservations(monkeypatch):
             {"value_input_option": "RAW"},
         )
     ]
+
+
+def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
+    worksheet = StubWorksheet()
+    row = ["", "Clan", "#CCC", "", "legacy", "", "3"] + [""] * 30
+
+    monkeypatch.setattr(
+        availability.recruitment,
+        "find_clan_row",
+        lambda tag: (12, list(row)),
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {"open_spots": 6},
+    )
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+
+    updated_rows = {}
+    monkeypatch.setattr(
+        availability.recruitment,
+        "update_cached_clan_row",
+        lambda sheet_row, row_values: updated_rows.update(
+            {"sheet_row": sheet_row, "row_values": list(row_values)}
+        ),
+    )
+
+    new_value = asyncio.run(availability.adjust_manual_open_spots("#CCC", -1))
+
+    assert new_value == 2
+    assert worksheet.updates == [("G12", [["2"]], {"value_input_option": "RAW"})]
+    assert updated_rows["sheet_row"] == 12
+    assert updated_rows["row_values"][6] == "2"
+
+
+def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
+    monkeypatch.setattr(
+        availability.recruitment,
+        "find_clan_row",
+        lambda tag: (12, ["", "Clan", "#CCC", "", "3"] + [""] * 30),
+    )
+    monkeypatch.setattr(availability.recruitment, "get_clan_header_map", lambda: {})
+
+    with pytest.raises(ValueError, match="open_spots"):
+        asyncio.run(availability.adjust_manual_open_spots("#CCC", -1))


### PR DESCRIPTION
### Motivation
- Prod observed `decision_result=applied_open_delta` with deltas like `C1CC:-1` but sheet snapshots remained unchanged because the write path used a hardcoded/legacy column instead of the configured header index. 
- The change makes the open-spot adjustment honest about the column it reads/writes so logged before/after snapshots reflect the actual sheet update.

### Description
- `adjust_manual_open_spots` now resolves the `open_spots` column from `recruitment.get_clan_header_map()` and errors if that header is not present, removing the silent fallback; this avoids writing to the wrong column. 
- The manual-parsing helper `_parse_manual_open_spots` was extended to accept an `open_index` so the value is read from the resolved column rather than a hardcoded index. 
- The sheet write uses the resolved column index (converted to A1 label via `_column_label`) so the single-cell update targets the correct cell for the clan row. 
- Added tests `test_adjust_manual_open_spots_applies_delta_to_resolved_column` and `test_adjust_manual_open_spots_requires_open_spots_header` to assert the delta is written to the resolved column and that missing header mapping raises a clear error.

### Testing
- Ran `pytest -q tests/recruitment/test_availability_recompute.py` and all tests in that file passed. 
- Ran the targeted onboarding/visibility subset `pytest -q tests/recruitment/test_availability_recompute.py tests/onboarding/test_welcome_reservations.py -k "open_spots or delta or finalize_clan_math_log"` and the selected tests passed. 
- New tests verify the update payload, cached row update, and the error path when `open_spots` header is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1a3be8e483238244119575abf51d)