### PR TITLE
Support manual_open_spots_seen, rebased AF, and flexible reservation columns

### DIFF
--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -16,40 +16,75 @@ log = logging.getLogger(__name__)
 async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
     """Adjust manual open spots for ``clan_tag`` and return the new value."""
 
-    if delta == 0:
-        entry = recruitment.find_clan_row(clan_tag)
-        if entry is None:
-            raise ValueError(f"Unknown clan tag: {clan_tag}")
-        return _parse_manual_open_spots(entry[1])
-
     entry = recruitment.find_clan_row(clan_tag)
     if entry is None:
         raise ValueError(f"Unknown clan tag: {clan_tag}")
 
     sheet_row, row = entry
     header_map = recruitment.get_clan_header_map()
+    manual_open_index = header_map.get("manual_open_spots")
     open_index = header_map.get("open_spots")
-    if open_index is None:
-        raise ValueError("clan header missing required open_spots column")
-    current = _parse_manual_open_spots(row, open_index=open_index)
-    new_value = max(current + delta, 0)
+    seen_index = header_map.get("manual_open_spots_seen")
+    if manual_open_index is None or open_index is None or seen_index is None:
+        raise ValueError(
+            "clan header missing required manual_open_spots/open_spots/manual_open_spots_seen column"
+        )
+    manual_open = _parse_manual_open_spots(row, open_index=manual_open_index)
+    current_available = _parse_manual_open_spots(row, open_index=open_index)
+    seen_manual_open = _parse_manual_open_spots(row, open_index=seen_index)
+    rebase_manual_open_spots = manual_open != seen_manual_open
+    base_available = manual_open if rebase_manual_open_spots else current_available
+    new_value = max(base_available + delta, 0)
 
     updated_row = list(row)
-    _ensure_row_length(updated_row, open_index + 1)
+    _ensure_row_length(updated_row, max(open_index, seen_index) + 1)
     updated_row[open_index] = str(new_value)
+    updated_row[seen_index] = str(manual_open)
 
     sheet_id = recruitment.get_recruitment_sheet_id()
     tab_name = recruitment.get_clans_tab_name()
     worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
-    column = _column_label(open_index)
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{column}{sheet_row}",
-        [[str(new_value)]],
-        value_input_option="RAW",
-    )
+    open_column = _column_label(open_index)
+    seen_column = _column_label(seen_index)
+    if abs(open_index - seen_index) == 1:
+        first_index = min(open_index, seen_index)
+        second_index = max(open_index, seen_index)
+        first_value = str(new_value) if first_index == open_index else str(manual_open)
+        second_value = str(manual_open) if second_index == seen_index else str(new_value)
+        await async_core.acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(first_index)}{sheet_row}:{_column_label(second_index)}{sheet_row}",
+            [[first_value, second_value]],
+            value_input_option="RAW",
+        )
+    else:
+        await async_core.acall_with_backoff(
+            worksheet.update,
+            f"{open_column}{sheet_row}",
+            [[str(new_value)]],
+            value_input_option="RAW",
+        )
+        await async_core.acall_with_backoff(
+            worksheet.update,
+            f"{seen_column}{sheet_row}",
+            [[str(manual_open)]],
+            value_input_option="RAW",
+        )
 
     recruitment.update_cached_clan_row(sheet_row, updated_row)
+    log.info(
+        "adjusted clan availability",
+        extra={
+            "clan_tag": _normalize_tag(clan_tag),
+            "rebase_manual_open_spots": rebase_manual_open_spots,
+            "open_spots_e_before": manual_open,
+            "af_before": current_available,
+            "af_after": new_value,
+            "aj_before": seen_manual_open,
+            "aj_after": manual_open,
+            "delta": delta,
+        },
+    )
     return new_value
 
 
@@ -66,11 +101,33 @@ async def recompute_clan_availability(
         raise ValueError(f"Unknown clan tag: {clan_tag}")
 
     sheet_row, row = clan_entry
-    manual_open = _parse_manual_open_spots(row)
+    header_map = recruitment.get_clan_header_map()
+    manual_open_index = header_map.get("manual_open_spots")
+    open_index = header_map.get("open_spots")
+    seen_index = header_map.get("manual_open_spots_seen")
+    inactives_index = header_map.get("inactives")
+    reservation_count_index = header_map.get("reservation_count")
+    reservation_summary_index = header_map.get("reservation_summary")
+    if (
+        manual_open_index is None
+        or open_index is None
+        or seen_index is None
+        or inactives_index is None
+        or reservation_count_index is None
+        or reservation_summary_index is None
+    ):
+        raise ValueError(
+            "clan header missing required manual_open_spots/open_spots/manual_open_spots_seen/inactives/reservation_count/reservation_summary column"
+        )
+    manual_open = _parse_manual_open_spots(row, open_index=manual_open_index)
+    current_available = _parse_manual_open_spots(row, open_index=open_index)
+    seen_manual_open = _parse_manual_open_spots(row, open_index=seen_index)
+    rebase_manual_open_spots = manual_open != seen_manual_open
+    base_available = manual_open if rebase_manual_open_spots else current_available
 
     active_reservations = await reservations.get_active_reservations_for_clan(clan_tag)
     reservation_count = len(active_reservations)
-    available_after_reservations = max(manual_open - reservation_count, 0)
+    available_after_reservations = max(base_available - reservation_count, 0)
 
     names = await reservations.resolve_reservation_names(
         active_reservations,
@@ -80,29 +137,56 @@ async def recompute_clan_availability(
     reservation_summary = _format_reservation_summary(reservation_count, names)
 
     updated_row = list(row)
-    _ensure_row_length(updated_row, 35)
+    _ensure_row_length(
+        updated_row,
+        max(
+            open_index,
+            seen_index,
+            inactives_index,
+            reservation_count_index,
+            reservation_summary_index,
+        )
+        + 1,
+    )
 
-    ag_value = updated_row[32] if len(updated_row) > 32 else ""
-    updated_row[31] = str(available_after_reservations)
-    updated_row[33] = str(reservation_count)
-    updated_row[34] = reservation_summary
+    inactives_value = updated_row[inactives_index] if len(updated_row) > inactives_index else ""
+    updated_row[open_index] = str(available_after_reservations)
+    updated_row[seen_index] = str(manual_open)
+    updated_row[reservation_count_index] = str(reservation_count)
+    updated_row[reservation_summary_index] = reservation_summary
 
     sheet_id = recruitment.get_recruitment_sheet_id()
     tab_name = recruitment.get_clans_tab_name()
     worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
 
-    payload = [
-        [
-            available_after_reservations,
-            ag_value,
-            reservation_count,
-            reservation_summary,
-        ]
-    ]
     await async_core.acall_with_backoff(
         worksheet.update,
-        f"AF{sheet_row}:AI{sheet_row}",
-        payload,
+        f"{_column_label(open_index)}{sheet_row}",
+        [[available_after_reservations]],
+        value_input_option="RAW",
+    )
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(seen_index)}{sheet_row}",
+        [[manual_open]],
+        value_input_option="RAW",
+    )
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(inactives_index)}{sheet_row}",
+        [[inactives_value]],
+        value_input_option="RAW",
+    )
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(reservation_count_index)}{sheet_row}",
+        [[reservation_count]],
+        value_input_option="RAW",
+    )
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(reservation_summary_index)}{sheet_row}",
+        [[reservation_summary]],
         value_input_option="RAW",
     )
 
@@ -113,8 +197,12 @@ async def recompute_clan_availability(
         extra={
             "clan_tag": _normalize_tag(clan_tag),
             "manual_open": manual_open,
+            "rebase_manual_open_spots": rebase_manual_open_spots,
+            "af_before": current_available,
             "active_reservations": reservation_count,
             "available_after_reservations": available_after_reservations,
+            "aj_before": seen_manual_open,
+            "aj_after": manual_open,
         },
     )
 

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -68,6 +68,17 @@ def _column_aliases(*aliases: str) -> tuple[str, ...]:
 
 
 HEADER_MAP: Dict[str, tuple[str, ...]] = {
+    "manual_open_spots": _column_aliases(
+        "manual open spots",
+        "manual_open_spots",
+        "open spots manual",
+        "manual baseline open spots",
+    ),
+    "manual_open_spots_seen": _column_aliases(
+        "manual_open_spots_seen",
+        "manual open spots seen",
+        "manual open seen",
+    ),
     "cb": _column_aliases("cb", "clan boss", "clanboss"),
     "hydra": _column_aliases("hydra", "hydra difficulty"),
     "chimera": _column_aliases("chimera", "chimera difficulty"),
@@ -99,6 +110,18 @@ HEADER_MAP: Dict[str, tuple[str, ...]] = {
         "reserved count",
         "reserved spots",
         "manual reserved",
+    ),
+    "reservation_count": _column_aliases(
+        "reservation count",
+        "reservations count",
+        "reserved count",
+        "active reservations",
+    ),
+    "reservation_summary": _column_aliases(
+        "reservation summary",
+        "reservations summary",
+        "reserved summary",
+        "reservation details",
     ),
     "roster": _column_aliases(
         "roster",

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -61,6 +61,18 @@ def test_recompute_clan_availability_updates_sheet(monkeypatch):
 
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 31,
+            "manual_open_spots_seen": 35,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+        },
+    )
     async def fake_aget(sheet_id: str, tab_name: str):
         assert sheet_id == "sheet"
         assert tab_name == "bot_info"
@@ -83,16 +95,17 @@ def test_recompute_clan_availability_updates_sheet(monkeypatch):
     asyncio.run(availability.recompute_clan_availability("#AAA"))
 
     assert worksheet.updates == [
-        (
-            "AF7:AI7",
-            [[2, "", 1, "1 -> Alice"]],
-            {"value_input_option": "RAW"},
-        )
+        ("AF7", [[2]], {"value_input_option": "RAW"}),
+        ("AJ7", [[3]], {"value_input_option": "RAW"}),
+        ("AG7", [[""]], {"value_input_option": "RAW"}),
+        ("AH7", [[1]], {"value_input_option": "RAW"}),
+        ("AI7", [["1 -> Alice"]], {"value_input_option": "RAW"}),
     ]
     assert updated_rows["sheet_row"] == 7
     assert updated_rows["row"][31] == "2"
     assert updated_rows["row"][33] == "1"
     assert updated_rows["row"][34] == "1 -> Alice"
+    assert updated_rows["row"][35] == "3"
 
 
 def test_recompute_clan_availability_zero_reservations(monkeypatch):
@@ -117,6 +130,18 @@ def test_recompute_clan_availability_zero_reservations(monkeypatch):
     )
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 31,
+            "manual_open_spots_seen": 35,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+        },
+    )
 
     async def fake_aget(sheet_id: str, tab_name: str):
         return worksheet
@@ -132,17 +157,196 @@ def test_recompute_clan_availability_zero_reservations(monkeypatch):
     asyncio.run(availability.recompute_clan_availability("#BBB"))
 
     assert worksheet.updates == [
-        (
-            "AF9:AI9",
-            [[5, "", 0, ""]],
-            {"value_input_option": "RAW"},
-        )
+        ("AF9", [[5]], {"value_input_option": "RAW"}),
+        ("AJ9", [[5]], {"value_input_option": "RAW"}),
+        ("AG9", [[""]], {"value_input_option": "RAW"}),
+        ("AH9", [[0]], {"value_input_option": "RAW"}),
+        ("AI9", [[""]], {"value_input_option": "RAW"}),
     ]
+
+
+def test_recompute_clan_availability_uses_reordered_reservation_columns(monkeypatch):
+    worksheet = StubWorksheet()
+
+    async def fake_get_active_reservations(clan_tag: str):
+        return [
+            reservations.ReservationRow(
+                row_number=2,
+                thread_id="t1",
+                ticket_user_id=1,
+                recruiter_id=123,
+                clan_tag=clan_tag,
+                reserved_until=None,
+                created_at=None,
+                status="active",
+                notes="",
+                username_snapshot="Alice",
+                raw=[],
+            )
+        ]
+
+    async def fake_resolve_names(_rows, *, guild=None, resolver=None):
+        return ["Alice"]
+
+    monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
+    monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
+    row = ["", "Clan", "#EEE", "", "4"] + [""] * 40
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (11, list(row)))
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 20,
+            "manual_open_spots_seen": 41,
+            "inactives": 32,
+            "reservation_count": 36,
+            "reservation_summary": 25,
+        },
+    )
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+    monkeypatch.setattr(availability.recruitment, "update_cached_clan_row", lambda *args, **kwargs: None)
+
+    asyncio.run(availability.recompute_clan_availability("#EEE"))
+
+    assert worksheet.updates == [
+        ("U11", [[3]], {"value_input_option": "RAW"}),
+        ("AP11", [[4]], {"value_input_option": "RAW"}),
+        ("AG11", [[""]], {"value_input_option": "RAW"}),
+        ("AK11", [[1]], {"value_input_option": "RAW"}),
+        ("Z11", [["1 -> Alice"]], {"value_input_option": "RAW"}),
+    ]
+
+
+def test_recompute_clan_availability_requires_reservation_headers(monkeypatch):
+    monkeypatch.setattr(
+        availability.recruitment,
+        "find_clan_row",
+        lambda tag: (10, ["", "Clan", "#AAA", "", "2"] + [""] * 40),
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {"manual_open_spots": 4, "open_spots": 31, "inactives": 32, "manual_open_spots_seen": 35},
+    )
+
+    with pytest.raises(ValueError, match="reservation_count/reservation_summary"):
+        asyncio.run(availability.recompute_clan_availability("#AAA"))
+
+
+def test_recompute_clan_availability_keeps_runtime_af_when_manual_seen_matches(monkeypatch):
+    worksheet = StubWorksheet()
+
+    async def fake_get_active_reservations(clan_tag: str):
+        return []
+
+    async def fake_resolve_names(_rows, *, guild=None, resolver=None):
+        return []
+
+    monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
+    monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
+    row = ["", "Clan", "#AAA", "", "3"] + [""] * 26 + ["2", "", "", "", "3"] + [""] * 4
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (12, list(row)))
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 31,
+            "manual_open_spots_seen": 35,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+        },
+    )
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+    captured = {}
+    monkeypatch.setattr(
+        availability.recruitment,
+        "update_cached_clan_row",
+        lambda sheet_row, row_values: captured.update({"sheet_row": sheet_row, "row_values": list(row_values)}),
+    )
+
+    asyncio.run(availability.recompute_clan_availability("#AAA"))
+    assert worksheet.updates[0] == ("AF12", [[2]], {"value_input_option": "RAW"})
+    assert worksheet.updates[1] == ("AJ12", [[3]], {"value_input_option": "RAW"})
+    assert captured["row_values"][31] == "2"
+    assert captured["row_values"][35] == "3"
+
+
+def test_recompute_clan_availability_rebases_runtime_af_when_manual_changes(monkeypatch):
+    worksheet = StubWorksheet()
+
+    async def fake_get_active_reservations(clan_tag: str):
+        return []
+
+    async def fake_resolve_names(_rows, *, guild=None, resolver=None):
+        return []
+
+    monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
+    monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
+    row = ["", "Clan", "#AAA", "", "4"] + [""] * 26 + ["2", "", "", "", "3"] + [""] * 4
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (13, list(row)))
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 31,
+            "manual_open_spots_seen": 35,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+        },
+    )
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+    captured = {}
+    monkeypatch.setattr(
+        availability.recruitment,
+        "update_cached_clan_row",
+        lambda sheet_row, row_values: captured.update({"sheet_row": sheet_row, "row_values": list(row_values)}),
+    )
+
+    asyncio.run(availability.recompute_clan_availability("#AAA"))
+    assert worksheet.updates[0] == ("AF13", [[4]], {"value_input_option": "RAW"})
+    assert worksheet.updates[1] == ("AJ13", [[4]], {"value_input_option": "RAW"})
+    assert captured["row_values"][31] == "4"
+    assert captured["row_values"][35] == "4"
 
 
 def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
     worksheet = StubWorksheet()
-    row = ["", "Clan", "#CCC", "", "legacy", "", "3"] + [""] * 30
+    row = ["", "Clan", "#CCC", "", "3"] + [""] * 15 + ["3"] + [""] * 15 + ["3"]
 
     monkeypatch.setattr(
         availability.recruitment,
@@ -152,7 +356,7 @@ def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "get_clan_header_map",
-        lambda: {"open_spots": 6},
+        lambda: {"manual_open_spots": 4, "open_spots": 20, "manual_open_spots_seen": 36},
     )
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
@@ -178,9 +382,13 @@ def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
     new_value = asyncio.run(availability.adjust_manual_open_spots("#CCC", -1))
 
     assert new_value == 2
-    assert worksheet.updates == [("G12", [["2"]], {"value_input_option": "RAW"})]
+    assert worksheet.updates == [
+        ("U12", [["2"]], {"value_input_option": "RAW"}),
+        ("AK12", [["3"]], {"value_input_option": "RAW"}),
+    ]
     assert updated_rows["sheet_row"] == 12
-    assert updated_rows["row_values"][6] == "2"
+    assert updated_rows["row_values"][20] == "2"
+    assert updated_rows["row_values"][36] == "3"
 
 
 def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
@@ -189,7 +397,64 @@ def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
         "find_clan_row",
         lambda tag: (12, ["", "Clan", "#CCC", "", "3"] + [""] * 30),
     )
-    monkeypatch.setattr(availability.recruitment, "get_clan_header_map", lambda: {})
+    monkeypatch.setattr(availability.recruitment, "get_clan_header_map", lambda: {"manual_open_spots": 4, "open_spots": 20})
 
-    with pytest.raises(ValueError, match="open_spots"):
+    with pytest.raises(ValueError, match="manual_open_spots_seen"):
         asyncio.run(availability.adjust_manual_open_spots("#CCC", -1))
+
+
+def test_adjust_manual_open_spots_rebases_when_manual_changes(monkeypatch):
+    worksheet = StubWorksheet()
+    row = ["", "Clan", "#DDD", "", "4"] + [""] * 15 + ["2"] + [""] * 16 + ["3"]
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (15, list(row)))
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {"manual_open_spots": 4, "open_spots": 20, "manual_open_spots_seen": 36},
+    )
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+    monkeypatch.setattr(availability.recruitment, "update_cached_clan_row", lambda *args, **kwargs: None)
+
+    new_value = asyncio.run(availability.adjust_manual_open_spots("#DDD", -1))
+    assert new_value == 3
+    assert worksheet.updates == [
+        ("U15", [["3"]], {"value_input_option": "RAW"}),
+        ("AK15", [["4"]], {"value_input_option": "RAW"}),
+    ]
+
+
+def test_adjust_manual_open_spots_rebase_without_delta(monkeypatch):
+    worksheet = StubWorksheet()
+    row = ["", "Clan", "#DDD", "", "4"] + [""] * 15 + ["2"] + [""] * 16 + ["3"]
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (15, list(row)))
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clan_header_map",
+        lambda: {"manual_open_spots": 4, "open_spots": 20, "manual_open_spots_seen": 36},
+    )
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+    monkeypatch.setattr(availability.recruitment, "update_cached_clan_row", lambda *args, **kwargs: None)
+
+    new_value = asyncio.run(availability.adjust_manual_open_spots("#DDD", 0))
+    assert new_value == 4
+    assert worksheet.updates == [
+        ("U15", [["4"]], {"value_input_option": "RAW"}),
+        ("AK15", [["4"]], {"value_input_option": "RAW"}),
+    ]


### PR DESCRIPTION
### Motivation
- Make availability calculations robust to reordered/renamed sheet columns and support an explicit `manual_open_spots_seen` column. 
- Ensure runtime available spots (AF) are rebased when a user edits the manual baseline and preserve existing runtime AF when the baseline hasn't changed.
- Emit more precise sheet updates and logging when updating multiple related columns.

### Description
- Switch `adjust_manual_open_spots` and `recompute_clan_availability` to use `get_clan_header_map()` and look up header indices for `manual_open_spots`, `open_spots`, `manual_open_spots_seen`, `inactives`, `reservation_count`, and `reservation_summary` instead of hard-coded column indices. 
- Add `manual_open_spots_seen` handling and compute `rebase_manual_open_spots` to decide whether to rebase runtime AF from the manual baseline or keep the current runtime AF.
- Update sheet-write logic to update individual columns (and batch two adjacent columns when possible) using `_column_label` and `async_core.acall_with_backoff`, and ensure `updated_row` length covers dynamic columns.
- Add logging of availability adjustments including rebase metadata and normalized `clan_tag`.
- Extend `HEADER_MAP` in `shared/sheets/recruitment.py` with aliases for `manual_open_spots`, `manual_open_spots_seen`, `reservation_count`, and `reservation_summary`.
- Update and add unit tests in `tests/recruitment/test_availability_recompute.py` to cover reordered reservation columns, header requirements, rebase behavior, and adjusted sheet update expectations.

### Testing
- Ran unit tests in `tests/recruitment/test_availability_recompute.py`, including `test_recompute_clan_availability_updates_sheet`, `test_recompute_clan_availability_zero_reservations`, `test_recompute_clan_availability_uses_reordered_reservation_columns`, `test_recompute_clan_availability_requires_reservation_headers`, `test_recompute_clan_availability_keeps_runtime_af_when_manual_seen_matches`, `test_recompute_clan_availability_rebases_runtime_af_when_manual_changes`, `test_adjust_manual_open_spots_applies_delta_to_resolved_column`, `test_adjust_manual_open_spots_requires_open_spots_header`, `test_adjust_manual_open_spots_rebases_when_manual_changes`, and `test_adjust_manual_open_spots_rebase_without_delta`. 
- All updated and new tests executed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1e15a6dc8323a0c18d7363914bca)