### PR TITLE
Await preload, dedupe startup summary, and include cache preload details in summary

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,6 +68,7 @@ bot.remove_command("help")
 runtime: Runtime
 _shutdown_lock: asyncio.Lock | None = None
 _shutdown_started = False
+_startup_summary_lock: asyncio.Lock | None = None
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -302,18 +303,31 @@ async def on_ready():
             log.info("[cron] summary scheduler started (00:05Z)")
 
         await keepalive.ensure_started(bot)
-        runtime.schedule_startup_preload()
     except Exception:
         log.warning("non-critical ready task failed", exc_info=True)
 
     try:
-        summary = render_startup_summary(
-            bot_client=bot,
-            runtime=runtime,
-            jobs=runtime.scheduler.jobs,
-        )
-        await runtime.send_log_message(summary)
+        preload_task = runtime.schedule_startup_preload(bot)
+        await preload_task
     except Exception:
+        log.warning("startup preload task failed before summary render", exc_info=True)
+
+    global _startup_summary_lock
+    if _startup_summary_lock is None:
+        _startup_summary_lock = asyncio.Lock()
+    try:
+        async with _startup_summary_lock:
+            if getattr(bot, "_startup_summary_sent", False):
+                return
+            bot._startup_summary_sent = True
+            summary = render_startup_summary(
+                bot_client=bot,
+                runtime=runtime,
+                jobs=runtime.scheduler.jobs,
+            )
+            await runtime.send_log_message(summary)
+    except Exception:
+        bot._startup_summary_sent = False
         log.exception("startup summary failed", exc_info=True)
 
 

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -267,6 +267,25 @@ async def _startup_preload(bot: commands.Bot | None = None) -> None:
         log.info("Cache preloader completed with no rows")
         return
 
+    startup_rows: list[dict[str, object]] = []
+    for result in refresh_results:
+        snap = result.snapshot
+        state_raw = (snap.last_result or ("ok" if result.ok else "failed")).strip().lower()
+        state = "ok" if state_raw in {"ok", "success", "retry_ok"} else ("failed" if "fail" in state_raw or "error" in state_raw else state_raw)
+        marker = "stale" if snap.ttl_expired else "ttl"
+        startup_rows.append(
+            {
+                "name": result.name,
+                "state": state,
+                "duration_s": (result.duration_ms or 0) / 1000.0,
+                "count": snap.item_count,
+                "marker": marker,
+            }
+        )
+    if bot is not None:
+        setattr(bot, "_startup_refresh_rows", startup_rows)
+        setattr(bot, "_startup_refresh_total_s", total_ms / 1000.0)
+
     log.info("Cache preloader completed")
 
 
@@ -283,13 +302,13 @@ def get_active_runtime() -> "Runtime | None":
     return _ACTIVE_RUNTIME
 
 
-def schedule_startup_preload(bot: commands.Bot | None = None) -> None:
-    """Ensure the startup cache preload task has been scheduled."""
+def schedule_startup_preload(bot: commands.Bot | None = None) -> asyncio.Task[None]:
+    """Ensure the startup cache preload task has been scheduled and return it."""
 
     global _PRELOAD_TASK
     task = _PRELOAD_TASK
     if task is not None and not task.done():
-        return
+        return task
     if task is not None and task.done():
         try:  # pragma: no cover - defensive logging
             task.result()
@@ -298,6 +317,7 @@ def schedule_startup_preload(bot: commands.Bot | None = None) -> None:
     _PRELOAD_TASK = asyncio.create_task(
         _startup_preload(bot), name="cache_startup_preload"
     )
+    return _PRELOAD_TASK
 
 
 async def send_log_message(message: str) -> None:
@@ -1058,8 +1078,8 @@ class Runtime:
         except Exception:
             log.warning("failed to send log message (non-fatal)", exc_info=True)
 
-    def schedule_startup_preload(self) -> None:
-        schedule_startup_preload(self.bot)
+    def schedule_startup_preload(self) -> asyncio.Task[None]:
+        return schedule_startup_preload(self.bot)
 
     def watchdog(
         self,

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -1148,23 +1148,7 @@ class PromoTicketWatcher(commands.Cog):
             channel_id=channel_id_int,
             triggers=len(_PROMO_TRIGGER_MAP),
         )
-        trigger_lines = [f"• {label}" for label in _PROMO_TRIGGER_LABELS.values()]
-        message = "\n".join(
-            [
-                "✅ Promo watcher",
-                "",
-                "Status:",
-                "• enabled",
-                "",
-                "Channel:",
-                f"• <#{channel_id_int}>",
-                f"• path: {label}",
-                "",
-                "Triggers:",
-                *trigger_lines,
-            ]
-        )
-        asyncio.create_task(_send_runtime(message))
+        # Startup watcher status is included in the global startup summary.
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/modules/ops/startup_summary.py
+++ b/modules/ops/startup_summary.py
@@ -9,13 +9,11 @@ from discord.ext import commands
 
 from modules.common.runtime import Runtime
 from modules.onboarding.watcher_welcome import _channel_readable_label
-from shared.cache import telemetry as cache_telemetry
 from shared.config import get_promo_channel_id, get_welcome_channel_id
 from modules.common import feature_flags
 
 log = logging.getLogger("c1c.ops.startup_summary")
 
-_CACHE_BUCKETS = ["clan_tags", "clans", "fusion", "fusion_events", "leagues", "onboarding_questions", "reaction_roles", "templates"]
 _SCHEDULER_MAP = {
     "clans": "cache_refresh:clans",
     "templates": "cache_refresh:templates",
@@ -87,16 +85,17 @@ def render_startup_summary(*, bot_client: commands.Bot, runtime: Runtime, jobs: 
 
     try:
         cache_lines=["Cache"]
-        for bucket in _CACHE_BUCKETS:
-            try:
-                snap = cache_telemetry.get_snapshot(bucket)
-                raw = str((getattr(snap,'last_result',None) or 'pending')).lower()
-                status = raw if raw in {'ok','pending','stale','error'} else ('ok' if raw in {'success','retry_ok'} else 'pending')
-                count = getattr(snap,'item_count',None)
-                cache_lines.append(f"• {bucket}: {status} ({count if count is not None else '?'})")
-            except Exception:
-                log.exception('startup summary cache item unavailable', extra={'bucket':bucket})
-                cache_lines.append(f"• {bucket}: pending (?)")
+        startup_rows = getattr(bot_client, "_startup_refresh_rows", None)
+        startup_total = getattr(bot_client, "_startup_refresh_total_s", None)
+        if isinstance(startup_rows, list) and startup_rows:
+            for row in startup_rows:
+                cache_lines.append(
+                    f"• {row.get('name', '?')} {row.get('state', '?')} ({row.get('duration_s', 0):.1f}s, {row.get('count', '?')}, {row.get('marker', '?')})"
+                )
+            if isinstance(startup_total, (int, float)):
+                cache_lines.append(f"• total={startup_total:.1f}s")
+        else:
+            cache_lines.append("• cache refresh details unavailable")
         lines.extend(["",*cache_lines])
     except Exception:
         log.exception('startup summary cache section unavailable')


### PR DESCRIPTION
### Motivation

- Prevent duplicate startup summaries and ensure cache preload completes before the summary is rendered. 
- Surface cache preload results in the global startup summary rather than sending separate messages for individual watchers. 
- Make `schedule_startup_preload` return the background task so callers can await it. 

### Description

- Added a global `_startup_summary_lock` and guarded startup summary rendering in `app.py` to ensure only one summary is sent and to track `bot._startup_summary_sent`. 
- Changed startup flow to call and `await` the preload task returned by `runtime.schedule_startup_preload(bot)` before rendering the summary in `app.py`. 
- Modified the cache preloader in `modules/common/runtime.py` to collect `startup_rows` and total duration and attach them to the `bot` as `_startup_refresh_rows` and `_startup_refresh_total_s`. 
- Updated `schedule_startup_preload` to return the created `asyncio.Task` and updated `Runtime.schedule_startup_preload` to return that task. 
- Updated the startup summary renderer in `modules/ops/startup_summary.py` to read cache preload details from `bot_client._startup_refresh_rows` and `bot_client._startup_refresh_total_s` instead of using the removed telemetry path. 
- Removed the separate promo watcher startup message send in `modules/onboarding/watcher_promo.py` because watcher status is now included in the consolidated startup summary. 

### Testing

- Ran the test suite with `pytest` and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7dc6d03c8323b22af40be001f741)