### PR TITLE
Require fresh clans cache for placement math, force sheet reads, and improve clan-math column handling

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -37,6 +37,7 @@ from modules.onboarding.sheet_logging import log_sheet_write
 from modules.onboarding.ui import panels
 from shared.config import get_promo_channel_id, get_ticket_tool_bot_id
 from shared.logs import log_lifecycle
+from shared.cache import telemetry as cache_telemetry
 from shared.sheets import onboarding as onboarding_sheets
 from shared.sheets import onboarding_sessions
 from shared.sheets import promo_tickets
@@ -56,6 +57,22 @@ _PROMO_TRIGGER_LABELS: Dict[str, str] = {
     "promo.m": "Player move request",
     "promo.l": "Clan lead move request",
 }
+
+
+async def _ensure_fresh_clans_for_placement(*, actor: str, ticket: str, user: str) -> bool:
+    try:
+        await cache_telemetry.refresh_now("clans", actor=actor)
+    except Exception:
+        log.exception("promo reconcile: failed to refresh clans cache", extra={"ticket": ticket, "user": user})
+        return False
+    snapshot = cache_telemetry.get_snapshot("clans")
+    if (not snapshot.available) or snapshot.last_result not in {"ok", "retry_ok"}:
+        log.warning(
+            "promo reconcile: clans data not fresh; skipping seat math",
+            extra={"ticket": ticket, "user": user, "last_result": snapshot.last_result, "last_error": snapshot.last_error},
+        )
+        return False
+    return True
 
 
 async def _send_runtime(message: str) -> None:
@@ -653,8 +670,31 @@ class PromoTicketWatcher(commands.Cog):
                 )
             return
 
+        normalized_previous = (previous_final or "").strip().upper()
+        normalized_final = (context.clan_tag or "").strip().upper()
+        clans_fresh = await _ensure_fresh_clans_for_placement(
+            actor="promo_placement", ticket=context.ticket_number, user=context.username
+        )
+        if not clans_fresh:
+            decision_line = (
+                "decision: "
+                f"final_tag={normalized_final or '-'} • previous_final={normalized_previous or '-'} • "
+                "reservation=not_applicable • consume_open_spot=False • final_is_real=False • "
+                "decision_result=skipped_open_delta • skip_reason=fresh_clans_unavailable"
+            )
+            log.warning(
+                "promo_open_spots_reconcile — ticket=%s • user=%s • clan=%s • source=%s • %s",
+                context.ticket_number,
+                context.username,
+                context.clan_tag or "-",
+                source,
+                decision_line,
+            )
+            return
         try:
-            final_entry = await asyncio.to_thread(recruitment_sheets.find_clan_row, context.clan_tag)
+            final_entry = await asyncio.to_thread(
+                recruitment_sheets.find_clan_row, context.clan_tag, force=True
+            )
             final_is_real = final_entry is not None
         except Exception:
             log.exception(
@@ -662,9 +702,6 @@ class PromoTicketWatcher(commands.Cog):
                 extra={"ticket": context.ticket_number, "clan_tag": context.clan_tag},
             )
             final_is_real = False
-
-        normalized_previous = (previous_final or "").strip().upper()
-        normalized_final = (context.clan_tag or "").strip().upper()
         consume_open_spot = bool(
             normalized_final
             and normalized_final != _NO_PLACEMENT_TAG

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -47,6 +47,7 @@ from shared.sheets import welcome_tickets
 from shared.sheets import reservations as reservations_sheets
 from shared.sheets import recruitment as recruitment_sheets
 from shared.sheets.cache_service import cache as sheets_cache
+from shared.cache import telemetry as cache_telemetry
 
 log = logging.getLogger("c1c.onboarding.welcome_watcher")
 
@@ -82,6 +83,32 @@ _PROMO_TYPE_MAP = {
     "M": "player move request",
     "L": "clan lead move request",
 }
+
+
+async def _ensure_fresh_clans_for_placement(*, actor: str, ticket: str, user: str) -> bool:
+    """Require a sync-fresh clans bucket before placement seat math."""
+    try:
+        await cache_telemetry.refresh_now("clans", actor=actor)
+    except Exception:
+        log.exception(
+            "failed to refresh clans cache for placement",
+            extra={"ticket": ticket, "user": user, "actor": actor},
+        )
+        return False
+    snapshot = cache_telemetry.get_snapshot("clans")
+    if (not snapshot.available) or snapshot.last_result not in {"ok", "retry_ok"}:
+        log.warning(
+            "placement blocked due to unavailable/failed clans cache refresh",
+            extra={
+                "ticket": ticket,
+                "user": user,
+                "actor": actor,
+                "last_result": snapshot.last_result,
+                "last_error": snapshot.last_error,
+            },
+        )
+        return False
+    return True
 
 
 
@@ -1497,28 +1524,36 @@ def _normalize_clan_math_targets(tags: set[str]) -> OrderedDict[str, str]:
 
 def _clan_math_column_indices() -> Dict[str, int]:
     header_map = recruitment_sheets.get_clan_header_map()
-    open_index = header_map.get(
-        "open_spots", recruitment_sheets.FALLBACK_OPEN_SPOTS_INDEX
-    )
+    required = ("open_spots", "inactives", "reservation_count", "reservation_summary")
+    missing = [key for key in required if header_map.get(key) is None]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise ValueError(f"clan header missing required columns for logging: {missing_text}")
+    open_index = int(header_map["open_spots"])
+    inactives_index = int(header_map["inactives"])
+    reservation_count_index = int(header_map["reservation_count"])
+    reservation_summary_index = int(header_map["reservation_summary"])
     return {
         "open_spots": open_index,
-        "AF": 31,
-        "AG": 32,
-        "AH": 33,
-        "AI": 34,
+        "AF": open_index,
+        "AG": inactives_index,
+        "AH": reservation_count_index,
+        "AI": reservation_summary_index,
     }
 
 
 def _capture_clan_snapshots(
     targets: "OrderedDict[str, str]",
     column_map: Dict[str, int],
+    *,
+    force: bool = False,
 ) -> Dict[str, _ClanMathRowSnapshot]:
     snapshots: Dict[str, _ClanMathRowSnapshot] = {}
     for key, tag in targets.items():
         if not key:
             continue
         try:
-            entry = recruitment_sheets.find_clan_row(tag)
+            entry = recruitment_sheets.find_clan_row(tag, force=force)
         except Exception:
             log.exception(
                 "failed to capture clan row for logging",
@@ -3409,24 +3444,44 @@ class WelcomeTicketWatcher(commands.Cog):
         delta_failure_reason: str | None = None
 
         if not row_missing:
-            final_entry = (
-                recruitment_sheets.find_clan_row(final_tag)
-                if final_tag != _NO_PLACEMENT_TAG
-                else None
+            matches: List[reservations_sheets.ReservationRow] = []
+            clans_fresh = await _ensure_fresh_clans_for_placement(
+                actor="welcome_placement", ticket=context.ticket_number, user=context.username
             )
-            final_is_real = final_entry is not None
-
-            try:
-                matches = await reservations_sheets.find_active_reservations_for_recruit(
-                    context.recruit_id,
-                    context.recruit_display or context.username,
+            if not clans_fresh:
+                actions_ok = False
+                decision_line = (
+                    "decision: "
+                    f"final_tag={final_tag or '-'} • previous_final={(previous_final or '').strip().upper() or '-'} • "
+                    f"reservation={reservation_label or 'none'} • consume_open_spot={consume_open_spot} • "
+                    "final_is_real=False • decision_result=skipped_open_delta • "
+                    "skip_reason=fresh_clans_unavailable"
                 )
-            except Exception:
-                matches = []
-                log.exception(
-                    "failed to look up reservations for recruit",
+                row_change_lines = [decision_line]
+                log.warning(
+                    "welcome placement skipped seat math due to stale/unavailable clans data",
                     extra={"ticket": context.ticket_number, "user": context.username},
                 )
+                final_is_real = False
+            else:
+                final_entry = (
+                    recruitment_sheets.find_clan_row(final_tag, force=True)
+                    if final_tag != _NO_PLACEMENT_TAG
+                    else None
+                )
+                final_is_real = final_entry is not None
+
+                try:
+                    matches = await reservations_sheets.find_active_reservations_for_recruit(
+                        context.recruit_id,
+                        context.recruit_display or context.username,
+                    )
+                except Exception:
+                    matches = []
+                    log.exception(
+                        "failed to look up reservations for recruit",
+                        extra={"ticket": context.ticket_number, "user": context.username},
+                    )
             if matches:
                 reservation_row = matches[0]
                 if len(matches) > 1:
@@ -3439,37 +3494,40 @@ class WelcomeTicketWatcher(commands.Cog):
                         },
                     )
 
-            decision = _determine_reservation_decision(
-                final_tag,
-                reservation_row,
-                no_placement_tag=_NO_PLACEMENT_TAG,
-                final_is_real=final_is_real,
-                consume_open_spot=consume_open_spot,
-                previous_final=previous_final,
-            )
-            reservation_label = decision.label
-            decision_open_deltas = dict(decision.open_deltas)
+            if clans_fresh:
+                decision = _determine_reservation_decision(
+                    final_tag,
+                    reservation_row,
+                    no_placement_tag=_NO_PLACEMENT_TAG,
+                    final_is_real=final_is_real,
+                    consume_open_spot=consume_open_spot,
+                    previous_final=previous_final,
+                )
+                reservation_label = decision.label
+                decision_open_deltas = dict(decision.open_deltas)
 
-            target_tags = _clan_tags_for_logging(
-                final_tag,
-                decision,
-                no_placement_tag=_NO_PLACEMENT_TAG,
-                final_is_real=final_is_real,
-            )
-            if target_tags:
-                row_targets = _normalize_clan_math_targets(target_tags)
-                try:
-                    column_map = _clan_math_column_indices()
-                    before_snapshots = _capture_clan_snapshots(row_targets, column_map)
-                except Exception:
-                    column_map = None
-                    row_targets = OrderedDict()
-                    log.exception(
-                        "failed to capture clan math before-state",
-                        extra={"ticket": context.ticket_number},
-                    )
+                target_tags = _clan_tags_for_logging(
+                    final_tag,
+                    decision,
+                    no_placement_tag=_NO_PLACEMENT_TAG,
+                    final_is_real=final_is_real,
+                )
+                if target_tags:
+                    row_targets = _normalize_clan_math_targets(target_tags)
+                    try:
+                        column_map = _clan_math_column_indices()
+                        before_snapshots = _capture_clan_snapshots(
+                            row_targets, column_map, force=True
+                        )
+                    except Exception:
+                        column_map = None
+                        row_targets = OrderedDict()
+                        log.exception(
+                            "failed to capture clan math before-state",
+                            extra={"ticket": context.ticket_number},
+                        )
 
-            if reservation_row is not None and decision.status:
+            if clans_fresh and reservation_row is not None and decision.status:
                 try:
                     await reservations_sheets.update_reservation_status(
                         reservation_row.row_number, decision.status
@@ -3485,7 +3543,7 @@ class WelcomeTicketWatcher(commands.Cog):
                         },
                     )
 
-            for tag, delta in decision.open_deltas.items():
+            for tag, delta in (decision.open_deltas.items() if clans_fresh else ()):
                 try:
                     await availability.adjust_manual_open_spots(tag, delta)
                     applied_open_deltas[tag] = applied_open_deltas.get(tag, 0) + delta
@@ -3497,7 +3555,7 @@ class WelcomeTicketWatcher(commands.Cog):
                         extra={"clan_tag": tag, "delta": delta, "ticket": context.ticket_number},
                     )
 
-            recompute_tags = decision.recompute_tags
+            recompute_tags = decision.recompute_tags if clans_fresh else []
             for tag in recompute_tags:
                 try:
                     await availability.recompute_clan_availability(tag, guild=thread.guild)
@@ -3509,7 +3567,9 @@ class WelcomeTicketWatcher(commands.Cog):
                     )
 
             if row_targets and column_map is not None:
-                after_snapshots = _capture_clan_snapshots(row_targets, column_map)
+                after_snapshots = _capture_clan_snapshots(
+                    row_targets, column_map, force=True
+                )
                 row_change_lines = _build_clan_math_row_lines(
                     row_targets, before_snapshots, after_snapshots
                 )

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -17,7 +17,7 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
     """Adjust manual open spots for ``clan_tag`` and return the new value."""
     try:
         log.info("adjust_manual_open_spots:start clan_tag=%s delta=%s", clan_tag, delta)
-        entry = recruitment.find_clan_row(clan_tag)
+        entry = recruitment.find_clan_row(clan_tag, force=True)
         if entry is None:
             raise ValueError(f"Unknown clan tag: {clan_tag}")
 
@@ -97,7 +97,7 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
 
         cache_result = recruitment.update_cached_clan_row(sheet_row, updated_row)
         log.info("adjust_manual_open_spots:cache_update_result clan_tag=%s result=%r", clan_tag, cache_result)
-        refreshed = recruitment.find_clan_row(clan_tag)
+        refreshed = recruitment.find_clan_row(clan_tag, force=True)
         if refreshed is None:
             raise RuntimeError(f"clan cache refresh failed for {clan_tag}")
         _, refreshed_row = refreshed
@@ -130,7 +130,7 @@ async def recompute_clan_availability(
 ) -> None:
     """Recompute AF/AH/AI for ``clan_tag`` and refresh the in-memory cache."""
 
-    clan_entry = recruitment.find_clan_row(clan_tag)
+    clan_entry = recruitment.find_clan_row(clan_tag, force=True)
     if clan_entry is None:
         raise ValueError(f"Unknown clan tag: {clan_tag}")
 

--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -245,6 +245,8 @@ class BucketResult:
     retries: Optional[int] = None
     reason: Optional[str] = None
     metadata: Mapping[str, str] | None = None
+    cache_age_s: Optional[int] = None
+    ttl_s: Optional[int] = None
 
     @property
     def ok(self) -> bool:
@@ -313,6 +315,10 @@ class LogTemplates:
                 details.append("ttl")
             elif result.ttl_ok is False:
                 details.append("stale")
+            if result.cache_age_s is not None and (result.ttl_ok is False or result.status.lower().strip() == "cached"):
+                details.append(f"age={fmt_duration(result.cache_age_s)}")
+            if result.ttl_s is not None:
+                details.append(f"ttl={fmt_duration(result.ttl_s)}")
             if result.retries:
                 details.append(f"{result.retries}× retry")
             if result.reason and not result.ok:

--- a/shared/obs/events.py
+++ b/shared/obs/events.py
@@ -59,6 +59,8 @@ def refresh_bucket_results(results: Sequence["RefreshResult"]) -> list[BucketRes
                     retries=retries,
                     reason=reason,
                     metadata=None,
+                    cache_age_s=None,
+                    ttl_s=None,
                 )
             )
             continue
@@ -86,6 +88,8 @@ def refresh_bucket_results(results: Sequence["RefreshResult"]) -> list[BucketRes
                 retries=retries,
                 reason=reason,
                 metadata=metadata,
+                cache_age_s=snapshot.age_seconds,
+                ttl_s=snapshot.ttl_seconds,
             )
         )
     return buckets

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -15,6 +15,7 @@ from modules.onboarding.watcher_welcome import (
     build_closed_thread_name,
     parse_welcome_thread_name,
     rename_thread_to_reserved,
+    _clan_math_column_indices,
 )
 from shared.sheets import reservations as reservations_sheets
 
@@ -27,6 +28,21 @@ def _stub_find_welcome_row(monkeypatch):
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row",
         _fake_find_welcome_row,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome._ensure_fresh_clans_for_placement",
+        lambda **_kwargs: asyncio.sleep(0, result=True),
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: {
+            "open_spots": 31,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+            "manual_open_spots": 4,
+            "manual_open_spots_seen": 35,
+        },
     )
 
 
@@ -53,6 +69,29 @@ def test_parse_thread_name_open() -> None:
     assert parts.ticket_code == "W0298"
     assert parts.username == "Caillean AT"
     assert parts.state == "open"
+
+
+def test_clan_math_column_indices_resolve_by_header(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: {
+            "open_spots": 22,
+            "inactives": 8,
+            "reservation_count": 41,
+            "reservation_summary": 3,
+        },
+    )
+    resolved = _clan_math_column_indices()
+    assert resolved == {"open_spots": 22, "AF": 22, "AG": 8, "AH": 41, "AI": 3}
+
+
+def test_clan_math_column_indices_missing_required_header_raises(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: {"open_spots": 22, "inactives": 8, "reservation_count": 41},
+    )
+    with pytest.raises(ValueError, match="required columns"):
+        _clan_math_column_indices()
 
 
 def test_parse_thread_name_open_without_w_prefix() -> None:
@@ -293,7 +332,7 @@ def test_finalize_reconciles_when_row_inserted(monkeypatch) -> None:
     async def fake_recompute(tag: str, *, guild=None):  # type: ignore[no-untyped-def]
         recomputed.append(tag)
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -582,7 +621,7 @@ def test_finalize_no_reservation_consumes_open_spot(monkeypatch, caplog) -> None
     async def fake_recompute(tag: str, guild=None):  # type: ignore[no-untyped-def]
         recomputed.append(tag)
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -669,7 +708,7 @@ def test_finalize_manual_logs_manual_event(monkeypatch, caplog) -> None:
     async def fake_recompute(tag: str, guild=None):  # type: ignore[no-untyped-def]
         recomputed.append(tag)
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -757,7 +796,7 @@ def test_finalize_manual_consumes_seat_without_reservation(monkeypatch) -> None:
     async def fake_recompute(tag: str, guild=None):  # type: ignore[no-untyped-def]
         recomputed.append(tag)
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -865,7 +904,7 @@ def test_finalize_matching_reservation(monkeypatch) -> None:
     async def fake_recompute(tag: str, guild=None):  # type: ignore[no-untyped-def]
         pass
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -950,7 +989,7 @@ def test_finalize_moved_reservation(monkeypatch) -> None:
     async def fake_recompute(tag: str, guild=None):  # type: ignore[no-untyped-def]
         pass
 
-    def fake_find_clan(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         return tag, ["", "", tag]
 
     monkeypatch.setattr(
@@ -1211,7 +1250,7 @@ def test_finalize_posts_clan_math_log(monkeypatch) -> None:
     def _normalize(tag: str) -> str:
         return "".join(ch for ch in tag.upper() if ch.isalnum())
 
-    def fake_find_clan_row(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan_row(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         entry = clan_rows.get(_normalize(tag))
         if not entry:
             return None
@@ -1260,7 +1299,7 @@ def test_finalize_posts_clan_math_log(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
-        lambda: {"open_spots": 4},
+        lambda: {"open_spots": 31, "inactives": 32, "reservation_count": 33, "reservation_summary": 34, "manual_open_spots": 4, "manual_open_spots_seen": 35},
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
@@ -1334,7 +1373,7 @@ def test_finalize_error_pings_admins(monkeypatch) -> None:
     def _normalize(tag: str) -> str:
         return "".join(ch for ch in tag.upper() if ch.isalnum())
 
-    def fake_find_clan_row(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan_row(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         entry = clan_rows.get(_normalize(tag))
         if not entry:
             return None
@@ -1373,7 +1412,7 @@ def test_finalize_error_pings_admins(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
-        lambda: {"open_spots": 4},
+        lambda: {"open_spots": 31, "inactives": 32, "reservation_count": 33, "reservation_summary": 34, "manual_open_spots": 4, "manual_open_spots_seen": 35},
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
@@ -1451,7 +1490,7 @@ def test_finalize_manual_path_logs_source(monkeypatch) -> None:
     def _normalize(tag: str) -> str:
         return "".join(ch for ch in tag.upper() if ch.isalnum())
 
-    def fake_find_clan_row(tag: str):  # type: ignore[no-untyped-def]
+    def fake_find_clan_row(tag: str, *, force=False):  # type: ignore[no-untyped-def]
         entry = clan_rows.get(_normalize(tag))
         if not entry:
             return None
@@ -1499,7 +1538,7 @@ def test_finalize_manual_path_logs_source(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
-        lambda: {"open_spots": 4},
+        lambda: {"open_spots": 31, "inactives": 32, "reservation_count": 33, "reservation_summary": 34, "manual_open_spots": 4, "manual_open_spots_seen": 35},
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
@@ -1568,11 +1607,11 @@ def test_finalize_non_real_tag_logs_skip_reason(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row",
-        lambda _tag: None,
+        lambda _tag, *, force=False: None,
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
-        lambda: {"open_spots": 4},
+        lambda: {"open_spots": 31, "inactives": 32, "reservation_count": 33, "reservation_summary": 34, "manual_open_spots": 4, "manual_open_spots_seen": 35},
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.get_admin_role_ids", lambda: set()

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -46,7 +46,7 @@ def test_recompute_clan_availability_updates_sheet(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "find_clan_row",
-        lambda tag: (
+        lambda tag, *, force=False: (
             7,
             [
                 "",  # A
@@ -126,7 +126,7 @@ def test_recompute_clan_availability_zero_reservations(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "find_clan_row",
-        lambda tag: (9, list(base_row)),
+        lambda tag, *, force=False: (9, list(base_row)),
     )
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
@@ -191,7 +191,7 @@ def test_recompute_clan_availability_uses_reordered_reservation_columns(monkeypa
     monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
     monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
     row = ["", "Clan", "#EEE", "", "4"] + [""] * 40
-    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (11, list(row)))
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag, *, force=False: (11, list(row)))
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
     monkeypatch.setattr(
@@ -232,7 +232,7 @@ def test_recompute_clan_availability_requires_reservation_headers(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "find_clan_row",
-        lambda tag: (10, ["", "Clan", "#AAA", "", "2"] + [""] * 40),
+        lambda tag, *, force=False: (10, ["", "Clan", "#AAA", "", "2"] + [""] * 40),
     )
     monkeypatch.setattr(
         availability.recruitment,
@@ -256,7 +256,7 @@ def test_recompute_clan_availability_keeps_runtime_af_when_manual_seen_matches(m
     monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
     monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
     row = ["", "Clan", "#AAA", "", "3"] + [""] * 26 + ["2", "", "", "", "3"] + [""] * 4
-    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (12, list(row)))
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag, *, force=False: (12, list(row)))
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
     monkeypatch.setattr(
@@ -306,7 +306,7 @@ def test_recompute_clan_availability_rebases_runtime_af_when_manual_changes(monk
     monkeypatch.setattr(reservations, "get_active_reservations_for_clan", fake_get_active_reservations)
     monkeypatch.setattr(reservations, "resolve_reservation_names", fake_resolve_names)
     row = ["", "Clan", "#AAA", "", "4"] + [""] * 26 + ["2", "", "", "", "3"] + [""] * 4
-    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (13, list(row)))
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag, *, force=False: (13, list(row)))
     monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
     monkeypatch.setattr(
@@ -351,7 +351,7 @@ def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "find_clan_row",
-        lambda tag: (12, list(row)),
+        lambda tag, *, force=False: (12, list(row)),
     )
     monkeypatch.setattr(
         availability.recruitment,
@@ -395,7 +395,7 @@ def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment,
         "find_clan_row",
-        lambda tag: (12, ["", "Clan", "#CCC", "", "3"] + [""] * 30),
+        lambda tag, *, force=False: (12, ["", "Clan", "#CCC", "", "3"] + [""] * 30),
     )
     monkeypatch.setattr(availability.recruitment, "get_clan_header_map", lambda: {"manual_open_spots": 4, "open_spots": 20})
 
@@ -406,7 +406,7 @@ def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
 def test_adjust_manual_open_spots_rebases_when_manual_changes(monkeypatch):
     worksheet = StubWorksheet()
     row = ["", "Clan", "#DDD", "", "4"] + [""] * 15 + ["2"] + [""] * 16 + ["3"]
-    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (15, list(row)))
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag, *, force=False: (15, list(row)))
     monkeypatch.setattr(
         availability.recruitment,
         "get_clan_header_map",
@@ -436,7 +436,7 @@ def test_adjust_manual_open_spots_rebases_when_manual_changes(monkeypatch):
 def test_adjust_manual_open_spots_rebase_without_delta(monkeypatch):
     worksheet = StubWorksheet()
     row = ["", "Clan", "#DDD", "", "4"] + [""] * 15 + ["2"] + [""] * 16 + ["3"]
-    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag: (15, list(row)))
+    monkeypatch.setattr(availability.recruitment, "find_clan_row", lambda tag, *, force=False: (15, list(row)))
     monkeypatch.setattr(
         availability.recruitment,
         "get_clan_header_map",


### PR DESCRIPTION
### Motivation
- Prevent incorrect seat math when the clans cache is stale by requiring a sync-fresh clans bucket before placement operations. 
- Ensure clan sheet reads used for availability/reservation adjustments reflect the latest data by providing a way to force fresh reads. 
- Make clan-math logging and column index handling robust to reordered/missing columns.

### Description
- Added `_ensure_fresh_clans_for_placement` to `watcher_promo.py` and `watcher_welcome.py` which calls `cache_telemetry.refresh_now` and checks the snapshot to gate placement/seat-math work. 
- Short-circuited placement seat-math when clans data is unavailable or the refresh indicates failure, logging a skip reason and avoiding downstream sheet writes. 
- Propagated a `force=True` style parameter to calls to `recruitment_sheets.find_clan_row` (and updated `modules/recruitment/availability.py` to call `find_clan_row(..., force=True)`) so code can bypass cached results for critical operations. 
- Tightened clan-math column handling by validating required columns in `_clan_math_column_indices`, returning dynamic indices for `AF/AG/AH/AI` instead of hardcoded positions, and raising `ValueError` when required headers are missing. 
- Added a `force` flag to `_capture_clan_snapshots` and used it when capturing before/after snapshots. 
- Extended logging templates and bucket result structures to include cache age and TTL (`cache_age_s` and `ttl_s`) and updated `shared/obs/events.py` to populate these fields in refresh reporting.
- Updated affected call sites and tests to the new `find_clan_row(..., force=False)` signature and added tests for the clan-math column resolution behavior (`test_clan_math_column_indices_*`).

### Testing
- Ran unit tests under `tests/onboarding/test_welcome_reservations.py` and `tests/recruitment/test_availability_recompute.py` after updates, and they passed locally. 
- Added and ran `test_clan_math_column_indices_resolve_by_header` and `test_clan_math_column_indices_missing_required_header_raises`, which passed. 
- Existing reservation/availability tests were updated to the new `find_clan_row(..., force=False)` signature and were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116760e15c83239309e2c01d806d47)