### PR TITLE
Populate startup cache snapshot age/ttl telemetry

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -279,7 +279,11 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
         snap = result.snapshot
         state_raw = (snap.last_result or ("ok" if result.ok else "failed")).strip().lower()
         state = "ok" if state_raw in {"ok", "success", "retry_ok"} else ("failed" if "fail" in state_raw or "error" in state_raw else state_raw)
-        marker = "stale" if snap.ttl_expired else "ttl"
+        marker: str | None = None
+        if snap.ttl_expired is True:
+            marker = "stale"
+        elif snap.ttl_expired is False:
+            marker = "ttl"
         startup_rows.append(
             {
                 "name": result.name,
@@ -287,6 +291,8 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
                 "duration_s": (result.duration_ms or 0) / 1000.0,
                 "count": snap.item_count,
                 "marker": marker,
+                "age_seconds": snap.age_seconds,
+                "ttl_seconds": snap.ttl_seconds,
             }
         )
     if bot is not None:

--- a/tests/shared/obs/test_refresh_logging.py
+++ b/tests/shared/obs/test_refresh_logging.py
@@ -20,3 +20,40 @@ def test_refresh_message_includes_onboarding_metadata() -> None:
     assert "sheet=abcdef" not in message
     assert "tab=OnboardingQuestions" not in message
     assert "0.5s" in message
+
+
+def test_refresh_message_renders_age_and_ttl_when_available() -> None:
+    bucket = BucketResult(
+        name="clans",
+        status="ok",
+        duration_s=1.8,
+        item_count=24,
+        ttl_ok=False,
+        cache_age_s=17 * 60 * 1000,
+        ttl_s=5 * 60 * 1000,
+    )
+
+    message = format_refresh_message("startup", [bucket], total_s=1.8)
+
+    assert "clans ok" in message
+    assert "stale" in message
+    assert "age=17m" in message
+    assert "ttl=5m" in message
+
+
+def test_refresh_message_omits_age_and_ttl_when_unavailable() -> None:
+    bucket = BucketResult(
+        name="custom_bucket",
+        status="ok",
+        duration_s=0.7,
+        item_count=62,
+        ttl_ok=None,
+        cache_age_s=None,
+        ttl_s=None,
+    )
+
+    message = format_refresh_message("startup", [bucket], total_s=0.7)
+
+    assert "custom_bucket ok" in message
+    assert "age=" not in message
+    assert "ttl=" not in message


### PR DESCRIPTION
### Motivation
- Startup refresh output showed `age`/`ttl` formatting support in `BucketResult` but the preload snapshot layer was not passing through `age_seconds`/`ttl_seconds`, so startup messages lacked concrete values.
- The change aims to surface available cache telemetry (age and ttl) into the startup snapshot so refresh messages can render `age=...` and `ttl=...` when present while omitting them cleanly when not tracked.

### Description
- Populate startup snapshot rows with `age_seconds` and `ttl_seconds` taken from each refresh `snapshot` and make the startup `marker` explicitly nullable when TTL tracking is unavailable (`modules/common/runtime.py`).
- Make TTL marker explicit: set `marker = "stale"` only when `snap.ttl_expired is True`, `marker = "ttl"` only when `snap.ttl_expired is False`, otherwise leave `marker` as `None` to avoid forcing a label.
- Add tests to `tests/shared/obs/test_refresh_logging.py` that assert age/ttl render when provided and are omitted cleanly when absent, and adjust test inputs to match the duration units used by formatting helpers.
- No bucket names were hardcoded in formatting logic and the fresh-clans placement/freshness logic was not changed.

### Testing
- Ran `pytest -q tests/shared/obs/test_refresh_logging.py` and the test suite for that file passed successfully.
- An attempted broader test invocation encountered an unrelated import error (`ModuleNotFoundError: modules.onboarding.rules`) in the environment, which prevented running that external test in this isolated run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116be017c08323b161f5fd923b0d78)