### PR TITLE
Improve reservation recompute visibility and gate on fresh-clans cache

### DIFF
--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -28,6 +28,7 @@ from shared.config import (
     get_recruitment_interact_channel_id,
     get_welcome_channel_id,
 )
+from shared.cache import telemetry as cache_telemetry
 from shared.logfmt import channel_label
 from shared.sheets import recruitment, reservations
 
@@ -360,6 +361,39 @@ def _reservations_enabled() -> bool:
         except Exception:
             log.exception("feature toggle check failed", extra={"feature": key})
     return False
+
+
+async def _ensure_fresh_clans_for_reservations(*, actor: str, clan_tag: str, user: str, source: str) -> bool:
+    """Require a sync-fresh clans cache before reservation availability recompute."""
+    try:
+        await cache_telemetry.refresh_now("clans", actor=actor)
+    except Exception:
+        log.exception(
+            "failed to refresh clans cache for reservation availability recompute",
+            extra={
+                "actor": actor,
+                "clan_tag": _normalize_tag(clan_tag),
+                "user": user,
+                "source": source,
+            },
+        )
+        return False
+    snapshot = cache_telemetry.get_snapshot("clans")
+    if (not snapshot.available) or snapshot.last_result not in {"ok", "retry_ok"}:
+        log.warning(
+            "reservation availability recompute blocked due to unavailable/failed clans cache refresh",
+            extra={
+                "actor": actor,
+                "clan_tag": _normalize_tag(clan_tag),
+                "user": user,
+                "source": source,
+                "reason": "fresh_clans_unavailable",
+                "last_result": snapshot.last_result,
+                "last_error": snapshot.last_error,
+            },
+        )
+        return False
+    return True
 
 
 @dataclass(slots=True)
@@ -847,15 +881,48 @@ class ReservationCog(commands.Cog):
             )
             return
 
+        source = "reserve"
+        actor = "placement_reservation"
+        actor_user = channel_label(ctx.author)
+        clans_fresh = await _ensure_fresh_clans_for_reservations(
+            actor=actor,
+            clan_tag=sheet_tag,
+            user=actor_user,
+            source=source,
+        )
+        if not clans_fresh:
+            log.warning(
+                "skipped recompute clan availability",
+                extra={
+                    "reason": "fresh_clans_unavailable",
+                    "clan_tag": _normalize_tag(sheet_tag),
+                    "reservation_row": "append",
+                    "thread_id": getattr(ctx.channel, "id", None),
+                    "ticket_user_id": details.ticket_user_id,
+                    "user": actor_user,
+                    "source": source,
+                },
+            )
+            await ctx.send(
+                "Saved the reservation, but I couldn't refresh clan availability. Admin hint: clans cache refresh failed (fresh_clans_unavailable), so verify cache/headers and rerun recompute."
+            )
+            return
         try:
             await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)
         except Exception:
             log.exception(
                 "failed to recompute clan availability",
-                extra={"clan_tag": _normalize_tag(sheet_tag)},
+                extra={
+                    "clan_tag": _normalize_tag(sheet_tag),
+                    "reservation_row": "append",
+                    "thread_id": getattr(ctx.channel, "id", None),
+                    "ticket_user_id": details.ticket_user_id,
+                    "user": actor_user,
+                    "source": source,
+                },
             )
             await ctx.send(
-                "Saved the reservation, but I couldn't refresh clan availability. Please poke an admin to verify the sheet."
+                "Saved the reservation, but I couldn't refresh clan availability. Admin hint: check clan headers/cache config and see error logs for the exact exception."
             )
             return
 

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import logging
 from typing import List
 
 import discord
@@ -327,6 +328,26 @@ def test_reserve_accepts_inline_recruit(monkeypatch):
     assert any("Reserving a spot for" in sent.content for sent in thread.sent[:1])
     if appended:
         assert appended[0][1] == str(recruit.id)
+
+
+def test_ensure_fresh_clans_for_reservations_unavailable(monkeypatch, caplog):
+    class _Snapshot:
+        available = False
+        last_result = "error"
+        last_error = "boom"
+
+    caplog.set_level(logging.WARNING, logger=reserve_module.log.name)
+    monkeypatch.setattr(reserve_module.cache_telemetry, "refresh_now", lambda *_, **__: asyncio.sleep(0))
+    monkeypatch.setattr(reserve_module.cache_telemetry, "get_snapshot", lambda *_: _Snapshot())
+
+    result = asyncio.run(
+        reserve_module._ensure_fresh_clans_for_reservations(
+            actor="placement_reservation", clan_tag="C1C9", user="u", source="reserve"
+        )
+    )
+
+    assert result is False
+    assert any(getattr(record, "reason", None) == "fresh_clans_unavailable" for record in caplog.records)
 
 
 def test_reserve_inline_recruit_validation_error(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prod observed reservations saved while recompute failed but structured logs lacked the exception trace and contextual fields, hiding root cause and slowing recovery.
- Recompute depends on an up-to-date `clans` cache, but placement/reservation paths did not require a fresh cache before running availability math.

### Description
- Add a helper `_ensure_fresh_clans_for_reservations(...)` that forces a `clans` cache refresh via telemetry and rejects recompute when the snapshot is unavailable or failed, emitting structured context including `reason=fresh_clans_unavailable` and caller metadata. (imports `shared.cache.telemetry`) 
- Gate the reservation create flow so recompute runs only when fresh clans are available, and explicitly log a clear structured warning and send an actionable admin hint to the user when the fresh-clans check fails. 
- Improve recompute failure visibility by using `log.exception(...)` with richer `extra` context (`clan_tag`, `reservation_row` marker, `thread_id`, `ticket_user_id`, `user`, `source`) so the exact exception and traceback are preserved. 
- Keep reservation save behavior unchanged (the row is appended regardless of recompute outcome) and avoid hardcoding sheet columns/tabs or adding fallback recompute paths.

### Testing
- Added `test_ensure_fresh_clans_for_reservations_unavailable` to `tests/placement/test_reserve_command.py` to validate the fresh-clans gating and structured logging metadata. The test asserts helper returns `False` and that a `fresh_clans_unavailable` indicator appears in captured log records. 
- Ran targeted tests: `pytest -q tests/placement/test_reserve_command.py -k 'reserve_creates_row or ensure_fresh_clans_for_reservations_unavailable'` and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116cf0e2e88323b5d9d6f820882338)