### PR TITLE
Fix !reserve TypeError by using safe user label in reservations flow

### DIFF
--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -883,7 +883,7 @@ class ReservationCog(commands.Cog):
 
         source = "reserve"
         actor = "placement_reservation"
-        actor_user = channel_label(ctx.author)
+        actor_user = f"{ctx.author} ({getattr(ctx.author, 'id', '-')})"
         clans_fresh = await _ensure_fresh_clans_for_reservations(
             actor=actor,
             clan_tag=sheet_tag,


### PR DESCRIPTION
### Motivation
- Prevent a crash in `!reserve` where `channel_label()` (which expects `(guild, channel_id)`) was incorrectly called with a member object causing `TypeError: channel_label() missing 1 required positional argument: 'cid'`.

### Description
- Replace the incorrect call with a safe actor string `f"{ctx.author} ({getattr(ctx.author, 'id', '-')})"` in `modules/placement/reservations.py` so logs keep user context without using the channel helper, while leaving the fresh-clans reservation guard and contextual logging unchanged.

### Testing
- Ran `python -m compileall modules/placement/reservations.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117747673083239b98b94e045c9482)