### PR TITLE
Clarify startup refresh wording for expired-vs-stale cache states

### DIFF
--- a/shared/logfmt.py
+++ b/shared/logfmt.py
@@ -249,6 +249,8 @@ class BucketResult:
     cache_age_s: Optional[int] = None
     ttl_s: Optional[int] = None
     last_refresh_at: Optional[dt.datetime] = None
+    ttl_expired_before_refresh: Optional[bool] = None
+    currently_stale_after_refresh: Optional[bool] = None
 
     @property
     def ok(self) -> bool:
@@ -315,9 +317,17 @@ class LogTemplates:
                 details.append(fmt_count(result.item_count))
             if result.ttl_ok is True:
                 details.append("ttl")
-            elif result.ttl_ok is False:
+                if result.ttl_expired_before_refresh is True:
+                    details.append("ttl_expired")
+            elif result.currently_stale_after_refresh is True:
                 details.append("stale")
-            if result.cache_age_s is not None and (result.ttl_ok is False or result.status.lower().strip() == "cached"):
+            elif result.ttl_expired_before_refresh is True:
+                details.append("ttl_expired")
+            if result.cache_age_s is not None and (
+                result.currently_stale_after_refresh is True
+                or result.ttl_expired_before_refresh is True
+                or result.status.lower().strip() == "cached"
+            ):
                 details.append(f"age={fmt_duration(result.cache_age_s)}")
             if result.ttl_s is not None:
                 details.append(f"ttl={fmt_duration(result.ttl_s)}")

--- a/shared/obs/events.py
+++ b/shared/obs/events.py
@@ -65,14 +65,23 @@ def refresh_bucket_results(results: Sequence["RefreshResult"]) -> list[BucketRes
                 )
             )
             continue
+        ttl_expired_before_refresh = snapshot.ttl_expired
+        currently_stale_after_refresh = bool(ttl_expired_before_refresh and not getattr(item, "ok", False))
         ttl_ok: bool | None = None
-        if snapshot.ttl_expired is True:
+        if currently_stale_after_refresh is True:
             ttl_ok = False
-        elif snapshot.ttl_expired is False:
+        elif ttl_expired_before_refresh is False or getattr(item, "ok", False):
             ttl_ok = True
         reason = None
         if not getattr(item, "ok", False):
             reason = human_reason(getattr(item, "error", None) or snapshot.last_error)
+        if getattr(item, "ok", False):
+            if ttl_expired_before_refresh is True:
+                status = "refreshed"
+            elif ttl_expired_before_refresh is False:
+                status = "fresh"
+        elif ttl_expired_before_refresh is True:
+            status = "stale"
         metadata = snapshot.metadata
         if snapshot.name == "onboarding_questions" and metadata:
             metadata = {k: v for k, v in metadata.items() if k not in {"sheet", "tab"}}
@@ -92,6 +101,8 @@ def refresh_bucket_results(results: Sequence["RefreshResult"]) -> list[BucketRes
                 cache_age_s=snapshot.age_seconds,
                 ttl_s=snapshot.ttl_seconds,
                 last_refresh_at=snapshot.last_refresh_at,
+                ttl_expired_before_refresh=ttl_expired_before_refresh,
+                currently_stale_after_refresh=currently_stale_after_refresh,
             )
         )
     return buckets

--- a/tests/shared/obs/test_refresh_logging.py
+++ b/tests/shared/obs/test_refresh_logging.py
@@ -1,7 +1,8 @@
 import datetime as dt
 
+from shared.cache.telemetry import CacheSnapshot, RefreshResult
 from shared.logfmt import BucketResult
-from shared.obs.events import format_refresh_message
+from shared.obs.events import format_refresh_message, refresh_bucket_results
 
 
 def test_refresh_message_includes_onboarding_metadata() -> None:
@@ -27,18 +28,20 @@ def test_refresh_message_includes_onboarding_metadata() -> None:
 def test_refresh_message_renders_age_and_ttl_when_available() -> None:
     bucket = BucketResult(
         name="clans",
-        status="ok",
+        status="refreshed",
         duration_s=1.8,
         item_count=24,
-        ttl_ok=False,
+        ttl_ok=True,
+        ttl_expired_before_refresh=True,
+        currently_stale_after_refresh=False,
         cache_age_s=17 * 60 * 1000,
         ttl_s=5 * 60 * 1000,
     )
 
     message = format_refresh_message("startup", [bucket], total_s=1.8)
 
-    assert "clans ok" in message
-    assert "stale" in message
+    assert "clans refreshed" in message
+    assert "ttl_expired" in message
     assert "age=17m" in message
     assert "ttl=5m" in message
 
@@ -64,10 +67,12 @@ def test_refresh_message_omits_age_and_ttl_when_unavailable() -> None:
 def test_refresh_message_renders_last_refresh_when_available() -> None:
     bucket = BucketResult(
         name="clans",
-        status="ok",
+        status="refreshed",
         duration_s=2.0,
         item_count=24,
-        ttl_ok=False,
+        ttl_ok=True,
+        ttl_expired_before_refresh=True,
+        currently_stale_after_refresh=False,
         cache_age_s=17 * 60 * 1000,
         ttl_s=3 * 60 * 60 * 1000,
         last_refresh_at=dt.datetime(2026, 5, 23, 9, 11, tzinfo=dt.timezone.utc),
@@ -75,7 +80,7 @@ def test_refresh_message_renders_last_refresh_when_available() -> None:
 
     message = format_refresh_message("startup", [bucket], total_s=2.0)
 
-    assert "clans ok" in message
+    assert "clans refreshed" in message
     assert "age=17m" in message
     assert "ttl=3h" in message
     assert "last_refresh=09:11Z" in message
@@ -88,6 +93,7 @@ def test_refresh_message_renders_last_refresh_never_when_missing() -> None:
         duration_s=0.2,
         item_count=24,
         ttl_ok=False,
+        currently_stale_after_refresh=True,
         cache_age_s=None,
         ttl_s=None,
         last_refresh_at=None,
@@ -96,3 +102,55 @@ def test_refresh_message_renders_last_refresh_never_when_missing() -> None:
     message = format_refresh_message("startup", [bucket], total_s=0.2)
 
     assert "last_refresh=never" in message
+
+
+def test_refresh_message_renders_stale_only_when_refresh_failed() -> None:
+    bucket = BucketResult(
+        name="clans",
+        status="stale",
+        duration_s=2.0,
+        item_count=24,
+        ttl_ok=False,
+        ttl_expired_before_refresh=True,
+        currently_stale_after_refresh=True,
+        reason="refresh_failed",
+    )
+
+    message = format_refresh_message("startup", [bucket], total_s=2.0)
+
+    assert "clans stale" in message
+    assert "stale" in message
+
+
+def test_refresh_bucket_results_labels_refreshed_and_fresh_and_stale() -> None:
+    base_snapshot = CacheSnapshot(
+        name="clans",
+        available=True,
+        ttl_seconds=300,
+        ttl_human="5m",
+        ttl_sec=300,
+        last_refresh_at=dt.datetime(2026, 5, 23, 9, 11, tzinfo=dt.timezone.utc),
+        age_seconds=0,
+        age_human="0s",
+        age_sec=0,
+        next_refresh_at=None,
+        next_refresh_delta_seconds=None,
+        next_refresh_human=None,
+        last_result="ok",
+        last_error=None,
+        retries=0,
+        last_trigger="manual",
+        ttl_expired=True,
+        item_count=24,
+        metadata=None,
+    )
+    refreshed = RefreshResult(name="clans", ok=True, duration_ms=100, error=None, retries=0, snapshot=base_snapshot)
+    stale = RefreshResult(name="clans", ok=False, duration_ms=100, error="boom", retries=0, snapshot=base_snapshot)
+    fresh_snapshot = CacheSnapshot(**{**base_snapshot.__dict__, "ttl_expired": False})
+    fresh = RefreshResult(name="clans", ok=True, duration_ms=100, error=None, retries=0, snapshot=fresh_snapshot)
+
+    results = refresh_bucket_results([refreshed, stale, fresh])
+
+    assert results[0].status == "refreshed"
+    assert results[1].status == "stale"
+    assert results[2].status == "fresh"


### PR DESCRIPTION
### Motivation
- Startup refresh summaries used the pre-refresh TTL flag to label buckets `stale`, which misled operators when an expired cache was successfully refreshed. 
- Logs and summaries must reflect the cache state after refresh so admins can tell "expired then refreshed" from "expired and still stale".

### Description
- Add two explicit telemetry flags to `BucketResult`: `ttl_expired_before_refresh` and `currently_stale_after_refresh`, and propagate them from `shared/cache/telemetry` snapshots in `shared/obs/events.py`.
- Change refresh status derivation in `shared/obs/events.py` to emit `refreshed` when a previously-expired cache was successfully reloaded, `fresh` when cache was already valid, and `stale` only when an expired cache failed to refresh.
- Update `shared/logfmt.LogTemplates.refresh` to render `ttl_expired` for successful refresh-from-expired cases, show `age`/`ttl` appropriately, and avoid showing `stale` when `result.ok` is true.
- Add and modify tests in `tests/shared/obs/test_refresh_logging.py` to cover expired+success => `refreshed`, expired+failure => `stale`, valid => `fresh`, and message/detail formatting consistency.

### Testing
- Ran `pytest -q tests/shared/obs/test_refresh_logging.py` and the test suite for that file passed (all tests succeeded).
- New/updated unit tests include `test_refresh_bucket_results_labels_refreshed_and_fresh_and_stale` and `test_refresh_message_renders_stale_only_when_refresh_failed`, which validate the new semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118001c7f48323bdb4dd66490f8129)