### PR TITLE
Fix startup refresh summary to surface refreshed/fresh/stale statuses

### DIFF
--- a/app.py
+++ b/app.py
@@ -337,8 +337,10 @@ async def on_ready():
         if preload_report.rows:
             refresh_lines = ["♻️ Refresh"]
             for row in preload_report.rows:
+                detail_parts = row.get("detail_parts") or ["?"]
+                detail_text = ", ".join(str(part) for part in detail_parts)
                 refresh_lines.append(
-                    f"• {row.get('name', '?')} {row.get('state', '?')} ({row.get('duration_s', 0):.1f}s, {row.get('count', '?')}, {row.get('marker', '?')})"
+                    f"• {row.get('name', '?')} {row.get('status', '?')} ({detail_text})"
                 )
             refresh_lines.append(f"• total={preload_report.total_s:.1f}s")
         else:

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -37,6 +37,7 @@ from shared.config import (
     get_refresh_timezone,
     get_strict_emoji_proxy,
 )
+from shared.logfmt import fmt_duration
 from shared.ports import get_port
 from shared.logging import get_trace_id, set_trace_id, setup_logging
 from shared.obs.events import (
@@ -275,24 +276,23 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
         return StartupPreloadReport(rows=[], total_s=0.0, error="no refresh rows")
 
     startup_rows: list[dict[str, object]] = []
-    for result in refresh_results:
-        snap = result.snapshot
-        state_raw = (snap.last_result or ("ok" if result.ok else "failed")).strip().lower()
-        state = "ok" if state_raw in {"ok", "success", "retry_ok"} else ("failed" if "fail" in state_raw or "error" in state_raw else state_raw)
-        marker: str | None = None
-        if snap.ttl_expired is True:
-            marker = "stale"
-        elif snap.ttl_expired is False:
-            marker = "ttl"
+    for bucket in refresh_bucket_results(refresh_results):
+        details: list[str] = [f"{bucket.duration_s:.1f}s", str(bucket.item_count if bucket.item_count is not None else "?")]
+        if bucket.ttl_ok is True:
+            details.append("ttl")
+        if bucket.ttl_expired_before_refresh is True:
+            details.append("ttl_expired")
+        if bucket.currently_stale_after_refresh is True:
+            details.append("refresh_failed")
+        if bucket.cache_age_s is not None:
+            details.append(f"age={fmt_duration(bucket.cache_age_s)}")
+        if bucket.ttl_s is not None:
+            details.append(f"ttl={fmt_duration(bucket.ttl_s)}")
         startup_rows.append(
             {
-                "name": result.name,
-                "state": state,
-                "duration_s": (result.duration_ms or 0) / 1000.0,
-                "count": snap.item_count,
-                "marker": marker,
-                "age_seconds": snap.age_seconds,
-                "ttl_seconds": snap.ttl_seconds,
+                "name": bucket.name,
+                "status": bucket.status,
+                "detail_parts": details,
             }
         )
     if bot is not None:

--- a/tests/shared/test_runtime_startup_preload_rows.py
+++ b/tests/shared/test_runtime_startup_preload_rows.py
@@ -1,0 +1,63 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+from modules.common import runtime
+from shared.cache.telemetry import CacheSnapshot, RefreshResult
+
+
+def _snapshot(*, ttl_expired: bool) -> CacheSnapshot:
+    return CacheSnapshot(
+        name="clans",
+        available=True,
+        ttl_seconds=3600 * 1000,
+        ttl_human="1h",
+        ttl_sec=3600 * 1000,
+        last_refresh_at=dt.datetime(2026, 5, 23, 9, 11, tzinfo=dt.timezone.utc),
+        age_seconds=3 * 3600 * 1000,
+        age_human="3h",
+        age_sec=3 * 3600 * 1000,
+        next_refresh_at=None,
+        next_refresh_delta_seconds=None,
+        next_refresh_human=None,
+        last_result="ok",
+        last_error=None,
+        retries=0,
+        last_trigger="manual",
+        ttl_expired=ttl_expired,
+        item_count=24,
+        metadata=None,
+    )
+
+
+def test_startup_preload_rows_use_status_labels_and_details(monkeypatch) -> None:
+    async def runner() -> None:
+        async def no_sleep(_seconds: float) -> None:
+            return None
+
+        async def fake_refresh_now(name: str, actor: str):
+            if name == "clans":
+                return RefreshResult(name=name, ok=True, duration_ms=1500, error=None, retries=0, snapshot=_snapshot(ttl_expired=True))
+            if name == "templates":
+                return RefreshResult(name=name, ok=False, duration_ms=1200, error="boom", retries=0, snapshot=_snapshot(ttl_expired=True))
+            return RefreshResult(name=name, ok=True, duration_ms=700, error=None, retries=0, snapshot=_snapshot(ttl_expired=False))
+
+        monkeypatch.setattr(runtime.asyncio, "sleep", no_sleep)
+        monkeypatch.setattr("shared.cache.telemetry.list_buckets", lambda: ["clans", "templates", "onboarding_questions"])
+        monkeypatch.setattr("shared.cache.telemetry.refresh_now", fake_refresh_now)
+
+        report = await runtime._startup_preload(bot=SimpleNamespace())
+
+        assert any("clans refreshed" in f"{row['name']} {row['status']}" for row in report.rows)
+        assert any("templates stale" in f"{row['name']} {row['status']}" for row in report.rows)
+        assert any("onboarding_questions fresh" in f"{row['name']} {row['status']}" for row in report.rows)
+
+        clans_row = next(row for row in report.rows if row["name"] == "clans")
+        assert "ttl_expired" in clans_row["detail_parts"]
+        assert "age=3h" in clans_row["detail_parts"]
+        assert "ttl=1h" in clans_row["detail_parts"]
+
+        templates_row = next(row for row in report.rows if row["name"] == "templates")
+        assert "refresh_failed" in templates_row["detail_parts"]
+
+    asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Startup summary still rendered legacy `ok (..., stale)` wording because `_startup_preload` normalized results to `state=ok/failed` and `marker=stale|ttl`, bypassing the newer `BucketResult` status model.
- The intent is for startup messages to report canonical statuses (`refreshed`, `fresh`, `stale`) and show TTL/age/detail tokens so operators see accurate refresh outcomes.

### Description
- Replaced the legacy row builder in `modules/common/runtime.py::_startup_preload` to use `refresh_bucket_results(refresh_results)` and emit rows containing `name`, canonical `status`, and `detail_parts` (tokens such as `ttl_expired`, `refresh_failed`, `age=...`, `ttl=...`).
- Added human-friendly formatting via `fmt_duration` for age/ttl values when present.
- Updated `app.py` startup summary rendering to read `status` and `detail_parts` instead of old `state`/`marker` and to render the new detail list inside the summary lines.
- Added regression test `tests/shared/test_runtime_startup_preload_rows.py` that simulates buckets and verifies `refreshed`, `fresh`, `stale` labels and expected detail tokens are present.

### Testing
- Ran `pytest -q tests/shared/obs/test_refresh_logging.py tests/shared/test_runtime_startup_preload_rows.py`, and the suite passed successfully.
- New test covers expired-success -> `refreshed`, expired-fail -> `stale`, unexpired-success -> `fresh`, and ensures `ttl_expired`, `refresh_failed`, `age`, and `ttl` appear in `detail_parts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11848582608323adfb65e6e8e26996)