### PR TITLE
Handle reservation partial-save when availability recompute fails

### DIFF
--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -890,39 +890,66 @@ class ReservationCog(commands.Cog):
             user=actor_user,
             source=source,
         )
+        reservation_row_ref = f"append:{now.isoformat()}"
         if not clans_fresh:
             log.warning(
                 "skipped recompute clan availability",
                 extra={
                     "reason": "fresh_clans_unavailable",
                     "clan_tag": _normalize_tag(sheet_tag),
-                    "reservation_row": "append",
+                    "reservation_row": reservation_row_ref,
                     "thread_id": getattr(ctx.channel, "id", None),
                     "ticket_user_id": details.ticket_user_id,
                     "user": actor_user,
                     "source": source,
                 },
             )
+            human_log.human(
+                "warning",
+                "⚠️ reservation_partial_success — source=reserve • clan=%s • reservation_row=%s • thread=%s • ticket_user=%s • error_type=FreshClansUnavailable • error=fresh_clans_unavailable • action=rerun recompute/refresh for clan and verify recruiter-facing bot_info open spots"
+                % (
+                    _normalize_tag(sheet_tag),
+                    reservation_row_ref,
+                    getattr(ctx.channel, "id", "-"),
+                    details.ticket_user_id or "-",
+                ),
+            )
             await ctx.send(
-                "Saved the reservation, but I couldn't refresh clan availability. Admin hint: clans cache refresh failed (fresh_clans_unavailable), so verify cache/headers and rerun recompute."
+                "Reservation row was added, but recruiter-facing availability was NOT updated. Admin hint: rerun recompute/refresh for this clan and manually verify bot_info/open spots."
             )
             return
         try:
             await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)
-        except Exception:
+        except Exception as exc:
+            error_type = type(exc).__name__
+            error_text = str(exc) or repr(exc)
             log.exception(
                 "failed to recompute clan availability",
                 extra={
                     "clan_tag": _normalize_tag(sheet_tag),
-                    "reservation_row": "append",
+                    "reservation_row": reservation_row_ref,
                     "thread_id": getattr(ctx.channel, "id", None),
                     "ticket_user_id": details.ticket_user_id,
                     "user": actor_user,
                     "source": source,
+                    "error_type": error_type,
+                    "error": repr(exc),
                 },
             )
+            human_log.human(
+                "error",
+                "❌ reservation_partial_success — source=reserve • clan=%s • reservation_row=%s • thread=%s • ticket_user=%s • error_type=%s • error=%s • action=rerun recompute/refresh for clan and verify recruiter-facing bot_info open spots"
+                % (
+                    _normalize_tag(sheet_tag),
+                    reservation_row_ref,
+                    getattr(ctx.channel, "id", "-"),
+                    details.ticket_user_id or "-",
+                    error_type,
+                    error_text,
+                ),
+            )
             await ctx.send(
-                "Saved the reservation, but I couldn't refresh clan availability. Admin hint: check clan headers/cache config and see error logs for the exact exception."
+                "Reservation row was added, but recruiter-facing availability was NOT updated. Admin hint: rerun recompute/refresh for this clan and manually verify bot_info/open spots."
             )
             return
 

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -269,6 +269,99 @@ def test_reserve_success(monkeypatch):
         assert recomputed["tag"] == "#ABC"
 
 
+
+
+def test_reserve_partial_success_when_recompute_fails(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=999)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_control_channels(monkeypatch)
+
+    recruit = FakeMember(333, "Recruit Partial")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=557, parent_id=999)
+    author = FakeMember(112, "Recruiter")
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    clan_row = ["", "Clan", "#ABC", "", "3"] + [""] * 40
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row)))
+    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+
+    async def fake_count(*_args, **_kwargs):
+        return 0
+
+    async def fake_find_active(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(reserve_module.reservations, "count_active_reservations_for_clan", fake_count)
+    monkeypatch.setattr(reserve_module.reservations, "find_active_reservations_for_recruit", fake_find_active)
+
+    async def fake_flow_run(self):
+        return reserve_module.ReservationDetails(
+            ticket_user_id=recruit.id,
+            ticket_display=recruit.display_name,
+            ticket_username=recruit.display_name,
+            reserved_until=dt.date(2025, 12, 6),
+            notes="",
+        )
+
+    monkeypatch.setattr(reserve_module.ReservationConversation, "run", fake_flow_run)
+    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", lambda row: asyncio.sleep(0))
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("sheet update exploded")
+
+    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", _boom)
+    monkeypatch.setattr(reserve_module, "_ensure_fresh_clans_for_reservations", lambda **_: asyncio.sleep(0, result=True))
+
+    runtime_logs: list[tuple[str, str]] = []
+    monkeypatch.setattr(reserve_module.human_log, "human", lambda level, message, **_: runtime_logs.append((level, message)))
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "ABC"))
+
+    assert any("Reservation row was added, but recruiter-facing availability was NOT updated." in m.content for m in thread.sent)
+    assert any(level == "error" and "error_type=RuntimeError" in message and "source=reserve" in message for level, message in runtime_logs)
+
+def test_recompute_updates_recruiter_facing_clans_tab(monkeypatch):
+    worksheet_calls: list[str] = []
+
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag, force=True: (7, ["", "", "#ABC", "", "4"] + [""] * 60))
+    monkeypatch.setattr(
+        reserve_module.recruitment,
+        "get_clan_header_map",
+        lambda: {
+            "manual_open_spots": 4,
+            "open_spots": 31,
+            "manual_open_spots_seen": 35,
+            "inactives": 32,
+            "reservation_count": 33,
+            "reservation_summary": 34,
+        },
+    )
+    monkeypatch.setattr(reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(reserve_module.recruitment, "get_clans_tab_name", lambda: "bot_info")
+
+    class _Worksheet:
+        def update(self, cell_range, values, value_input_option="RAW"):
+            worksheet_calls.append(cell_range)
+            return {"ok": True}
+
+    async def _aget(sheet_id, tab_name):
+        assert sheet_id == "sheet-id"
+        assert tab_name == "bot_info"
+        return _Worksheet()
+
+    monkeypatch.setattr(reserve_module.availability.async_core, "aget_worksheet", _aget)
+    monkeypatch.setattr(reserve_module.availability.async_core, "acall_with_backoff", lambda fn, *a, **k: asyncio.sleep(0, result=fn(*a, **k)))
+    monkeypatch.setattr(reserve_module.availability.reservations, "get_active_reservations_for_clan", lambda *_: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(reserve_module.availability.reservations, "resolve_reservation_names", lambda *_a, **_k: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(reserve_module.recruitment, "update_cached_clan_row", lambda *_: True)
+
+    asyncio.run(reserve_module.availability.recompute_clan_availability("#ABC", guild=None))
+
+    assert worksheet_calls, "expected worksheet updates"
 def test_reserve_accepts_inline_recruit(monkeypatch):
     _enable_feature(monkeypatch, enabled=True)
     _setup_parents(monkeypatch, parent_id=999)


### PR DESCRIPTION
### Motivation
- Fix a production race where `!reserve` appended a ledger row but failed to refresh recruiter-facing availability, leaving recruiters unaware of the reserved spot.
- Provide clear user-facing feedback when availability recompute fails so staff know the ledger changed but recruiter-facing data did not.
- Surface exact recompute failures to Discord runtime/admin channel with actionable diagnostics and repair hints.

### Description
- Treat append+failed-recompute as a partial success path by recording a `reservation_row` reference and returning a clear user message: `Reservation row was added, but recruiter-facing availability was NOT updated.`
- Emit structured Discord runtime/admin logs via `human_log.human` for both cache-refresh blocked and recompute-exception cases, including `source=reserve`, `clan_tag`, `reservation_row`, thread/ticket context, `error_type`, and the exception string/`repr`.
- Stop claiming availability was refreshed unless `availability.recompute_clan_availability` completes successfully and keep existing recompute logic that uses `recruitment.get_clans_tab_name()` and header maps (no hardcoded tab names or column indices added).
- Add tests that validate the partial-success behavior (`test_reserve_partial_success_when_recompute_fails`) and that `recompute_clan_availability` writes to the configured clans tab (`test_recompute_updates_recruiter_facing_clans_tab`), and adjust existing `!reserve` success coverage.

### Testing
- Ran targeted tests with `pytest -q tests/placement/test_reserve_command.py -k "partial_success_when_recompute_fails or recompute_updates_recruiter_facing_clans_tab or reserve_success"` and the selection passed.
- Added `test_reserve_partial_success_when_recompute_fails` to assert the partial-success user message and that an `error`-level `human_log.human` entry includes `error_type=RuntimeError` and `source=reserve`.
- Added `test_recompute_updates_recruiter_facing_clans_tab` to assert `recompute_clan_availability` looks up the configured clans tab (via `get_clans_tab_name`) and performs worksheet updates.
- Existing `reserve` success behavior remains covered by `test_reserve_success` and continued to succeed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118ae8f50c8323b144717042eb21a2)