### PR TITLE
Add grouped-daily Fusion reminders, durable dedupe, and progress-save diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ from c1c_coreops.rbac import (
 from c1c_coreops.cron_summary import emit_daily_summary
 from modules.recruitment.reporting.daily_recruiter_update import ensure_scheduler_started
 from modules.ops.startup_summary import render_startup_summary
+from modules.community.fusion.reminders import collect_fusion_reminder_startup_summary
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -58,6 +59,16 @@ COREOPS_COMMANDS = tuple(COREOPS_SETTINGS.admin_bang_base_commands)
 COREOPS_ADMIN_ALLOWLIST = {
     normalize_command_text(item) for item in COREOPS_SETTINGS.admin_bang_allowlist
 }
+CRON_JOB_NAMES = (
+    "cache_refresh:clans",
+    "cache_refresh:templates",
+    "cache_refresh:clan_tags",
+    "cache_refresh:onboarding_questions",
+    "cleanup_watcher",
+    "housekeeping_keepalive",
+    "mirralith_overview",
+    "fusion_reminders",
+)
 
 bot = commands.Bot(
     command_prefix=commands.when_mentioned_or(BANG_PREFIX),
@@ -347,6 +358,19 @@ async def on_ready():
             refresh_lines = ["♻️ Refresh", f"• failed: {preload_report.error or 'unknown'}"]
 
     jobs = {getattr(job, "name", ""): job for job in runtime.scheduler.jobs}
+    fusion_reminder_lines: list[str]
+    try:
+        fusion_reminder_lines = await collect_fusion_reminder_startup_summary(
+            bot,
+            scheduler_started="fusion_reminders" in jobs,
+        )
+    except Exception as exc:
+        log.exception("fusion reminder startup summary failed")
+        fusion_reminder_lines = [
+            "🧬 Fusion reminders",
+            f"• started={'yes' if 'fusion_reminders' in jobs else 'no'}",
+            f"• failed={type(exc).__name__}",
+        ]
     scheduler_lines = [
         "🧭 Scheduler",
         "• intervals: clans=3h • templates=7d • clan_tags=7d • onboarding_questions=7d • cleanup=24h • mirralith_overview=not scheduled",
@@ -357,6 +381,8 @@ async def on_ready():
         f"• cleanup={_fmt_next_utc(jobs['cleanup_watcher']) if 'cleanup_watcher' in jobs else 'not scheduled'}",
         f"• housekeeping_keepalive={_fmt_next_utc(jobs['housekeeping_keepalive']) if 'housekeeping_keepalive' in jobs else 'not scheduled'}",
         f"• mirralith_overview={_fmt_next_utc(jobs['mirralith_overview']) if 'mirralith_overview' in jobs else 'not scheduled'}",
+        f"• fusion_reminders={_fmt_next_utc(jobs['fusion_reminders']) if 'fusion_reminders' in jobs else 'not scheduled'}",
+        *fusion_reminder_lines,
     ]
     watchers_lines = [
         "✅ Watchers",

--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -397,10 +397,7 @@ class _FusionProgressEventSelect(discord.ui.Select):
         selected_event_id = self.values[0] if self.values else ""
         view.selected_event_id = selected_event_id or None
         view.refresh_items()
-        await interaction.response.edit_message(
-            embed=view.build_embed(),
-            view=view,
-        )
+        await _edit_progress_message(interaction, view=view)
 
 
 class _FusionProgressStatusSelect(discord.ui.Select):
@@ -463,6 +460,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
                 "status": status,
             },
         )
+        await _safe_defer_progress_interaction(interaction)
         try:
             partial_amount = view.partial_by_event.get(event.event_id)
             if status in {"not_started", "skipped"}:
@@ -482,15 +480,13 @@ class _FusionProgressStatusSelect(discord.ui.Select):
                 "user_id": view.user_id,
                 "custom_id": _FUSION_PROGRESS_STATUS_CUSTOM_ID,
             }
-            log.exception("fusion progress status update failed", extra=context)
-            await fusion_logs.send_ops_alert(
+            await _send_progress_save_failure(
+                interaction,
                 component="my_progress",
-                summary="status_update_failed",
                 dedupe_key=f"fusion:progress:update:{view.fusion_id}:{event.event_id}",
                 error=exc,
                 fields=context,
             )
-            await _send_ephemeral(interaction, "Couldn’t save progress right now. Try again in a moment.")
             return
 
         view.progress_by_event[event.event_id] = status
@@ -499,10 +495,7 @@ class _FusionProgressStatusSelect(discord.ui.Select):
         view.selected_event_id = event.event_id
         view.last_update = (event.event_name, status)
         view.refresh_items()
-        await interaction.response.edit_message(
-            embed=view.build_embed(),
-            view=view,
-        )
+        await _edit_progress_message(interaction, view=view)
 
 
 class FusionProgressShareModeView(discord.ui.View):
@@ -604,12 +597,40 @@ class _FusionProgressMarkAllButton(discord.ui.Button):
             await _send_ephemeral(interaction, "Selected event has no milestones.")
             return
         now = dt.datetime.now(dt.timezone.utc)
-        for milestone in event.milestones:
-            milestone_key = str(milestone.points_needed)
-            await fusion_sheets.upsert_user_event_progress(view.fusion_id, str(view.user_id), event.event_id, "done", now, milestone_key=milestone_key)
+        await _safe_defer_progress_interaction(interaction)
+        pending_updates: list[str] = []
+        try:
+            for milestone in event.milestones:
+                milestone_key = str(milestone.points_needed)
+                await fusion_sheets.upsert_user_event_progress(
+                    view.fusion_id,
+                    str(view.user_id),
+                    event.event_id,
+                    "done",
+                    now,
+                    milestone_key=milestone_key,
+                )
+                pending_updates.append(milestone_key)
+        except Exception as exc:
+            await _send_progress_save_failure(
+                interaction,
+                component="my_progress",
+                dedupe_key=f"fusion:progress:mark_all:{view.fusion_id}:{event.event_id}",
+                error=exc,
+                fields={
+                    "fusion_id": view.fusion_id,
+                    "event_id": event.event_id,
+                    "user_id": view.user_id,
+                    "selected_status": "done",
+                    "custom_id": _FUSION_PROGRESS_MARK_ALL_CUSTOM_ID,
+                    "row_key": f"{view.fusion_id}|{view.user_id}|{event.event_id}|{pending_updates[-1] if pending_updates else ''}",
+                },
+            )
+            return
+        for milestone_key in pending_updates:
             view.progress_by_event[f"{event.event_id}:{milestone_key}"] = "done"
         view.last_update = (event.event_name, "done")
-        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+        await _edit_progress_message(interaction, view=view)
 
 class _FusionProgressShareButton(discord.ui.Button):
     def __init__(self) -> None:
@@ -688,19 +709,38 @@ class _FusionProgressModal(discord.ui.Modal, title="Log Partial Fragments"):
             await _send_ephemeral(interaction, f"Enter a value between 0 and {self.event.reward_amount:g}.")
             return
         now = dt.datetime.now(dt.timezone.utc)
-        await fusion_sheets.upsert_user_event_progress(
-            self.panel_view.fusion_id,
-            str(self.panel_view.user_id),
-            self.event.event_id,
-            "in_progress",
-            now,
-            partial_amount=amount,
-        )
+        await _safe_defer_progress_interaction(interaction)
+        try:
+            await fusion_sheets.upsert_user_event_progress(
+                self.panel_view.fusion_id,
+                str(self.panel_view.user_id),
+                self.event.event_id,
+                "in_progress",
+                now,
+                partial_amount=amount,
+            )
+        except Exception as exc:
+            await _send_progress_save_failure(
+                interaction,
+                component="my_progress",
+                dedupe_key=f"fusion:progress:partial:{self.panel_view.fusion_id}:{self.event.event_id}",
+                error=exc,
+                fields={
+                    "fusion_id": self.panel_view.fusion_id,
+                    "event_id": self.event.event_id,
+                    "user_id": self.panel_view.user_id,
+                    "selected_status": "in_progress",
+                    "custom_id": _FUSION_PROGRESS_UPDATE_CUSTOM_ID,
+                    "partial_amount": amount,
+                    "row_key": f"{self.panel_view.fusion_id}|{self.panel_view.user_id}|{self.event.event_id}|",
+                },
+            )
+            return
         self.panel_view.progress_by_event[self.event.event_id] = "in_progress"
         self.panel_view.partial_by_event[self.event.event_id] = amount
         self.panel_view.last_update = (self.event.event_name, "in_progress")
         self.panel_view.refresh_items()
-        await interaction.response.edit_message(embed=self.panel_view.build_embed(), view=self.panel_view)
+        await _edit_progress_message(interaction, view=self.panel_view)
 
 
 class FusionProgressPanelView(discord.ui.View):
@@ -857,6 +897,51 @@ async def _handle_my_progress(interaction: discord.Interaction) -> None:
         await interaction.followup.send(embed=embed, view=view, ephemeral=True)
         return
     await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+
+async def _safe_defer_progress_interaction(interaction: discord.Interaction) -> None:
+    response = getattr(interaction, "response", None)
+    if response is None or response.is_done():
+        return
+    defer = getattr(response, "defer", None)
+    if not callable(defer):
+        return
+    try:
+        await defer(thinking=False)
+    except Exception:
+        log.debug("fusion progress interaction defer failed; continuing", exc_info=True)
+
+
+async def _edit_progress_message(interaction: discord.Interaction, *, view: "FusionProgressPanelView") -> None:
+    if interaction.response.is_done():
+        edit_original = getattr(interaction, "edit_original_response", None)
+        if callable(edit_original):
+            await edit_original(embed=view.build_embed(), view=view)
+            return
+    await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+
+async def _send_progress_save_failure(
+    interaction: discord.Interaction,
+    *,
+    component: str,
+    dedupe_key: str,
+    error: BaseException,
+    fields: dict[str, object],
+) -> None:
+    diagnostics = await fusion_sheets.get_progress_sheet_diagnostics()
+    fields.update(diagnostics)
+    fields.setdefault("save_success", False)
+    fields.setdefault("save_failure_reason", str(error) or type(error).__name__)
+    log.exception("fusion progress save failed", extra=fields)
+    await fusion_logs.send_ops_alert(
+        component=component,
+        summary="progress_save_failed",
+        dedupe_key=dedupe_key,
+        error=error,
+        fields=fields,
+    )
+    await _send_ephemeral(interaction, "Couldn’t save progress right now. Try again in a moment.")
 
 
 def _normalize_saved_progress(

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -1,27 +1,27 @@
-"""Fusion reminder engine for pre-start and start notifications."""
+"""Fusion grouped daily reminder engine."""
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
-import hashlib
 import logging
 import os
 import time
-import asyncio
 
 import discord
 from discord.ext import commands
 
-from modules.community.fusion.announcements import ensure_fusion_announcement
 from modules.community.fusion import logs as fusion_logs
+from modules.community.fusion.announcements import ensure_fusion_announcement
 from modules.community.fusion.opt_in_view import build_fusion_opt_in_view
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.reminders")
 
-_LOOKBACK_MINUTES = max(5, int(os.getenv("FUSION_REMINDER_LOOKBACK_MIN", "30")))
 _DEDUP_TIMEOUT_BACKOFF_SEC = max(60, int(os.getenv("FUSION_REMINDER_DEDUPE_BACKOFF_SEC", "300")))
 _DEDUP_TIMEOUT_SEC = max(1.0, float(os.getenv("FUSION_REMINDER_DEDUPE_TIMEOUT_SEC", "10")))
+_GROUPED_REMINDER_TYPE = "grouped_daily"
+_GROUPED_EVENT_ID_PREFIX = "grouped_daily"
 
 _DEDUP_BACKOFF_UNTIL_MONOTONIC: float = 0.0
 _MEMORY_SENT_KEYS: set[tuple[str, str, str]] = set()
@@ -38,105 +38,11 @@ def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
     return now.astimezone(dt.timezone.utc)
 
 
-def _within_window(*, trigger_at: dt.datetime, now: dt.datetime, lookback: dt.timedelta) -> bool:
-    return trigger_at <= now <= (trigger_at + lookback)
-
-
-
-
-def _format_starts_at(value: dt.datetime) -> str:
-    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-
-
-def _format_starts_in(*, start_at: dt.datetime, now: dt.datetime) -> str:
-    delta = start_at - now
-    total_seconds = max(0, int(delta.total_seconds()))
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes = remainder // 60
-    if hours and minutes:
-        return f"{hours}h {minutes}m"
-    if hours:
-        return f"{hours}h"
-    return f"{minutes}m"
-
-
 def _interpolate_template(template: str, values: dict[str, str]) -> str:
     text = str(template or "")
     for key, value in values.items():
         text = text.replace("{" + key + "}", value)
     return text
-
-
-def _build_reminder_copy(
-    *,
-    fusion_id: str,
-    event: fusion_sheets.FusionEventRow,
-    start_at: dt.datetime,
-    now: dt.datetime,
-    fusion_title: str,
-    reward_unit: str,
-    jump_url: str,
-) -> tuple[str, str, str] | None:
-    placeholders = {
-        "event_label": event.event_name,
-        "fusion_title": fusion_title,
-        "starts_at": _format_starts_at(start_at),
-        "starts_in": _format_starts_in(start_at=start_at, now=now),
-        "reward_type": reward_unit,
-        "jump_url": jump_url,
-        "jump_link": jump_url,
-    }
-    title_template = (event.embed_title or "").strip()
-    description_template = (event.embed_description or "").strip()
-    footer_template = (event.embed_footer or "").strip()
-    if not title_template or not description_template or not footer_template:
-        log.warning(
-            "fusion reminder skipped; missing required sheet copy fields",
-            extra={
-                "fusion_id": fusion_id,
-                "event_id": event.event_id,
-                "has_embed_title": bool(title_template),
-                "has_embed_description": bool(description_template),
-                "has_embed_footer": bool(footer_template),
-            },
-        )
-        return None
-    title = _interpolate_template(title_template, placeholders)
-    description = _interpolate_template(description_template, placeholders)
-    footer = _interpolate_template(footer_template, placeholders)
-    return title, description, footer
-
-def _build_reminder_embed(
-    *,
-    fusion_id: str,
-    event: fusion_sheets.FusionEventRow,
-    start_at: dt.datetime,
-    jump_url: str,
-    reward_unit: str,
-    now: dt.datetime,
-    fusion_title: str,
-) -> discord.Embed | None:
-    copy = _build_reminder_copy(
-        fusion_id=fusion_id,
-        event=event,
-        start_at=start_at,
-        now=now,
-        fusion_title=fusion_title,
-        reward_unit=reward_unit,
-        jump_url=jump_url,
-    )
-    if copy is None:
-        return None
-    title, description, footer = copy
-
-    embed = discord.Embed(
-        title=title,
-        description=description,
-        color=discord.Color.blurple(),
-        timestamp=start_at,
-    )
-    embed.set_footer(text=footer)
-    return embed
 
 
 def _build_grouped_embed(
@@ -147,7 +53,7 @@ def _build_grouped_embed(
     live_events: list[fusion_sheets.FusionEventRow],
     upcoming_events: list[fusion_sheets.FusionEventRow],
     ending_events: list[fusion_sheets.FusionEventRow],
-) -> discord.Embed | None:
+) -> discord.Embed:
     jump_link = f"[{settings.grouped_jump_label}]({jump_url})"
     placeholders = {
         "fusion_title": fusion_title,
@@ -162,9 +68,15 @@ def _build_grouped_embed(
         description=_interpolate_template(settings.grouped_embed_description, placeholders),
         color=discord.Color.blurple(),
     )
+
     def _section(events: list[fusion_sheets.FusionEventRow], label: str) -> None:
         value = "\n".join(f"• {event.event_name}" for event in events[:10]) if events else settings.grouped_empty_value
-        embed.add_field(name=_interpolate_template(label, placeholders), value=_interpolate_template(value, placeholders), inline=False)
+        embed.add_field(
+            name=_interpolate_template(label, placeholders),
+            value=_interpolate_template(value, placeholders),
+            inline=False,
+        )
+
     _section(live_events, settings.grouped_live_label)
     _section(upcoming_events, settings.grouped_upcoming_label)
     _section(ending_events, settings.grouped_ending_label)
@@ -184,18 +96,297 @@ def _missing_grouped_copy_fields(settings: fusion_sheets.FusionReminderSettings)
     return [name for name, value in required.items() if not str(value or "").strip()]
 
 
-def _grouped_event_bucket_key(
+def _parse_grouped_post_time_utc(raw: object) -> dt.time | None:
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    for fmt in ("%H:%M", "%H:%M:%S"):
+        try:
+            parsed = dt.datetime.strptime(text, fmt).time()
+            return parsed.replace(tzinfo=dt.timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def _grouped_event_id_for_date(day: dt.date) -> str:
+    return f"{_GROUPED_EVENT_ID_PREFIX}:{day.isoformat()}"
+
+
+def _format_due(value: dt.datetime | None) -> str:
+    if value is None:
+        return "none"
+    return value.astimezone(dt.timezone.utc).replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _format_sent(value: dt.datetime | None) -> str:
+    return _format_due(value)
+
+
+def _grouped_due_for_day(day: dt.date, post_time: dt.time) -> dt.datetime:
+    return dt.datetime.combine(day, post_time, tzinfo=dt.timezone.utc)
+
+
+def _next_grouped_due(
     *,
-    live_events: list[fusion_sheets.FusionEventRow],
-    upcoming_events: list[fusion_sheets.FusionEventRow],
-    ending_events: list[fusion_sheets.FusionEventRow],
-) -> str:
-    tokens: list[str] = []
-    tokens.extend(f"live:{event.event_id}" for event in sorted(live_events, key=lambda e: e.event_id))
-    tokens.extend(f"upcoming:{event.event_id}" for event in sorted(upcoming_events, key=lambda e: e.event_id))
-    tokens.extend(f"ending:{event.event_id}" for event in sorted(ending_events, key=lambda e: e.event_id))
-    digest = hashlib.sha1("|".join(tokens).encode("utf-8")).hexdigest()[:12] if tokens else "empty"
-    return f"grouped:{digest}"
+    now: dt.datetime,
+    post_time: dt.time,
+    sent_keys: set[tuple[str, str]],
+) -> dt.datetime:
+    today_key = (_grouped_event_id_for_date(now.date()), _GROUPED_REMINDER_TYPE)
+    today_due = _grouped_due_for_day(now.date(), post_time)
+    if today_key not in sent_keys and now <= today_due:
+        return today_due
+    if today_key not in sent_keys and now > today_due:
+        return now
+    tomorrow = now.date() + dt.timedelta(days=1)
+    return _grouped_due_for_day(tomorrow, post_time)
+
+
+def _is_grouped_due(
+    *,
+    now: dt.datetime,
+    post_time: dt.time,
+    sent_keys: set[tuple[str, str]],
+) -> bool:
+    today_key = (_grouped_event_id_for_date(now.date()), _GROUPED_REMINDER_TYPE)
+    if today_key in sent_keys:
+        return False
+    return now >= _grouped_due_for_day(now.date(), post_time)
+
+
+def _append_skip(skipped: dict[str, int], reason: str) -> None:
+    skipped[reason] = skipped.get(reason, 0) + 1
+
+
+def _render_skips(skipped: dict[str, int]) -> str:
+    if not skipped:
+        return "none"
+    return ", ".join(f"{reason}={count}" for reason, count in sorted(skipped.items()))
+
+
+def _select_grouped_events(
+    *,
+    settings: fusion_sheets.FusionReminderSettings,
+    events: list[fusion_sheets.FusionEventRow],
+    reference: dt.datetime,
+) -> tuple[list[fusion_sheets.FusionEventRow], list[fusion_sheets.FusionEventRow], list[fusion_sheets.FusionEventRow], dict[str, int]]:
+    live_events: list[fusion_sheets.FusionEventRow] = []
+    upcoming_events: list[fusion_sheets.FusionEventRow] = []
+    ending_events: list[fusion_sheets.FusionEventRow] = []
+    skipped: dict[str, int] = {}
+    for event in events:
+        timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_grouped_reminders")
+        if timing is None:
+            _append_skip(skipped, "invalid_timing")
+            continue
+        start_at, end_at = timing
+        if settings.include_start_events and start_at <= reference and (end_at is None or reference < end_at):
+            live_events.append(event)
+        if settings.include_upcoming_events:
+            upcoming_horizon = reference + dt.timedelta(days=settings.upcoming_window_days)
+            if reference < start_at <= upcoming_horizon:
+                upcoming_events.append(event)
+        if settings.include_ending_events and end_at is not None and reference <= end_at <= reference + dt.timedelta(hours=settings.end_lookahead_hours):
+            ending_events.append(event)
+    return live_events, upcoming_events, ending_events, skipped
+
+
+async def _load_grouped_sent_keys(target: fusion_sheets.FusionRow) -> tuple[set[tuple[str, str]], bool]:
+    dedupe_meta = fusion_sheets.reminder_dedupe_backend_metadata()
+    dedupe_backend = dedupe_meta.get("backend_type", "unknown")
+    dedupe_tab = dedupe_meta.get("tab_name", "")
+    dedupe_config_key = dedupe_meta.get("config_key", "")
+    durable_dedupe_available = time.monotonic() >= _DEDUP_BACKOFF_UNTIL_MONOTONIC
+    if not durable_dedupe_available:
+        _register_dedupe_degraded_mode()
+        log.warning(
+            "fusion grouped reminder durable dedupe in backoff window; using in-memory fallback",
+            extra={
+                "fusion_id": target.fusion_id,
+                "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
+                "dedupe_backend": dedupe_backend,
+                "dedupe_tab": dedupe_tab,
+                "dedupe_config_key": dedupe_config_key,
+                "operation": "read_sent_reminder_keys",
+            },
+        )
+        return set(), False
+    try:
+        sent_keys = await asyncio.wait_for(
+            fusion_sheets.get_sent_reminder_keys(target.fusion_id),
+            timeout=_DEDUP_TIMEOUT_SEC,
+        )
+        _recover_from_dedupe_backoff()
+        return sent_keys, True
+    except TimeoutError as exc:
+        _register_dedupe_timeout_backoff()
+        context = {
+            "fusion_id": target.fusion_id,
+            "timeout_sec": _DEDUP_TIMEOUT_SEC,
+            "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
+            "dedupe_backend": dedupe_backend,
+            "dedupe_tab": dedupe_tab,
+            "dedupe_config_key": dedupe_config_key,
+            "operation": "read_sent_reminder_keys",
+        }
+        log.exception("fusion grouped reminder durable dedupe timed out; using in-memory fallback", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_dedupe_unavailable_degraded_mode",
+            dedupe_key=f"fusion:grouped_reminders:dedupe:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
+        return set(), False
+    except Exception as exc:
+        _register_dedupe_degraded_mode()
+        context = {
+            "fusion_id": target.fusion_id,
+            "dedupe_backend": dedupe_backend,
+            "dedupe_tab": dedupe_tab,
+            "dedupe_config_key": dedupe_config_key,
+            "operation": "read_sent_reminder_keys",
+        }
+        log.exception("fusion grouped reminder failed to load durable dedupe; using in-memory fallback", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_dedupe_unavailable_degraded_mode",
+            dedupe_key=f"fusion:grouped_reminders:dedupe:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
+        return set(), False
+
+
+async def _resolve_channel_role_status(bot: commands.Bot, target: fusion_sheets.FusionRow) -> dict[str, object]:
+    channel_id = target.announcement_channel_id
+    role_id = target.opt_in_role_id
+    channel = None
+    if channel_id:
+        get_channel = getattr(bot, "get_channel", None)
+        if callable(get_channel):
+            channel = get_channel(int(channel_id))
+        if channel is None:
+            fetch_channel = getattr(bot, "fetch_channel", None)
+            if callable(fetch_channel):
+                try:
+                    channel = await fetch_channel(int(channel_id))
+                except Exception:
+                    channel = None
+    role_resolved = False
+    if role_id:
+        for guild in getattr(bot, "guilds", []) or []:
+            get_role = getattr(guild, "get_role", None)
+            if callable(get_role) and get_role(int(role_id)) is not None:
+                role_resolved = True
+                break
+    return {
+        "channel_id": channel_id,
+        "channel_resolved": channel is not None,
+        "thread_id": getattr(channel, "id", None) if isinstance(channel, discord.Thread) else None,
+        "thread_resolved": isinstance(channel, discord.Thread),
+        "role_id": role_id,
+        "role_resolved": role_resolved if role_id else None,
+    }
+
+
+async def collect_fusion_reminder_startup_summary(
+    bot: commands.Bot,
+    *,
+    scheduler_started: bool,
+    now: dt.datetime | None = None,
+) -> list[str]:
+    """Build non-secret grouped Fusion reminder scheduler diagnostics for startup logs."""
+
+    reference = _utc_now(now)
+    lines = ["🧬 Fusion grouped reminders"]
+    lines.append(f"• scheduler_started={'yes' if scheduler_started else 'no'}")
+    try:
+        target = await fusion_sheets.get_publishable_fusion()
+    except Exception as exc:
+        await fusion_logs.send_ops_alert(
+            component="grouped_reminders_startup",
+            summary="load_target_fusion_failed",
+            dedupe_key="fusion:grouped_reminders_startup:target",
+            error=exc,
+        )
+        lines.extend(["• enabled=no", "• skipped=load_target_failed"])
+        return lines
+    if target is None:
+        lines.extend(["• enabled=no", "• skipped=no_publishable_fusion"])
+        return lines
+
+    try:
+        settings = await fusion_sheets.get_fusion_reminder_settings()
+    except Exception as exc:
+        await fusion_logs.send_ops_alert(
+            component="grouped_reminders_startup",
+            summary="load_settings_failed",
+            dedupe_key=f"fusion:grouped_reminders_startup:settings:{target.fusion_id}",
+            error=exc,
+            fields={"fusion_id": target.fusion_id},
+        )
+        lines.extend(["• enabled=no", "• skipped=load_settings_failed"])
+        return lines
+
+    post_time = _parse_grouped_post_time_utc(settings.grouped_post_time_utc)
+    enabled = settings.group_events and post_time is not None
+    lines.append(f"• enabled={'yes' if enabled else 'no'}")
+    lines.append(f"• configured_post_time_utc={settings.grouped_post_time_utc or 'missing'}")
+    resolve_status = await _resolve_channel_role_status(bot, target)
+    lines.append(
+        "• channel_resolved={channel_resolved} channel_id={channel_id} thread_resolved={thread_resolved} thread_id={thread_id} role_resolved={role_resolved} role_id={role_id}".format(
+            **resolve_status
+        )
+    )
+
+    if not settings.group_events:
+        lines.append("• skipped=grouped_reminders_disabled")
+        return lines
+    if post_time is None:
+        lines.append("• skipped=missing_or_invalid_grouped_post_time_utc")
+        return lines
+
+    try:
+        sent_keys, _durable = await _load_grouped_sent_keys(target)
+        last_sent = await fusion_sheets.get_last_reminder_sent_at(target.fusion_id, reminder_type=_GROUPED_REMINDER_TYPE)
+    except Exception as exc:
+        await fusion_logs.send_ops_alert(
+            component="grouped_reminders_startup",
+            summary="load_dedupe_failed",
+            dedupe_key=f"fusion:grouped_reminders_startup:dedupe:{target.fusion_id}",
+            error=exc,
+            fields={"fusion_id": target.fusion_id},
+        )
+        sent_keys = set()
+        last_sent = None
+    next_due = _next_grouped_due(now=reference, post_time=post_time, sent_keys=sent_keys)
+
+    try:
+        events = await fusion_sheets.get_fusion_events(target.fusion_id)
+        live_events, upcoming_events, ending_events, skipped = _select_grouped_events(
+            settings=settings,
+            events=events,
+            reference=reference,
+        )
+        active_count = len(live_events) + len(upcoming_events) + len(ending_events)
+        skip_text = _render_skips(skipped) if active_count else "no_grouped_events"
+        lines.append(f"• rows_loaded={len(events)}")
+        lines.append(f"• grouped_events={active_count}")
+        lines.append(f"• next_grouped_due={_format_due(next_due)}")
+        lines.append(f"• last_grouped_sent={_format_sent(last_sent)}")
+        lines.append(f"• skipped={skip_text}")
+    except Exception as exc:
+        await fusion_logs.send_ops_alert(
+            component="grouped_reminders_startup",
+            summary="load_events_failed",
+            dedupe_key=f"fusion:grouped_reminders_startup:events:{target.fusion_id}",
+            error=exc,
+            fields={"fusion_id": target.fusion_id},
+        )
+        lines.append("• skipped=load_events_failed")
+    return lines
 
 
 async def process_fusion_reminders(
@@ -211,261 +402,191 @@ async def process_fusion_reminders(
         return
 
     reference = _utc_now(now)
-    lookback = dt.timedelta(minutes=_LOOKBACK_MINUTES)
 
     try:
         target = await fusion_sheets.get_publishable_fusion()
     except Exception as exc:
-        log.exception("fusion reminder failed to load target fusion")
+        log.exception("fusion grouped reminder failed to load target fusion")
         await fusion_logs.send_ops_alert(
             component="reminders",
-            summary="load_target_fusion_failed",
-            dedupe_key="fusion:reminders:load_target",
+            summary="grouped_load_target_fusion_failed",
+            dedupe_key="fusion:grouped_reminders:load_target",
             error=exc,
         )
         return
-
     if target is None:
         return
 
-    dedupe_meta = fusion_sheets.reminder_dedupe_backend_metadata()
-    dedupe_backend = dedupe_meta.get("backend_type", "unknown")
-    dedupe_tab = dedupe_meta.get("tab_name", "")
-    dedupe_config_key = dedupe_meta.get("config_key", "")
-    now_monotonic = time.monotonic()
-    durable_dedupe_available = now_monotonic >= _DEDUP_BACKOFF_UNTIL_MONOTONIC
-    sent_keys: set[tuple[str, str]] = set()
-    if durable_dedupe_available:
-        try:
-            sent_keys = await asyncio.wait_for(
-                fusion_sheets.get_sent_reminder_keys(target.fusion_id),
-                timeout=_DEDUP_TIMEOUT_SEC,
-            )
-            _recover_from_dedupe_backoff()
-        except TimeoutError as exc:
-            _register_dedupe_timeout_backoff()
-            durable_dedupe_available = False
-            context = {
-                "fusion_id": target.fusion_id,
-                "timeout_sec": _DEDUP_TIMEOUT_SEC,
-                "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
-                "dedupe_backend": dedupe_backend,
-                "dedupe_tab": dedupe_tab,
-                "dedupe_config_key": dedupe_config_key,
-                "operation": "read_sent_reminder_keys",
-            }
-            log.exception(
-                "fusion reminder durable dedupe timed out; using in-memory single-send fallback",
-                extra=context,
-                exc_info=True,
-            )
-            await fusion_logs.send_ops_alert(
-                component="reminders",
-                summary="durable_dedupe_unavailable_degraded_mode",
-                dedupe_key=f"fusion:reminders:dedupe:{target.fusion_id}",
-                error=exc,
-                fields=context,
-            )
-        except Exception as exc:
-            _register_dedupe_degraded_mode()
-            log.exception(
-                "fusion reminder failed to load durable dedupe state; using in-memory single-send fallback",
-                extra={
-                    "fusion_id": target.fusion_id,
-                    "dedupe_backend": dedupe_backend,
-                    "dedupe_tab": dedupe_tab,
-                    "dedupe_config_key": dedupe_config_key,
-                    "operation": "read_sent_reminder_keys",
-                },
-                exc_info=True,
-            )
-            await fusion_logs.send_ops_alert(
-                component="reminders",
-                summary="durable_dedupe_unavailable_degraded_mode",
-                dedupe_key=f"fusion:reminders:dedupe:{target.fusion_id}",
-                error=exc,
-                fields={
-                    "fusion_id": target.fusion_id,
-                    "dedupe_backend": dedupe_backend,
-                    "dedupe_tab": dedupe_tab,
-                    "dedupe_config_key": dedupe_config_key,
-                    "operation": "read_sent_reminder_keys",
-                },
-            )
-            durable_dedupe_available = False
-    else:
-        _register_dedupe_degraded_mode()
-        log.warning(
-            "fusion reminder durable dedupe in backoff window; using in-memory single-send fallback",
-            extra={
-                "fusion_id": target.fusion_id,
-                "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
-                "dedupe_backend": dedupe_backend,
-                "dedupe_tab": dedupe_tab,
-                "dedupe_config_key": dedupe_config_key,
-                "operation": "read_sent_reminder_keys",
-            },
-        )
-
     try:
-        events = await fusion_sheets.get_fusion_events(target.fusion_id)
+        settings = await fusion_sheets.get_fusion_reminder_settings()
     except Exception as exc:
         context = {"fusion_id": target.fusion_id}
-        log.exception("fusion reminder failed to load events", extra=context)
+        log.exception("fusion grouped reminder failed to load settings", extra=context)
         await fusion_logs.send_ops_alert(
             component="reminders",
-            summary="load_events_failed",
-            dedupe_key=f"fusion:reminders:events:{target.fusion_id}",
+            summary="grouped_load_settings_failed",
+            dedupe_key=f"fusion:grouped_reminders:settings:{target.fusion_id}",
             error=exc,
             fields=context,
         )
         return
 
-    settings = await fusion_sheets.get_fusion_reminder_settings()
-    if settings.group_events:
-        live_events: list[fusion_sheets.FusionEventRow] = []
-        upcoming_events: list[fusion_sheets.FusionEventRow] = []
-        ending_events: list[fusion_sheets.FusionEventRow] = []
-        for event in events:
-            timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_reminders")
-            if timing is None:
-                continue
-            start_at, end_at = timing
-            if settings.include_start_events and start_at <= reference and (end_at is None or reference < end_at):
-                live_events.append(event)
-            if settings.include_upcoming_events:
-                start_due_at = start_at - dt.timedelta(minutes=settings.start_offset_minutes)
-                upcoming_horizon = reference + dt.timedelta(days=settings.upcoming_window_days)
-                if start_due_at <= reference < start_at:
-                    upcoming_events.append(event)
-                elif reference < start_at <= upcoming_horizon:
-                    upcoming_events.append(event)
-            if settings.include_ending_events and end_at is not None and reference <= end_at <= reference + dt.timedelta(hours=settings.end_lookahead_hours):
-                ending_events.append(event)
-        if live_events or ending_events or upcoming_events:
-            reminder_type = "grouped"
-            group_event_key = _grouped_event_bucket_key(
-                live_events=live_events,
-                upcoming_events=upcoming_events,
-                ending_events=ending_events,
-            )
-            group_key = (group_event_key, reminder_type)
-            if group_key not in sent_keys:
-                announcement_message = await ensure_fusion_announcement(bot, target)
-                if announcement_message is not None:
-                    missing = _missing_grouped_copy_fields(settings)
-                    if missing:
-                        log.warning("fusion grouped reminder skipped; missing required sheet copy fields", extra={"fusion_id": target.fusion_id, "missing_fields": ",".join(missing)})
-                        return
-                    embed = _build_grouped_embed(
-                        settings=settings,
-                        fusion_title=target.fusion_name,
-                        jump_url=announcement_message.jump_url,
-                        live_events=live_events,
-                        upcoming_events=upcoming_events,
-                        ending_events=ending_events,
-                    )
-                    mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
-                    await announcement_message.channel.send(content=mention_content, embed=embed, view=build_fusion_opt_in_view(target))
-                    if durable_dedupe_available:
-                        await fusion_sheets.mark_reminder_sent(target.fusion_id, event_id=group_event_key, reminder_type=reminder_type, sent_at=reference)
-                    sent_keys.add(group_key)
+    if not settings.group_events:
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_reminders_disabled",
+            dedupe_key=f"fusion:grouped_reminders:disabled:{target.fusion_id}",
+            fields={"fusion_id": target.fusion_id},
+        )
         return
 
-    for event in events:
-        timing = fusion_sheets.get_valid_event_timing(event, for_helper="fusion_reminders")
-        if timing is None:
-            continue
-        start_at, _ = timing
-        prestart_hours = max(1, int(os.getenv("FUSION_PRESTART_REMINDER_HOURS", "6")))
+    post_time = _parse_grouped_post_time_utc(settings.grouped_post_time_utc)
+    if post_time is None:
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_post_time_missing_or_invalid",
+            dedupe_key=f"fusion:grouped_reminders:post_time:{target.fusion_id}",
+            fields={"fusion_id": target.fusion_id, "configured_post_time_utc": settings.grouped_post_time_utc or "missing"},
+        )
+        return
 
-        triggers: list[tuple[str, dt.datetime]] = [
-            ("prestart_6h", start_at - dt.timedelta(hours=prestart_hours)),
-            ("start", start_at),
-        ]
+    sent_keys, durable_dedupe_available = await _load_grouped_sent_keys(target)
+    grouped_event_id = _grouped_event_id_for_date(reference.date())
+    grouped_key = (grouped_event_id, _GROUPED_REMINDER_TYPE)
+    memory_key = (target.fusion_id, grouped_event_id, _GROUPED_REMINDER_TYPE)
+    await _maybe_alert_prolonged_dedupe_degradation(
+        target.fusion_id,
+        reminder_type=_GROUPED_REMINDER_TYPE,
+        backend=fusion_sheets.reminder_dedupe_backend_metadata().get("backend_type", "unknown"),
+    )
+    if grouped_key in sent_keys or memory_key in _MEMORY_SENT_KEYS:
+        return
+    if not _is_grouped_due(now=reference, post_time=post_time, sent_keys=sent_keys):
+        return
 
-        for reminder_type, trigger_at in triggers:
-            key = (event.event_id, reminder_type)
-            if key in sent_keys:
-                continue
-            memory_key = (target.fusion_id, event.event_id, reminder_type)
-            await _maybe_alert_prolonged_dedupe_degradation(
+    try:
+        events = await fusion_sheets.get_fusion_events(target.fusion_id)
+    except Exception as exc:
+        context = {"fusion_id": target.fusion_id}
+        log.exception("fusion grouped reminder failed to load events", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_load_events_failed",
+            dedupe_key=f"fusion:grouped_reminders:events:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
+        return
+
+    live_events, upcoming_events, ending_events, skipped = _select_grouped_events(
+        settings=settings,
+        events=events,
+        reference=reference,
+    )
+    if not (live_events or upcoming_events or ending_events):
+        context = {"fusion_id": target.fusion_id, "skipped": _render_skips(skipped) or "no_grouped_events"}
+        log.warning("fusion grouped reminder skipped; no grouped events selected", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_no_events_selected",
+            dedupe_key=f"fusion:grouped_reminders:no_events:{target.fusion_id}:{grouped_event_id}",
+            fields=context,
+        )
+        return
+
+    missing = _missing_grouped_copy_fields(settings)
+    if missing:
+        context = {"fusion_id": target.fusion_id, "missing_fields": ",".join(missing)}
+        log.warning("fusion grouped reminder skipped; missing required sheet copy fields", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_copy_missing",
+            dedupe_key=f"fusion:grouped_reminders:copy:{target.fusion_id}",
+            fields=context,
+        )
+        return
+
+    try:
+        announcement_message = await ensure_fusion_announcement(bot, target)
+    except Exception as exc:
+        context = {"fusion_id": target.fusion_id, "announcement_channel_id": target.announcement_channel_id}
+        log.exception("fusion grouped reminder failed to resolve announcement", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_announcement_resolve_failed",
+            dedupe_key=f"fusion:grouped_reminders:announcement:{target.fusion_id}",
+            error=exc,
+            fields=context,
+        )
+        return
+    if announcement_message is None:
+        context = {"fusion_id": target.fusion_id, "announcement_channel_id": target.announcement_channel_id}
+        log.warning("fusion grouped reminder skipped; announcement unavailable", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_announcement_unavailable",
+            dedupe_key=f"fusion:grouped_reminders:announcement_unavailable:{target.fusion_id}",
+            fields=context,
+        )
+        return
+
+    embed = _build_grouped_embed(
+        settings=settings,
+        fusion_title=target.fusion_name,
+        jump_url=announcement_message.jump_url,
+        live_events=live_events,
+        upcoming_events=upcoming_events,
+        ending_events=ending_events,
+    )
+    mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
+    try:
+        await announcement_message.channel.send(content=mention_content, embed=embed, view=build_fusion_opt_in_view(target))
+    except Exception as exc:
+        context = {
+            "fusion_id": target.fusion_id,
+            "event_id": grouped_event_id,
+            "reminder_type": _GROUPED_REMINDER_TYPE,
+            "channel_id": getattr(getattr(announcement_message, "channel", None), "id", None),
+            "thread_id": getattr(getattr(announcement_message, "channel", None), "id", None)
+            if isinstance(getattr(announcement_message, "channel", None), discord.Thread)
+            else None,
+        }
+        log.exception("fusion grouped reminder send failed", extra=context)
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_send_failed",
+            dedupe_key=f"fusion:grouped_reminders:send:{target.fusion_id}:{grouped_event_id}",
+            error=exc,
+            fields=context,
+        )
+        return
+
+    _MEMORY_SENT_KEYS.add(memory_key)
+    if durable_dedupe_available:
+        try:
+            await fusion_sheets.mark_reminder_sent(
                 target.fusion_id,
-                reminder_type=reminder_type,
-                backend=dedupe_backend,
+                event_id=grouped_event_id,
+                reminder_type=_GROUPED_REMINDER_TYPE,
+                sent_at=reference,
             )
-            if memory_key in _MEMORY_SENT_KEYS:
-                continue
-            if not _within_window(trigger_at=trigger_at, now=reference, lookback=lookback):
-                continue
-
-            try:
-                announcement_message = await ensure_fusion_announcement(bot, target)
-                if announcement_message is None:
-                    context = {
-                        "fusion_id": target.fusion_id,
-                        "event_id": event.event_id,
-                        "reminder_type": reminder_type,
-                    }
-                    log.warning(
-                        "fusion reminder skipped; announcement unavailable",
-                        extra=context,
-                    )
-                    continue
-
-                embed = _build_reminder_embed(
-                    fusion_id=target.fusion_id,
-                    event=event,
-                    start_at=start_at,
-                    jump_url=announcement_message.jump_url,
-                    reward_unit=str(target.reward_type or "").strip(),
-                    now=reference,
-                    fusion_title=target.fusion_name,
-                )
-                if embed is None:
-                    continue
-                mention_content = f"<@&{target.opt_in_role_id}>" if target.opt_in_role_id else None
-                reminder_view = build_fusion_opt_in_view(target)
-                await announcement_message.channel.send(content=mention_content, embed=embed, view=reminder_view)
-                if durable_dedupe_available:
-                    await fusion_sheets.mark_reminder_sent(
-                        target.fusion_id,
-                        event_id=event.event_id,
-                        reminder_type=reminder_type,
-                        sent_at=reference,
-                    )
-                sent_keys.add(key)
-                _MEMORY_SENT_KEYS.add(memory_key)
-            except Exception as exc:
-                context = {
-                    "fusion_id": target.fusion_id,
-                    "event_id": event.event_id,
-                    "reminder_type": reminder_type,
-                    "channel_id": getattr(getattr(announcement_message, "channel", None), "id", None)
-                    if "announcement_message" in locals()
-                    else None,
-                    "thread_id": getattr(getattr(announcement_message, "channel", None), "id", None)
-                    if "announcement_message" in locals()
-                    and isinstance(getattr(announcement_message, "channel", None), discord.Thread)
-                    else None,
-                }
-                log.exception(
-                    "fusion reminder send failed",
-                    extra=context,
-                    exc_info=True,
-                )
-                await fusion_logs.send_ops_alert(
-                    component="reminders",
-                    summary="send_failed",
-                    dedupe_key=(
-                        f"fusion:reminders:send:{target.fusion_id}:{event.event_id}:{reminder_type}"
-                    ),
-                    error=exc,
-                    fields=context,
-                )
+        except Exception as exc:
+            context = {
+                "fusion_id": target.fusion_id,
+                "event_id": grouped_event_id,
+                "reminder_type": _GROUPED_REMINDER_TYPE,
+            }
+            log.exception("fusion grouped reminder sent but dedupe write failed", extra=context)
+            await fusion_logs.send_ops_alert(
+                component="reminders",
+                summary="grouped_dedupe_write_failed_after_send",
+                dedupe_key=f"fusion:grouped_reminders:dedupe_write:{target.fusion_id}:{grouped_event_id}",
+                error=exc,
+                fields=context,
+            )
 
 
-__all__ = ["process_fusion_reminders"]
+__all__ = ["process_fusion_reminders", "collect_fusion_reminder_startup_summary"]
 
 
 def _register_dedupe_timeout_backoff() -> None:
@@ -506,8 +627,8 @@ async def _maybe_alert_prolonged_dedupe_degradation(
     _DEDUP_DEGRADED_ALERTED_KEYS.add(alert_key)
     await fusion_logs.send_ops_alert(
         component="reminders",
-        summary="durable_dedupe_unavailable_degraded_mode",
-        dedupe_key=f"fusion:reminders:dedupe_degraded:{fusion_id}:{reminder_type}",
+        summary="grouped_dedupe_unavailable_degraded_mode",
+        dedupe_key=f"fusion:grouped_reminders:dedupe_degraded:{fusion_id}:{reminder_type}",
         fields={
             "fusion_id": fusion_id,
             "reminder_type": reminder_type,

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -105,11 +105,27 @@ class FusionUserEventProgressRow:
 
 
 @dataclass(frozen=True, slots=True)
+class FusionProgressSaveResult:
+    fusion_id: str
+    event_id: str
+    user_id: str
+    selected_status: str
+    tab_name: str
+    headers: tuple[str, ...]
+    row_key: tuple[str, str, str, str]
+    row_number: int
+    operation: str
+    saved: bool
+    failure_reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class FusionReminderSettings:
     start_offset_minutes: int = 360
     end_lookahead_hours: int = 24
     upcoming_window_days: int = 2
     group_events: bool = False
+    grouped_post_time_utc: str = ""
     include_start_events: bool = True
     include_ending_events: bool = False
     include_upcoming_events: bool = False
@@ -781,6 +797,13 @@ async def get_fusion_reminder_settings() -> FusionReminderSettings:
         end_lookahead_hours=_parse_nonnegative_int(parsed.get("end_lookahead_hours"), 24),
         upcoming_window_days=_parse_nonnegative_int(parsed.get("upcoming_window_days"), 2),
         group_events=_parse_bool(parsed.get("group_events")),
+        grouped_post_time_utc=str(
+            parsed.get("grouped_post_time_utc")
+            or parsed.get("grouped_daily_post_time_utc")
+            or parsed.get("grouped_post_time")
+            or parsed.get("post_time_utc")
+            or ""
+        ).strip(),
         include_start_events=_parse_bool(parsed.get("include_start_events", True)),
         include_ending_events=_parse_bool(parsed.get("include_ending_events")),
         include_upcoming_events=_parse_bool(parsed.get("include_upcoming_events")),
@@ -855,6 +878,41 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
         if event_id and reminder_type:
             keys.add((event_id, reminder_type))
     return keys
+
+
+async def get_last_reminder_sent_at(
+    fusion_id: str,
+    *,
+    reminder_type: str,
+) -> dt.datetime | None:
+    """Return the latest sent_at marker for one fusion/reminder type."""
+
+    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return None
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    reminder_idx = index_by_field["reminder_type"]
+    sent_idx = index_by_field["sent_at_utc"]
+    target_fusion = str(fusion_id or "").strip()
+    target_type = str(reminder_type or "").strip()
+
+    latest: dt.datetime | None = None
+    for row in matrix[1:]:
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_type = str(row[reminder_idx] if reminder_idx < len(row) else "").strip()
+        if row_fusion != target_fusion or row_type != target_type:
+            continue
+        sent_at = _parse_iso_utc_optional(row[sent_idx] if sent_idx < len(row) else "")
+        if sent_at is not None and (latest is None or sent_at > latest):
+            latest = sent_at
+    return latest
 
 
 async def mark_reminder_sent(
@@ -975,6 +1033,88 @@ async def get_user_event_progress(fusion_id: str, user_id: str) -> dict[str, str
     return {"progress": rows, "partials": partials}
 
 
+def _progress_row_matches(
+    row: list[object],
+    *,
+    index_by_field: Mapping[str, int],
+    row_key: tuple[str, str, str, str],
+    status: str,
+    partial_idx: int,
+    partial_amount: float | None,
+) -> bool:
+    fusion_idx = index_by_field["fusion_id"]
+    user_idx = index_by_field["user_id"]
+    event_idx = index_by_field["event_id"]
+    milestone_idx = index_by_field["milestone_key"]
+    status_idx = index_by_field["status"]
+    current_key = (
+        str(row[fusion_idx] if fusion_idx < len(row) else "").strip(),
+        str(row[user_idx] if user_idx < len(row) else "").strip(),
+        str(row[event_idx] if event_idx < len(row) else "").strip(),
+        str(row[milestone_idx] if milestone_idx < len(row) else "").strip(),
+    )
+    if current_key != row_key:
+        return False
+    current_status = str(row[status_idx] if status_idx < len(row) else "").strip().lower()
+    if current_status != status:
+        return False
+    if partial_idx < 0:
+        return True
+    expected_partial = "" if partial_amount is None else f"{max(0.0, partial_amount):g}"
+    current_partial = str(row[partial_idx] if partial_idx < len(row) else "").strip()
+    return current_partial == expected_partial
+
+
+async def _verify_progress_save(
+    *,
+    tab_name: str,
+    index_by_field: Mapping[str, int],
+    row_key: tuple[str, str, str, str],
+    status: str,
+    partial_idx: int,
+    partial_amount: float | None,
+) -> None:
+    refreshed = await afetch_values(_sheet_id(), tab_name)
+    for row in refreshed[1:]:
+        if _progress_row_matches(
+            row,
+            index_by_field=index_by_field,
+            row_key=row_key,
+            status=status,
+            partial_idx=partial_idx,
+            partial_amount=partial_amount,
+        ):
+            return
+    raise RuntimeError(
+        "Fusion progress save verification failed "
+        f"(tab={tab_name}, row_key={'|'.join(row_key)}, status={status})"
+    )
+
+
+async def get_progress_sheet_diagnostics() -> dict[str, object]:
+    """Return non-secret progress-sheet schema details for failure logs."""
+
+    tab_name = ""
+    headers: list[str] = []
+    try:
+        tab_name, _aliases = _resolve_progress_sheet_schema()
+        matrix = await afetch_values(_sheet_id(), tab_name)
+        if matrix:
+            headers = [str(cell or "").strip().lower() for cell in matrix[0]]
+    except Exception as exc:
+        return {
+            "progress_config_key": _FUSION_PROGRESS_TAB_KEY,
+            "tab_name": tab_name or str(cfg.get(_FUSION_PROGRESS_TAB_KEY) or "").strip(),
+            "headers_resolved": ",".join(headers),
+            "diagnostics_error": str(exc),
+        }
+    return {
+        "progress_config_key": _FUSION_PROGRESS_TAB_KEY,
+        "tab_name": tab_name,
+        "headers_resolved": ",".join(headers),
+    }
+
+
 async def upsert_user_event_progress(
     fusion_id: str,
     user_id: str,
@@ -983,7 +1123,7 @@ async def upsert_user_event_progress(
     updated_at: dt.datetime,
     milestone_key: str = "",
     partial_amount: float | None = None,
-) -> None:
+) -> FusionProgressSaveResult:
     """Write user progress status for one fusion/user/event tuple."""
 
     normalized_status = str(status or "").strip().lower()
@@ -1018,6 +1158,7 @@ async def upsert_user_event_progress(
     target_event = str(event_id or "").strip()
     target_milestone = str(milestone_key or "").strip()
     timestamp = updated_at.astimezone(dt.timezone.utc).isoformat()
+    row_key = (target_fusion, target_user, target_event, target_milestone)
 
     worksheet = await aget_worksheet(_sheet_id(), tab_name)
     if partial_idx < 0:
@@ -1046,7 +1187,7 @@ async def upsert_user_event_progress(
         row_user = str(row[user_idx] if user_idx < len(row) else "").strip()
         row_event = str(row[event_idx] if event_idx < len(row) else "").strip()
         row_milestone = str(row[milestone_idx] if milestone_idx < len(row) else "").strip()
-        if (row_fusion, row_user, row_event, row_milestone) != (target_fusion, target_user, target_event, target_milestone):
+        if (row_fusion, row_user, row_event, row_milestone) != row_key:
             continue
         await acall_with_backoff(
             worksheet.update,
@@ -1068,7 +1209,28 @@ async def upsert_user_event_progress(
                 [[partial_token]],
                 value_input_option="RAW",
             )
-        return
+        await _verify_progress_save(
+            tab_name=tab_name,
+            index_by_field=index_by_field,
+            row_key=row_key,
+            status=normalized_status,
+            partial_idx=partial_idx,
+            partial_amount=partial_amount,
+        )
+        result = FusionProgressSaveResult(
+            fusion_id=target_fusion,
+            event_id=target_event,
+            user_id=target_user,
+            selected_status=normalized_status,
+            tab_name=tab_name,
+            headers=tuple(header),
+            row_key=row_key,
+            row_number=row_idx,
+            operation="updated",
+            saved=True,
+        )
+        log.info("fusion progress save succeeded", extra=_progress_save_log_fields(result))
+        return result
 
     row_values = [""] * len(header)
     row_values[fusion_idx] = target_fusion
@@ -1084,6 +1246,44 @@ async def upsert_user_event_progress(
         row_values,
         value_input_option="RAW",
     )
+    await _verify_progress_save(
+        tab_name=tab_name,
+        index_by_field=index_by_field,
+        row_key=row_key,
+        status=normalized_status,
+        partial_idx=partial_idx,
+        partial_amount=partial_amount,
+    )
+    result = FusionProgressSaveResult(
+        fusion_id=target_fusion,
+        event_id=target_event,
+        user_id=target_user,
+        selected_status=normalized_status,
+        tab_name=tab_name,
+        headers=tuple(header),
+        row_key=row_key,
+        row_number=len(matrix) + 1,
+        operation="inserted",
+        saved=True,
+    )
+    log.info("fusion progress save succeeded", extra=_progress_save_log_fields(result))
+    return result
+
+
+def _progress_save_log_fields(result: FusionProgressSaveResult) -> dict[str, object]:
+    return {
+        "fusion_id": result.fusion_id,
+        "event_id": result.event_id,
+        "user_id": result.user_id,
+        "selected_status": result.selected_status,
+        "tab_name": result.tab_name,
+        "headers_resolved": ",".join(result.headers),
+        "row_key": "|".join(result.row_key),
+        "row_number": result.row_number,
+        "row_operation": result.operation,
+        "save_success": result.saved,
+        "save_failure_reason": result.failure_reason,
+    }
 
 
 
@@ -1273,6 +1473,7 @@ __all__ = [
     "FusionEventRow",
     "FusionRow",
     "FusionUserEventProgressRow",
+    "FusionProgressSaveResult",
     "FusionReminderSettings",
     "get_active_fusion",
     "get_ended_fusions",
@@ -1286,8 +1487,10 @@ __all__ = [
     "get_sent_reminder_keys",
     "reminder_dedupe_backend_metadata",
     "get_user_event_progress",
+    "get_progress_sheet_diagnostics",
     "get_upcoming_events",
     "get_fusion_reminder_settings",
+    "get_last_reminder_sent_at",
     "mark_reminder_sent",
     "upsert_user_event_progress",
     "update_fusion_publication",

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime as dt
-from dataclasses import replace
 from unittest.mock import AsyncMock
 
 from modules.community.fusion import reminders
@@ -45,14 +44,12 @@ def _event(*, event_id: str, start_at: dt.datetime) -> fusion_sheets.FusionEvent
         points_needed=1000,
         is_estimated=False,
         sort_order=1,
-        embed_title="{fusion_title}: {event_label}",
-        embed_description="At {starts_at} ({starts_in}) {jump_link}",
-        embed_footer="Rewards: {reward_type}",
     )
 
 
 class _DummyChannel:
     def __init__(self) -> None:
+        self.id = 123
         self.sent = []
 
     async def send(self, *, content=None, embed=None, view=None):
@@ -70,27 +67,27 @@ def _settings(**overrides):
         start_offset_minutes=overrides.get("start_offset_minutes", 360),
         end_lookahead_hours=overrides.get("end_lookahead_hours", 24),
         upcoming_window_days=overrides.get("upcoming_window_days", 2),
-        group_events=overrides.get("group_events", False),
+        group_events=overrides.get("group_events", True),
+        grouped_post_time_utc=overrides.get("grouped_post_time_utc", "12:00"),
         include_start_events=overrides.get("include_start_events", True),
         include_ending_events=overrides.get("include_ending_events", False),
         include_upcoming_events=overrides.get("include_upcoming_events", False),
-        grouped_embed_title=overrides.get("grouped_embed_title", ""),
-        grouped_embed_description=overrides.get("grouped_embed_description", ""),
-        grouped_live_label=overrides.get("grouped_live_label", ""),
-        grouped_upcoming_label=overrides.get("grouped_upcoming_label", ""),
-        grouped_ending_label=overrides.get("grouped_ending_label", ""),
-        grouped_empty_value=overrides.get("grouped_empty_value", ""),
-        grouped_jump_label=overrides.get("grouped_jump_label", ""),
+        grouped_embed_title=overrides.get("grouped_embed_title", "{fusion_title} Summary"),
+        grouped_embed_description=overrides.get("grouped_embed_description", "Jump: {jump_link} | live={live_count} upcoming={upcoming_count}"),
+        grouped_live_label=overrides.get("grouped_live_label", "Live"),
+        grouped_upcoming_label=overrides.get("grouped_upcoming_label", "Upcoming"),
+        grouped_ending_label=overrides.get("grouped_ending_label", "Ending"),
+        grouped_empty_value=overrides.get("grouped_empty_value", "None"),
+        grouped_jump_label=overrides.get("grouped_jump_label", "Open"),
     )
 
 
-def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
+def test_grouped_daily_reminder_posts_once_and_ignores_old_non_grouped_rows(monkeypatch):
     now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
     event = _event(event_id="e-start", start_at=now)
     channel = _DummyChannel()
     announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
-
-    persisted: set[tuple[str, str, str]] = set()
+    persisted: set[tuple[str, str, str]] = {("f-1", "e-start", "start"), ("f-1", "e-pre", "prestart_6h")}
 
     async def _get_sent_keys(fusion_id: str):
         return {(event_id, reminder_type) for f_id, event_id, reminder_type in persisted if f_id == fusion_id}
@@ -98,50 +95,15 @@ def test_start_reminder_fires_once_and_is_restart_safe(monkeypatch):
     async def _mark_sent(fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
         persisted.add((fusion_id, event_id, reminder_type))
 
-    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
-    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (now, now + dt.timedelta(hours=1)))
-    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
-    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
-    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
-    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
-    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
-
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
-
-    assert len(channel.sent) == 1
-    assert channel.sent[0]["content"] is None
-    assert channel.sent[0]["view"] is None
-    embed = channel.sent[0]["embed"]
-    assert embed.title == "Mavara: Event e-start"
-    assert embed.description == "At 2026-04-10 12:00 UTC (0m) https://discord.test/jump"
-    assert embed.footer.text == "Rewards: fragments"
-    assert ("f-1", "e-start", "start") in persisted
-
-
-def test_prestart_reminder_fires_once(monkeypatch):
-    now = dt.datetime(2026, 4, 10, 6, 0, tzinfo=dt.timezone.utc)
-    event_start = now + dt.timedelta(hours=6)
-    event = _event(event_id="e-pre", start_at=event_start)
-    channel = _DummyChannel()
-    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
-    sent: set[tuple[str, str]] = set()
-
-    async def _get_sent_keys(_fusion_id: str):
-        return set(sent)
-
-    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
-        sent.add((event_id, reminder_type))
-
     monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
     monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (event_start, event_start + dt.timedelta(hours=1)))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
     monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
     monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    reminders._MEMORY_SENT_KEYS.clear()
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(minutes=1)))
@@ -150,178 +112,127 @@ def test_prestart_reminder_fires_once(monkeypatch):
     assert channel.sent[0]["content"] == "<@&777>"
     assert channel.sent[0]["view"] == "view"
     embed = channel.sent[0]["embed"]
-    assert embed.title == "Mavara: Event e-pre"
-    assert embed.description == "At 2026-04-10 12:00 UTC (6h) https://discord.test/jump"
-    assert embed.footer.text == "Rewards: fragments"
-    assert ("e-pre", "prestart_6h") in sent
-
-
-def test_invalid_events_skipped_and_no_role_mention_when_absent(monkeypatch):
-    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
-    good = _event(event_id="good", start_at=now)
-    bad = _event(event_id="bad", start_at=now)
-    channel = _DummyChannel()
-    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
-
-    def _timing(event, **_kwargs):
-        if event.event_id == "bad":
-            return None
-        return (now, now + dt.timedelta(hours=1))
-
-    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=None)))
-    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[bad, good]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", _timing)
-    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
-    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
-    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
-    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
-    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
-
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
-
-    assert len(channel.sent) == 1
-    assert channel.sent[0]["content"] is None
-    assert channel.sent[0]["view"] is None
-
-
-def test_announcement_self_heals_before_sending(monkeypatch):
-    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
-    event = _event(event_id="heal", start_at=now)
-    channel = _DummyChannel()
-    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
-    ensure = AsyncMock(return_value=announcement)
-
-    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
-    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (now, now + dt.timedelta(hours=1)))
-    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
-    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
-    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
-    monkeypatch.setattr(reminders, "ensure_fusion_announcement", ensure)
-
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
-
-    ensure.assert_awaited_once()
-    assert channel.sent
-
-
-def test_group_events_true_sends_one_grouped_message_with_sheet_copy(monkeypatch):
-    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
-    e1 = _event(event_id="a", start_at=now)
-    channel = _DummyChannel()
-    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
-    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
-    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[e1]))
-    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
-    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
-    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
-    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
-    settings = _settings(
-        group_events=True,
-        include_upcoming_events=True,
-        grouped_embed_title="{fusion_title} Summary",
-        grouped_embed_description="Jump: {jump_link} | live={live_count} upcoming={upcoming_count}",
-        grouped_live_label="Sheet Live",
-        grouped_upcoming_label="Sheet Upcoming",
-        grouped_ending_label="Sheet Ending",
-        grouped_empty_value="None",
-        grouped_jump_label="Jump Label",
-    )
-    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=settings))
-
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
-
-    assert len(channel.sent) == 1
-    embed = channel.sent[0]["embed"]
     assert embed.title == "Mavara Summary"
-    assert "[Jump Label](https://discord.test/jump)" in embed.description
-    names = [field.name for field in embed.fields]
-    assert names == ["Sheet Live", "Sheet Upcoming", "Sheet Ending"]
+    assert "[Open](https://discord.test/jump)" in embed.description
+    assert any(field.name == "Live" and "Event e-start" in field.value for field in embed.fields)
+    assert ("f-1", "grouped_daily:2026-04-10", "grouped_daily") in persisted
 
 
-def test_grouped_missing_grouped_jump_label_logs_and_skips(monkeypatch, caplog):
-    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
-    e1 = _event(event_id="a", start_at=now)
+def test_grouped_daily_reminder_waits_until_configured_post_time(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 11, 59, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-live", start_at=now - dt.timedelta(hours=1))
     channel = _DummyChannel()
     announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
     monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
-    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[e1]))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(grouped_post_time_utc="12:00")))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
-    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
-    monkeypatch.setattr(
-        fusion_sheets,
-        "get_fusion_reminder_settings",
-        AsyncMock(return_value=_settings(group_events=True, grouped_embed_title="x", grouped_embed_description="y", grouped_live_label="a", grouped_upcoming_label="c", grouped_ending_label="d", grouped_empty_value="e", grouped_jump_label="")),
-    )
+    reminders._MEMORY_SENT_KEYS.clear()
+
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
     assert channel.sent == []
-    assert "grouped reminder skipped; missing required sheet copy fields" in caplog.text
+    fusion_sheets.mark_reminder_sent.assert_not_awaited()
 
 
-def test_grouped_event_bucket_key_changes_when_only_upcoming_changes():
-    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
-    live = _event(event_id="live", start_at=now)
-    upcoming_a = _event(event_id="u-a", start_at=now + dt.timedelta(hours=2))
-    upcoming_b = _event(event_id="u-b", start_at=now + dt.timedelta(hours=3))
-
-    key_a = reminders._grouped_event_bucket_key(
-        live_events=[live],
-        upcoming_events=[upcoming_a],
-        ending_events=[],
-    )
-    key_b = reminders._grouped_event_bucket_key(
-        live_events=[live],
-        upcoming_events=[upcoming_b],
-        ending_events=[],
-    )
-
-    assert key_a != key_b
-
-
-def test_custom_reminder_copy_wins_and_interpolates(monkeypatch):
-    now = dt.datetime(2026, 4, 10, 6, 0, tzinfo=dt.timezone.utc)
-    event_start = now + dt.timedelta(hours=6)
-    event = _event(event_id="e-custom", start_at=event_start)
-    event = replace(event, embed_title="{fusion_title}: {event_label}", embed_description="Starts at {starts_at} ({starts_in}) for {reward_type}", embed_footer="Footer {event_label}")
+def test_grouped_daily_reminder_posts_again_next_day(monkeypatch):
+    first = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    second = first + dt.timedelta(days=1)
+    event = _event(event_id="e-live", start_at=first)
     channel = _DummyChannel()
     announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    persisted: set[tuple[str, str]] = set()
 
-    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+    async def _get_sent_keys(_fusion_id: str):
+        return set(persisted)
+
+    async def _mark_sent(_fusion_id: str, *, event_id: str, reminder_type: str, sent_at: dt.datetime):
+        persisted.add((event_id, reminder_type))
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
     monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (event_start, event_start + dt.timedelta(hours=1)))
-    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
-    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda _event, **_kwargs: (first, second + dt.timedelta(hours=2)))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", _mark_sent)
     monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
-    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    reminders._MEMORY_SENT_KEYS.clear()
 
-    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=first))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=second))
 
-    embed = channel.sent[0]["embed"]
-    assert embed.title == "Mavara: Event e-custom"
-    assert embed.description == "Starts at 2026-04-10 12:00 UTC (6h) for fragments"
-    assert embed.footer.text == "Footer Event e-custom"
+    assert len(channel.sent) == 2
+    assert ("grouped_daily:2026-04-10", "grouped_daily") in persisted
+    assert ("grouped_daily:2026-04-11", "grouped_daily") in persisted
 
 
-def test_missing_required_copy_skips_reminder_and_logs_warning(monkeypatch, caplog):
-    now = dt.datetime(2026, 4, 10, 6, 0, tzinfo=dt.timezone.utc)
-    event_start = now + dt.timedelta(hours=6)
-    event = _event(event_id="e-empty", start_at=event_start)
-    event = replace(event, embed_title="", embed_description="", embed_footer="")
+def test_grouped_missing_copy_logs_and_skips(monkeypatch, caplog):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-empty", start_at=now)
     channel = _DummyChannel()
     announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
     monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
     monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
-    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda *_args, **_kwargs: (event_start, event_start + dt.timedelta(hours=1)))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
     monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
     monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
-    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(grouped_embed_title="")))
     monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
     monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: None)
+    reminders._MEMORY_SENT_KEYS.clear()
 
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
 
     assert channel.sent == []
     assert "missing required sheet copy fields" in caplog.text
+
+
+def test_startup_summary_reports_grouped_daily_status(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 11, 30, tzinfo=dt.timezone.utc)
+    due_event = _event(event_id="due", start_at=now)
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[due_event]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "get_last_reminder_sent_at", AsyncMock(return_value=dt.datetime(2026, 4, 9, 12, tzinfo=dt.timezone.utc)))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(grouped_post_time_utc="12:00")))
+    monkeypatch.setattr(
+        fusion_sheets,
+        "get_valid_event_timing",
+        lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc),
+    )
+
+    lines = asyncio.run(
+        reminders.collect_fusion_reminder_startup_summary(object(), scheduler_started=True, now=now)
+    )
+
+    assert "• scheduler_started=yes" in lines
+    assert "• enabled=yes" in lines
+    assert "• configured_post_time_utc=12:00" in lines
+    assert any(line.startswith("• next_grouped_due=2026-04-10 12:00 UTC") for line in lines)
+    assert "• last_grouped_sent=2026-04-09 12:00 UTC" in lines
+    assert "• grouped_events=1" in lines
+
+
+def test_non_grouped_config_does_not_send_per_event_reminders(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-start", start_at=now)
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(group_events=False)))
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    reminders._MEMORY_SENT_KEYS.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert channel.sent == []
+    fusion_sheets.mark_reminder_sent.assert_not_awaited()

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -432,3 +432,47 @@ def test_load_fusions_normalizes_fragment_fusion_type_case(
 
     assert len(rows) == 1
     assert rows[0].fusion_type == "fragment"
+
+
+def test_upsert_user_event_progress_returns_insert_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
+    matrix = [["fusion_id", "user_id", "event_id", "milestone_key", "status", "updated_at_utc", "partial_amount"]]
+
+    class _Worksheet:
+        async def append_row(self, *_args, **_kwargs):
+            return None
+
+    worksheet = _Worksheet()
+    appended: list[list[str]] = []
+
+    async def _afetch_values(_sheet_id: str, tab_name: str):
+        assert tab_name == "User Progress"
+        return matrix
+
+    async def _acall_with_backoff(func, *args, **kwargs):
+        if getattr(func, "__name__", "") == "append_row":
+            appended.append(args[0])
+            matrix.append(args[0])
+        return None
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "User Progress")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
+    monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
+
+    result = asyncio.run(
+        fusion.upsert_user_event_progress(
+            "f-1",
+            "10",
+            "e-1",
+            "done",
+            dt.datetime(2026, 4, 10, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    assert result.tab_name == "User Progress"
+    assert result.headers == tuple(matrix[0])
+    assert result.row_key == ("f-1", "10", "e-1", "")
+    assert result.operation == "inserted"
+    assert result.saved is True
+    assert appended[0][4] == "done"

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -133,6 +133,35 @@ def test_get_sent_reminder_keys_does_not_require_sent_at_header(monkeypatch: pyt
     assert sent == {("e-1", "start")}
 
 
+def test_get_last_reminder_sent_at_reads_grouped_marker(monkeypatch: pytest.MonkeyPatch):
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_REMINDER_TAB": "FusionReminders",
+        },
+    )
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "FusionReminders"
+        return [
+            ["fusion_id", "event_id", "reminder_type", "sent_at_utc"],
+            ["f-1", "e-old", "start", "2026-04-09T01:00:00+00:00"],
+            ["f-1", "grouped_daily:2026-04-09", "grouped_daily", "2026-04-09T12:00:00+00:00"],
+            ["f-1", "grouped_daily:2026-04-10", "grouped_daily", "2026-04-10T12:00:00+00:00"],
+            ["f-2", "grouped_daily:2026-04-11", "grouped_daily", "2026-04-11T12:00:00+00:00"],
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    sent_at = asyncio.run(
+        fusion_sheets.get_last_reminder_sent_at("f-1", reminder_type="grouped_daily")
+    )
+
+    assert sent_at == dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
+
+
 def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.MonkeyPatch):
     _install_config(
         monkeypatch,
@@ -147,6 +176,7 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
         assert tab_name == "FusionReminderSettings"
         return [
             {"key": "group_events", "value": "TRUE"},
+            {"key": "grouped_post_time_utc", "value": "12:30"},
             {"key": "upcoming_window_days", "value": "3"},
             {"key": "include_upcoming_events", "value": "TRUE"},
             {"key": "grouped_embed_title", "value": "Title {fusion_title}"},
@@ -161,6 +191,7 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
     monkeypatch.setattr(fusion_sheets, "afetch_records", _afetch_records)
     settings = asyncio.run(fusion_sheets.get_fusion_reminder_settings())
     assert settings.group_events is True
+    assert settings.grouped_post_time_utc == "12:30"
     assert settings.upcoming_window_days == 3
     assert settings.include_upcoming_events is True
     assert settings.grouped_embed_title == "Title {fusion_title}"


### PR DESCRIPTION
### Motivation
- Replace per-event prestart/start reminders with a configurable grouped daily reminder flow and expose its status at startup. 
- Improve reliability and observability for Fusion progress saves by verifying sheet writes and surfacing diagnostics on failures. 
- Make the interactive Fusion progress UI more robust by ensuring interactions are deferred/edited safely and failures are reported consistently.

### Description
- Reimplemented the Fusion reminders engine as a grouped-daily reminder system in `modules/community/fusion/reminders.py` with configurable post time, grouped event selection, durable dedupe loading (`_load_grouped_sent_keys`), in-memory fallback, and startup diagnostics via `collect_fusion_reminder_startup_summary`.
- Added helper functions to parse post times, compute grouped event ids/due times, select grouped events, resolve announcement channel/role resolution, and render grouped embed copy; also added dedupe degradation alerts and backoff handling.
- Hooked the new startup summary into `app.py` so Fusion grouped-reminder status is included in the bot startup summary and added `fusion_reminders` to `CRON_JOB_NAMES`.
- Improved Fusion progress flow in `modules/community/fusion/opt_in_view.py` by adding `_safe_defer_progress_interaction`, `_edit_progress_message`, and `_send_progress_save_failure`, and updated callbacks to use these helpers for consistent deferral, editing, and error reporting.
- Enhanced sheet-side progress handling in `shared/sheets/fusion.py` by adding `FusionProgressSaveResult`, `get_progress_sheet_diagnostics`, `get_last_reminder_sent_at`, verification logic `_verify_progress_save`, and returning detailed diagnostics from `upsert_user_event_progress` while logging structured save metadata.
- Updated public exports and adjusted reminder settings to include `grouped_post_time_utc` and related fields.
- Updated and added unit tests to reflect grouped reminders and progress-save diagnostics in `tests/community/test_fusion_reminders.py`, `tests/shared/sheets/test_fusion.py`, and `tests/shared/sheets/test_fusion_reminder_schema.py`.

### Testing
- Ran the modified fusion reminder unit tests in `tests/community/test_fusion_reminders.py` which exercise grouped-post timing, single-send behavior, missing-copy handling, and startup summary reporting, and they passed.
- Ran the shared sheets unit tests in `tests/shared/sheets/test_fusion.py` including the new `upsert_user_event_progress` diagnostics test, and they passed.
- Ran the reminder schema tests in `tests/shared/sheets/test_fusion_reminder_schema.py` including `get_last_reminder_sent_at` behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a242d657eec83238d27f7a373762ae6)