### PR TITLE
Fix Fusion My Progress mobile ephemeral panel

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import time
 from collections.abc import Mapping, Sequence
 from typing import Literal
 
@@ -55,6 +56,7 @@ _STATUS_INDEX_TO_CANONICAL = {
     "4": "skipped",
 }
 _EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
+_PROGRESS_EVENT_PAGE_SIZE = 10
 
 
 def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, status: str | None) -> bool:
@@ -347,27 +349,38 @@ def _build_progress_summary_embed(
     return embed
 
 
+def _ordered_progress_events(
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str],
+) -> list[fusion_sheets.FusionEventRow]:
+    now = dt.datetime.now(dt.timezone.utc)
+    event_rows = list(enumerate(events))
+    ordered_events = sorted(
+        event_rows,
+        key=lambda item: (
+            _EVENT_DROPDOWN_STATUS_RANK.get(
+                _effective_display_status(event=item[1], progress_by_event=progress_by_event, now=now),
+                len(_EVENT_DROPDOWN_STATUS_RANK),
+            ),
+            item[0],
+        ),
+    )
+    return [event for _, event in ordered_events]
+
+
 class _FusionProgressEventSelect(discord.ui.Select):
     def __init__(
         self,
         events: Sequence[fusion_sheets.FusionEventRow],
         selected_event_id: str | None,
         progress_by_event: Mapping[str, str],
+        *,
+        page_index: int = 0,
+        page_count: int = 1,
     ) -> None:
         now = dt.datetime.now(dt.timezone.utc)
-        event_rows = list(enumerate(events))
-        ordered_events = sorted(
-            event_rows,
-            key=lambda item: (
-                _EVENT_DROPDOWN_STATUS_RANK.get(
-                    _effective_display_status(event=item[1], progress_by_event=progress_by_event, now=now),
-                    len(_EVENT_DROPDOWN_STATUS_RANK),
-                ),
-                item[0],
-            ),
-        )
         options: list[discord.SelectOption] = []
-        for _, event in ordered_events[:25]:
+        for event in events[:_PROGRESS_EVENT_PAGE_SIZE]:
             status = _effective_display_status(event=event, progress_by_event=progress_by_event, now=now)
             icon = _STATUS_ICONS.get(status, _STATUS_ICONS["not_started"])
             options.append(
@@ -377,8 +390,11 @@ class _FusionProgressEventSelect(discord.ui.Select):
                     default=event.event_id == selected_event_id,
                 )
             )
+        placeholder = "Choose event"
+        if page_count > 1:
+            placeholder = f"Choose event (page {page_index + 1}/{page_count})"
         super().__init__(
-            placeholder="Choose event",
+            placeholder=placeholder,
             min_values=1,
             max_values=1,
             options=options,
@@ -632,6 +648,29 @@ class _FusionProgressMarkAllButton(discord.ui.Button):
         view.last_update = (event.event_name, "done")
         await _edit_progress_message(interaction, view=view)
 
+class _FusionProgressPageButton(discord.ui.Button):
+    def __init__(self, *, direction: Literal["previous", "next"], disabled: bool) -> None:
+        self.direction = direction
+        label = "Previous" if direction == "previous" else "Next"
+        custom_id = f"fusion:progress:page:{direction}"
+        super().__init__(label=label, style=discord.ButtonStyle.secondary, custom_id=custom_id, row=2, disabled=disabled)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FusionProgressPanelView):
+            return
+        if interaction.user.id != view.user_id:
+            await _send_ephemeral(interaction, "This progress panel belongs to a different user.")
+            return
+        if self.direction == "previous":
+            view.event_page_index = max(view.event_page_index - 1, 0)
+        else:
+            view.event_page_index = min(view.event_page_index + 1, view.event_page_count - 1)
+        view.selected_event_id = view.first_event_id_on_current_page()
+        view.refresh_items()
+        await _edit_progress_message(interaction, view=view)
+
+
 class _FusionProgressShareButton(discord.ui.Button):
     def __init__(self) -> None:
         super().__init__(
@@ -763,17 +802,39 @@ class FusionProgressPanelView(discord.ui.View):
         self.events_by_id = {event.event_id: event for event in self.events}
         self.progress_by_event = dict(progress_by_event)
         self.partial_by_event = dict(partial_by_event or {})
+        self.event_page_index = 0
         self.selected_event_id = self.events[0].event_id if self.events else None
         self.last_update: tuple[str, str] | None = None
         self.refresh_items()
+
+    @property
+    def ordered_events(self) -> list[fusion_sheets.FusionEventRow]:
+        return _ordered_progress_events(self.events, self.progress_by_event)
+
+    @property
+    def event_page_count(self) -> int:
+        if not self.events:
+            return 1
+        return max(1, (len(self.events) + _PROGRESS_EVENT_PAGE_SIZE - 1) // _PROGRESS_EVENT_PAGE_SIZE)
+
+    def current_page_events(self) -> list[fusion_sheets.FusionEventRow]:
+        ordered = self.ordered_events
+        self.event_page_index = min(max(self.event_page_index, 0), self.event_page_count - 1)
+        start = self.event_page_index * _PROGRESS_EVENT_PAGE_SIZE
+        return ordered[start : start + _PROGRESS_EVENT_PAGE_SIZE]
+
+    def first_event_id_on_current_page(self) -> str | None:
+        current_events = self.current_page_events()
+        return current_events[0].event_id if current_events else None
 
     def _coerce_selected_event_id(self) -> None:
         if not self.events:
             self.selected_event_id = None
             return
-        if self.selected_event_id in self.events_by_id:
+        current_event_ids = {event.event_id for event in self.current_page_events()}
+        if self.selected_event_id in current_event_ids:
             return
-        self.selected_event_id = self.events[0].event_id
+        self.selected_event_id = self.first_event_id_on_current_page()
 
     def refresh_items(self) -> None:
         self.clear_items()
@@ -781,7 +842,16 @@ class FusionProgressPanelView(discord.ui.View):
             return
 
         self._coerce_selected_event_id()
-        self.add_item(_FusionProgressEventSelect(self.events, self.selected_event_id, self.progress_by_event))
+        current_events = self.current_page_events()
+        self.add_item(
+            _FusionProgressEventSelect(
+                current_events,
+                self.selected_event_id,
+                self.progress_by_event,
+                page_index=self.event_page_index,
+                page_count=self.event_page_count,
+            )
+        )
         selected_status = None
         selected_event = None
         if self.selected_event_id:
@@ -794,6 +864,9 @@ class FusionProgressPanelView(discord.ui.View):
             self.add_item(_FusionProgressUpdateButton())
         if selected_event is not None and selected_event.milestones:
             self.add_item(_FusionProgressMarkAllButton())
+        if self.event_page_count > 1:
+            self.add_item(_FusionProgressPageButton(direction="previous", disabled=self.event_page_index <= 0))
+            self.add_item(_FusionProgressPageButton(direction="next", disabled=self.event_page_index >= self.event_page_count - 1))
         self.add_item(_FusionProgressShareButton())
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -813,7 +886,60 @@ class FusionProgressPanelView(discord.ui.View):
         )
 
 
+def _progress_panel_diagnostics(
+    interaction: discord.Interaction,
+    *,
+    target: fusion_sheets.FusionRow | None = None,
+    events: Sequence[fusion_sheets.FusionEventRow] | None = None,
+    view: "FusionProgressPanelView" | None = None,
+    response_path: str,
+    elapsed_ms: int,
+) -> dict[str, object]:
+    context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_MY_PROGRESS_CUSTOM_ID)
+    if target is not None:
+        context["fusion_id"] = target.fusion_id
+    if events is not None:
+        context["event_count"] = len(events)
+        context["event_page_size"] = _PROGRESS_EVENT_PAGE_SIZE
+        context["event_page_count"] = max(1, (len(events) + _PROGRESS_EVENT_PAGE_SIZE - 1) // _PROGRESS_EVENT_PAGE_SIZE)
+    if view is not None:
+        context["component_count"] = len(view.children)
+        context["event_options_visible"] = len(view.current_page_events())
+        context["selected_event_id"] = view.selected_event_id or ""
+        context["embed_field_count"] = len(view.build_embed().fields)
+    context["response_path"] = response_path
+    context["response_done_before_send"] = interaction.response.is_done()
+    context["elapsed_ms"] = elapsed_ms
+    return context
+
+
+async def _send_my_progress_panel(
+    interaction: discord.Interaction,
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    view: "FusionProgressPanelView",
+    started_at: float,
+) -> None:
+    embed = view.build_embed()
+    response_path = "followup_send_ephemeral" if interaction.response.is_done() else "direct_send_ephemeral"
+    diagnostics = _progress_panel_diagnostics(
+        interaction,
+        target=target,
+        events=events,
+        view=view,
+        response_path=response_path,
+        elapsed_ms=int((time.monotonic() - started_at) * 1000),
+    )
+    log.info("fusion my-progress response path selected", extra=diagnostics)
+    if interaction.response.is_done():
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        return
+    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+
 async def _handle_my_progress(interaction: discord.Interaction) -> None:
+    started_at = time.monotonic()
     try:
         target = await fusion_sheets.get_publishable_fusion()
     except Exception as exc:
@@ -892,11 +1018,7 @@ async def _handle_my_progress(interaction: discord.Interaction) -> None:
         progress_by_event=progress_by_event,
         partial_by_event=partial_by_event,
     )
-    embed = view.build_embed()
-    if interaction.response.is_done():
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
-        return
-    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+    await _send_my_progress_panel(interaction, target=target, events=events, view=view, started_at=started_at)
 
 
 async def _safe_defer_progress_interaction(interaction: discord.Interaction) -> None:
@@ -913,6 +1035,15 @@ async def _safe_defer_progress_interaction(interaction: discord.Interaction) -> 
 
 
 async def _edit_progress_message(interaction: discord.Interaction, *, view: "FusionProgressPanelView") -> None:
+    diagnostics = _progress_panel_diagnostics(
+        interaction,
+        target=view.target,
+        events=view.events,
+        view=view,
+        response_path="edit_original_response" if interaction.response.is_done() else "response_edit_message",
+        elapsed_ms=0,
+    )
+    log.info("fusion progress panel edit path selected", extra=diagnostics)
     if interaction.response.is_done():
         edit_original = getattr(interaction, "edit_original_response", None)
         if callable(edit_original):

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime as dt
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from modules.community.fusion import opt_in_view
 from shared.sheets import fusion as fusion_sheets
@@ -562,3 +562,70 @@ def test_mark_all_button_shown_for_milestone_event():
     )
     custom_ids = [item.custom_id for item in view.children]
     assert "fusion:progress:mark_all" in custom_ids
+
+
+def test_my_progress_direct_send_logs_mobile_diagnostics(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        events = [_event_row("e1"), _event_row("e2")]
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
+        monkeypatch.setattr(fusion_sheets, "get_user_event_progress", AsyncMock(return_value={}))
+        info_mock = Mock()
+        monkeypatch.setattr(opt_in_view.log, "info", info_mock)
+
+        await opt_in_view._handle_my_progress(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert interaction.response.send_message.await_args.kwargs["ephemeral"] is True
+        interaction.followup.send.assert_not_awaited()
+        info_mock.assert_called()
+        diagnostics = info_mock.call_args.kwargs["extra"]
+        assert diagnostics["response_path"] == "direct_send_ephemeral"
+        assert diagnostics["event_count"] == 2
+        assert diagnostics["event_options_visible"] == 2
+        assert diagnostics["component_count"] == 3
+
+    asyncio.run(_run())
+
+
+def test_my_progress_event_select_is_paginated_for_mobile():
+    events = [_event_row(f"e{i:02d}", event_name=f"Event {i:02d}") for i in range(12)]
+    view = opt_in_view.FusionProgressPanelView(
+        user_id=10,
+        target=_fusion_row(opt_in_role_id=777),
+        events=events,
+        progress_by_event={},
+    )
+
+    event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+    custom_ids = [item.custom_id for item in view.children]
+    assert len(event_select.options) == 10
+    assert event_select.placeholder == "Choose event (page 1/2)"
+    assert "fusion:progress:page:previous" in custom_ids
+    assert "fusion:progress:page:next" in custom_ids
+
+
+def test_my_progress_next_page_rebuilds_smaller_event_options():
+    async def _run() -> None:
+        events = [_event_row(f"e{i:02d}", event_name=f"Event {i:02d}") for i in range(12)]
+        view = opt_in_view.FusionProgressPanelView(
+            user_id=10,
+            target=_fusion_row(opt_in_role_id=777),
+            events=events,
+            progress_by_event={},
+        )
+        interaction = _interaction(guild=None, member=SimpleNamespace(id=10))
+        next_button = next(item for item in view.children if item.custom_id == "fusion:progress:page:next")
+
+        await next_button.callback(interaction)
+
+        assert view.event_page_index == 1
+        assert view.selected_event_id == "e10"
+        event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
+        assert [option.value for option in event_select.options] == ["e10", "e11"]
+        assert event_select.placeholder == "Choose event (page 2/2)"
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Mobile clients sometimes failed to surface the ephemeral "My Progress" panel even though desktop showed it, likely due to heavy select menus / view composition and unstable defer/edit patterns. 
- The event select previously emitted up to 25 options in a single select alongside an embed and several controls which increases mobile rendering risk. 
- We need reliable, private (ephemeral) behavior on mobile without changing sheet persistence or save semantics.

### Description
- Paginate the event dropdown to `10` options per page and add `Previous`/`Next` controls with paging state on `FusionProgressPanelView` to reduce mobile rendering load. 
- Preserve the existing ephemeral semantics and choose the initial send path deterministically using `_send_my_progress_panel()` which does a direct ephemeral `interaction.response.send_message(...)` unless the interaction was already acknowledged, in which case it uses an ephemeral followup. 
- Add diagnostic helpers `_progress_panel_diagnostics()` and `_send_my_progress_panel()` so logs record `response_path`, `elapsed_ms`, `event_count`, `event_page_count`, `event_options_visible`, `component_count`, `selected_event_id`, `embed_field_count`, and whether the response was done before send/edit. 
- Log edit-path diagnostics from `_edit_progress_message()` so `response_edit_message` and `edit_original_response` paths are distinguishable. 
- Keep all existing save/update flows and sheet writes unchanged; paging is purely a UI/rendering change. 

### Testing
- Ran `pytest tests/community/test_fusion_opt_in_view.py -q` and all tests passed. 
- Linted with `python -m ruff check modules/community/fusion/opt_in_view.py tests/community/test_fusion_opt_in_view.py` which passed. 
- Byte-compiled with `python -m compileall modules/community/fusion/opt_in_view.py` with no errors. 
- Ran `git diff --check` to validate no stray whitespace issues.

[meta]
labels: fix, comp:modules, robustness, observability
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2442d045548323a1f2a5f0a9fcaf8f)