### PR TITLE
Fix Fusion grouped reminder settings parsing

### DIFF
--- a/modules/community/fusion/logs.py
+++ b/modules/community/fusion/logs.py
@@ -30,6 +30,7 @@ async def send_ops_alert(
     summary: str,
     dedupe_key: str | None = None,
     error: BaseException | None = None,
+    reason: str | None = None,
     fields: Mapping[str, Any] | None = None,
 ) -> None:
     """Emit a Fusion-focused alert to the configured internal log channel."""
@@ -39,8 +40,8 @@ async def send_ops_alert(
         return
 
     detail = _render_fields(fields or {})
-    reason = human_reason(error) if error is not None else "-"
-    message = f"❌ Fusion — component={component} • summary={summary} • reason={reason}"
+    resolved_reason = human_reason(error) if error is not None else (reason or "-")
+    message = f"❌ Fusion — component={component} • summary={summary} • reason={resolved_reason}"
     if detail:
         message = f"{message} • {detail}"
 

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -96,6 +96,21 @@ def _missing_grouped_copy_fields(settings: fusion_sheets.FusionReminderSettings)
     return [name for name, value in required.items() if not str(value or "").strip()]
 
 
+
+def _group_events_config_fields(settings: fusion_sheets.FusionReminderSettings) -> dict[str, object]:
+    source = settings.group_events_source
+    fields: dict[str, object] = {
+        "group_events_resolved": "true" if settings.group_events else "false",
+        "group_events_raw_value": source.raw_value or "missing",
+        "group_events_source_tab": source.tab_name or "missing",
+        "group_events_key_header": source.key_header or "missing",
+        "group_events_value_header": source.value_header or "missing",
+    }
+    if source.duplicate_count:
+        fields["group_events_duplicate_count"] = source.duplicate_count
+    return fields
+
+
 def _parse_grouped_post_time_utc(raw: object) -> dt.time | None:
     text = str(raw or "").strip()
     if not text:
@@ -334,6 +349,16 @@ async def collect_fusion_reminder_startup_summary(
     enabled = settings.group_events and post_time is not None
     lines.append(f"• enabled={'yes' if enabled else 'no'}")
     lines.append(f"• configured_post_time_utc={settings.grouped_post_time_utc or 'missing'}")
+    source = settings.group_events_source
+    lines.append(
+        "• group_events_resolved={resolved} raw_value={raw_value} source_tab={source_tab} key_header={key_header} value_header={value_header}".format(
+            resolved="true" if settings.group_events else "false",
+            raw_value=source.raw_value or "missing",
+            source_tab=source.tab_name or "missing",
+            key_header=source.key_header or "missing",
+            value_header=source.value_header or "missing",
+        )
+    )
     resolve_status = await _resolve_channel_role_status(bot, target)
     lines.append(
         "• channel_resolved={channel_resolved} channel_id={channel_id} thread_resolved={thread_resolved} thread_id={thread_id} role_resolved={role_resolved} role_id={role_id}".format(
@@ -342,7 +367,7 @@ async def collect_fusion_reminder_startup_summary(
     )
 
     if not settings.group_events:
-        lines.append("• skipped=grouped_reminders_disabled")
+        lines.append("• skipped=grouped_reminders_disabled reason=group_events_resolved_false")
         return lines
     if post_time is None:
         lines.append("• skipped=missing_or_invalid_grouped_post_time_utc")
@@ -436,7 +461,8 @@ async def process_fusion_reminders(
             component="reminders",
             summary="grouped_reminders_disabled",
             dedupe_key=f"fusion:grouped_reminders:disabled:{target.fusion_id}",
-            fields={"fusion_id": target.fusion_id},
+            reason="group_events_resolved_false",
+            fields={"fusion_id": target.fusion_id, **_group_events_config_fields(settings)},
         )
         return
 

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from shared.config import cfg, get_milestones_sheet_id
@@ -120,6 +120,15 @@ class FusionProgressSaveResult:
 
 
 @dataclass(frozen=True, slots=True)
+class FusionReminderSettingSource:
+    tab_name: str = ""
+    key_header: str = ""
+    value_header: str = ""
+    raw_value: str = ""
+    duplicate_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
 class FusionReminderSettings:
     start_offset_minutes: int = 360
     end_lookahead_hours: int = 24
@@ -136,6 +145,7 @@ class FusionReminderSettings:
     grouped_ending_label: str = ""
     grouped_empty_value: str = ""
     grouped_jump_label: str = ""
+    group_events_source: FusionReminderSettingSource = field(default_factory=FusionReminderSettingSource)
 
 
 def _resolve_tab_name(key: str) -> str:
@@ -237,8 +247,14 @@ def _parse_milestones(value: object, *, fusion_id: str, event_id: str) -> tuple[
     return tuple(parsed)
 
 def _parse_bool(value: object) -> bool:
-    text = str(value or "").strip().lower()
-    return text in {"1", "true", "yes", "y"}
+    if isinstance(value, bool):
+        return value
+    text = ("" if value is None else str(value)).strip().casefold()
+    if text in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    return False
 
 
 def _parse_nonnegative_int(value: object, default: int) -> int:
@@ -785,35 +801,81 @@ async def get_active_events(
 async def get_fusion_reminder_settings() -> FusionReminderSettings:
     tab_name = _resolve_tab_name(_FUSION_REMINDER_SETTINGS_TAB_KEY)
     rows = await afetch_records(_sheet_id(), tab_name)
-    parsed: dict[str, object] = {}
+
+    @dataclass(slots=True)
+    class _SettingEntry:
+        value: object
+        key_header: str
+        value_header: str
+        duplicate_count: int = 0
+
+    def _pick_setting_cell(row: Mapping[str, object], *headers: str) -> tuple[object, str]:
+        for header in headers:
+            if header in row:
+                value = row[header]
+                if ("" if value is None else str(value)).strip() != "":
+                    return value, header
+        return "", ""
+
+    parsed: dict[str, _SettingEntry] = {}
     for raw in rows or []:
         row = _normalize(raw)
-        key = str(_pick(row, "key", "setting", "name") or "").strip().lower()
-        value = _pick(row, "value", "setting_value")
-        if key:
-            parsed[key] = value
+        key, key_header = _pick_setting_cell(row, "setting_key", "key", "setting", "name")
+        value, value_header = _pick_setting_cell(row, "setting_value", "value")
+        normalized_key = str(key or "").strip().casefold()
+        if normalized_key:
+            duplicate_count = parsed.get(normalized_key).duplicate_count + 1 if normalized_key in parsed else 0
+            parsed[normalized_key] = _SettingEntry(
+                value=value,
+                key_header=key_header,
+                value_header=value_header,
+                duplicate_count=duplicate_count,
+            )
+
+
+    def _value(key: str, default: object = None) -> object:
+        entry = parsed.get(key)
+        return entry.value if entry is not None else default
+
+    def _first_value(*keys: str) -> object:
+        for key in keys:
+            if key in parsed:
+                return parsed[key].value
+        return ""
+
+    group_events_entry = parsed.get("group_events")
+    group_events_source = FusionReminderSettingSource(
+        tab_name=tab_name,
+        key_header=group_events_entry.key_header if group_events_entry else "",
+        value_header=group_events_entry.value_header if group_events_entry else "",
+        raw_value=str(group_events_entry.value).strip() if group_events_entry else "",
+        duplicate_count=group_events_entry.duplicate_count if group_events_entry else 0,
+    )
+
     return FusionReminderSettings(
-        start_offset_minutes=_parse_nonnegative_int(parsed.get("start_offset_minutes"), 360),
-        end_lookahead_hours=_parse_nonnegative_int(parsed.get("end_lookahead_hours"), 24),
-        upcoming_window_days=_parse_nonnegative_int(parsed.get("upcoming_window_days"), 2),
-        group_events=_parse_bool(parsed.get("group_events")),
+        start_offset_minutes=_parse_nonnegative_int(_value("start_offset_minutes"), 360),
+        end_lookahead_hours=_parse_nonnegative_int(_value("end_lookahead_hours"), 24),
+        upcoming_window_days=_parse_nonnegative_int(_value("upcoming_window_days"), 2),
+        group_events=_parse_bool(group_events_entry.value if group_events_entry else None),
         grouped_post_time_utc=str(
-            parsed.get("grouped_post_time_utc")
-            or parsed.get("grouped_daily_post_time_utc")
-            or parsed.get("grouped_post_time")
-            or parsed.get("post_time_utc")
-            or ""
+            _first_value(
+                "grouped_post_time_utc",
+                "grouped_daily_post_time_utc",
+                "grouped_post_time",
+                "post_time_utc",
+            )
         ).strip(),
-        include_start_events=_parse_bool(parsed.get("include_start_events", True)),
-        include_ending_events=_parse_bool(parsed.get("include_ending_events")),
-        include_upcoming_events=_parse_bool(parsed.get("include_upcoming_events")),
-        grouped_embed_title=str(parsed.get("grouped_embed_title") or "").strip(),
-        grouped_embed_description=str(parsed.get("grouped_embed_description") or "").strip(),
-        grouped_live_label=str(parsed.get("grouped_live_label") or "").strip(),
-        grouped_upcoming_label=str(parsed.get("grouped_upcoming_label") or "").strip(),
-        grouped_ending_label=str(parsed.get("grouped_ending_label") or "").strip(),
-        grouped_empty_value=str(parsed.get("grouped_empty_value") or "").strip(),
-        grouped_jump_label=str(parsed.get("grouped_jump_label") or "").strip(),
+        include_start_events=_parse_bool(_value("include_start_events", True)),
+        include_ending_events=_parse_bool(_value("include_ending_events")),
+        include_upcoming_events=_parse_bool(_value("include_upcoming_events")),
+        grouped_embed_title=str(_value("grouped_embed_title") or "").strip(),
+        grouped_embed_description=str(_value("grouped_embed_description") or "").strip(),
+        grouped_live_label=str(_value("grouped_live_label") or "").strip(),
+        grouped_upcoming_label=str(_value("grouped_upcoming_label") or "").strip(),
+        grouped_ending_label=str(_value("grouped_ending_label") or "").strip(),
+        grouped_empty_value=str(_value("grouped_empty_value") or "").strip(),
+        grouped_jump_label=str(_value("grouped_jump_label") or "").strip(),
+        group_events_source=group_events_source,
     )
 
 

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
 from modules.community.fusion import reminders
@@ -236,3 +237,40 @@ def test_non_grouped_config_does_not_send_per_event_reminders(monkeypatch):
 
     assert channel.sent == []
     fusion_sheets.mark_reminder_sent.assert_not_awaited()
+
+def test_disabled_grouped_config_logs_resolved_source(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    source = fusion_sheets.FusionReminderSettingSource(
+        tab_name="FusionReminderSettings",
+        key_header="setting_key",
+        value_header="setting_value",
+        raw_value="FALSE",
+    )
+    settings = replace(_settings(group_events=False), group_events_source=source)
+    alerts = []
+
+    async def _send_ops_alert(**kwargs):
+        alerts.append(kwargs)
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=settings))
+    monkeypatch.setattr(reminders.fusion_logs, "send_ops_alert", _send_ops_alert)
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert alerts == [
+        {
+            "component": "reminders",
+            "summary": "grouped_reminders_disabled",
+            "dedupe_key": "fusion:grouped_reminders:disabled:f-1",
+            "reason": "group_events_resolved_false",
+            "fields": {
+                "fusion_id": "f-1",
+                "group_events_resolved": "false",
+                "group_events_raw_value": "FALSE",
+                "group_events_source_tab": "FusionReminderSettings",
+                "group_events_key_header": "setting_key",
+                "group_events_value_header": "setting_value",
+            },
+        }
+    ]

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -175,7 +175,7 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
         assert sheet_id == "sheet-1"
         assert tab_name == "FusionReminderSettings"
         return [
-            {"key": "group_events", "value": "TRUE"},
+            {"setting_key": "group_events", "setting_value": "TRUE"},
             {"key": "grouped_post_time_utc", "value": "12:30"},
             {"key": "upcoming_window_days", "value": "3"},
             {"key": "include_upcoming_events", "value": "TRUE"},
@@ -191,12 +191,27 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
     monkeypatch.setattr(fusion_sheets, "afetch_records", _afetch_records)
     settings = asyncio.run(fusion_sheets.get_fusion_reminder_settings())
     assert settings.group_events is True
+    assert settings.group_events_source.tab_name == "FusionReminderSettings"
+    assert settings.group_events_source.key_header == "setting_key"
+    assert settings.group_events_source.value_header == "setting_value"
+    assert settings.group_events_source.raw_value == "TRUE"
     assert settings.grouped_post_time_utc == "12:30"
     assert settings.upcoming_window_days == 3
     assert settings.include_upcoming_events is True
     assert settings.grouped_embed_title == "Title {fusion_title}"
     assert settings.grouped_empty_value == "None"
     assert settings.grouped_jump_label == "Open"
+
+
+def test_fusion_reminder_bool_parser_accepts_sheet_true_false_values():
+    assert fusion_sheets._parse_bool(True) is True
+    assert fusion_sheets._parse_bool(False) is False
+    assert fusion_sheets._parse_bool("TRUE") is True
+    assert fusion_sheets._parse_bool("FALSE") is False
+    assert fusion_sheets._parse_bool("yes") is True
+    assert fusion_sheets._parse_bool("1") is True
+    assert fusion_sheets._parse_bool("0") is False
+    assert fusion_sheets._parse_bool("") is False
 
 
 def test_load_fusion_events_reads_optional_embed_copy_columns(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### Motivation
- Grouped reminders were being skipped even when `group_events = TRUE` in Sheets because the settings loader only handled simple `key`/`value` headers and a narrow boolean parser. 
- Ops logs did not include the resolved config value or the sheet/header source, leaving `reason=-` and making investigations hard. 
- The scheduler needs reliable boolean handling for Google Sheets-style values and explicit diagnostics so `TRUE`/`FALSE` in Sheets behaves as operators expect. 

### Description
- Update `shared/sheets/fusion.py` to support `setting_key`/`setting_value` (and legacy `key`/`value`) rows, preserve the matched header, raw value, and duplicate count, and expose a `FusionReminderSettingSource` on `FusionReminderSettings`. 
- Harden `_parse_bool` to accept native booleans and common true/false tokens (`TRUE`/`FALSE`, `1`/`0`, `yes`/`no`, `on`/`off`, plus short forms) so sheet `TRUE` reliably maps to `True`. 
- Add startup diagnostics in `modules/community/fusion/reminders.py` showing the resolved `group_events` value, raw sheet value, source tab, and matched key/value headers, and include an explicit skip reason `group_events_resolved_false` when disabled. 
- Extend `modules/community/fusion/logs.py` `send_ops_alert` to accept an explicit `reason` parameter and propagate the resolved reason into ops alerts sent when grouped reminders are disabled. 

### Testing
- Ran style checks: `python -m ruff check shared/sheets/fusion.py modules/community/fusion/logs.py modules/community/fusion/reminders.py tests/shared/sheets/test_fusion_reminder_schema.py tests/community/test_fusion_reminders.py`, which passed. 
- Ran targeted tests: `python -m pytest tests/shared/sheets/test_fusion_reminder_schema.py tests/community/test_fusion_reminders.py`, resulting in all tests passing (`15 passed`). 
- Added unit tests covering `setting_key`/`setting_value` handling, the boolean parser, and that disabled grouped-config sends an ops alert with resolved source metadata, and these tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2443eab0508323bf64f41a3f4088db)