### PR TITLE
Parse local reminder times, preserve raw settings, and add diagnostics for fusion reminders

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -83,6 +83,33 @@ def _build_grouped_embed(
     return embed
 
 
+def _format_setting_value(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.10g}"
+    text = str(value or "")
+    if len(text) > 80:
+        text = text[:77] + "..."
+    return repr(text)
+
+
+def _grouped_settings_diagnostic_lines(settings: fusion_sheets.FusionReminderSettings) -> list[str]:
+    raw_parts = []
+    for key in sorted(settings.settings_raw_values):
+        value = settings.settings_raw_values[key]
+        raw_type = settings.settings_raw_types.get(key, type(value).__name__)
+        raw_name = settings.settings_raw_key_names.get(key, key)
+        raw_parts.append(f"{raw_name}={_format_setting_value(value)} ({raw_type})")
+    raw_map = "; ".join(raw_parts) if raw_parts else "empty"
+    return [
+        f"• settings_sheet={settings.settings_sheet_id_tail or 'missing'}",
+        f"• settings_source_tab={settings.settings_source_tab or 'missing'}",
+        f"• settings_headers={','.join(settings.settings_headers) or 'missing'}",
+        f"• settings_resolved_headers key={settings.settings_key_header or 'missing'} value={settings.settings_value_header or 'missing'}",
+        f"• settings_cache={settings.settings_cache_status or 'unknown'}",
+        f"• raw_grouped_reminder_settings={raw_map}",
+    ]
+
+
 def _missing_grouped_copy_fields(settings: fusion_sheets.FusionReminderSettings) -> list[str]:
     required = {
         "grouped_embed_title": settings.grouped_embed_title,
@@ -318,7 +345,7 @@ async def collect_fusion_reminder_startup_summary(
         return lines
 
     try:
-        settings = await fusion_sheets.get_fusion_reminder_settings()
+        settings = await fusion_sheets.get_fusion_reminder_settings(now=reference)
     except Exception as exc:
         await fusion_logs.send_ops_alert(
             component="grouped_reminders_startup",
@@ -330,10 +357,15 @@ async def collect_fusion_reminder_startup_summary(
         lines.extend(["• enabled=no", "• skipped=load_settings_failed"])
         return lines
 
+    lines.extend(_grouped_settings_diagnostic_lines(settings))
     post_time = _parse_grouped_post_time_utc(settings.grouped_post_time_utc)
     enabled = settings.group_events and post_time is not None
+    raw_group_events = settings.settings_raw_values.get("group_events", "missing")
+    raw_daily_post_time = settings.settings_raw_values.get("grouped_daily_post_time", "missing")
     lines.append(f"• enabled={'yes' if enabled else 'no'}")
+    lines.append(f"• parsed_group_events={'yes' if settings.group_events else 'no'} raw={_format_setting_value(raw_group_events)}")
     lines.append(f"• configured_post_time_utc={settings.grouped_post_time_utc or 'missing'}")
+    lines.append(f"• parsed_grouped_post_time={'ok' if post_time is not None else 'missing_or_invalid'} raw={_format_setting_value(raw_daily_post_time)}")
     resolve_status = await _resolve_channel_role_status(bot, target)
     lines.append(
         "• channel_resolved={channel_resolved} channel_id={channel_id} thread_resolved={thread_resolved} thread_id={thread_id} role_resolved={role_resolved} role_id={role_id}".format(
@@ -418,7 +450,7 @@ async def process_fusion_reminders(
         return
 
     try:
-        settings = await fusion_sheets.get_fusion_reminder_settings()
+        settings = await fusion_sheets.get_fusion_reminder_settings(now=reference)
     except Exception as exc:
         context = {"fusion_id": target.fusion_id}
         log.exception("fusion grouped reminder failed to load settings", extra=context)

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from shared.config import cfg, get_milestones_sheet_id
 from shared.sheets.async_core import (
@@ -27,6 +28,10 @@ _LAST_FUSION_PARSE_ERRORS: dict[str, str] = {}
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
 _FUSION_REMINDER_SETTINGS_TAB_KEY = "FUSION_REMINDER_SETTINGS_TAB"
+_FUSION_REMINDER_SETTINGS_COLUMN_HEADERS: dict[str, tuple[str, ...]] = {
+    "setting_key": ("setting_key",),
+    "value": ("value",),
+}
 _PROGRESS_ALLOWED_STATUSES = {"not_started", "in_progress", "done", "done_bonus", "skipped"}
 _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "fusion_id": ("fusion_id",),
@@ -136,6 +141,15 @@ class FusionReminderSettings:
     grouped_ending_label: str = ""
     grouped_empty_value: str = ""
     grouped_jump_label: str = ""
+    settings_source_tab: str = ""
+    settings_sheet_id_tail: str = ""
+    settings_headers: tuple[str, ...] = tuple()
+    settings_key_header: str = ""
+    settings_value_header: str = ""
+    settings_raw_values: Mapping[str, object] = field(default_factory=dict)
+    settings_raw_types: Mapping[str, str] = field(default_factory=dict)
+    settings_raw_key_names: Mapping[str, str] = field(default_factory=dict)
+    settings_cache_status: str = "not_cached"
 
 
 def _resolve_tab_name(key: str) -> str:
@@ -167,6 +181,67 @@ def _pick(row: Mapping[str, object], *keys: str) -> object:
             if str(value or "").strip() != "":
                 return value
     return ""
+
+
+def _sheet_tail(sheet_id: object) -> str:
+    text = str(sheet_id or "").strip()
+    if not text:
+        return "missing"
+    tail = text[-6:] if len(text) >= 6 else text
+    return f"…{tail}" if len(text) > len(tail) else tail
+
+
+def _time_from_sheet_value(value: object) -> dt.time | None:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        return value.time().replace(tzinfo=None, microsecond=0)
+    if isinstance(value, dt.time):
+        return value.replace(tzinfo=None, microsecond=0)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        raw = float(value)
+        fraction = raw % 1
+        total_seconds = int(round(fraction * 24 * 60 * 60)) % (24 * 60 * 60)
+        return (dt.datetime.min + dt.timedelta(seconds=total_seconds)).time().replace(microsecond=0)
+
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        numeric = float(text)
+    except ValueError:
+        numeric = None
+    if numeric is not None and 0 <= numeric < 1:
+        return _time_from_sheet_value(numeric)
+    for fmt in ("%H:%M", "%H:%M:%S", "%I:%M %p", "%I:%M:%S %p"):
+        try:
+            parsed = dt.datetime.strptime(text, fmt).time()
+            return parsed.replace(tzinfo=None, microsecond=0)
+        except ValueError:
+            continue
+    return None
+
+
+def _configured_timezone() -> ZoneInfo:
+    raw = str(cfg.get("TIMEZONE") or "Europe/Vienna").strip() or "Europe/Vienna"
+    try:
+        return ZoneInfo(raw)
+    except ZoneInfoNotFoundError:
+        log.warning("fusion reminder settings timezone invalid; falling back to Europe/Vienna", extra={"timezone": raw})
+        return ZoneInfo("Europe/Vienna")
+
+
+def _local_time_to_utc_text(value: object, *, reference: dt.datetime | None = None) -> str:
+    parsed = _time_from_sheet_value(value)
+    if parsed is None:
+        return ""
+    ref = reference or dt.datetime.now(dt.timezone.utc)
+    if ref.tzinfo is None:
+        ref = ref.replace(tzinfo=dt.timezone.utc)
+    local_zone = _configured_timezone()
+    local_day = ref.astimezone(local_zone).date()
+    local_dt = dt.datetime.combine(local_day, parsed, tzinfo=local_zone)
+    return local_dt.astimezone(dt.timezone.utc).strftime("%H:%M")
 
 
 def _parse_int(value: object) -> int:
@@ -211,8 +286,6 @@ def _parse_float_optional(value: object) -> float | None:
         return float(text)
     except ValueError:
         return None
-
-
 
 
 def _parse_milestones(value: object, *, fusion_id: str, event_id: str) -> tuple[FusionEventMilestone, ...]:
@@ -782,28 +855,48 @@ async def get_active_events(
     return [item[1] for item in active]
 
 
-async def get_fusion_reminder_settings() -> FusionReminderSettings:
+async def get_fusion_reminder_settings(*, now: dt.datetime | None = None) -> FusionReminderSettings:
     tab_name = _resolve_tab_name(_FUSION_REMINDER_SETTINGS_TAB_KEY)
-    rows = await afetch_records(_sheet_id(), tab_name)
+    sheet_id, values, header = await _load_fusion_sheet_matrix(tab_name)
+    key_idx = _resolve_header_index(
+        tab_name=tab_name,
+        header=header,
+        field="setting_key",
+        aliases_by_field=_FUSION_REMINDER_SETTINGS_COLUMN_HEADERS,
+    )
+    value_idx = _resolve_header_index(
+        tab_name=tab_name,
+        header=header,
+        field="value",
+        aliases_by_field=_FUSION_REMINDER_SETTINGS_COLUMN_HEADERS,
+    )
+    key_header = header[key_idx]
+    value_header = header[value_idx]
+
     parsed: dict[str, object] = {}
-    for raw in rows or []:
-        row = _normalize(raw)
-        key = str(_pick(row, "key", "setting", "name") or "").strip().lower()
-        value = _pick(row, "value", "setting_value")
-        if key:
-            parsed[key] = value
+    raw_types: dict[str, str] = {}
+    raw_key_names: dict[str, str] = {}
+    for row in values[1:]:
+        key_value = row[key_idx] if key_idx < len(row) else ""
+        key = str(key_value or "").strip().lower()
+        if not key:
+            continue
+        value = row[value_idx] if value_idx < len(row) else ""
+        parsed[key] = value
+        raw_types[key] = type(value).__name__
+        raw_key_names[key] = str(key_value or "").strip()
+
+    grouped_post_time_utc = _local_time_to_utc_text(
+        parsed.get("grouped_daily_post_time"),
+        reference=now,
+    )
+
     return FusionReminderSettings(
         start_offset_minutes=_parse_nonnegative_int(parsed.get("start_offset_minutes"), 360),
         end_lookahead_hours=_parse_nonnegative_int(parsed.get("end_lookahead_hours"), 24),
         upcoming_window_days=_parse_nonnegative_int(parsed.get("upcoming_window_days"), 2),
         group_events=_parse_bool(parsed.get("group_events")),
-        grouped_post_time_utc=str(
-            parsed.get("grouped_post_time_utc")
-            or parsed.get("grouped_daily_post_time_utc")
-            or parsed.get("grouped_post_time")
-            or parsed.get("post_time_utc")
-            or ""
-        ).strip(),
+        grouped_post_time_utc=grouped_post_time_utc,
         include_start_events=_parse_bool(parsed.get("include_start_events", True)),
         include_ending_events=_parse_bool(parsed.get("include_ending_events")),
         include_upcoming_events=_parse_bool(parsed.get("include_upcoming_events")),
@@ -814,6 +907,15 @@ async def get_fusion_reminder_settings() -> FusionReminderSettings:
         grouped_ending_label=str(parsed.get("grouped_ending_label") or "").strip(),
         grouped_empty_value=str(parsed.get("grouped_empty_value") or "").strip(),
         grouped_jump_label=str(parsed.get("grouped_jump_label") or "").strip(),
+        settings_source_tab=tab_name,
+        settings_sheet_id_tail=_sheet_tail(sheet_id),
+        settings_headers=tuple(header),
+        settings_key_header=key_header,
+        settings_value_header=value_header,
+        settings_raw_values=parsed,
+        settings_raw_types=raw_types,
+        settings_raw_key_names=raw_key_names,
+        settings_cache_status="not_cached",
     )
 
 

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -167,28 +167,30 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
         monkeypatch,
         {
             "FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings",
+            "TIMEZONE": "UTC",
         },
     )
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
-    async def _afetch_records(sheet_id: str, tab_name: str):
+    async def _afetch_values(sheet_id: str, tab_name: str):
         assert sheet_id == "sheet-1"
         assert tab_name == "FusionReminderSettings"
         return [
-            {"key": "group_events", "value": "TRUE"},
-            {"key": "grouped_post_time_utc", "value": "12:30"},
-            {"key": "upcoming_window_days", "value": "3"},
-            {"key": "include_upcoming_events", "value": "TRUE"},
-            {"key": "grouped_embed_title", "value": "Title {fusion_title}"},
-            {"key": "grouped_embed_description", "value": "Desc {jump_link}"},
-            {"key": "grouped_live_label", "value": "Live"},
-            {"key": "grouped_upcoming_label", "value": "Up"},
-            {"key": "grouped_ending_label", "value": "End"},
-            {"key": "grouped_empty_value", "value": "None"},
-            {"key": "grouped_jump_label", "value": "Open"},
+            ["setting_key", "value", "notes"],
+            ["group_events", "TRUE", "enable grouped reminders"],
+            ["grouped_daily_post_time", "12:30", "local daily post time"],
+            ["upcoming_window_days", "3", ""],
+            ["include_upcoming_events", "TRUE", ""],
+            ["grouped_embed_title", "Title {fusion_title}", ""],
+            ["grouped_embed_description", "Desc {jump_link}", ""],
+            ["grouped_live_label", "Live", ""],
+            ["grouped_upcoming_label", "Up", ""],
+            ["grouped_ending_label", "End", ""],
+            ["grouped_empty_value", "None", ""],
+            ["grouped_jump_label", "Open", ""],
         ]
 
-    monkeypatch.setattr(fusion_sheets, "afetch_records", _afetch_records)
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
     settings = asyncio.run(fusion_sheets.get_fusion_reminder_settings())
     assert settings.group_events is True
     assert settings.grouped_post_time_utc == "12:30"
@@ -197,6 +199,65 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
     assert settings.grouped_embed_title == "Title {fusion_title}"
     assert settings.grouped_empty_value == "None"
     assert settings.grouped_jump_label == "Open"
+    assert settings.settings_headers == ("setting_key", "value", "notes")
+    assert settings.settings_key_header == "setting_key"
+    assert settings.settings_value_header == "value"
+
+
+def test_get_fusion_reminder_settings_reads_setting_key_and_local_sheet_time(monkeypatch: pytest.MonkeyPatch):
+    _install_config(
+        monkeypatch,
+        {
+            "FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings",
+            "TIMEZONE": "Europe/Vienna",
+        },
+    )
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "milestones-sheet-123456")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "milestones-sheet-123456"
+        assert tab_name == "FusionReminderSettings"
+        return [
+            ["setting_key", "value", "notes"],
+            ["group_events", "TRUE", "enable grouped reminders"],
+            ["grouped_daily_post_time", 10 / 24, "local daily post time"],
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    settings = asyncio.run(
+        fusion_sheets.get_fusion_reminder_settings(
+            now=dt.datetime(2026, 6, 6, 12, tzinfo=dt.timezone.utc)
+        )
+    )
+
+    assert settings.group_events is True
+    assert settings.grouped_post_time_utc == "08:00"
+    assert settings.settings_source_tab == "FusionReminderSettings"
+    assert settings.settings_sheet_id_tail == "…123456"
+    assert settings.settings_headers == ("setting_key", "value", "notes")
+    assert settings.settings_key_header == "setting_key"
+    assert settings.settings_value_header == "value"
+    assert settings.settings_raw_values["grouped_daily_post_time"] == 10 / 24
+    assert settings.settings_raw_types["grouped_daily_post_time"] == "float"
+
+
+def test_get_fusion_reminder_settings_requires_production_headers(monkeypatch: pytest.MonkeyPatch):
+    _install_config(monkeypatch, {"FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings"})
+    monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
+    async def _afetch_values(sheet_id: str, tab_name: str):
+        assert sheet_id == "sheet-1"
+        assert tab_name == "FusionReminderSettings"
+        return [
+            ["key", "setting_value"],
+            ["group_events", "TRUE"],
+        ]
+
+    monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
+
+    with pytest.raises(RuntimeError, match="setting_key"):
+        asyncio.run(fusion_sheets.get_fusion_reminder_settings())
 
 
 def test_load_fusion_events_reads_optional_embed_copy_columns(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### Motivation
- Interpret reminder post times authored in the local sheet timezone and preserve raw setting metadata to improve diagnostics and robustness of grouped reminder scheduling.
- Surface non-secret settings/context in startup logs to aid operators when reminders are disabled or misconfigured.

### Description
- Extend `FusionReminderSettings` with sheet metadata and raw values (`settings_source_tab`, `settings_sheet_id_tail`, `settings_headers`, `settings_key_header`, `settings_value_header`, `settings_raw_values`, `settings_raw_types`, `settings_raw_key_names`, `settings_cache_status`).
- Replace record-based settings loading with a matrix-based parser in `get_fusion_reminder_settings(*, now)` that validates header indices and preserves raw cell types and names, and compute `grouped_post_time_utc` from a local sheet time key `grouped_daily_post_time` using the configured `TIMEZONE`.
- Add helper functions: `_time_from_sheet_value`, `_local_time_to_utc_text`, `_configured_timezone`, and `_sheet_tail` for parsing sheet time values, converting local times to UTC text, resolving timezone, and summarizing sheet id tails.
- Add diagnostics and formatting helpers in reminders module (`_format_setting_value`, `_grouped_settings_diagnostic_lines`) and include detailed non-secret setting diagnostics and raw values when collecting startup summary and processing reminders, and pass `now` reference into settings loading calls.
- Update tests to exercise the new matrix parsing, timezone conversion, header validation, and metadata fields.

### Testing
- Ran unit tests in `tests/shared/sheets/test_fusion_reminder_schema.py` (updated/added cases for header-driven parsing, local-sheet time conversion, and header validation) using `pytest`, and they passed.
- Ran the repository test suite subset covering Fusion sheets parsing and reminder settings with `pytest` and observed success for the modified tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24459e228c8323aabd80165a2ac979)