### PR TITLE
Add tracking for next scheduled reset posts and improve scheduling/error handling

### DIFF
--- a/modules/community/reset_reminders/models.py
+++ b/modules/community/reset_reminders/models.py
@@ -22,4 +22,5 @@ class ResetReminder:
     button_label_opt_in: str
     button_label_opt_out: str
     last_sent_for_reset_utc: Optional[datetime]
+    next_scheduled_post_utc: Optional[datetime]
     last_message_id: Optional[int]

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -44,6 +44,7 @@ _REQUIRED_COLUMNS: tuple[str, ...] = (
     "button_label_opt_in",
     "button_label_opt_out",
     "last_sent_for_reset_utc",
+    "next_scheduled_post_utc",
     "last_message_id",
 )
 
@@ -170,6 +171,7 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                 button_label_opt_in=_cell(row, header_map["button_label_opt_in"]),
                 button_label_opt_out=_cell(row, header_map["button_label_opt_out"]),
                 last_sent_for_reset_utc=_parse_dt_optional(_cell(row, header_map["last_sent_for_reset_utc"])),
+                next_scheduled_post_utc=_parse_dt_optional(_cell(row, header_map["next_scheduled_post_utc"])),
                 last_message_id=_parse_optional_int(_cell(row, header_map["last_message_id"])),
             )
             records.append(_ResetReminderRecord(row_number=row_number, reminder=reminder))
@@ -221,18 +223,37 @@ def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
     return now.astimezone(dt.timezone.utc)
 
 
-def _next_reset(reference_date_utc: dt.datetime, cycle_days: int, now_utc: dt.datetime) -> dt.datetime:
+def _reminder_time(reset_time_utc: dt.datetime, lead_minutes: int) -> dt.datetime:
+    return reset_time_utc - dt.timedelta(minutes=lead_minutes)
+
+
+def _reset_cycle_for_reminder(
+    reference_date_utc: dt.datetime,
+    cycle_days: int,
+    lead_minutes: int,
+    now_utc: dt.datetime,
+) -> dt.datetime:
     cycle = dt.timedelta(days=cycle_days)
-    delta = now_utc - reference_date_utc
-    cycles_passed = math.floor(delta / cycle)
-    return reference_date_utc + (cycles_passed + 1) * cycle
+    first_reminder_time = _reminder_time(reference_date_utc, lead_minutes)
+    if now_utc < first_reminder_time:
+        return reference_date_utc
+    cycles_passed = math.floor((now_utc - first_reminder_time) / cycle)
+    return reference_date_utc + cycles_passed * cycle
+
+
+def _following_reset(reset_time_utc: dt.datetime, cycle_days: int) -> dt.datetime:
+    return reset_time_utc + dt.timedelta(days=cycle_days)
 
 
 async def register_persistent_reset_views(bot: commands.Bot) -> None:
     if not _is_feature_enabled():
         log.info("reset reminders disabled via feature toggle; skipping persistent view registration")
         return
-    _, _, records = await _load_reset_reminder_records(active_only=True)
+    try:
+        _, _, records = await _load_reset_reminder_records(active_only=True)
+    except Exception:
+        log.exception("failed to load reset reminders for persistent views; skipping reset reminder views")
+        return
     for record in records:
         reminder = record.reminder
         bot.add_view(
@@ -244,12 +265,27 @@ async def register_persistent_reset_views(bot: commands.Bot) -> None:
         )
 
 
+async def _send_ops_log(message: str) -> None:
+    try:
+        await rt.send_log_message(message)
+    except Exception:
+        log.warning("failed to send reset reminder ops alert", exc_info=True)
+
+
 async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) -> discord.abc.Messageable | None:
     base_channel = bot.get_channel(reminder.channel_id)
     if base_channel is None:
         try:
             base_channel = await bot.fetch_channel(reminder.channel_id)
-        except Exception:
+        except Exception as exc:
+            log.exception(
+                "reset reminder target channel fetch failed",
+                extra={"reset_id": reminder.reset_id, "channel_id": reminder.channel_id},
+            )
+            await _send_ops_log(
+                "⚠️ Reset reminder target fetch failed "
+                f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id} • error={type(exc).__name__}"
+            )
             return None
 
     if reminder.thread_id:
@@ -257,15 +293,61 @@ async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) ->
         if thread is None:
             try:
                 thread = await bot.fetch_channel(reminder.thread_id)
-            except Exception:
+            except Exception as exc:
+                log.exception(
+                    "reset reminder target thread fetch failed",
+                    extra={
+                        "reset_id": reminder.reset_id,
+                        "channel_id": reminder.channel_id,
+                        "thread_id": reminder.thread_id,
+                    },
+                )
+                await _send_ops_log(
+                    "⚠️ Reset reminder thread fetch failed "
+                    f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id} "
+                    f"• thread_id={reminder.thread_id} • error={type(exc).__name__}"
+                )
                 return None
         if isinstance(thread, discord.abc.Messageable):
             return thread
+        log.warning(
+            "reset reminder target thread is not messageable",
+            extra={"reset_id": reminder.reset_id, "channel_id": reminder.channel_id, "thread_id": reminder.thread_id},
+        )
+        await _send_ops_log(
+            "⚠️ Reset reminder thread is not messageable "
+            f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id} • thread_id={reminder.thread_id}"
+        )
         return None
 
     if isinstance(base_channel, discord.abc.Messageable):
         return base_channel
+    log.warning(
+        "reset reminder target channel is not messageable",
+        extra={"reset_id": reminder.reset_id, "channel_id": reminder.channel_id},
+    )
+    await _send_ops_log(
+        "⚠️ Reset reminder channel is not messageable "
+        f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id}"
+    )
     return None
+
+
+async def _update_next_scheduled_post(
+    *,
+    tab_name: str,
+    header_map: dict[str, int],
+    row_number: int,
+    reminder_time: dt.datetime,
+) -> None:
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    next_col = _column_label(header_map["next_scheduled_post_utc"])
+    await acall_with_backoff(
+        worksheet.update,
+        f"{next_col}{row_number}",
+        [[reminder_time.astimezone(dt.timezone.utc).isoformat()]],
+        value_input_option="RAW",
+    )
 
 
 async def _update_row_after_send(
@@ -273,18 +355,32 @@ async def _update_row_after_send(
     tab_name: str,
     header_map: dict[str, int],
     row_number: int,
-    next_reset: dt.datetime,
+    reset_time: dt.datetime,
+    next_scheduled_post: dt.datetime,
     message_id: int,
 ) -> None:
     worksheet = await aget_worksheet(_sheet_id(), tab_name)
 
     sent_col = _column_label(header_map["last_sent_for_reset_utc"])
+    next_col = _column_label(header_map["next_scheduled_post_utc"])
     message_col = _column_label(header_map["last_message_id"])
 
     await acall_with_backoff(
         worksheet.update,
-        f"{sent_col}{row_number}:{message_col}{row_number}",
-        [[next_reset.astimezone(dt.timezone.utc).isoformat(), str(message_id)]],
+        f"{sent_col}{row_number}",
+        [[reset_time.astimezone(dt.timezone.utc).isoformat()]],
+        value_input_option="RAW",
+    )
+    await acall_with_backoff(
+        worksheet.update,
+        f"{next_col}{row_number}",
+        [[next_scheduled_post.astimezone(dt.timezone.utc).isoformat()]],
+        value_input_option="RAW",
+    )
+    await acall_with_backoff(
+        worksheet.update,
+        f"{message_col}{row_number}",
+        [[str(message_id)]],
         value_input_option="RAW",
     )
 
@@ -310,8 +406,12 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
 
         try:
             tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
-        except Exception:
-            log.exception("failed to load reset reminders")
+        except Exception as exc:
+            log.exception("failed to load reset reminders; scheduler tick skipped")
+            await _send_ops_log(
+                "⚠️ Reset reminders failed to load; scheduler tick skipped "
+                f"• error={type(exc).__name__}: {str(exc)[:180]}"
+            )
             return
 
         if not records:
@@ -324,9 +424,6 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 log.warning("reset reminder skipped; cycle_days must be > 0", extra={"reset_id": reminder.reset_id})
                 continue
 
-            if reminder.reference_date_utc > now_utc:
-                continue
-
             if reminder.role_id <= 0 or reminder.channel_id <= 0:
                 log.warning(
                     "reset reminder skipped; missing role/channel",
@@ -335,21 +432,68 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 continue
 
             try:
-                next_reset = _next_reset(reminder.reference_date_utc, reminder.cycle_days, now_utc)
+                reset_time = _reset_cycle_for_reminder(
+                    reminder.reference_date_utc,
+                    reminder.cycle_days,
+                    reminder.lead_minutes,
+                    now_utc,
+                )
+                reminder_time = _reminder_time(reset_time, reminder.lead_minutes)
             except Exception:
                 log.exception("reset reminder skipped; failed to compute cycle", extra={"reset_id": reminder.reset_id})
                 continue
 
-            trigger_time = next_reset - dt.timedelta(minutes=reminder.lead_minutes)
-            if now_utc < trigger_time:
+            if reminder.last_sent_for_reset_utc == reset_time:
+                following_reminder_time = _reminder_time(
+                    _following_reset(reset_time, reminder.cycle_days),
+                    reminder.lead_minutes,
+                )
+                if reminder.next_scheduled_post_utc != following_reminder_time:
+                    try:
+                        await _update_next_scheduled_post(
+                            tab_name=tab_name,
+                            header_map=header_map,
+                            row_number=record.row_number,
+                            reminder_time=following_reminder_time,
+                        )
+                    except Exception:
+                        log.exception(
+                            "reset reminder next scheduled update failed",
+                            extra={"reset_id": reminder.reset_id, "row_number": record.row_number},
+                        )
                 continue
 
-            if reminder.last_sent_for_reset_utc == next_reset:
+            if reminder.next_scheduled_post_utc != reminder_time:
+                try:
+                    await _update_next_scheduled_post(
+                        tab_name=tab_name,
+                        header_map=header_map,
+                        row_number=record.row_number,
+                        reminder_time=reminder_time,
+                    )
+                except Exception:
+                    log.exception(
+                        "reset reminder next scheduled update failed",
+                        extra={"reset_id": reminder.reset_id, "row_number": record.row_number},
+                    )
+
+            if now_utc < reminder_time:
                 continue
 
             target = await _resolve_target_channel(bot, reminder)
             if target is None:
-                log.warning("reset reminder skipped; target channel not found", extra={"reset_id": reminder.reset_id})
+                log.warning(
+                    "reset reminder skipped; target channel/thread not found",
+                    extra={
+                        "reset_id": reminder.reset_id,
+                        "channel_id": reminder.channel_id,
+                        "thread_id": reminder.thread_id,
+                    },
+                )
+                await _send_ops_log(
+                    "⚠️ Reset reminder target unavailable "
+                    f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id} • thread_id={reminder.thread_id or '-'}"
+                )
                 continue
 
             if reminder.last_message_id:
@@ -366,7 +510,7 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 title=reminder.embed_title or reminder.label,
                 description=reminder.embed_description,
                 color=get_embed_colour("community"),
-                timestamp=next_reset,
+                timestamp=reset_time,
             )
             if reminder.embed_footer:
                 embed.set_footer(text=reminder.embed_footer)
@@ -383,16 +527,33 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                     embed=embed,
                     view=view,
                 )
-            except Exception:
-                log.exception("reset reminder send failed", extra={"reset_id": reminder.reset_id})
+            except Exception as exc:
+                log.exception(
+                    "reset reminder send failed",
+                    extra={
+                        "reset_id": reminder.reset_id,
+                        "channel_id": reminder.channel_id,
+                        "thread_id": reminder.thread_id,
+                        "reset_time": reset_time.isoformat(),
+                    },
+                )
+                await _send_ops_log(
+                    "⚠️ Reset reminder send failed "
+                    f"• reset_id={reminder.reset_id} • channel_id={reminder.channel_id} "
+                    f"• thread_id={reminder.thread_id or '-'} • reset_time={reset_time.isoformat()} "
+                    f"• error={type(exc).__name__}"
+                )
                 continue
 
+            following_reset = _following_reset(reset_time, reminder.cycle_days)
+            following_reminder_time = _reminder_time(following_reset, reminder.lead_minutes)
             try:
                 await _update_row_after_send(
                     tab_name=tab_name,
                     header_map=header_map,
                     row_number=record.row_number,
-                    next_reset=next_reset,
+                    reset_time=reset_time,
+                    next_scheduled_post=following_reminder_time,
                     message_id=message.id,
                 )
             except Exception:

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -109,19 +109,21 @@ def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> Non
         button_label_opt_in="Opt in",
         button_label_opt_out="Opt out",
         last_sent_for_reset_utc=None,
+        next_scheduled_post_utc=None,
         last_message_id=111,
     )
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     updates = []
 
     async def _load(*, active_only: bool):
-        return "ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record]
+        return "ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]
 
     async def _update(**kwargs):
         updates.append(kwargs)
 
     monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
     monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", _update)
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
 
     channel = _DummyChannel()
@@ -137,8 +139,9 @@ def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> Non
     assert channel.last_message.deleted is True
     assert len(channel.sent) == 1
     assert channel.sent[0]["content"] == "<@&999>"
-    assert len(updates) == 1
+    assert len(updates) == 2
     assert updates[0]["row_number"] == 7
+    assert updates[-1]["row_number"] == 7
 
 
 def test_process_reset_reminder_dedupes_by_last_sent(monkeypatch) -> None:
@@ -160,16 +163,20 @@ def test_process_reset_reminder_dedupes_by_last_sent(monkeypatch) -> None:
         button_label_opt_in="Opt in",
         button_label_opt_out="Opt out",
         last_sent_for_reset_utc=next_reset,
+        next_scheduled_post_utc=dt.datetime(2026, 6, 21, 23, 0, tzinfo=dt.timezone.utc),
         last_message_id=111,
     )
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     channel = _DummyChannel()
     updates = []
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
-    monkeypatch.setattr(scheduler, "_next_reset", lambda *_args: next_reset)
-    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record])))
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record])))
     monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
-    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: updates.append(kwargs))
+    async def _update(**kwargs):
+        updates.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", _update)
     bot = _DummyBot(channel)
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
     assert channel.sent == []
@@ -204,27 +211,32 @@ def test_process_reset_reminder_delete_failure_does_not_block_send(monkeypatch) 
         button_label_opt_in="Opt in",
         button_label_opt_out="Opt out",
         last_sent_for_reset_utc=None,
+        next_scheduled_post_utc=None,
         last_message_id=111,
     )
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     updates = []
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
-    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "last_message_id": 15}, [record])))
-    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: updates.append(kwargs))
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record])))
+    async def _update(**kwargs):
+        updates.append(kwargs)
+
+    monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", _update)
     channel = _DeleteFailChannel()
     monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
     bot = _DummyBot(channel)
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
     assert len(channel.sent) == 1
-    assert len(updates) == 1
+    assert len(updates) == 2
 
 
 def test_invalid_rows_skipped_without_crash(monkeypatch) -> None:
     async def _fetch_values(_sheet_id, _tab):
         return [
-            ["reset_id", "label", "status", "reference_date_utc", "cycle_days", "lead_minutes", "role_id", "channel_id", "thread_id", "embed_title", "embed_description", "embed_footer", "button_label_opt_in", "button_label_opt_out", "last_sent_for_reset_utc", "last_message_id"],
-            ["doom", "Doom", "active", "not-a-date", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", ""],
-            ["grim", "Grim", "active", "2026-01-01T00:00:00Z", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", ""],
+            ["reset_id", "label", "status", "reference_date_utc", "cycle_days", "lead_minutes", "role_id", "channel_id", "thread_id", "embed_title", "embed_description", "embed_footer", "button_label_opt_in", "button_label_opt_out", "last_sent_for_reset_utc", "next_scheduled_post_utc", "last_message_id"],
+            ["doom", "Doom", "active", "not-a-date", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", "", ""],
+            ["grim", "Grim", "active", "2026-01-01T00:00:00Z", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", "", ""],
         ]
 
     monkeypatch.setattr(scheduler, "afetch_values", _fetch_values)
@@ -274,6 +286,7 @@ def test_register_persistent_views_active_rows(monkeypatch) -> None:
         button_label_opt_in="Opt in",
         button_label_opt_out="Opt out",
         last_sent_for_reset_utc=None,
+        next_scheduled_post_utc=None,
         last_message_id=None,
     )
     record = scheduler._ResetReminderRecord(row_number=2, reminder=reminder)
@@ -291,3 +304,168 @@ def test_register_persistent_views_active_rows(monkeypatch) -> None:
     assert view.timeout is None
     custom_ids = [child.custom_id for child in view.children]
     assert custom_ids == ["reset_reminder:999:in", "reset_reminder:999:out"]
+
+
+def _make_reset_reminder(**overrides):
+    values = {
+        "reset_id": "cursed_city",
+        "label": "Cursed City",
+        "status": "active",
+        "reference_date_utc": dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc),
+        "cycle_days": 28,
+        "lead_minutes": 0,
+        "role_id": 999,
+        "channel_id": 123,
+        "thread_id": None,
+        "embed_title": "",
+        "embed_description": "Reset incoming",
+        "embed_footer": "footer",
+        "button_label_opt_in": "Opt in",
+        "button_label_opt_out": "Opt out",
+        "last_sent_for_reset_utc": None,
+        "next_scheduled_post_utc": None,
+        "last_message_id": None,
+    }
+    values.update(overrides)
+    return scheduler.ResetReminder(**values)
+
+
+def _run_reset_process(monkeypatch, reminder, now):
+    record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    channel = _DummyChannel()
+    updates = []
+
+    async def _load(*, active_only: bool):
+        return (
+            "ResetTab",
+            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            [record],
+        )
+
+    async def _update(**kwargs):
+        updates.append(kwargs)
+
+    async def _resolve_target(_bot, resolved_reminder):
+        assert resolved_reminder.thread_id is reminder.thread_id
+        return channel
+
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
+    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", _update)
+    monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
+    monkeypatch.setattr(scheduler, "_resolve_target_channel", _resolve_target)
+    bot = _DummyBot(channel)
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+    return channel, updates
+
+
+def test_next_scheduled_post_written_from_reference_minus_lead(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60)
+
+    channel, updates = _run_reset_process(
+        monkeypatch,
+        reminder,
+        dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc),
+    )
+
+    assert channel.sent == []
+    assert updates == [
+        {
+            "tab_name": "ResetTab",
+            "header_map": {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            "row_number": 7,
+            "reminder_time": dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        }
+    ]
+
+
+def test_lead_zero_posts_at_reset_time(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=0)
+
+    channel, updates = _run_reset_process(monkeypatch, reminder, reference)
+
+    assert len(channel.sent) == 1
+    assert updates[-1]["reset_time"] == reference
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc)
+
+
+def test_lead_zero_posts_after_reset_time_when_not_already_sent(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=0)
+
+    channel, updates = _run_reset_process(
+        monkeypatch,
+        reminder,
+        dt.datetime(2026, 5, 29, 10, 5, tzinfo=dt.timezone.utc),
+    )
+
+    assert len(channel.sent) == 1
+    assert updates[-1]["reset_time"] == reference
+
+
+def test_positive_lead_posts_before_reset_time(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60)
+
+    channel, updates = _run_reset_process(
+        monkeypatch,
+        reminder,
+        dt.datetime(2026, 5, 29, 9, 30, tzinfo=dt.timezone.utc),
+    )
+
+    assert len(channel.sent) == 1
+    assert updates[-1]["reset_time"] == reference
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+
+
+def test_successful_post_updates_last_sent_and_next_scheduled(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=0)
+
+    _channel, updates = _run_reset_process(monkeypatch, reminder, reference)
+
+    assert updates[-1]["reset_time"] == reference
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc)
+    assert updates[-1]["message_id"] == 222
+
+
+def test_same_last_sent_suppresses_duplicate(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    following = dt.datetime(2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=0,
+        last_sent_for_reset_utc=reference,
+        next_scheduled_post_utc=following,
+    )
+
+    channel, updates = _run_reset_process(monkeypatch, reminder, reference)
+
+    assert channel.sent == []
+    assert updates == []
+
+
+def test_older_last_sent_does_not_suppress_current_reset(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=0,
+        last_sent_for_reset_utc=dt.datetime(2026, 5, 1, 10, 0, tzinfo=dt.timezone.utc),
+    )
+
+    channel, updates = _run_reset_process(monkeypatch, reminder, reference)
+
+    assert len(channel.sent) == 1
+    assert updates[-1]["reset_time"] == reference
+
+
+def test_empty_thread_id_posts_to_channel_id(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(reference_date_utc=reference, thread_id=None)
+
+    channel, updates = _run_reset_process(monkeypatch, reminder, reference)
+
+    assert len(channel.sent) == 1
+    assert updates[-1]["reset_time"] == reference


### PR DESCRIPTION
### Motivation

- Persist the next planned reminder time in the sheet so the scheduler can avoid duplicate sends and surface the next post time. 
- Make reminder timing calculations explicit (reset time vs reminder time) to support leads and correct next-cycle computation. 
- Improve robustness and observability by surfacing failures to ops and handling channel/thread resolution errors more clearly. 

### Description

- Added a new `next_scheduled_post_utc` field to `ResetReminder` and the `_REQUIRED_COLUMNS` header map, and load it from the sheet in `_load_reset_reminder_records`. 
- Reworked scheduling logic by introducing `_reminder_time`, `_reset_cycle_for_reminder`, and `_following_reset` to compute reset and reminder times and to determine the next scheduled post. 
- Persist the `next_scheduled_post_utc` back to the worksheet via `_update_next_scheduled_post` and updated `_update_row_after_send` to write `last_sent_for_reset_utc`, `next_scheduled_post_utc`, and `last_message_id` as separate updates. 
- Added operational logging and alerts via `_send_ops_log`, wrapped critical loads with try/except, and improved error handling/logging when fetching channels/threads and when sends fail. 

### Testing

- Updated and ran the unit tests in `tests/community/test_reset_reminder_scheduler.py`, which were modified to assert the new `next_scheduled_post_utc` behavior and additional branching, and they passed. 
- Ran scheduler unit tests that exercise posting, deduplication by `last_sent_for_reset_utc`, and sheet update flows, which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a245e6b6a108323b7803240bf481c46)