### PR TITLE
Refactor clan availability preflight and integrate config-driven headers; update reservation flows and tests

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -3761,31 +3761,24 @@ class WelcomeTicketWatcher(commands.Cog):
             decision_open_deltas = dict(decision.open_deltas)
 
             preflight_failed = False
-            should_preflight_open_deltas = (
-                getattr(availability.adjust_manual_open_spots, "__module__", "")
-                == "modules.recruitment.availability"
-                or getattr(
-                    availability.preflight_manual_open_spots_adjustment,
-                    "__module__",
-                    "",
-                )
-                != "modules.recruitment.availability"
-            )
-            for tag, delta in (
-                decision_open_deltas.items() if should_preflight_open_deltas else ()
-            ):
+            preflight_targets: "OrderedDict[str, int]" = OrderedDict()
+            for tag, delta in decision_open_deltas.items():
+                preflight_targets[tag] = delta
+            for tag in decision.recompute_tags:
+                preflight_targets.setdefault(tag, 0)
+            for tag, delta in preflight_targets.items():
                 try:
-                    await availability.preflight_manual_open_spots_adjustment(
-                        tag, delta
+                    await availability.preflight_clan_availability_update(
+                        tag, delta=delta
                     )
                 except Exception:
                     preflight_failed = True
                     actions_ok = False
                     delta_failure_reason = (
-                        f"preflight_manual_open_spots_failed:{tag}:{delta}"
+                        f"preflight_availability_failed:{tag}:{delta}"
                     )
                     log.exception(
-                        "welcome placement blocked before Discord/member actions because open spot adjustment preflight failed",
+                        "welcome placement blocked before Discord/member actions because availability preflight failed",
                         extra={
                             "clan_tag": tag,
                             "delta": delta,

--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -143,7 +143,9 @@ class ReservationConversation:
 
             mention = next(iter(getattr(message, "mentions", []) or []), None)
             if mention is not None:
-                display = getattr(mention, "mention", f"<@{getattr(mention, 'id', '???')}>")
+                display = getattr(
+                    mention, "mention", f"<@{getattr(mention, 'id', '???')}>"
+                )
                 ticket_username = _display_name(mention)
                 return getattr(mention, "id", None), display, ticket_username
 
@@ -211,17 +213,19 @@ class ReservationConversation:
                 raise ReservationFlowAbort("cancelled")
             if content:
                 return content
-            await self.ctx.send("Please add a short reason (or type `cancel` to abort).")
+            await self.ctx.send(
+                "Please add a short reason (or type `cancel` to abort)."
+            )
 
-    async def _confirm(
-        self, display: str, reserved_until: dt.date, notes: str
-    ) -> str:
+    async def _confirm(self, display: str, reserved_until: dt.date, notes: str) -> str:
         lines = [
             f"Reserve 1 spot in `{self._clan_label}` for {display} until `{reserved_until.isoformat()}`.",
         ]
         if notes:
             lines.append(f"Reason: {notes}")
-        lines.append("Type `yes` to save, `no` to cancel, or `change` to edit the recruit/date.")
+        lines.append(
+            "Type `yes` to save, `no` to cancel, or `change` to edit the recruit/date."
+        )
         await self.ctx.send("\n".join(lines))
 
         while True:
@@ -233,7 +237,9 @@ class ReservationConversation:
             if content in {"yes", "y"}:
                 return "yes"
             if content in {"change", "c"}:
-                await self.ctx.send("Type `user` to change the recruit or `date` to change the end date.")
+                await self.ctx.send(
+                    "Type `user` to change the recruit or `date` to change the end date."
+                )
                 while True:
                     followup = await self._next_message()
                     follow_content = (followup.content or "").strip().lower()
@@ -244,9 +250,13 @@ class ReservationConversation:
                         return "user"
                     if "date" in follow_content:
                         return "date"
-                    await self.ctx.send("Please type `user` or `date`, or `cancel` to abort.")
+                    await self.ctx.send(
+                        "Please type `user` or `date`, or `cancel` to abort."
+                    )
                 continue
-            await self.ctx.send("Please reply with `yes`, `no`, or `change` (or type `cancel`).")
+            await self.ctx.send(
+                "Please reply with `yes`, `no`, or `change` (or type `cancel`)."
+            )
 
     async def _next_message(self) -> discord.Message:
         if self._wait_for is None:
@@ -290,6 +300,11 @@ def _resolve_member(guild: object, member_id: int):
                 extra={"member_id": member_id},
             )
     return None
+
+
+def _resolve_configured_reservation_clan_tag(clan_tag: str) -> str:
+    """Resolve the sheet clan tag through the availability Config clan_tag header."""
+    return availability.resolve_configured_clan_tag(clan_tag)
 
 
 def _normalize_tag(tag: str | None) -> str:
@@ -354,7 +369,11 @@ def _is_ticket_thread(channel: object) -> bool:
 
 
 def _reservations_enabled() -> bool:
-    for key in ("FEATURE_RESERVATIONS", "feature_reservations", "placement_reservations"):
+    for key in (
+        "FEATURE_RESERVATIONS",
+        "feature_reservations",
+        "placement_reservations",
+    ):
         try:
             if feature_flags.is_enabled(key):
                 return True
@@ -363,7 +382,9 @@ def _reservations_enabled() -> bool:
     return False
 
 
-async def _ensure_fresh_clans_for_reservations(*, actor: str, clan_tag: str, user: str, source: str) -> bool:
+async def _ensure_fresh_clans_for_reservations(
+    *, actor: str, clan_tag: str, user: str, source: str
+) -> bool:
     """Require a sync-fresh clans cache before reservation availability recompute."""
     try:
         await cache_telemetry.refresh_now("clans", actor=actor)
@@ -430,7 +451,9 @@ def _reservation_display_date(reserved_until: dt.date | None) -> str:
     return reserved_until.isoformat()
 
 
-def _reservation_creator_display(guild: discord.Guild | None, recruiter_id: Optional[int]) -> str:
+def _reservation_creator_display(
+    guild: discord.Guild | None, recruiter_id: Optional[int]
+) -> str:
     if recruiter_id is None:
         return "unknown recruiter"
     if guild is not None:
@@ -478,7 +501,9 @@ def _thread_recruit_display(
     parsed_username: str,
 ) -> str:
     for row in rows:
-        display = _reservation_user_display(guild, row, fallback_username=parsed_username)
+        display = _reservation_user_display(
+            guild, row, fallback_username=parsed_username
+        )
         if display:
             return display
     return parsed_username
@@ -757,20 +782,50 @@ class ReservationCog(commands.Cog):
             mention_text = getattr(member, "mention", f"<@{member_id}>")
             preset_user = (member_id, mention_text, _display_name(member))
 
-        clan_entry = recruitment.find_clan_row(clan_tag)
-        if clan_entry is None:
+        try:
+            preflight_plan = await availability.preflight_clan_availability_update(
+                clan_tag
+            )
+        except ValueError as exc:
+            reason = str(exc)
+            if reason.startswith("Unknown clan tag"):
+                await ctx.reply(
+                    f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
+                    mention_author=False,
+                )
+            else:
+                log.exception(
+                    "reservation availability preflight failed before prompt",
+                    extra={"clan_tag": _normalize_tag(clan_tag), "reason": reason},
+                )
+                await ctx.reply(
+                    "I could not verify the clan availability sheet configuration/value, so no reservation was created. Please contact an admin and try again after it is fixed.",
+                    mention_author=False,
+                )
+            return
+        except Exception as exc:
+            log.exception(
+                "reservation availability preflight failed before prompt",
+                extra={"clan_tag": _normalize_tag(clan_tag), "reason": repr(exc)},
+            )
             await ctx.reply(
-                f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
+                "I could not verify the clan availability sheet configuration/value, so no reservation was created. Please contact an admin and try again after it is fixed.",
                 mention_author=False,
             )
             return
 
-        _, row = clan_entry
-        sheet_tag = row[2] if len(row) > 2 and row[2] else clan_tag
-        manual_open = _parse_manual_open(row)
+        tag_index = preflight_plan.headers.header_map["clan_tag"]
+        sheet_tag = (
+            preflight_plan.row[tag_index]
+            if tag_index < len(preflight_plan.row) and preflight_plan.row[tag_index]
+            else clan_tag
+        )
+        manual_open = preflight_plan.numeric_values["manual_open_spots"]
 
         try:
-            active_reservations = await reservations.count_active_reservations_for_clan(sheet_tag)
+            active_reservations = await reservations.count_active_reservations_for_clan(
+                sheet_tag
+            )
         except Exception:
             log.exception(
                 "failed to count active reservations",
@@ -824,11 +879,21 @@ class ReservationCog(commands.Cog):
         if existing_matches:
             existing_matches.sort(key=_reservation_sort_key)
             blocker = existing_matches[0]
-            blocker_tag = blocker.normalized_clan_tag or (blocker.clan_tag or "unknown clan")
+            blocker_tag = blocker.normalized_clan_tag or (
+                blocker.clan_tag or "unknown clan"
+            )
             ticket_label = "unknown"
             blocker_thread = await _resolve_thread(self.bot, blocker.thread_id)
-            thread_label = _thread_name(blocker_thread) if blocker_thread is not None else "unknown thread"
-            parts = parse_welcome_thread_name(getattr(blocker_thread, "name", None)) if blocker_thread else None
+            thread_label = (
+                _thread_name(blocker_thread)
+                if blocker_thread is not None
+                else "unknown thread"
+            )
+            parts = (
+                parse_welcome_thread_name(getattr(blocker_thread, "name", None))
+                if blocker_thread
+                else None
+            )
             if parts and parts.ticket_code:
                 ticket_label = parts.ticket_code
             control_hint = _control_thread_hint()
@@ -865,6 +930,26 @@ class ReservationCog(commands.Cog):
             details.notes,
             username_snapshot or "",
         ]
+
+        try:
+            preflight_plan = await availability.preflight_clan_availability_update(
+                sheet_tag
+            )
+        except Exception as exc:
+            log.exception(
+                "reservation availability preflight failed before append",
+                extra={
+                    "clan_tag": _normalize_tag(sheet_tag),
+                    "thread_id": getattr(ctx.channel, "id", None),
+                    "ticket_user_id": details.ticket_user_id,
+                    "error_type": type(exc).__name__,
+                    "error": repr(exc),
+                },
+            )
+            await ctx.send(
+                "I could not verify the clan availability sheet configuration/value, so no reservation row was added. Please fix the sheet configuration/value and try again."
+            )
+            return
 
         try:
             await reservations.append_reservation_row(row_values)
@@ -998,7 +1083,6 @@ class ReservationCog(commands.Cog):
             },
         )
 
-
     async def _handle_release(self, ctx: commands.Context, args: list[str]) -> None:
         if not _reservations_enabled():
             await ctx.reply(
@@ -1016,7 +1100,9 @@ class ReservationCog(commands.Cog):
 
         await self._handle_global_release(ctx, args)
 
-    async def _handle_global_release(self, ctx: commands.Context, args: list[str]) -> None:
+    async def _handle_global_release(
+        self, ctx: commands.Context, args: list[str]
+    ) -> None:
         if len(args) < 2:
             await ctx.reply(
                 "Usage: `!reserve release @user <clan_tag>`.",
@@ -1041,15 +1127,15 @@ class ReservationCog(commands.Cog):
             return
 
         clan_tag = args[1]
-        clan_entry = recruitment.find_clan_row(clan_tag)
-        if clan_entry is None:
+        try:
+            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+        except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
                 mention_author=False,
             )
             return
 
-        sheet_tag = clan_entry[1][2] if len(clan_entry[1]) > 2 and clan_entry[1][2] else clan_tag
         normalized_tag = _normalize_tag(sheet_tag)
         display_member = getattr(member, "mention", f"<@{member_id}>")
         member_name = _display_name(member)
@@ -1150,7 +1236,9 @@ class ReservationCog(commands.Cog):
                     },
                 )
             try:
-                await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)
+                await availability.recompute_clan_availability(
+                    sheet_tag, guild=ctx.guild
+                )
             except Exception:
                 log.exception(
                     "failed to recompute availability after global release",
@@ -1175,7 +1263,6 @@ class ReservationCog(commands.Cog):
             ),
         )
 
-
     async def _handle_extend(self, ctx: commands.Context, args: list[str]) -> None:
         if not _reservations_enabled():
             await ctx.reply(
@@ -1193,7 +1280,9 @@ class ReservationCog(commands.Cog):
 
         await self._handle_global_extend(ctx, args)
 
-    async def _handle_global_extend(self, ctx: commands.Context, args: list[str]) -> None:
+    async def _handle_global_extend(
+        self, ctx: commands.Context, args: list[str]
+    ) -> None:
         if len(args) < 3:
             await ctx.reply(
                 "Usage: `!reserve extend @user <clan_tag> <YYYY-MM-DD>`.",
@@ -1218,15 +1307,15 @@ class ReservationCog(commands.Cog):
             return
 
         clan_tag = args[1]
-        clan_entry = recruitment.find_clan_row(clan_tag)
-        if clan_entry is None:
+        try:
+            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+        except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
                 mention_author=False,
             )
             return
 
-        sheet_tag = clan_entry[1][2] if len(clan_entry[1]) > 2 and clan_entry[1][2] else clan_tag
         normalized_tag = _normalize_tag(sheet_tag)
         display_member = getattr(member, "mention", f"<@{member_id}>")
         member_name = _display_name(member)
@@ -1361,7 +1450,6 @@ class ReservationCog(commands.Cog):
             ),
         )
 
-
     @tier("staff")
     @help_metadata(
         function_group="recruitment",
@@ -1373,7 +1461,9 @@ class ReservationCog(commands.Cog):
         help="List active reservations for a recruit or clan.",
         brief="Show active reservation details.",
     )
-    async def reservations_command(self, ctx: commands.Context, clan_tag: str | None = None) -> None:
+    async def reservations_command(
+        self, ctx: commands.Context, clan_tag: str | None = None
+    ) -> None:
         if not _reservations_enabled():
             await ctx.reply(
                 "Reservations are currently disabled. Please poke an admin if you think this is wrong.",
@@ -1447,7 +1537,9 @@ class ReservationCog(commands.Cog):
             if stamp is not None and stamp.tzinfo is None:
                 stamp = stamp.replace(tzinfo=dt.timezone.utc)
             if stamp is None and row.reserved_until is not None:
-                stamp = dt.datetime.combine(row.reserved_until, dt.time.min, dt.timezone.utc)
+                stamp = dt.datetime.combine(
+                    row.reserved_until, dt.time.min, dt.timezone.utc
+                )
             return stamp
 
         recent: list[tuple[dt.datetime, reservations.ReservationRow]] = []
@@ -1458,7 +1550,9 @@ class ReservationCog(commands.Cog):
             recent.append((stamp, row))
 
         if not recent:
-            await ctx.send("No reservations have been created or updated in the last 28 days.")
+            await ctx.send(
+                "No reservations have been created or updated in the last 28 days."
+            )
             human_log.human(
                 "info",
                 "🧭 reservations_global — channel=%s • count=0 • window=28d • result=empty"
@@ -1512,9 +1606,11 @@ class ReservationCog(commands.Cog):
         human_log.human(
             "info",
             "🧭 reservations_global — channel=%s • count=%d • window=28d • result=ok"
-            % (channel_label(ctx.guild, getattr(ctx.channel, "id", None)), len(entries)),
+            % (
+                channel_label(ctx.guild, getattr(ctx.channel, "id", None)),
+                len(entries),
+            ),
         )
-
 
     async def _handle_thread_reservations(self, ctx: commands.Context) -> None:
         if not _is_ticket_thread(ctx.channel):
@@ -1574,7 +1670,9 @@ class ReservationCog(commands.Cog):
             return
 
         if view.status == "mismatch" and view.reservation is not None:
-            ledger_tag = view.reservation.normalized_clan_tag or (view.reservation.clan_tag or "unknown")
+            ledger_tag = view.reservation.normalized_clan_tag or (
+                view.reservation.clan_tag or "unknown"
+            )
             thread_tag = view.thread_tag_display or "unknown"
             await ctx.send(
                 (
@@ -1624,10 +1722,12 @@ class ReservationCog(commands.Cog):
             % (view.context.ticket_code, view.context.username, thread_label),
         )
 
-
-    async def _handle_clan_reservations(self, ctx: commands.Context, clan_tag: str) -> None:
-        entry = recruitment.find_clan_row(clan_tag)
-        if entry is None:
+    async def _handle_clan_reservations(
+        self, ctx: commands.Context, clan_tag: str
+    ) -> None:
+        try:
+            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+        except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
                 mention_author=False,
@@ -1638,8 +1738,6 @@ class ReservationCog(commands.Cog):
                 % clan_tag,
             )
             return
-
-        sheet_tag = entry[1][2] if len(entry[1]) > 2 and entry[1][2] else clan_tag
 
         try:
             rows = await reservations.get_active_reservations_for_clan(sheet_tag)
@@ -1666,7 +1764,8 @@ class ReservationCog(commands.Cog):
             await ctx.send(f"No active reservations for `{sheet_tag}`.")
             human_log.human(
                 "info",
-                "🧭 reservations_list — clan=%s • count=0 • scope=clan • result=empty" % sheet_tag,
+                "🧭 reservations_list — clan=%s • count=0 • scope=clan • result=empty"
+                % sheet_tag,
             )
             return
 
@@ -1681,12 +1780,12 @@ class ReservationCog(commands.Cog):
                     ticket_code = parts.ticket_code
                     if parts.username:
                         username = parts.username
-            user_display = _reservation_user_display(ctx.guild, row, fallback_username=username)
+            user_display = _reservation_user_display(
+                ctx.guild, row, fallback_username=username
+            )
             expiry = _reservation_display_date(row.reserved_until)
             ticket_label = ticket_code or "unknown"
-            lines.append(
-                f"• {user_display} — expires {expiry} (ticket {ticket_label})"
-            )
+            lines.append(f"• {user_display} — expires {expiry} (ticket {ticket_label})")
 
         await ctx.send("\n".join(lines))
 
@@ -1697,7 +1796,9 @@ class ReservationCog(commands.Cog):
         )
 
 
-async def _resolve_thread(bot: commands.Bot, thread_id: str | int | None) -> Optional[object]:
+async def _resolve_thread(
+    bot: commands.Bot, thread_id: str | int | None
+) -> Optional[object]:
     if thread_id is None:
         return None
     try:

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -5,13 +5,52 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Any, Sequence
 
 from shared.sheets import async_core
 from shared.sheets import recruitment
 from shared.sheets import reservations
 
 log = logging.getLogger(__name__)
+
+
+AVAILABILITY_FIELDS = (
+    "manual_open_spots",
+    "open_spots",
+    "inactives",
+    "reservation_count",
+    "reservation_summary",
+    "manual_open_spots_seen",
+    "clan_tag",
+)
+
+NUMERIC_AVAILABILITY_FIELDS = (
+    "manual_open_spots",
+    "open_spots",
+    "inactives",
+    "reservation_count",
+    "manual_open_spots_seen",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AvailabilityHeaderResolution:
+    tab_name: str
+    sheet_id_masked: str
+    header_row_index: int
+    header_row: tuple[str, ...]
+    header_map: dict[str, int]
+    configured_headers: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class AvailabilityPreflightPlan:
+    clan_tag: str
+    sheet_row: int
+    row: tuple[str, ...]
+    headers: AvailabilityHeaderResolution
+    numeric_values: dict[str, int]
+    write_ranges: dict[str, str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +73,289 @@ class ManualOpenSpotAdjustmentPlan:
     open_range: str
     seen_range: str
     combined_range: str | None
+
+
+def _mask_sheet_id(sheet_id: str | None) -> str:
+    text = (sheet_id or "").strip()
+    if not text:
+        return "<unset>"
+    if len(text) <= 8:
+        return f"{text[:2]}…{text[-2:]}" if len(text) > 4 else "****"
+    return f"{text[:4]}…{text[-4:]}"
+
+
+def _normalize_configured_header(value: Any) -> str:
+    text = "" if value is None else str(value).strip().lower()
+    return re.sub(r"[\s_]+", "", text)
+
+
+def _diagnostic_header_values(header_row: Sequence[Any]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for index in (4, *range(31, 37)):
+        values[_column_label(index)] = str(
+            header_row[index] if index < len(header_row) else ""
+        )
+    return values
+
+
+def _availability_header_map_columns(header_map: dict[str, int]) -> dict[str, str]:
+    return {key: _column_label(index) for key, index in sorted(header_map.items())}
+
+
+def _log_availability_diagnostics(
+    *,
+    reason: str,
+    tab_name: str,
+    sheet_id: str | None,
+    header_row_index: int,
+    header_row: Sequence[Any],
+    configured_headers: dict[str, str] | None = None,
+    header_map: dict[str, int] | None = None,
+    missing_config_key: str | None = None,
+    configured_header_value: str | None = None,
+    clan_tag: str | None = None,
+    sheet_row: int | None = None,
+) -> None:
+    raw_values = _diagnostic_header_values(header_row)
+    normalized_values = {
+        column: _normalize_configured_header(value)
+        for column, value in raw_values.items()
+    }
+    resolved_header_map = _availability_header_map_columns(header_map or {})
+    extra = {
+        "reason": reason,
+        "configured_tab_name": tab_name,
+        "clans_tab_name": tab_name,
+        "sheet_id_masked": _mask_sheet_id(sheet_id),
+        "header_row_index": header_row_index,
+        "missing_config_key": missing_config_key,
+        "configured_header_value": configured_header_value,
+        "raw_header_diagnostics": raw_values,
+        "normalized_header_diagnostics": normalized_values,
+        "resolved_header_map": resolved_header_map,
+        "configured_headers": dict(configured_headers or {}),
+        "clan_tag": _normalize_tag(clan_tag),
+        "bot_info_row_number": sheet_row,
+    }
+    log_method = log.info if reason in {"resolved", "preflight_ok"} else log.warning
+    log_method(
+        "bot_info availability header diagnostics: tab=%r sheet_id=%s header_row_index=%s "
+        "reason=%s missing_config_key=%s configured_header_value=%r raw=%s normalized=%s header_map=%s",
+        tab_name,
+        _mask_sheet_id(sheet_id),
+        header_row_index,
+        reason,
+        missing_config_key,
+        configured_header_value,
+        raw_values,
+        normalized_values,
+        resolved_header_map,
+        extra=extra,
+    )
+
+
+def _resolve_availability_headers() -> AvailabilityHeaderResolution:
+    tab_name = recruitment.get_clans_tab_name()
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    header_row_getter = getattr(recruitment, "get_clan_header_row", None)
+    if callable(header_row_getter):
+        try:
+            header_row = list(header_row_getter(force=True))
+        except TypeError:
+            header_row = list(header_row_getter())
+    else:
+        header_row = []
+    header_row_index = 3
+
+    configured_headers: dict[str, str] = {}
+    for field in AVAILABILITY_FIELDS:
+        config_key = f"clans_header_{field}"
+        value = recruitment.get_config_value(config_key, None)
+        if value is None or not str(value).strip():
+            _log_availability_diagnostics(
+                reason="missing_required_config_key",
+                tab_name=tab_name,
+                sheet_id=sheet_id,
+                header_row_index=header_row_index,
+                header_row=header_row,
+                configured_headers=configured_headers,
+                missing_config_key=config_key,
+            )
+            raise ValueError(f"missing required Config key: {config_key}")
+        configured_headers[field] = str(value).strip()
+
+    lookup: dict[str, int] = {}
+    for index, cell in enumerate(header_row):
+        normalized = _normalize_configured_header(cell)
+        if normalized:
+            lookup[normalized] = index
+
+    header_map: dict[str, int] = {}
+    for field, configured_value in configured_headers.items():
+        normalized = _normalize_configured_header(configured_value)
+        if normalized not in lookup:
+            _log_availability_diagnostics(
+                reason="configured_header_not_found",
+                tab_name=tab_name,
+                sheet_id=sheet_id,
+                header_row_index=header_row_index,
+                header_row=header_row,
+                configured_headers=configured_headers,
+                header_map=header_map,
+                configured_header_value=configured_value,
+            )
+            raise ValueError(
+                f"configured bot_info header not found for {field}: {configured_value}"
+            )
+        header_map[field] = lookup[normalized]
+
+    _log_availability_diagnostics(
+        reason="resolved",
+        tab_name=tab_name,
+        sheet_id=sheet_id,
+        header_row_index=header_row_index,
+        header_row=header_row,
+        configured_headers=configured_headers,
+        header_map=header_map,
+    )
+    return AvailabilityHeaderResolution(
+        tab_name=tab_name,
+        sheet_id_masked=_mask_sheet_id(sheet_id),
+        header_row_index=header_row_index,
+        header_row=tuple(str(cell) if cell is not None else "" for cell in header_row),
+        header_map=header_map,
+        configured_headers=configured_headers,
+    )
+
+
+def _find_availability_clan_row(
+    clan_tag: str, headers: AvailabilityHeaderResolution
+) -> tuple[int, list[str]] | None:
+    tag_index = headers.header_map["clan_tag"]
+    normalized_target = _normalize_tag(clan_tag)
+    try:
+        try:
+            clan_rows = recruitment.fetch_clans(force=True)
+        except TypeError:
+            clan_rows = recruitment.fetch_clans()
+    except Exception:
+        clan_rows = []
+    for idx, row in enumerate(clan_rows):
+        tag_value = row[tag_index] if tag_index < len(row) else ""
+        if _normalize_tag(tag_value) == normalized_target:
+            return idx + headers.header_row_index + 1, list(row)
+    if not clan_rows:
+        try:
+            return recruitment.find_clan_row(clan_tag, force=True)
+        except TypeError:
+            return recruitment.find_clan_row(clan_tag)
+    return None
+
+
+def resolve_configured_clan_tag(clan_tag: str) -> str:
+    """Resolve a clan tag from bot_info using the Config-provided clan_tag header."""
+    headers = _resolve_availability_headers()
+    entry = _find_availability_clan_row(clan_tag, headers)
+    if entry is None:
+        _log_availability_diagnostics(
+            reason="bot_info_row_not_found",
+            tab_name=headers.tab_name,
+            sheet_id=recruitment.get_recruitment_sheet_id(),
+            header_row_index=headers.header_row_index,
+            header_row=headers.header_row,
+            configured_headers=headers.configured_headers,
+            header_map=headers.header_map,
+            clan_tag=clan_tag,
+        )
+        raise ValueError(f"Unknown clan tag: {clan_tag}")
+    _sheet_row, row = entry
+    tag_index = headers.header_map["clan_tag"]
+    value = row[tag_index] if tag_index < len(row) else ""
+    return (str(value).strip() if value is not None else "") or clan_tag
+
+
+async def preflight_clan_availability_update(
+    clan_tag: str, *, delta: int = 0
+) -> AvailabilityPreflightPlan:
+    """Preflight Config-resolved bot_info availability dependencies before mutating flows."""
+    headers = _resolve_availability_headers()
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    try:
+        worksheet = await async_core.aget_worksheet(sheet_id, headers.tab_name)
+    except Exception:
+        _log_availability_diagnostics(
+            reason="worksheet_not_accessible",
+            tab_name=headers.tab_name,
+            sheet_id=sheet_id,
+            header_row_index=headers.header_row_index,
+            header_row=headers.header_row,
+            configured_headers=headers.configured_headers,
+            header_map=headers.header_map,
+            clan_tag=clan_tag,
+        )
+        raise
+    if worksheet is None:
+        raise ValueError("bot_info worksheet not accessible")
+
+    entry = _find_availability_clan_row(clan_tag, headers)
+    if entry is None:
+        _log_availability_diagnostics(
+            reason="bot_info_row_not_found",
+            tab_name=headers.tab_name,
+            sheet_id=sheet_id,
+            header_row_index=headers.header_row_index,
+            header_row=headers.header_row,
+            configured_headers=headers.configured_headers,
+            header_map=headers.header_map,
+            clan_tag=clan_tag,
+        )
+        raise ValueError(f"Unknown clan tag: {clan_tag}")
+
+    sheet_row, row = entry
+    numeric_values: dict[str, int] = {}
+    for field in NUMERIC_AVAILABILITY_FIELDS:
+        index = headers.header_map[field]
+        raw_value = row[index] if index < len(row) else ""
+        numeric_values[field] = _parse_required_int(
+            raw_value,
+            clan_tag=clan_tag,
+            delta=delta,
+            sheet_row=sheet_row,
+            tab_name=headers.tab_name,
+            header_key=field,
+            header_name=headers.configured_headers[field],
+        )
+
+    write_ranges = {
+        field: f"{_column_label(headers.header_map[field])}{sheet_row}"
+        for field in (
+            "manual_open_spots",
+            "open_spots",
+            "inactives",
+            "reservation_count",
+            "reservation_summary",
+            "manual_open_spots_seen",
+        )
+    }
+    _log_availability_diagnostics(
+        reason="preflight_ok",
+        tab_name=headers.tab_name,
+        sheet_id=sheet_id,
+        header_row_index=headers.header_row_index,
+        header_row=headers.header_row,
+        configured_headers=headers.configured_headers,
+        header_map=headers.header_map,
+        clan_tag=clan_tag,
+        sheet_row=sheet_row,
+    )
+    return AvailabilityPreflightPlan(
+        clan_tag=clan_tag,
+        sheet_row=sheet_row,
+        row=tuple(str(cell) if cell is not None else "" for cell in row),
+        headers=headers,
+        numeric_values=numeric_values,
+        write_ranges=write_ranges,
+    )
 
 
 def _adjust_context(
@@ -78,6 +400,8 @@ def _parse_required_int(
     header_name: str | None,
 ) -> int:
     raw = "" if value is None else str(value).strip()
+    if raw in {"", "-", "—"}:
+        return 0
     if not re.fullmatch(r"[+-]?\d+", raw):
         reason = (
             "non_numeric_manual_open_spots_value"
@@ -105,80 +429,26 @@ async def preflight_manual_open_spots_adjustment(
     clan_tag: str, delta: int
 ) -> ManualOpenSpotAdjustmentPlan:
     """Resolve and validate the row, configured headers, parseable cells, and writable worksheet."""
-    tab_name = recruitment.get_clans_tab_name()
-    entry = recruitment.find_clan_row(clan_tag, force=True)
-    if entry is None:
-        log.warning(
-            "manual open spot adjustment preflight failed",
-            extra=_adjust_context(
-                clan_tag, delta, tab_name=tab_name, reason="bot_info_row_not_found"
-            ),
-        )
-        raise ValueError(f"Unknown clan tag: {clan_tag}")
-
-    sheet_row, row = entry
-    header_map = recruitment.get_clan_header_map()
-    header_row_getter = getattr(recruitment, "get_clan_header_row", None)
-    header_row = header_row_getter() if callable(header_row_getter) else []
-    required_keys = ("manual_open_spots", "open_spots", "manual_open_spots_seen")
-    missing = [key for key in required_keys if header_map.get(key) is None]
-    if missing:
-        missing_key = missing[0]
-        log.warning(
-            "manual open spot adjustment preflight failed",
-            extra=_adjust_context(
-                clan_tag,
-                delta,
-                sheet_row=sheet_row,
-                tab_name=tab_name,
-                header_key=missing_key,
-                reason="configured_column_not_found",
-            ),
-        )
-        raise ValueError(f"clan header missing required column: {missing_key}")
+    plan = await preflight_clan_availability_update(clan_tag, delta=delta)
+    header_map = plan.headers.header_map
+    row = plan.row
+    sheet_row = plan.sheet_row
+    tab_name = plan.headers.tab_name
 
     manual_open_index = int(header_map["manual_open_spots"])
     open_index = int(header_map["open_spots"])
     seen_index = int(header_map["manual_open_spots_seen"])
 
-    manual_header_name = _header_name(header_row, manual_open_index)
-    manual_raw = row[manual_open_index] if manual_open_index < len(row) else ""
-    open_raw = row[open_index] if open_index < len(row) else ""
-    seen_raw = row[seen_index] if seen_index < len(row) else ""
-    manual_open = _parse_required_int(
-        manual_raw,
-        clan_tag=clan_tag,
-        delta=delta,
-        sheet_row=sheet_row,
-        tab_name=tab_name,
-        header_key="manual_open_spots",
-        header_name=manual_header_name,
-    )
-    current_available = _parse_required_int(
-        open_raw,
-        clan_tag=clan_tag,
-        delta=delta,
-        sheet_row=sheet_row,
-        tab_name=tab_name,
-        header_key="open_spots",
-        header_name=_header_name(header_row, open_index),
-    )
-    seen_manual_open = _parse_required_int(
-        seen_raw,
-        clan_tag=clan_tag,
-        delta=delta,
-        sheet_row=sheet_row,
-        tab_name=tab_name,
-        header_key="manual_open_spots_seen",
-        header_name=_header_name(header_row, seen_index),
-    )
+    manual_open = plan.numeric_values["manual_open_spots"]
+    current_available = plan.numeric_values["open_spots"]
+    seen_manual_open = plan.numeric_values["manual_open_spots_seen"]
 
     base_available = (
         manual_open if manual_open != seen_manual_open else current_available
     )
     new_value = max(base_available + delta, 0)
-    open_range = f"{_column_label(open_index)}{sheet_row}"
-    seen_range = f"{_column_label(seen_index)}{sheet_row}"
+    open_range = plan.write_ranges["open_spots"]
+    seen_range = plan.write_ranges["manual_open_spots_seen"]
     combined_range = None
     if abs(open_index - seen_index) == 1:
         combined_range = (
@@ -186,31 +456,11 @@ async def preflight_manual_open_spots_adjustment(
             f"{_column_label(max(open_index, seen_index))}{sheet_row}"
         )
 
-    # Resolve the worksheet during preflight so missing tabs/permissions fail before Discord mutations.
-    sheet_id = recruitment.get_recruitment_sheet_id()
-    try:
-        await async_core.aget_worksheet(sheet_id, tab_name)
-    except Exception:
-        log.exception(
-            "manual open spot adjustment preflight failed",
-            extra=_adjust_context(
-                clan_tag,
-                delta,
-                sheet_row=sheet_row,
-                tab_name=tab_name,
-                header_key="manual_open_spots",
-                header_name=manual_header_name,
-                raw_value=manual_raw,
-                reason="worksheet_not_writable",
-            ),
-        )
-        raise
-
     return ManualOpenSpotAdjustmentPlan(
         clan_tag=clan_tag,
         delta=delta,
         sheet_row=sheet_row,
-        row=tuple(str(cell) if cell is not None else "" for cell in row),
+        row=row,
         manual_open_index=manual_open_index,
         open_index=open_index,
         seen_index=seen_index,
@@ -221,7 +471,7 @@ async def preflight_manual_open_spots_adjustment(
         tab_key="clans_tab",
         tab_name=tab_name,
         manual_header_key="manual_open_spots",
-        manual_header_name=manual_header_name or "",
+        manual_header_name=plan.headers.configured_headers["manual_open_spots"],
         open_range=open_range,
         seen_range=seen_range,
         combined_range=combined_range,
@@ -402,34 +652,22 @@ async def recompute_clan_availability(
     guild: reservations.SupportsMemberLookup | None = None,
     resolver: reservations.ResolveUserFn | None = None,
 ) -> None:
-    """Recompute AF/AH/AI for ``clan_tag`` and refresh the in-memory cache."""
+    """Recompute Config-resolved bot_info availability for ``clan_tag`` and refresh cache."""
 
-    clan_entry = recruitment.find_clan_row(clan_tag, force=True)
-    if clan_entry is None:
-        raise ValueError(f"Unknown clan tag: {clan_tag}")
+    plan = await preflight_clan_availability_update(clan_tag, delta=0)
+    sheet_row = plan.sheet_row
+    row = plan.row
+    header_map = plan.headers.header_map
+    manual_open_index = header_map["manual_open_spots"]
+    open_index = header_map["open_spots"]
+    seen_index = header_map["manual_open_spots_seen"]
+    inactives_index = header_map["inactives"]
+    reservation_count_index = header_map["reservation_count"]
+    reservation_summary_index = header_map["reservation_summary"]
 
-    sheet_row, row = clan_entry
-    header_map = recruitment.get_clan_header_map()
-    manual_open_index = header_map.get("manual_open_spots")
-    open_index = header_map.get("open_spots")
-    seen_index = header_map.get("manual_open_spots_seen")
-    inactives_index = header_map.get("inactives")
-    reservation_count_index = header_map.get("reservation_count")
-    reservation_summary_index = header_map.get("reservation_summary")
-    if (
-        manual_open_index is None
-        or open_index is None
-        or seen_index is None
-        or inactives_index is None
-        or reservation_count_index is None
-        or reservation_summary_index is None
-    ):
-        raise ValueError(
-            "clan header missing required manual_open_spots/open_spots/manual_open_spots_seen/inactives/reservation_count/reservation_summary column"
-        )
-    manual_open = _parse_manual_open_spots(row, open_index=manual_open_index)
-    current_available = _parse_manual_open_spots(row, open_index=open_index)
-    seen_manual_open = _parse_manual_open_spots(row, open_index=seen_index)
+    manual_open = plan.numeric_values["manual_open_spots"]
+    current_available = plan.numeric_values["open_spots"]
+    seen_manual_open = plan.numeric_values["manual_open_spots_seen"]
     rebase_manual_open_spots = manual_open != seen_manual_open
     base_available = manual_open if rebase_manual_open_spots else current_available
 
@@ -457,48 +695,61 @@ async def recompute_clan_availability(
         + 1,
     )
 
-    inactives_value = (
-        updated_row[inactives_index] if len(updated_row) > inactives_index else ""
-    )
+    inactives_value = updated_row[inactives_index]
     updated_row[open_index] = str(available_after_reservations)
     updated_row[seen_index] = str(manual_open)
     updated_row[reservation_count_index] = str(reservation_count)
     updated_row[reservation_summary_index] = reservation_summary
 
     sheet_id = recruitment.get_recruitment_sheet_id()
-    tab_name = recruitment.get_clans_tab_name()
-    worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
+    worksheet = await async_core.aget_worksheet(sheet_id, plan.headers.tab_name)
 
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{_column_label(open_index)}{sheet_row}",
-        [[available_after_reservations]],
-        value_input_option="RAW",
-    )
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{_column_label(seen_index)}{sheet_row}",
-        [[manual_open]],
-        value_input_option="RAW",
-    )
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{_column_label(inactives_index)}{sheet_row}",
-        [[inactives_value]],
-        value_input_option="RAW",
-    )
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{_column_label(reservation_count_index)}{sheet_row}",
-        [[reservation_count]],
-        value_input_option="RAW",
-    )
-    await async_core.acall_with_backoff(
-        worksheet.update,
-        f"{_column_label(reservation_summary_index)}{sheet_row}",
-        [[reservation_summary]],
-        value_input_option="RAW",
-    )
+    writes = [
+        ("open_spots", plan.write_ranges["open_spots"], available_after_reservations),
+        (
+            "manual_open_spots_seen",
+            plan.write_ranges["manual_open_spots_seen"],
+            manual_open,
+        ),
+        ("inactives", plan.write_ranges["inactives"], inactives_value),
+        (
+            "reservation_count",
+            plan.write_ranges["reservation_count"],
+            reservation_count,
+        ),
+        (
+            "reservation_summary",
+            plan.write_ranges["reservation_summary"],
+            reservation_summary,
+        ),
+    ]
+    for field, write_range, value in writes:
+        try:
+            log.info(
+                "recompute_clan_availability:worksheet_update clan_tag=%s field=%s range=%s",
+                clan_tag,
+                field,
+                write_range,
+            )
+            await async_core.acall_with_backoff(
+                worksheet.update,
+                write_range,
+                [[value]],
+                value_input_option="RAW",
+            )
+        except Exception:
+            log.exception(
+                "recompute_clan_availability:worksheet_update_exception clan_tag=%s field=%s range=%s",
+                clan_tag,
+                field,
+                write_range,
+                extra={
+                    "clan_tag": _normalize_tag(clan_tag),
+                    "field": field,
+                    "write_range": write_range,
+                },
+            )
+            raise
 
     recruitment.update_cached_clan_row(sheet_row, updated_row)
 
@@ -513,6 +764,7 @@ async def recompute_clan_availability(
             "available_after_reservations": available_after_reservations,
             "aj_before": seen_manual_open,
             "aj_after": manual_open,
+            "resolved_header_map": _availability_header_map_columns(header_map),
         },
     )
 
@@ -568,5 +820,7 @@ def _normalize_tag(tag: str | None) -> str:
 __all__ = [
     "adjust_manual_open_spots",
     "preflight_manual_open_spots_adjustment",
+    "preflight_clan_availability_update",
+    "resolve_configured_clan_tag",
     "recompute_clan_availability",
 ]

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -45,6 +45,14 @@ def _stub_find_welcome_row(monkeypatch):
         },
     )
 
+    async def _fake_preflight(_tag, *, delta=0):
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
+        _fake_preflight,
+    )
+
 
 def _make_reservation(
     tag: str, *, created: dt.datetime | None = None
@@ -1337,6 +1345,14 @@ def test_finalize_posts_clan_math_log(monkeypatch) -> None:
             "manual_open_spots_seen": 35,
         },
     )
+
+    async def _fake_preflight(_tag, *, delta=0):
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
+        _fake_preflight,
+    )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
     )
@@ -1456,6 +1472,14 @@ def test_finalize_error_pings_admins(monkeypatch) -> None:
             "manual_open_spots": 4,
             "manual_open_spots_seen": 35,
         },
+    )
+
+    async def _fake_preflight(_tag, *, delta=0):
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
+        _fake_preflight,
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
@@ -1590,6 +1614,14 @@ def test_finalize_manual_path_logs_source(monkeypatch) -> None:
             "manual_open_spots_seen": 35,
         },
     )
+
+    async def _fake_preflight(_tag, *, delta=0):
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
+        _fake_preflight,
+    )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.rt.send_log_message", fake_send_log
     )
@@ -1669,6 +1701,14 @@ def test_finalize_non_real_tag_logs_skip_reason(monkeypatch) -> None:
             "manual_open_spots": 4,
             "manual_open_spots_seen": 35,
         },
+    )
+
+    async def _fake_preflight(_tag, *, delta=0):
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
+        _fake_preflight,
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.get_admin_role_ids", lambda: set()
@@ -1909,12 +1949,12 @@ def test_finalize_preflight_failure_applies_no_discord_actions(monkeypatch) -> N
         },
     )
 
-    async def failing_preflight(tag: str, delta: int):
+    async def failing_preflight(tag: str, *, delta=0):
         raise ValueError("non_numeric_manual_open_spots_value")
 
     adjust_calls: list[tuple[str, int]] = []
     monkeypatch.setattr(
-        "modules.onboarding.watcher_welcome.availability.preflight_manual_open_spots_adjustment",
+        "modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update",
         failing_preflight,
     )
     monkeypatch.setattr(

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -4,9 +4,62 @@ import logging
 from typing import List
 
 import discord
+import pytest
 
 from modules.placement import reservations as reserve_module
 from shared.sheets import reservations as reservations_sheet
+
+
+@pytest.fixture(autouse=True)
+def _stub_availability_preflight(monkeypatch):
+    header_map = {
+        "clan_tag": 2,
+        "manual_open_spots": 4,
+        "open_spots": 31,
+        "inactives": 32,
+        "reservation_count": 33,
+        "reservation_summary": 34,
+        "manual_open_spots_seen": 35,
+    }
+
+    class Plan:
+        sheet_row = 7
+        row = (
+            ("", "Clan", "#ABC", "", "3")
+            + ("",) * 26
+            + ("3", "0", "0", "", "3")
+            + ("",) * 10
+        )
+        numeric_values = {
+            "manual_open_spots": 3,
+            "open_spots": 3,
+            "inactives": 0,
+            "reservation_count": 0,
+            "manual_open_spots_seen": 3,
+        }
+        write_ranges = {
+            "open_spots": "AF7",
+            "inactives": "AG7",
+            "reservation_count": "AH7",
+            "reservation_summary": "AI7",
+            "manual_open_spots_seen": "AJ7",
+            "manual_open_spots": "E7",
+        }
+        headers = type(
+            "Headers", (), {"header_map": header_map, "tab_name": "bot_info"}
+        )()
+
+    async def fake_preflight(_tag, *, delta=0):
+        return Plan()
+
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "preflight_clan_availability_update",
+        fake_preflight,
+    )
+    monkeypatch.setattr(
+        reserve_module, "_resolve_configured_reservation_clan_tag", lambda tag: tag
+    )
 
 
 class FakeMember:
@@ -76,7 +129,12 @@ class FakeMessage:
 
 
 class FakeBot:
-    def __init__(self, messages: List[FakeMessage], *, channels: dict[int, FakeThread] | None = None) -> None:
+    def __init__(
+        self,
+        messages: List[FakeMessage],
+        *,
+        channels: dict[int, FakeThread] | None = None,
+    ) -> None:
         self._messages = list(messages)
         self._channels = dict(channels or {})
 
@@ -92,7 +150,9 @@ class FakeBot:
 
 
 class FakeContext:
-    def __init__(self, bot: FakeBot, guild: FakeGuild, channel: FakeThread, author) -> None:
+    def __init__(
+        self, bot: FakeBot, guild: FakeGuild, channel: FakeThread, author
+    ) -> None:
         self.bot = bot
         self.guild = guild
         self.channel = channel
@@ -133,7 +193,9 @@ def _setup_control_channels(
     recruiters_thread: int | None = None,
     interact_channel: int | None = None,
 ) -> None:
-    monkeypatch.setattr(reserve_module, "get_recruiters_thread_id", lambda: recruiters_thread)
+    monkeypatch.setattr(
+        reserve_module, "get_recruiters_thread_id", lambda: recruiters_thread
+    )
     monkeypatch.setattr(
         reserve_module,
         "get_recruitment_interact_channel_id",
@@ -198,7 +260,9 @@ def test_reserve_success(monkeypatch):
     guild = FakeGuild([recruit])
     thread = FakeThread(thread_id=555, parent_id=999)
 
-    mention_message = FakeMessage("reserve user", author=None, channel=thread, mentions=[recruit])
+    mention_message = FakeMessage(
+        "reserve user", author=None, channel=thread, mentions=[recruit]
+    )
     date_message = FakeMessage("2025-12-01", author=None, channel=thread)
     confirm_message = FakeMessage("yes", author=None, channel=thread)
 
@@ -210,7 +274,9 @@ def test_reserve_success(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     clan_row = ["", "Clan", "#ABC", "", "3"] + [""] * 40
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row)))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row))
+    )
 
     def fake_updated_row(tag):
         updated = list(clan_row)
@@ -245,14 +311,18 @@ def test_reserve_success(monkeypatch):
     async def fake_append(row_values):
         appended.append(list(row_values))
 
-    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+    monkeypatch.setattr(
+        reserve_module.reservations, "append_reservation_row", fake_append
+    )
 
     recomputed = {}
 
     async def fake_recompute(clan_tag, *, guild=None, resolver=None):
         recomputed["tag"] = clan_tag
 
-    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", fake_recompute)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", fake_recompute
+    )
 
     cog = _make_cog(bot)
     asyncio.run(cog.reserve.callback(cog, ctx, "ABC"))
@@ -269,8 +339,6 @@ def test_reserve_success(monkeypatch):
         assert recomputed["tag"] == "#ABC"
 
 
-
-
 def test_reserve_partial_success_when_recompute_fails(monkeypatch):
     _enable_feature(monkeypatch, enabled=True)
     _setup_parents(monkeypatch, parent_id=999)
@@ -285,8 +353,12 @@ def test_reserve_partial_success_when_recompute_fails(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     clan_row = ["", "Clan", "#ABC", "", "3"] + [""] * 40
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row)))
-    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row))
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row
+    )
 
     async def fake_count(*_args, **_kwargs):
         return 0
@@ -294,8 +366,14 @@ def test_reserve_partial_success_when_recompute_fails(monkeypatch):
     async def fake_find_active(*_args, **_kwargs):
         return []
 
-    monkeypatch.setattr(reserve_module.reservations, "count_active_reservations_for_clan", fake_count)
-    monkeypatch.setattr(reserve_module.reservations, "find_active_reservations_for_recruit", fake_find_active)
+    monkeypatch.setattr(
+        reserve_module.reservations, "count_active_reservations_for_clan", fake_count
+    )
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        fake_find_active,
+    )
 
     async def fake_flow_run(self):
         return reserve_module.ReservationDetails(
@@ -307,27 +385,55 @@ def test_reserve_partial_success_when_recompute_fails(monkeypatch):
         )
 
     monkeypatch.setattr(reserve_module.ReservationConversation, "run", fake_flow_run)
-    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", lambda row: asyncio.sleep(0))
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "append_reservation_row",
+        lambda row: asyncio.sleep(0),
+    )
 
     async def _boom(*_args, **_kwargs):
         raise RuntimeError("sheet update exploded")
 
-    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", _boom)
-    monkeypatch.setattr(reserve_module, "_ensure_fresh_clans_for_reservations", lambda **_: asyncio.sleep(0, result=True))
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", _boom
+    )
+    monkeypatch.setattr(
+        reserve_module,
+        "_ensure_fresh_clans_for_reservations",
+        lambda **_: asyncio.sleep(0, result=True),
+    )
 
     runtime_logs: list[tuple[str, str]] = []
-    monkeypatch.setattr(reserve_module.human_log, "human", lambda level, message, **_: runtime_logs.append((level, message)))
+    monkeypatch.setattr(
+        reserve_module.human_log,
+        "human",
+        lambda level, message, **_: runtime_logs.append((level, message)),
+    )
 
     cog = _make_cog(bot)
     asyncio.run(cog.reserve.callback(cog, ctx, "ABC"))
 
-    assert any("Reservation row was added, but recruiter-facing availability was NOT updated." in m.content for m in thread.sent)
-    assert any(level == "error" and "error_type=RuntimeError" in message and "source=reserve" in message for level, message in runtime_logs)
+    assert any(
+        "Reservation row was added, but recruiter-facing availability was NOT updated."
+        in m.content
+        for m in thread.sent
+    )
+    assert any(
+        level == "error"
+        and "error_type=RuntimeError" in message
+        and "source=reserve" in message
+        for level, message in runtime_logs
+    )
+
 
 def test_recompute_updates_recruiter_facing_clans_tab(monkeypatch):
     worksheet_calls: list[str] = []
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag, force=True: (7, ["", "", "#ABC", "", "4"] + [""] * 60))
+    monkeypatch.setattr(
+        reserve_module.recruitment,
+        "find_clan_row",
+        lambda tag, force=True: (7, ["", "", "#ABC", "", "4"] + [""] * 60),
+    )
     monkeypatch.setattr(
         reserve_module.recruitment,
         "get_clan_header_map",
@@ -340,8 +446,12 @@ def test_recompute_updates_recruiter_facing_clans_tab(monkeypatch):
             "reservation_summary": 34,
         },
     )
-    monkeypatch.setattr(reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id")
-    monkeypatch.setattr(reserve_module.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id"
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clans_tab_name", lambda: "bot_info"
+    )
 
     class _Worksheet:
         def update(self, cell_range, values, value_input_option="RAW"):
@@ -354,14 +464,32 @@ def test_recompute_updates_recruiter_facing_clans_tab(monkeypatch):
         return _Worksheet()
 
     monkeypatch.setattr(reserve_module.availability.async_core, "aget_worksheet", _aget)
-    monkeypatch.setattr(reserve_module.availability.async_core, "acall_with_backoff", lambda fn, *a, **k: asyncio.sleep(0, result=fn(*a, **k)))
-    monkeypatch.setattr(reserve_module.availability.reservations, "get_active_reservations_for_clan", lambda *_: asyncio.sleep(0, result=[]))
-    monkeypatch.setattr(reserve_module.availability.reservations, "resolve_reservation_names", lambda *_a, **_k: asyncio.sleep(0, result=[]))
-    monkeypatch.setattr(reserve_module.recruitment, "update_cached_clan_row", lambda *_: True)
+    monkeypatch.setattr(
+        reserve_module.availability.async_core,
+        "acall_with_backoff",
+        lambda fn, *a, **k: asyncio.sleep(0, result=fn(*a, **k)),
+    )
+    monkeypatch.setattr(
+        reserve_module.availability.reservations,
+        "get_active_reservations_for_clan",
+        lambda *_: asyncio.sleep(0, result=[]),
+    )
+    monkeypatch.setattr(
+        reserve_module.availability.reservations,
+        "resolve_reservation_names",
+        lambda *_a, **_k: asyncio.sleep(0, result=[]),
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "update_cached_clan_row", lambda *_: True
+    )
 
-    asyncio.run(reserve_module.availability.recompute_clan_availability("#ABC", guild=None))
+    asyncio.run(
+        reserve_module.availability.recompute_clan_availability("#ABC", guild=None)
+    )
 
     assert worksheet_calls, "expected worksheet updates"
+
+
 def test_reserve_accepts_inline_recruit(monkeypatch):
     _enable_feature(monkeypatch, enabled=True)
     _setup_parents(monkeypatch, parent_id=999)
@@ -382,8 +510,12 @@ def test_reserve_accepts_inline_recruit(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     clan_row = ["", "Clan", "#ABC", "", "3"] + [""] * 40
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row)))
-    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (10, list(clan_row))
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row
+    )
 
     async def fake_count(tag):
         return 0
@@ -408,7 +540,9 @@ def test_reserve_accepts_inline_recruit(monkeypatch):
     async def fake_append(row_values):
         appended.append(list(row_values))
 
-    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+    monkeypatch.setattr(
+        reserve_module.reservations, "append_reservation_row", fake_append
+    )
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
@@ -430,8 +564,12 @@ def test_ensure_fresh_clans_for_reservations_unavailable(monkeypatch, caplog):
         last_error = "boom"
 
     caplog.set_level(logging.WARNING, logger=reserve_module.log.name)
-    monkeypatch.setattr(reserve_module.cache_telemetry, "refresh_now", lambda *_, **__: asyncio.sleep(0))
-    monkeypatch.setattr(reserve_module.cache_telemetry, "get_snapshot", lambda *_: _Snapshot())
+    monkeypatch.setattr(
+        reserve_module.cache_telemetry, "refresh_now", lambda *_, **__: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        reserve_module.cache_telemetry, "get_snapshot", lambda *_: _Snapshot()
+    )
 
     result = asyncio.run(
         reserve_module._ensure_fresh_clans_for_reservations(
@@ -440,7 +578,10 @@ def test_ensure_fresh_clans_for_reservations_unavailable(monkeypatch, caplog):
     )
 
     assert result is False
-    assert any(getattr(record, "reason", None) == "fresh_clans_unavailable" for record in caplog.records)
+    assert any(
+        getattr(record, "reason", None) == "fresh_clans_unavailable"
+        for record in caplog.records
+    )
 
 
 def test_reserve_inline_recruit_validation_error(monkeypatch):
@@ -479,7 +620,9 @@ def test_reserve_duplicate_blocked(monkeypatch):
     )
     author = FakeMember(3001)
 
-    mention_message = FakeMessage("reserve user", author=author, channel=thread, mentions=[recruit])
+    mention_message = FakeMessage(
+        "reserve user", author=author, channel=thread, mentions=[recruit]
+    )
     date_message = FakeMessage("2025-12-01", author=author, channel=thread)
     confirm_message = FakeMessage("yes", author=author, channel=thread)
 
@@ -487,8 +630,13 @@ def test_reserve_duplicate_blocked(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     clan_row = ["", "Clan", "#ZZZ", "", "5"] + [""] * 40
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (12, list(clan_row)))
-    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (12, list(clan_row))
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row
+    )
+
     async def fake_count(*_args, **_kwargs):
         return 0
 
@@ -517,7 +665,12 @@ def test_reserve_duplicate_blocked(monkeypatch):
     )
 
     async def fake_resolve(bot, thread_id):
-        return FakeThread(thread_id=int(thread_id), parent_id=1000, name="Res-W0499-Other-C1CM", owner_id=recruit.id)
+        return FakeThread(
+            thread_id=int(thread_id),
+            parent_id=1000,
+            name="Res-W0499-Other-C1CM",
+            owner_id=recruit.id,
+        )
 
     monkeypatch.setattr(reserve_module, "_resolve_thread", fake_resolve)
 
@@ -526,7 +679,9 @@ def test_reserve_duplicate_blocked(monkeypatch):
     async def fake_append(row_values):
         appended.append(list(row_values))
 
-    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+    monkeypatch.setattr(
+        reserve_module.reservations, "append_reservation_row", fake_append
+    )
 
     cog = _make_cog(bot)
     asyncio.run(cog.reserve.callback(cog, ctx, "ZZZ"))
@@ -549,7 +704,9 @@ def test_reserve_requires_reason(monkeypatch):
     messages = [
         FakeMessage("who", author=author, channel=thread, mentions=[recruit]),
         FakeMessage("2025-11-30", author=author, channel=thread),
-        FakeMessage("Because they confirmed a start date", author=author, channel=thread),
+        FakeMessage(
+            "Because they confirmed a start date", author=author, channel=thread
+        ),
         FakeMessage("yes", author=author, channel=thread),
     ]
 
@@ -557,8 +714,13 @@ def test_reserve_requires_reason(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     clan_row = ["", "Clan", "#DEF", "", "1"] + [""] * 40
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (11, list(clan_row)))
-    monkeypatch.setattr(reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (11, list(clan_row))
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_by_tag", lambda tag: clan_row
+    )
+
     async def fake_count(tag):
         return 1
 
@@ -582,7 +744,9 @@ def test_reserve_requires_reason(monkeypatch):
     async def fake_append(row_values):
         appended.append(list(row_values))
 
-    monkeypatch.setattr(reserve_module.reservations, "append_reservation_row", fake_append)
+    monkeypatch.setattr(
+        reserve_module.reservations, "append_reservation_row", fake_append
+    )
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
@@ -644,7 +808,9 @@ def test_reserve_requires_ticket_thread(monkeypatch):
 
     recruit = FakeMember(888)
     guild = FakeGuild([recruit])
-    thread = FakeThread(thread_id=999, parent_id=123)  # parent does not match configured id
+    thread = FakeThread(
+        thread_id=999, parent_id=123
+    )  # parent does not match configured id
     author = FakeMember(889)
 
     bot = FakeBot([])
@@ -696,7 +862,9 @@ def test_reservations_thread_no_matches(monkeypatch):
     asyncio.run(cog.reservations_command.callback(cog, ctx))
 
     assert thread.sent and "No active reservations" in thread.sent[0].content
-    assert logs and "thread=W0455-Recruit Thread" in logs[0] and "result=empty" in logs[0]
+    assert (
+        logs and "thread=W0455-Recruit Thread" in logs[0] and "result=empty" in logs[0]
+    )
 
 
 def test_reservations_thread_lists_matches(monkeypatch):
@@ -754,7 +922,9 @@ def test_reservations_thread_lists_matches(monkeypatch):
     lines = content.splitlines()
     assert lines[0].startswith("Active reservation for")
     assert "`ABC`" in lines[1]
-    assert any("thread=W0460-Thread User" in entry and "result=ok" in entry for entry in logs)
+    assert any(
+        "thread=W0460-Thread User" in entry and "result=ok" in entry for entry in logs
+    )
 
 
 def test_reservations_thread_mismatch(monkeypatch):
@@ -806,7 +976,9 @@ def test_reservations_thread_mismatch(monkeypatch):
     asyncio.run(cog.reservations_command.callback(cog, ctx))
 
     assert thread.sent and "ledger shows" in thread.sent[0].content
-    assert any("result=error" in entry and "reason=tag_mismatch" in entry for entry in logs)
+    assert any(
+        "result=error" in entry and "reason=tag_mismatch" in entry for entry in logs
+    )
 
 
 def test_reservations_thread_multiple_rows(monkeypatch):
@@ -928,8 +1100,12 @@ def test_reservations_global_listing_recent(monkeypatch):
     )
 
     thread_lookup = {
-        3100: FakeThread(3100, parent_id=0, name="W0500-Recent Recruit-C1CE", owner_id=None),
-        3200: FakeThread(3200, parent_id=0, name="W0499-Old Recruit-C1CM", owner_id=None),
+        3100: FakeThread(
+            3100, parent_id=0, name="W0500-Recent Recruit-C1CE", owner_id=None
+        ),
+        3200: FakeThread(
+            3200, parent_id=0, name="W0499-Old Recruit-C1CM", owner_id=None
+        ),
     }
 
     async def fake_resolve(bot, thread_id):
@@ -977,7 +1153,9 @@ def test_reservations_clan_listing(monkeypatch):
 
     clan_row = ["", "Clan", "C1CE", ""] + [""] * 10
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (5, clan_row))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (5, clan_row)
+    )
 
     rows = [
         _reservation_row(
@@ -1009,8 +1187,12 @@ def test_reservations_clan_listing(monkeypatch):
     )
 
     thread_lookup = {
-        1300: FakeThread(1300, parent_id=700, name="W0471-User One-C1CE", owner_id=recruit.id),
-        1400: FakeThread(1400, parent_id=700, name="W0472-User Two-C1CE", owner_id=None),
+        1300: FakeThread(
+            1300, parent_id=700, name="W0471-User One-C1CE", owner_id=recruit.id
+        ),
+        1400: FakeThread(
+            1400, parent_id=700, name="W0472-User Two-C1CE", owner_id=None
+        ),
     }
 
     logs: list[str] = []
@@ -1039,7 +1221,9 @@ def test_reservations_clan_listing_requires_channel(monkeypatch):
     _setup_control_channels(monkeypatch, interact_channel=5555)
 
     guild = FakeGuild([])
-    channel = FakeThread(thread_id=4444, parent_id=0, name="general", owner_id=None, guild=guild)
+    channel = FakeThread(
+        thread_id=4444, parent_id=0, name="general", owner_id=None, guild=guild
+    )
     author = FakeMember(950)
 
     bot = FakeBot([], channels={channel.id: channel})
@@ -1062,7 +1246,9 @@ def test_reservations_clan_listing_allows_lead(monkeypatch):
     monkeypatch.setattr(reserve_module, "get_clan_lead_ids", lambda: {author.id})
 
     clan_row = ["", "Clan", "C1CM", ""] + [""] * 10
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (7, clan_row))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (7, clan_row)
+    )
 
     rows = [
         _reservation_row(
@@ -1137,7 +1323,6 @@ def test_reservations_clan_listing_denies_non_lead(monkeypatch):
     assert "Only Recruiters (or Admins)" in ctx.replies[-1].content
 
 
-
 def test_reserve_release_global_success(monkeypatch):
     _enable_feature(monkeypatch, enabled=True)
     _setup_permissions(monkeypatch, recruiter=True)
@@ -1190,16 +1375,22 @@ def test_reserve_release_global_success(monkeypatch):
     async def fake_adjust(tag: str, delta: int):
         adjustments.append((tag, delta))
 
-    monkeypatch.setattr(reserve_module.availability, "adjust_manual_open_spots", fake_adjust)
+    monkeypatch.setattr(
+        reserve_module.availability, "adjust_manual_open_spots", fake_adjust
+    )
 
     recomputed: list[str] = []
 
     async def fake_recompute(tag: str, *, guild=None):
         recomputed.append(tag)
 
-    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", fake_recompute)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", fake_recompute
+    )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1228,7 +1419,9 @@ def test_reserve_release_allowed_outside_control(monkeypatch):
 
     recruit = FakeMember(940, "Release User")
     guild = FakeGuild([recruit])
-    thread = FakeThread(thread_id=8000, parent_id=600, name="W0001-Test", owner_id=recruit.id)
+    thread = FakeThread(
+        thread_id=8000, parent_id=600, name="W0001-Test", owner_id=recruit.id
+    )
     author = FakeMember(941)
 
     row = _reservation_row(
@@ -1266,16 +1459,22 @@ def test_reserve_release_allowed_outside_control(monkeypatch):
     async def fake_adjust(tag: str, delta: int):
         adjustments.append((tag, delta))
 
-    monkeypatch.setattr(reserve_module.availability, "adjust_manual_open_spots", fake_adjust)
+    monkeypatch.setattr(
+        reserve_module.availability, "adjust_manual_open_spots", fake_adjust
+    )
 
     recomputed: list[str] = []
 
     async def fake_recompute(tag: str, *, guild=None):
         recomputed.append(tag)
 
-    monkeypatch.setattr(reserve_module.availability, "recompute_clan_availability", fake_recompute)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", fake_recompute
+    )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1314,7 +1513,9 @@ def test_reserve_release_global_not_found(monkeypatch):
     )
     author = FakeMember(932)
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     async def fake_lookup(*_, **__):
         return []
@@ -1351,7 +1552,13 @@ def test_reserve_release_global_multiple_rows(monkeypatch):
 
     recruit = FakeMember(932, "Release Multi")
     guild = FakeGuild([recruit])
-    channel = FakeThread(control_thread_id, parent_id=0, name="recruiters-control", owner_id=None, guild=guild)
+    channel = FakeThread(
+        control_thread_id,
+        parent_id=0,
+        name="recruiters-control",
+        owner_id=None,
+        guild=guild,
+    )
     author = FakeMember(933)
 
     rows = [
@@ -1382,7 +1589,9 @@ def test_reserve_release_global_multiple_rows(monkeypatch):
         fake_lookup,
     )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1408,7 +1617,9 @@ def test_reserve_extend_allowed_outside_control(monkeypatch):
 
     recruit = FakeMember(960, "Extend User")
     guild = FakeGuild([recruit])
-    thread = FakeThread(thread_id=9000, parent_id=600, name="W0002-Test", owner_id=recruit.id)
+    thread = FakeThread(
+        thread_id=9000, parent_id=600, name="W0002-Test", owner_id=recruit.id
+    )
     author = FakeMember(961)
 
     row = _reservation_row(
@@ -1441,7 +1652,9 @@ def test_reserve_extend_allowed_outside_control(monkeypatch):
         fake_extend,
     )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1454,7 +1667,11 @@ def test_reserve_extend_allowed_outside_control(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
 
     cog = _make_cog(bot)
-    asyncio.run(cog.reserve.callback(cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2999-01-01"))
+    asyncio.run(
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2999-01-01"
+        )
+    )
 
     assert updated == [(19, dt.date(2999, 1, 1))]
     assert thread.sent and "Extended the reservation" in thread.sent[-1].content
@@ -1469,7 +1686,13 @@ def test_reserve_extend_global_success(monkeypatch):
 
     recruit = FakeMember(970, "Extend User")
     guild = FakeGuild([recruit])
-    channel = FakeThread(control_thread_id, parent_id=0, name="recruiters-control", owner_id=None, guild=guild)
+    channel = FakeThread(
+        control_thread_id,
+        parent_id=0,
+        name="recruiters-control",
+        owner_id=None,
+        guild=guild,
+    )
     author = FakeMember(971)
 
     row = _reservation_row(
@@ -1508,14 +1731,18 @@ def test_reserve_extend_global_success(monkeypatch):
         logs.append(message)
 
     monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     bot = FakeBot([])
     ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
 
     cog = _make_cog(bot)
     asyncio.run(
-        cog.reserve.callback(cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2999-01-01")
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2999-01-01"
+        )
     )
 
     assert updates == [(14, dt.date(2999, 1, 1))]
@@ -1531,7 +1758,13 @@ def test_reserve_extend_global_invalid_date(monkeypatch):
 
     recruit = FakeMember(980, "Extend Fail")
     guild = FakeGuild([recruit])
-    channel = FakeThread(control_thread_id, parent_id=0, name="recruiters-control", owner_id=None, guild=guild)
+    channel = FakeThread(
+        control_thread_id,
+        parent_id=0,
+        name="recruiters-control",
+        owner_id=None,
+        guild=guild,
+    )
     author = FakeMember(981)
 
     row = _reservation_row(
@@ -1559,13 +1792,19 @@ def test_reserve_extend_global_invalid_date(monkeypatch):
         logs.append(message)
 
     monkeypatch.setattr(reserve_module.human_log, "human", fake_log)
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     bot = FakeBot([])
     ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
 
     cog = _make_cog(bot)
-    asyncio.run(cog.reserve.callback(cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2020-01-01"))
+    asyncio.run(
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2020-01-01"
+        )
+    )
 
     assert ctx.replies, "expected invalid date message"
     assert "valid date" in ctx.replies[-1].content
@@ -1580,7 +1819,13 @@ def test_reserve_extend_global_not_found(monkeypatch):
 
     recruit = FakeMember(981, "Extend Missing")
     guild = FakeGuild([recruit])
-    channel = FakeThread(control_thread_id, parent_id=0, name="recruiters-control", owner_id=None, guild=guild)
+    channel = FakeThread(
+        control_thread_id,
+        parent_id=0,
+        name="recruiters-control",
+        owner_id=None,
+        guild=guild,
+    )
     author = FakeMember(982)
 
     async def fake_lookup(*_, **__):
@@ -1592,7 +1837,9 @@ def test_reserve_extend_global_not_found(monkeypatch):
         fake_lookup,
     )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1605,7 +1852,11 @@ def test_reserve_extend_global_not_found(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
 
     cog = _make_cog(bot)
-    asyncio.run(cog.reserve.callback(cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2030-01-01"))
+    asyncio.run(
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2030-01-01"
+        )
+    )
 
     assert ctx.replies and "No active reservation" in ctx.replies[-1].content
     assert any("result=not_found" in entry for entry in logs)
@@ -1619,7 +1870,13 @@ def test_reserve_extend_global_multiple_rows(monkeypatch):
 
     recruit = FakeMember(982, "Extend Multi")
     guild = FakeGuild([recruit])
-    channel = FakeThread(control_thread_id, parent_id=0, name="recruiters-control", owner_id=None, guild=guild)
+    channel = FakeThread(
+        control_thread_id,
+        parent_id=0,
+        name="recruiters-control",
+        owner_id=None,
+        guild=guild,
+    )
     author = FakeMember(983)
 
     rows = [
@@ -1650,7 +1907,9 @@ def test_reserve_extend_global_multiple_rows(monkeypatch):
         fake_lookup,
     )
 
-    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""]))
+    monkeypatch.setattr(
+        reserve_module.recruitment, "find_clan_row", lambda tag: (9, ["", "", tag, ""])
+    )
 
     logs: list[str] = []
 
@@ -1663,7 +1922,235 @@ def test_reserve_extend_global_multiple_rows(monkeypatch):
     ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
 
     cog = _make_cog(bot)
-    asyncio.run(cog.reserve.callback(cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2030-01-01"))
+    asyncio.run(
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2030-01-01"
+        )
+    )
 
     assert ctx.replies and "Multiple reservations" in ctx.replies[-1].content
     assert any("reason=multiple_rows" in entry for entry in logs)
+
+
+def test_reservation_preflight_failure_does_not_append(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_parents(monkeypatch, parent_id=999)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_control_channels(monkeypatch)
+
+    recruit = FakeMember(333, "Recruit Blocked")
+    guild = FakeGuild([recruit])
+    thread = FakeThread(thread_id=557, parent_id=999)
+    author = FakeMember(112, "Recruiter")
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
+
+    appended: list[list[str]] = []
+
+    async def failing_preflight(_tag, *, delta=0):
+        raise ValueError("configured bot_info header not found for open_spots: missing")
+
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "preflight_clan_availability_update",
+        failing_preflight,
+    )
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "append_reservation_row",
+        lambda row: appended.append(row),
+    )
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "ABC"))
+
+    assert appended == []
+    assert any(
+        "no reservation was created" in (reply.content or "") for reply in ctx.replies
+    )
+
+
+def _use_configured_ak_clan_tag(monkeypatch):
+    header = [""] * 37
+    header[4] = "manual_open_spots"
+    header[31] = "open_spots"
+    header[32] = "inactives"
+    header[33] = "reservation_count"
+    header[34] = "reservation_summary"
+    header[35] = "manual_open_spots_seen"
+    header[36] = "clan_tag"
+    row = [""] * 37
+    row[4] = "3"
+    row[31] = "3"
+    row[32] = "0"
+    row[33] = "0"
+    row[35] = "3"
+    row[36] = "C1CE"
+    config = {
+        f"clans_header_{field}": field
+        for field in reserve_module.availability.AVAILABILITY_FIELDS
+    }
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clans_tab_name", lambda: "bot_info"
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "sheet"
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_header_row", lambda force=False: header
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment,
+        "get_config_value",
+        lambda key, default=None: config.get(key, default),
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "fetch_clans", lambda force=False: [list(row)]
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment,
+        "find_clan_row",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("column C lookup should not be used")
+        ),
+    )
+    monkeypatch.setattr(
+        reserve_module,
+        "_resolve_configured_reservation_clan_tag",
+        reserve_module.availability.resolve_configured_clan_tag,
+    )
+
+
+def test_reserve_release_uses_configured_clan_tag_header_not_column_c(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_control_channels(monkeypatch, recruiters_thread=2500)
+    _use_configured_ak_clan_tag(monkeypatch)
+
+    recruit = FakeMember(3001, "Release AK")
+    guild = FakeGuild([recruit])
+    channel = FakeThread(2500, parent_id=0, name="recruiters-control", guild=guild)
+    author = FakeMember(3002)
+    row = _reservation_row(21, clan_tag="C1CE", ticket_user_id=recruit.id)
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        lambda *_args, **_kwargs: asyncio.sleep(0, result=[row]),
+    )
+    updated: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "update_reservation_status",
+        lambda row_number, status: asyncio.sleep(
+            0, result=updated.append((row_number, status))
+        ),
+    )
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "adjust_manual_open_spots",
+        lambda *_args, **_kwargs: asyncio.sleep(0),
+    )
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "recompute_clan_availability",
+        lambda *_args, **_kwargs: asyncio.sleep(0),
+    )
+    monkeypatch.setattr(
+        reserve_module.human_log, "human", lambda *_args, **_kwargs: None
+    )
+
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "release", f"<@{recruit.id}>", "C1CE"))
+
+    assert updated == [(21, "released")]
+    assert channel.sent and "Released the reserved seat" in channel.sent[-1].content
+
+
+def test_reserve_extend_uses_configured_clan_tag_header_not_column_c(monkeypatch):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_control_channels(monkeypatch, recruiters_thread=2600)
+    _use_configured_ak_clan_tag(monkeypatch)
+
+    recruit = FakeMember(3011, "Extend AK")
+    guild = FakeGuild([recruit])
+    channel = FakeThread(2600, parent_id=0, name="recruiters-control", guild=guild)
+    author = FakeMember(3012)
+    row = _reservation_row(22, clan_tag="C1CE", ticket_user_id=recruit.id)
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "find_active_reservations_for_recruit",
+        lambda *_args, **_kwargs: asyncio.sleep(0, result=[row]),
+    )
+    updated: list[tuple[int, dt.date]] = []
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "update_reservation_expiry",
+        lambda row_number, new_date: asyncio.sleep(
+            0, result=updated.append((row_number, new_date))
+        ),
+    )
+    monkeypatch.setattr(
+        reserve_module.human_log, "human", lambda *_args, **_kwargs: None
+    )
+
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild=guild, channel=channel, author=author)
+    cog = _make_cog(bot)
+    asyncio.run(
+        cog.reserve.callback(
+            cog, ctx, "extend", f"<@{recruit.id}>", "C1CE", "2999-01-01"
+        )
+    )
+
+    assert updated == [(22, dt.date(2999, 1, 1))]
+    assert channel.sent and "Extended the reservation" in channel.sent[-1].content
+
+
+def test_reservations_clan_listing_uses_configured_clan_tag_header_not_column_c(
+    monkeypatch,
+):
+    _enable_feature(monkeypatch, enabled=True)
+    _setup_permissions(monkeypatch, recruiter=True)
+    _setup_parents(monkeypatch, parent_id=700)
+    _setup_control_channels(monkeypatch, interact_channel=1200)
+    _use_configured_ak_clan_tag(monkeypatch)
+
+    recruit = FakeMember(3021, "List AK")
+    guild = FakeGuild([recruit])
+    channel = FakeThread(1200, parent_id=0, name="recruitment-interact", guild=guild)
+    rows = [
+        _reservation_row(
+            23,
+            clan_tag="C1CE",
+            thread_id=1300,
+            ticket_user_id=recruit.id,
+            username_snapshot="List AK",
+        )
+    ]
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "get_active_reservations_for_clan",
+        lambda tag: asyncio.sleep(0, result=list(rows)),
+    )
+    monkeypatch.setattr(
+        reserve_module.human_log, "human", lambda *_args, **_kwargs: None
+    )
+    bot = FakeBot(
+        [],
+        channels={
+            1300: FakeThread(
+                1300, parent_id=700, name="W3021-List AK-C1CE", owner_id=recruit.id
+            ),
+            1200: channel,
+        },
+    )
+    ctx = FakeContext(bot, guild=guild, channel=channel, author=FakeMember(3022))
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reservations_command.callback(cog, ctx, "C1CE"))
+
+    assert channel.sent, "expected clan reservation listing"
+    assert "ticket W3021" in channel.sent[0].content

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -25,11 +25,29 @@ def _default_recruitment_config(monkeypatch):
         availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet"
     )
     header = [""] * 42
+
+    config_values = {
+        "clans_header_manual_open_spots": "Manual open spots",
+        "clans_header_open_spots": "Effective open spots",
+        "clans_header_inactives": "Inactives",
+        "clans_header_reservation_count": "Reservation count",
+        "clans_header_reservation_summary": "Reservation summary",
+        "clans_header_manual_open_spots_seen": "Manual open spots seen",
+        "clans_header_clan_tag": "Clan Tag",
+    }
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_config_value",
+        lambda key, default=None: config_values.get(key, default),
+    )
     header[4] = "Manual open spots"
     header[20] = "Effective open spots"
     header[31] = "Effective open spots"
+    header[32] = "Inactives"
+    header[33] = "Reservation count"
+    header[34] = "Reservation summary"
     header[35] = "Manual open spots seen"
-    header[36] = "Manual open spots seen"
+    header[36] = "Clan Tag"
     monkeypatch.setattr(availability.recruitment, "get_clan_header_row", lambda: header)
 
 
@@ -262,11 +280,11 @@ def test_recompute_clan_availability_uses_reordered_reservation_columns(monkeypa
     asyncio.run(availability.recompute_clan_availability("#EEE"))
 
     assert worksheet.updates == [
-        ("U11", [[3]], {"value_input_option": "RAW"}),
-        ("AP11", [[4]], {"value_input_option": "RAW"}),
+        ("AF11", [[3]], {"value_input_option": "RAW"}),
+        ("AJ11", [[4]], {"value_input_option": "RAW"}),
         ("AG11", [[""]], {"value_input_option": "RAW"}),
-        ("AK11", [[1]], {"value_input_option": "RAW"}),
-        ("Z11", [["1 -> Alice"]], {"value_input_option": "RAW"}),
+        ("AH11", [[1]], {"value_input_option": "RAW"}),
+        ("AI11", [["1 -> Alice"]], {"value_input_option": "RAW"}),
     ]
 
 
@@ -287,7 +305,23 @@ def test_recompute_clan_availability_requires_reservation_headers(monkeypatch):
         },
     )
 
-    with pytest.raises(ValueError, match="reservation_count/reservation_summary"):
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_config_value",
+        lambda key, default=None: (
+            None
+            if key == "clans_header_reservation_count"
+            else {
+                "clans_header_manual_open_spots": "Manual open spots",
+                "clans_header_open_spots": "Effective open spots",
+                "clans_header_inactives": "Inactives",
+                "clans_header_reservation_summary": "Reservation summary",
+                "clans_header_manual_open_spots_seen": "Manual open spots seen",
+                "clans_header_clan_tag": "Clan Tag",
+            }.get(key, default)
+        ),
+    )
+    with pytest.raises(ValueError, match="clans_header_reservation_count"):
         asyncio.run(availability.recompute_clan_availability("#AAA"))
 
 
@@ -443,9 +477,13 @@ def test_adjust_manual_open_spots_applies_delta_to_resolved_column(monkeypatch):
     monkeypatch.setattr(
         availability.recruitment, "get_clans_tab_name", lambda: "bot_info"
     )
-    header = [""] * 37
+    header = [""] * 42
+    header[2] = "Clan Tag"
     header[4] = "Manual open spots"
     header[20] = "Effective open spots"
+    header[32] = "Inactives"
+    header[33] = "Reservation count"
+    header[34] = "Reservation summary"
     header[36] = "Manual open spots seen"
     monkeypatch.setattr(availability.recruitment, "get_clan_header_row", lambda: header)
 
@@ -491,7 +529,23 @@ def test_adjust_manual_open_spots_requires_open_spots_header(monkeypatch):
         lambda: {"manual_open_spots": 4, "open_spots": 20},
     )
 
-    with pytest.raises(ValueError, match="manual_open_spots_seen"):
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_config_value",
+        lambda key, default=None: (
+            None
+            if key == "clans_header_manual_open_spots_seen"
+            else {
+                "clans_header_manual_open_spots": "Manual open spots",
+                "clans_header_open_spots": "Effective open spots",
+                "clans_header_inactives": "Inactives",
+                "clans_header_reservation_count": "Reservation count",
+                "clans_header_reservation_summary": "Reservation summary",
+                "clans_header_clan_tag": "Clan Tag",
+            }.get(key, default)
+        ),
+    )
+    with pytest.raises(ValueError, match="clans_header_manual_open_spots_seen"):
         asyncio.run(availability.adjust_manual_open_spots("#CCC", -1))
 
 
@@ -534,8 +588,8 @@ def test_adjust_manual_open_spots_rebases_when_manual_changes(monkeypatch):
     new_value = asyncio.run(availability.adjust_manual_open_spots("#DDD", -1))
     assert new_value == 3
     assert worksheet.updates == [
-        ("U15", [["3"]], {"value_input_option": "RAW"}),
-        ("AK15", [["4"]], {"value_input_option": "RAW"}),
+        ("AF15", [["3"]], {"value_input_option": "RAW"}),
+        ("AJ15", [["4"]], {"value_input_option": "RAW"}),
     ]
 
 
@@ -578,8 +632,8 @@ def test_adjust_manual_open_spots_rebase_without_delta(monkeypatch):
     new_value = asyncio.run(availability.adjust_manual_open_spots("#DDD", 0))
     assert new_value == 4
     assert worksheet.updates == [
-        ("U15", [["4"]], {"value_input_option": "RAW"}),
-        ("AK15", [["4"]], {"value_input_option": "RAW"}),
+        ("AF15", [["4"]], {"value_input_option": "RAW"}),
+        ("AJ15", [["4"]], {"value_input_option": "RAW"}),
     ]
 
 
@@ -596,9 +650,13 @@ def _patch_adjust_common(monkeypatch, *, row, header_map=None, worksheet=None):
         lambda: header_map
         or {"manual_open_spots": 4, "open_spots": 20, "manual_open_spots_seen": 36},
     )
-    header = [""] * 37
+    header = [""] * 42
+    header[2] = "Clan Tag"
     header[4] = "Manual open spots"
     header[20] = "Effective open spots"
+    header[32] = "Inactives"
+    header[33] = "Reservation count"
+    header[34] = "Reservation summary"
     header[36] = "Manual open spots seen"
     monkeypatch.setattr(availability.recruitment, "get_clan_header_row", lambda: header)
     monkeypatch.setattr(
@@ -630,7 +688,7 @@ def test_adjust_manual_open_spots_missing_bot_info_row_logs_context(
     _patch_adjust_common(monkeypatch, row=[""] * 37)
     with pytest.raises(ValueError, match="Unknown clan tag"):
         asyncio.run(availability.preflight_manual_open_spots_adjustment("#MISS", -1))
-    assert "manual open spot adjustment preflight failed" in caplog.text
+    assert "bot_info availability header diagnostics" in caplog.text
     assert any(
         getattr(r, "reason", None) == "bot_info_row_not_found" for r in caplog.records
     )
@@ -645,19 +703,27 @@ def test_adjust_manual_open_spots_missing_configured_manual_column_logs_context(
     row = [""] * 37
     row[20] = "3"
     row[36] = "3"
-    _patch_adjust_common(
-        monkeypatch,
-        row=row,
-        header_map={"open_spots": 20, "manual_open_spots_seen": 36},
+    _patch_adjust_common(monkeypatch, row=row)
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_config_value",
+        lambda key, default=None: (
+            None
+            if key == "clans_header_manual_open_spots"
+            else {
+                "clans_header_open_spots": "Effective open spots",
+                "clans_header_inactives": "Inactives",
+                "clans_header_reservation_count": "Reservation count",
+                "clans_header_reservation_summary": "Reservation summary",
+                "clans_header_manual_open_spots_seen": "Manual open spots seen",
+                "clans_header_clan_tag": "Clan Tag",
+            }.get(key, default)
+        ),
     )
-    with pytest.raises(ValueError, match="manual_open_spots"):
+    with pytest.raises(ValueError, match="clans_header_manual_open_spots"):
         asyncio.run(availability.preflight_manual_open_spots_adjustment("#CCC", -1))
     assert any(
-        getattr(r, "reason", None) == "configured_column_not_found"
-        for r in caplog.records
-    )
-    assert any(
-        getattr(r, "configured_column_header_key", None) == "manual_open_spots"
+        getattr(r, "missing_config_key", None) == "clans_header_manual_open_spots"
         for r in caplog.records
     )
 
@@ -693,3 +759,46 @@ def test_adjust_manual_open_spots_sheet_update_exception_logs_range(
     assert "range=U12" in caplog.text
     assert "boom U12" in caplog.text
     assert any(getattr(r, "write_range", None) == "U12" for r in caplog.records)
+
+
+def test_availability_header_config_resolves_production_columns(monkeypatch):
+    header = [""] * 37
+    header[4] = "manual_open_spots"
+    header[31] = "open_spots"
+    header[32] = "inactives"
+    header[33] = "reservation_count"
+    header[34] = "reservation_summary"
+    header[35] = "manual_open_spots_seen"
+    header[36] = "clan_tag"
+    config_values = {
+        f"clans_header_{field}": field for field in availability.AVAILABILITY_FIELDS
+    }
+    monkeypatch.setattr(
+        availability.recruitment, "get_clans_tab_name", lambda: "bot_info"
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet"
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_clan_header_row", lambda force=False: header
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_config_value",
+        lambda key, default=None: config_values.get(key, default),
+    )
+
+    resolved = availability._resolve_availability_headers()
+
+    assert {
+        key: availability._column_label(index)
+        for key, index in resolved.header_map.items()
+    } == {
+        "manual_open_spots": "E",
+        "open_spots": "AF",
+        "inactives": "AG",
+        "reservation_count": "AH",
+        "reservation_summary": "AI",
+        "manual_open_spots_seen": "AJ",
+        "clan_tag": "AK",
+    }


### PR DESCRIPTION
### Motivation
- Replace ad-hoc column-index lookups with a Config-driven availability preflight to make availability updates robust to header reordering and to provide better diagnostics.
- Ensure reservation and onboarding flows validate availability sheet configuration before performing Discord/member actions or appending rows to the ledger.
- Centralize clan-tag resolution via the availability header configuration to avoid relying on hard-coded column C semantics.

### Description
- Added a new config-driven availability layer in `modules/recruitment/availability.py` including `AvailabilityHeaderResolution`, `AvailabilityPreflightPlan`, `_resolve_availability_headers`, `preflight_clan_availability_update`, and `resolve_configured_clan_tag`, plus richer diagnostic logging for header/config issues and sheet access.
- Reworked `preflight_manual_open_spots_adjustment`, `adjust_manual_open_spots`, and `recompute_clan_availability` to use the new preflight/plan objects and named write ranges, removing brittle fixed-column assumptions and consolidating worksheet access and validation.
- Updated reservation and onboarding code paths to call `preflight_clan_availability_update` before applying Discord or sheet mutations; added `_resolve_configured_reservation_clan_tag` to resolve clan tags via the availability headers and replaced old direct `find_clan_row` usages in key flows.
- Minor refactors and formatting cleanup across `modules/placement/reservations.py` and `modules/onboarding/watcher_welcome.py` to support the new API and to improve logging/error messages.
- Tests were updated to exercise the new preflight API and header-resolution behavior and new tests added to assert header resolution and preflight-blocking semantics.

### Testing
- Ran the unit test suite with `pytest` covering onboarding, placement, and recruitment availability behavior including updated tests under `tests/onboarding`, `tests/placement`, and `tests/recruitment`; all tests passed.
- Added unit tests for availability header resolution and for reservation preflight blocking to validate error handling when the sheet config or values are invalid, which succeeded in CI test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25579d4a4c8323bf65c4d1771baa9c)