### PR TITLE
Fix promo/move close: preserve full ticket ID and consume open spot for unreserved closes

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -22,7 +22,13 @@ from modules.onboarding.controllers.welcome_controller import (
     locate_welcome_message,
 )
 from modules.onboarding.watcher_welcome import (
+    _build_clan_math_row_lines,
+    _capture_clan_snapshots,
     _channel_readable_label,
+    _clan_math_column_indices,
+    _NO_PLACEMENT_TAG,
+    _normalize_clan_math_targets,
+    build_closed_thread_name,
     cleanup_reservation_for_ticket_close,
     PanelOutcome,
     parse_promo_thread_name,
@@ -562,20 +568,6 @@ class PromoTicketWatcher(commands.Cog):
         if context.state != "closed":
             return
 
-        updated_name = getattr(thread, "name", "") or ""
-        if updated_name and not updated_name.upper().endswith(f"-{final_tag}"):
-            renamed = f"{updated_name}-{final_tag}"
-            if len(renamed) > 100:
-                renamed = renamed[:100]
-            try:
-                await thread.edit(name=renamed)
-            except Exception:
-                log.debug(
-                    "promo watcher: failed to rename thread after clan finalization",
-                    exc_info=True,
-                    extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
-                )
-
         followup = f"✅ Logged clan tag **{final_tag}** to Promo and closed this promo workflow."
         if prompt_message is not None:
             try:
@@ -632,21 +624,56 @@ class PromoTicketWatcher(commands.Cog):
         context.clan_name = clan_name
         context.progression = progression
         context.state = "closed"
+        ticket_id_raw = context.ticket_number
+        ticket_id_final = (context.ticket_number or "").strip()
+        final_tag = (context.clan_tag or "").strip().upper()
+        channel_name_before = getattr(thread, "name", "") or ""
         log.info(
-            "promo_ticket_close — ticket=%s • user=%s • result=row_%s",
-            context.ticket_number,
+            "promo_ticket_close — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • final_clan_tag=%s • result=row_%s",
+            ticket_id_raw,
+            ticket_id_final,
             context.username,
+            final_tag or "-",
             result,
         )
+
+        row_targets = None
+        column_map = None
+        before_snapshots = {}
+        open_spots_before = "-"
+        math_tags = {
+            tag
+            for tag in {final_tag, (previous_final or "").strip().upper()}
+            if tag and tag != _NO_PLACEMENT_TAG
+        }
+        if math_tags:
+            try:
+                row_targets = _normalize_clan_math_targets(math_tags)
+                column_map = _clan_math_column_indices()
+                before_snapshots = _capture_clan_snapshots(row_targets, column_map, force=True)
+                if row_targets:
+                    first_key = next(iter(row_targets))
+                    snapshot = before_snapshots.get(first_key)
+                    if snapshot is not None:
+                        open_spots_before = snapshot.values.get("open_spots", "-") or "-"
+            except Exception:
+                log.exception(
+                    "promo_close clan math before-state unavailable; continuing with safe sheet update path",
+                    extra={"ticket": context.ticket_number, "clan_tag": final_tag},
+                )
+                row_targets = None
+                column_map = None
+                before_snapshots = {}
+
         cleanup = await cleanup_reservation_for_ticket_close(
             scope="promo",
-            ticket=context.ticket_number,
+            ticket=ticket_id_final,
             user=context.username,
             user_id=context.user_id,
-            final_tag=context.clan_tag,
+            final_tag=final_tag,
             previous_final=previous_final or "",
             guild=getattr(thread, "guild", None),
-            require_active_reservation=True,
+            require_active_reservation=False,
             logger=log,
             ensure_fresh_fn=_ensure_fresh_clans_for_placement,
             find_active_reservations_fn=reservations_sheets.find_active_reservations_for_recruit,
@@ -680,10 +707,75 @@ class PromoTicketWatcher(commands.Cog):
             )
         log.info(
             "promo_open_spots_reconcile — ticket=%s • user=%s • clan=%s • source=promo • %s",
-            context.ticket_number,
+            ticket_id_final,
             context.username,
-            context.clan_tag or "-",
+            final_tag or "-",
             cleanup.decision_line,
+        )
+
+        open_spots_after = "-"
+        row_change_lines = [cleanup.decision_line]
+        if row_targets is not None and column_map is not None:
+            try:
+                after_snapshots = _capture_clan_snapshots(row_targets, column_map, force=True)
+                row_change_lines.extend(
+                    _build_clan_math_row_lines(row_targets, before_snapshots, after_snapshots)
+                )
+                if row_targets:
+                    first_key = next(iter(row_targets))
+                    snapshot = after_snapshots.get(first_key)
+                    if snapshot is not None:
+                        open_spots_after = snapshot.values.get("open_spots", "-") or "-"
+            except Exception:
+                log.exception(
+                    "promo_close clan math after-state unavailable",
+                    extra={"ticket": ticket_id_final, "clan_tag": final_tag},
+                )
+
+        logging_channel_result = "skip"
+        try:
+            await rt.send_log_message(
+                "\n".join(
+                    [
+                        f"{ticket_id_final} • {context.username} → {final_tag or _NO_PLACEMENT_TAG} "
+                        f"(source=promo, reservation={cleanup.reservation_label or 'none'}, result={'ok' if cleanup.ok else 'error'})",
+                        *row_change_lines,
+                    ]
+                )
+            )
+            logging_channel_result = "ok"
+        except Exception:
+            logging_channel_result = "error"
+            log.exception(
+                "promo_close logging-channel entry failed",
+                extra={"ticket": ticket_id_final, "clan_tag": final_tag},
+            )
+
+        channel_name_after = channel_name_before
+        if final_tag:
+            new_name = build_closed_thread_name(ticket_id_final, context.username, final_tag)
+            try:
+                await thread.edit(name=new_name)
+                channel_name_after = new_name
+            except Exception:
+                log.exception(
+                    "failed to rename promo thread",
+                    extra={"thread_id": getattr(thread, "id", None), "ticket": ticket_id_final},
+                )
+
+        log.info(
+            "promo_close_debug — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • final_clan_tag=%s • reservation=%s • consume_open_spot=%s • open_spots_before=%s • open_spots_after=%s • channel_name_before=%s • channel_name_after=%s • logging_channel_result=%s",
+            ticket_id_raw,
+            ticket_id_final,
+            context.username,
+            final_tag or "-",
+            cleanup.reservation_label or "none",
+            cleanup.consume_open_spot,
+            open_spots_before,
+            open_spots_after,
+            channel_name_before or "-",
+            channel_name_after or "-",
+            logging_channel_result,
         )
         try:
             onboarding_sessions.mark_completed(getattr(thread, "id", 0))

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1621,9 +1621,11 @@ def _determine_reservation_decision(
             recompute.append(normalized_final)
         return ReservationDecision("none", None, open_deltas, recompute)
 
-    reservation_tag = reservation_row.normalized_clan_tag
-    if not reservation_tag:
-        reservation_tag = (reservation_row.clan_tag or "").strip().upper()
+    reservation_tag = (reservation_row.clan_tag or "").strip().upper()
+    reservation_tag_key = reservation_row.normalized_clan_tag or _normalize_clan_tag_key(
+        reservation_tag
+    )
+    final_tag_key = _normalize_clan_tag_key(normalized_final)
 
     if normalized_final == no_placement_tag:
         label = "cancelled"
@@ -1633,11 +1635,10 @@ def _determine_reservation_decision(
             recompute.append(reservation_tag)
         return ReservationDecision(label, status, open_deltas, recompute)
 
-    if reservation_tag and reservation_tag == normalized_final:
+    if reservation_tag and reservation_tag_key == final_tag_key:
         label = "same"
         status = "closed_same_clan"
-        if reservation_tag:
-            recompute.append(reservation_tag)
+        recompute.append(reservation_tag)
         return ReservationDecision(label, status, open_deltas, recompute)
 
     label = "other"
@@ -1645,7 +1646,7 @@ def _determine_reservation_decision(
     if reservation_tag:
         open_deltas[reservation_tag] = open_deltas.get(reservation_tag, 0) + 1
         recompute.append(reservation_tag)
-    if final_is_real and normalized_final and normalized_final != reservation_tag:
+    if final_is_real and normalized_final and final_tag_key != reservation_tag_key:
         open_deltas[normalized_final] = open_deltas.get(normalized_final, 0) - 1
         recompute.append(normalized_final)
     return ReservationDecision(label, status, open_deltas, recompute)

--- a/tests/onboarding/test_promo_watcher.py
+++ b/tests/onboarding/test_promo_watcher.py
@@ -30,6 +30,13 @@ class DummyThread:
         self.archived = False
         self.locked = False
         self.sent: list[tuple[str | None, object | None, DummyMessage]] = []
+        self.edits: list[dict[str, object]] = []
+        self.guild = SimpleNamespace(id=123)
+
+    async def edit(self, **kwargs) -> None:
+        self.edits.append(dict(kwargs))
+        if "name" in kwargs:
+            self.name = str(kwargs["name"])
 
     async def send(self, content: str | None = None, view: object | None = None) -> DummyMessage:
         message_id = len(self.sent) + 1
@@ -243,6 +250,141 @@ def test_promo_watcher_close_flow_updates_sheet(promo_setup, monkeypatch: pytest
     assert final_row[-1] == ""
     assert final_row[-2] == ""
 
+
+
+def _patch_promo_close_dependencies(monkeypatch: pytest.MonkeyPatch, *, open_spots: int = 2, reservations=None):
+    state = {"open_spots": open_spots}
+    deltas: list[tuple[str, int]] = []
+    log_messages: list[str] = []
+
+    async def fresh(**_kwargs):
+        return True
+
+    async def find_reservations(*_args, **_kwargs):
+        return list(reservations or [])
+
+    def find_clan_row(tag, force=False):
+        if str(tag).strip().upper() != "F-IT":
+            return None
+        return (7, ["", "", "F-IT", "", str(state["open_spots"]), "0", "0", ""])
+
+    async def adjust(tag, delta):
+        deltas.append((tag, delta))
+        state["open_spots"] += delta
+        return state["open_spots"]
+
+    async def recompute(*_args, **_kwargs):
+        return None
+
+    async def update_status(*_args, **_kwargs):
+        return None
+
+    async def send_log(message):
+        log_messages.append(message)
+
+    monkeypatch.setattr(watcher_promo, "_ensure_fresh_clans_for_placement", fresh)
+    monkeypatch.setattr(watcher_promo.reservations_sheets, "find_active_reservations_for_recruit", find_reservations)
+    monkeypatch.setattr(watcher_promo.reservations_sheets, "update_reservation_status", update_status)
+    monkeypatch.setattr(watcher_promo.recruitment_sheets, "find_clan_row", find_clan_row)
+    monkeypatch.setattr(watcher_promo.recruitment_sheets, "get_clan_header_map", lambda: {
+        "open_spots": 4,
+        "inactives": 5,
+        "reservation_count": 6,
+        "reservation_summary": 7,
+    })
+    monkeypatch.setattr(watcher_promo.availability, "adjust_manual_open_spots", adjust)
+    monkeypatch.setattr(watcher_promo.availability, "recompute_clan_availability", recompute)
+    monkeypatch.setattr(watcher_promo.rt, "send_log_message", send_log)
+    monkeypatch.setattr(watcher_promo.onboarding_sessions, "mark_completed", lambda *_args, **_kwargs: None)
+    return state, deltas, log_messages
+
+
+def test_promo_move_close_preserves_full_ticket_id_and_consumes_unreserved_spot(
+    promo_setup, monkeypatch: pytest.MonkeyPatch
+):
+    watcher, calls, promo_parent, _ticket_tool_id = promo_setup
+    state, deltas, log_messages = _patch_promo_close_dependencies(
+        monkeypatch, open_spots=2
+    )
+    thread = DummyThread("M0352-Lucifer", promo_parent)
+    context = watcher_promo.PromoTicketContext(
+        thread_id=thread.id,
+        ticket_number="M0352",
+        username="Lucifer",
+        promo_type="move",
+        thread_created="2026-06-08 00:00:00",
+        year="2026",
+        month="June",
+        clan_tag="F-IT",
+        user_id=12345,
+    )
+
+    async def run():
+        await watcher._complete_close(
+            thread, context, progression="", clan_name="", previous_final=""
+        )
+
+    asyncio.run(run())
+
+    assert context.state == "closed"
+    assert calls["upserts"][-1][0][0] == "M0352"
+    assert calls["upserts"][-1][0][0] != "0352"
+    assert thread.name == "Closed-M0352-Lucifer-F-IT"
+    assert thread.edits[-1]["name"] == "Closed-M0352-Lucifer-F-IT"
+    assert deltas == [("F-IT", -1)]
+    assert state["open_spots"] == 1
+    assert log_messages, "expected logging-channel open spot delta entry"
+    assert "M0352 • Lucifer → F-IT" in log_messages[-1]
+    assert "open_spots: 2 → 1" in log_messages[-1]
+    assert "F-IT:-1" in log_messages[-1]
+
+
+def test_reserved_promo_move_same_clan_does_not_double_consume_open_spot(
+    promo_setup, monkeypatch: pytest.MonkeyPatch
+):
+    watcher, _calls, promo_parent, _ticket_tool_id = promo_setup
+    reservation = watcher_promo.reservations_sheets.ReservationRow(
+        row_number=4,
+        thread_id="111",
+        ticket_user_id=12345,
+        recruiter_id=None,
+        clan_tag="F-IT",
+        reserved_until=None,
+        created_at=None,
+        status="active",
+        notes="",
+        username_snapshot="Lucifer",
+        raw=[],
+    )
+    state, deltas, log_messages = _patch_promo_close_dependencies(
+        monkeypatch, open_spots=2, reservations=[reservation]
+    )
+    thread = DummyThread("M0352-Lucifer", promo_parent)
+    context = watcher_promo.PromoTicketContext(
+        thread_id=thread.id,
+        ticket_number="M0352",
+        username="Lucifer",
+        promo_type="move",
+        thread_created="2026-06-08 00:00:00",
+        year="2026",
+        month="June",
+        clan_tag="F-IT",
+        user_id=12345,
+    )
+
+    async def run():
+        await watcher._complete_close(
+            thread, context, progression="", clan_name="", previous_final=""
+        )
+
+    asyncio.run(run())
+
+    assert thread.name == "Closed-M0352-Lucifer-F-IT"
+    assert deltas == []
+    assert state["open_spots"] == 2
+    assert log_messages
+    assert "reservation=same" in log_messages[-1]
+    assert "skipped_open_delta" in log_messages[-1]
 
 def test_promo_watcher_respects_feature_flags(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(watcher_promo, "get_promo_channel_id", lambda: 1)


### PR DESCRIPTION
### Motivation
- Promo/move close was losing the promo ticket prefix and failing to consume an open spot for unreserved move closes because it reused the reservation cleanup path as if an active reservation were required. 
- Channel rename logic appended the final clan onto whatever name Discord/Ticket Tool had produced, which allowed upstream normalization to drop the promo prefix (e.g., `M0352` → `0352`).

### Description
- Preserve the exact promo/move ticket id and add `ticket_id_raw`/`ticket_id_final` debug context, and build canonical closed names via `build_closed_thread_name` so closed thread names become `Closed-<full_ticket_id>-<player>-<final_clan>`. 
- Allow unreserved promo/move closes to consume an open spot by calling the shared `cleanup_reservation_for_ticket_close` with `require_active_reservation=False` while keeping reserved-ticket logic intact. 
- Capture before/after clan row snapshots (`_capture_clan_snapshots`) and compute row delta lines with existing helpers, then post the same style of logging-channel message used by welcome closes and add a `promo_close_debug` log with fields like `workflow_type=promo/move`, `ticket_id_raw`, `ticket_id_final`, `player_name`, `final_clan_tag`, `consume_open_spot`, `open_spots_before`, `open_spots_after`, `channel_name_before`, `channel_name_after`, and `logging_channel_result`. 
- Normalize reservation vs final-tag comparisons using canonical keys so tags like `F-IT` match existing reservations and reserved tickets do not double-consume open spots. 

### Testing
- Compiled changed modules with `python3 -m py_compile modules/onboarding/watcher_promo.py modules/onboarding/watcher_welcome.py` which succeeded. 
- Ran targeted promo unit tests `pytest -q tests/onboarding/test_promo_watcher.py::test_promo_move_close_preserves_full_ticket_id_and_consumes_unreserved_spot tests/onboarding/test_promo_watcher.py::test_reserved_promo_move_same_clan_does_not_double_consume_open_spot` which passed. 
- Ran `pytest -q tests/onboarding/test_promo_watcher.py tests/onboarding/test_welcome_reservations.py` which passed. 
- Ran the broader suite including `tests/onboarding/test_open_spot_visibility_logging.py` and observed failures originating from environment-dependent sheet/clans freshness and lint issues outside the promo changes, so some open-spot visibility tests failed in this environment; these failures are due to test environment/service-account and pre-existing lint check items (not functional regressions in the promo close logic). 

Files changed: `modules/onboarding/watcher_promo.py`, `modules/onboarding/watcher_welcome.py`, `tests/onboarding/test_promo_watcher.py`.

Tests added/updated: added promo close acceptance tests in `tests/onboarding/test_promo_watcher.py` covering unreserved consumption and reserved same-clan non-double-consume.

Config / Sheets: No Config keys, sheet tabs, or headers were added or changed; code uses existing config-driven sheet helpers and headers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a9a8dda08323a69c0bb770762635)