### PR TITLE
Promo: add source_clan_tag support, configurable header, UI flow, and reservation cleanup

### DIFF
--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -241,13 +241,16 @@ explicitly configured in the sheet.
 - 'ONBOARDING_TAB'
 - 'WELCOME_TICKETS_TAB'
 - 'PROMO_TICKETS_TAB'
+- `PROMO_SOURCE_CLAN_TAG_HEADER` (required; value `source_clan_tag`)
 - 'CLANLIST_TAB'
 
 **Promo tab columns (PROMO_TICKETS_TAB)**
 
 ```
-ticket number | username | clantag | date closed | type | thread created | year | month | join_month | clan name | progression
+ticket number | username | clantag | source_clan_tag | date closed | type | thread created | year | month | join_month | clan name | progression
 ```
+
+`source_clan_tag` records the previous/came-from clan selected during promo/move close; `clantag` remains the destination/final clan used in the closed thread name. The bot resolves this source column through `PROMO_SOURCE_CLAN_TAG_HEADER`; missing Config/header mapping is treated as an operational error instead of silently falling back to destination-only math.
 
 Promo tickets use the R/M/L prefixes to map to `type` values:
 
@@ -376,4 +379,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2025-12-31 (v0.9.8.2)
+Doc last updated: 2026-06-08 (v0.9.8.2)

--- a/docs/ops/PromoTickets.md
+++ b/docs/ops/PromoTickets.md
@@ -19,14 +19,17 @@ The promo watcher (`modules.onboarding.watcher_promo.PromoTicketWatcher`):
 - Logs opens and closes to the `PROMO_TICKETS_TAB` worksheet using the following
   columns:
 
-  `ticket number | username | clantag | date closed | type | thread created |
+  `ticket number | username | clantag | source_clan_tag | date closed | type | thread created |
   year | month | join_month | clan name | progression`
 
 - Maps prefixes to types: `R` → `returning player`, `M` → `player move request`,
   `L` → `clan lead move request`.
-- On closure, prompts for a clan tag and progression text; responses update the
-  `clantag`, `date closed`, `clan name`, and `progression` fields. Dialog/panel
-  onboarding for promo tickets will arrive in a later release.
+- On closure, prompts the closer for both **where the member came from** (`source_clan_tag`)
+  and **where the member is going** (`clantag`). Successful close math releases one
+  source open spot and consumes one destination open spot, unless the normalized
+  source and destination are the same clan or either side is `NONE`.
+- Destination reservations still prevent double-consuming the destination spot,
+  while source-clan release still runs for member moves.
 - Lifecycle logs surface as `Promo panel — scope=promo` entries; welcome only
   handles threads that begin with `W####-…`.
 
@@ -34,6 +37,7 @@ The promo watcher (`modules.onboarding.watcher_promo.PromoTicketWatcher`):
 
 - **Channels:** `PROMO_CHANNEL_ID`
 - **Sheet tab:** `PROMO_TICKETS_TAB`
+- **Required Promo source header:** Config key `PROMO_SOURCE_CLAN_TAG_HEADER=source_clan_tag`; the resolved header must exist in `PROMO_TICKETS_TAB`.
 - **Toggles:** `PROMO_ENABLED`, `ENABLE_PROMO_HOOK` (promo dialog toggle
   reserved for later: `promo_dialog`)
 
@@ -51,4 +55,4 @@ The promo watcher (`modules.onboarding.watcher_promo.PromoTicketWatcher`):
   the watcher misses the trigger. Removing the trigger lines prevents the bot
   from recognising promo tickets.
 
-Doc last updated: 2025-11-29 (v0.9.8.2)
+Doc last updated: 2026-06-08 (v0.9.8.2)

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -46,10 +46,40 @@ from shared.sheets import onboarding_sessions
 from shared.sheets import promo_tickets
 from shared.sheets import recruitment as recruitment_sheets
 from shared.sheets import reservations as reservations_sheets
-from shared.sheets.onboarding import PROMO_HEADERS
 
 UTC = dt.timezone.utc
 log = logging.getLogger("c1c.onboarding.promo_watcher")
+
+
+def _promo_headers_for_write(*, ticket: str | None = None) -> list[str]:
+    try:
+        return onboarding_sheets.get_promo_headers()
+    except Exception:
+        log.exception(
+            "promo source clan header mapping unavailable; cannot write Promo row",
+            extra={"ticket": ticket or "-"},
+        )
+        raise
+
+
+def _source_clan_from_promo_values(values: dict[str, str], *, ticket: str | None = None) -> str:
+    try:
+        source_header = onboarding_sheets.get_promo_source_clan_tag_header()
+    except Exception:
+        log.exception(
+            "promo source clan header mapping unavailable; cannot read source clan",
+            extra={"ticket": ticket or "-"},
+        )
+        return ""
+    if source_header not in values:
+        log.warning(
+            "promo row missing configured source clan header",
+            extra={"ticket": ticket or "-", "source_header": source_header},
+        )
+        return ""
+    return (values.get(source_header, "") or "").strip()
+
+
 _CLOSED_MESSAGE_TOKEN = "ticket closed"
 _PROMO_TRIGGER_MAP: Dict[str, str] = {
     "<!-- trigger:promo.r -->": "promo.r",
@@ -97,6 +127,7 @@ class PromoTicketContext:
     month: str
     join_month: str = ""
     clan_tag: str = ""
+    source_clan_tag: str = ""
     clan_name: str = ""
     progression: str = ""
     state: str = "open"
@@ -106,9 +137,9 @@ class PromoTicketContext:
 
 
 class PromoClanSelect(discord.ui.Select):
-    def __init__(self, parent_view: "PromoClanSelectView", tags: List[str]) -> None:
+    def __init__(self, parent_view: "PromoClanSelectView", tags: List[str], *, role: str) -> None:
         options = [discord.SelectOption(label=tag, value=tag) for tag in tags[:25]]
-        placeholder = "Select a clan tag"
+        placeholder = "Where did they come from?" if role == "source" else "Where are they going?"
         super().__init__(placeholder=placeholder, min_values=1, max_values=1, options=options)
         self._parent_view = parent_view
 
@@ -120,16 +151,20 @@ class PromoClanSelect(discord.ui.Select):
 
 
 class PromoClanSelectView(discord.ui.View):
-    def __init__(self, watcher: "PromoTicketWatcher", context: PromoTicketContext, tags: List[str]):
+    def __init__(self, watcher: "PromoTicketWatcher", context: PromoTicketContext, tags: List[str], *, role: str):
         super().__init__(timeout=300)
         self.watcher = watcher
         self.context = context
+        self.role = role
         self.message: Optional[discord.Message] = None
-        self.select = PromoClanSelect(self, tags)
+        self.select = PromoClanSelect(self, tags, role=role)
         self.add_item(self.select)
 
     async def handle_selection(self, interaction: discord.Interaction, tag: str) -> None:
         await interaction.response.defer()
+        if self.role == "source":
+            await self.watcher.source_from_interaction(self.context, tag, interaction, self)
+            return
         await self.watcher.finalize_from_interaction(self.context, tag, interaction, self)
 
     async def on_timeout(self) -> None:  # pragma: no cover - timeout path
@@ -324,6 +359,7 @@ class PromoTicketWatcher(commands.Cog):
         if found:
             _, values = found
             context.clan_tag = values.get("clantag", "") or context.clan_tag
+            context.source_clan_tag = _source_clan_from_promo_values(values, ticket=parts.ticket_code) or context.source_clan_tag
             context.clan_name = values.get("clan name", "") or context.clan_name
             context.progression = values.get("progression", "") or context.progression
             context.thread_created = values.get("thread created", "") or context.thread_created
@@ -356,6 +392,7 @@ class PromoTicketWatcher(commands.Cog):
                     context.ticket_number,
                     context.username,
                     context.clan_tag,
+                    context.source_clan_tag,
                     context.promo_type,
                     context.thread_created,
                     context.year,
@@ -398,6 +435,7 @@ class PromoTicketWatcher(commands.Cog):
         if found:
             _, values = found
             context.clan_tag = values.get("clantag", "") or context.clan_tag
+            context.source_clan_tag = _source_clan_from_promo_values(values, ticket=context.ticket_number) or context.source_clan_tag
             context.clan_name = values.get("clan name", "") or context.clan_name
             context.progression = values.get("progression", "") or context.progression
             context.thread_created = values.get("thread created", "") or context.thread_created
@@ -435,9 +473,16 @@ class PromoTicketWatcher(commands.Cog):
 
         await self._ensure_row_initialized(thread, context)
 
-        context.state = "awaiting_clan"
-        content = f"Which clan tag applies to {context.username} (ticket {context.ticket_number})?\n{CLAN_TAG_PROMPT_HELPER}"
-        view = PromoClanSelectView(self, context, tags)
+        context.state = "awaiting_source_clan"
+        content = (
+            f"Where did the member come from?\n"
+            f"Where is the member going?\n"
+            f"First select the source clan for {context.username} (ticket {context.ticket_number}).\n"
+            f"Use **{_NO_PLACEMENT_TAG}** only when there was no source placement.\n{CLAN_TAG_PROMPT_HELPER}"
+        )
+        source_tags = [tag for tag in tags if tag != _NO_PLACEMENT_TAG]
+        source_tags.insert(0, _NO_PLACEMENT_TAG)
+        view = PromoClanSelectView(self, context, source_tags, role="source")
         try:
             message = await thread.send(content, view=view)
         except Exception:
@@ -490,6 +535,81 @@ class PromoTicketWatcher(commands.Cog):
                         extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
                     )
 
+
+    async def source_from_interaction(
+        self,
+        context: PromoTicketContext,
+        tag: str,
+        interaction: discord.Interaction,
+        view: PromoClanSelectView,
+    ) -> None:
+        thread = interaction.channel if isinstance(interaction.channel, discord.Thread) else None
+        if thread is None:
+            await interaction.followup.send(
+                "⚠️ I lost track of the ticket thread. Please try again.", ephemeral=True
+            )
+            return
+        await self._set_source_clan_tag(
+            thread,
+            context,
+            tag,
+            actor=getattr(interaction, "user", None),
+            prompt_message=interaction.message,
+            view=view,
+        )
+
+    async def _set_source_clan_tag(
+        self,
+        thread: discord.Thread,
+        context: PromoTicketContext,
+        source_tag: str,
+        *,
+        actor: discord.abc.User | None,
+        prompt_message: Optional[discord.Message],
+        view: Optional[PromoClanSelectView],
+    ) -> None:
+        if context.state != "awaiting_source_clan":
+            return
+        source_tag = (source_tag or "").strip().upper()
+        if not source_tag:
+            return
+
+        tags = await self._load_clan_tags()
+        valid_sources = set(tags) | {_NO_PLACEMENT_TAG}
+        if source_tag not in valid_sources:
+            await self._send_invalid_tag_notice(thread, actor, source_tag)
+            return
+
+        context.source_clan_tag = source_tag
+        context.state = "awaiting_destination_clan"
+        if view is not None:
+            view.stop()
+
+        destination_content = (
+            f"Source recorded as **{source_tag}**. Where is the member going?\n"
+            f"Select the destination clan for {context.username} (ticket {context.ticket_number}).\n"
+            f"{CLAN_TAG_PROMPT_HELPER}"
+        )
+        destination_view = PromoClanSelectView(self, context, tags, role="destination")
+        if prompt_message is not None:
+            try:
+                await prompt_message.edit(content=destination_content, view=destination_view)
+                destination_view.message = prompt_message
+                return
+            except Exception:
+                log.debug("failed to edit promo source prompt into destination prompt", exc_info=True)
+        try:
+            message = await thread.send(destination_content, view=destination_view)
+        except Exception:
+            context.state = "awaiting_source_clan"
+            log.exception(
+                "failed to post promo destination clan selection prompt",
+                extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
+            )
+            return
+        destination_view.message = message
+        context.prompt_message_id = message.id
+
     async def finalize_from_interaction(
         self,
         context: PromoTicketContext,
@@ -522,7 +642,7 @@ class PromoTicketWatcher(commands.Cog):
         prompt_message: Optional[discord.Message],
         view: Optional[PromoClanSelectView],
     ) -> None:
-        if context.state != "awaiting_clan":
+        if context.state not in {"awaiting_clan", "awaiting_destination_clan"}:
             return
         final_tag = (final_tag or "").strip().upper()
         if not final_tag:
@@ -543,20 +663,7 @@ class PromoTicketWatcher(commands.Cog):
             except Exception:
                 prompt_message = None
 
-        previous_final: str | None = ""
-        try:
-            existing_row = await asyncio.to_thread(
-                onboarding_sheets.find_promo_row, context.ticket_number
-            )
-            if existing_row:
-                row_values = existing_row[1]
-                previous_final = (row_values.get("clantag", "") or "").strip()
-        except Exception:
-            previous_final = None
-            log.exception(
-                "promo reconcile: failed to fetch promo row before close write",
-                extra={"ticket": context.ticket_number},
-            )
+        previous_final: str | None = (context.source_clan_tag or "").strip().upper()
 
         await self._complete_close(
             thread,
@@ -588,10 +695,17 @@ class PromoTicketWatcher(commands.Cog):
         previous_final: str | None = "",
     ) -> None:
         timestamp = _format_date(dt.datetime.now(UTC))
+        try:
+            promo_headers = _promo_headers_for_write(ticket=context.ticket_number)
+        except Exception:
+            await thread.send("⚠️ Promo source clan header mapping is missing. Please fix Config before closing this promo ticket.")
+            return
+
         row = [
             context.ticket_number,
             context.username,
             context.clan_tag,
+            context.source_clan_tag,
             timestamp,
             context.promo_type,
             context.thread_created,
@@ -610,7 +724,7 @@ class PromoTicketWatcher(commands.Cog):
                 thread=thread,
                 user=context.username,
                 write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_promo, row, PROMO_HEADERS
+                    onboarding_sheets.upsert_promo, row, promo_headers
                 ),
             )
         except Exception:
@@ -627,12 +741,14 @@ class PromoTicketWatcher(commands.Cog):
         ticket_id_raw = context.ticket_number
         ticket_id_final = (context.ticket_number or "").strip()
         final_tag = (context.clan_tag or "").strip().upper()
+        source_tag = (context.source_clan_tag or "").strip().upper()
         channel_name_before = getattr(thread, "name", "") or ""
         log.info(
-            "promo_ticket_close — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • final_clan_tag=%s • result=row_%s",
+            "promo_ticket_close — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • source_clan_tag=%s • destination_clan_tag=%s • result=row_%s",
             ticket_id_raw,
             ticket_id_final,
             context.username,
+            source_tag or "-",
             final_tag or "-",
             result,
         )
@@ -643,7 +759,7 @@ class PromoTicketWatcher(commands.Cog):
         open_spots_before = "-"
         math_tags = {
             tag
-            for tag in {final_tag, (previous_final or "").strip().upper()}
+            for tag in {final_tag, source_tag}
             if tag and tag != _NO_PLACEMENT_TAG
         }
         if math_tags:
@@ -671,7 +787,8 @@ class PromoTicketWatcher(commands.Cog):
             user=context.username,
             user_id=context.user_id,
             final_tag=final_tag,
-            previous_final=previous_final or "",
+            previous_final=source_tag,
+            require_source_for_open_spot_math=True,
             guild=getattr(thread, "guild", None),
             require_active_reservation=False,
             logger=log,
@@ -714,6 +831,7 @@ class PromoTicketWatcher(commands.Cog):
         )
 
         open_spots_after = "-"
+        after_snapshots = {}
         row_change_lines = [cleanup.decision_line]
         if row_targets is not None and column_map is not None:
             try:
@@ -737,7 +855,8 @@ class PromoTicketWatcher(commands.Cog):
             await rt.send_log_message(
                 "\n".join(
                     [
-                        f"{ticket_id_final} • {context.username} → {final_tag or _NO_PLACEMENT_TAG} "
+                        f"{ticket_id_final} • {context.username}: "
+                        f"{source_tag or '-'} → {final_tag or _NO_PLACEMENT_TAG} "
                         f"(source=promo, reservation={cleanup.reservation_label or 'none'}, result={'ok' if cleanup.ok else 'error'})",
                         *row_change_lines,
                     ]
@@ -763,16 +882,22 @@ class PromoTicketWatcher(commands.Cog):
                     extra={"thread_id": getattr(thread, "id", None), "ticket": ticket_id_final},
                 )
 
+        release_source_open_spot = cleanup.applied_open_deltas.get(source_tag, 0) > 0
+        consume_destination_open_spot = cleanup.applied_open_deltas.get(final_tag, 0) < 0
         log.info(
-            "promo_close_debug — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • final_clan_tag=%s • reservation=%s • consume_open_spot=%s • open_spots_before=%s • open_spots_after=%s • channel_name_before=%s • channel_name_after=%s • logging_channel_result=%s",
+            "promo_close_debug — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • source_clan_tag=%s • destination_clan_tag=%s • reservation_status=%s • consume_destination_open_spot=%s • release_source_open_spot=%s • open_spots_before=%s • open_spots_after=%s • open_spots_before_by_clan=%s • open_spots_after_by_clan=%s • channel_name_before=%s • channel_name_after=%s • logging_channel_result=%s",
             ticket_id_raw,
             ticket_id_final,
             context.username,
+            source_tag or "-",
             final_tag or "-",
             cleanup.reservation_label or "none",
-            cleanup.consume_open_spot,
+            consume_destination_open_spot,
+            release_source_open_spot,
             open_spots_before,
             open_spots_after,
+            {tag: (before_snapshots.get(key).values.get("open_spots", "-") if before_snapshots.get(key) else "-") for key, tag in (row_targets or {}).items()},
+            {tag: (after_snapshots.get(key).values.get("open_spots", "-") if after_snapshots.get(key) else "-") for key, tag in (row_targets or {}).items()} if 'after_snapshots' in locals() else {},
             channel_name_before or "-",
             channel_name_after or "-",
             logging_channel_result,
@@ -796,6 +921,14 @@ class PromoTicketWatcher(commands.Cog):
     ) -> None:
         created_value = created_at.isoformat()
         updated_value = dt.datetime.now(UTC).isoformat()
+        try:
+            promo_headers = _promo_headers_for_write(ticket=context.ticket_number)
+        except Exception:
+            log.warning(
+                "promo reminder: source clan header mapping missing; skipping sheet touch",
+                extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
+            )
+            return
 
         try:
             existing = await asyncio.to_thread(
@@ -810,12 +943,17 @@ class PromoTicketWatcher(commands.Cog):
             existing = None
 
         if existing:
-            row_values = list(existing[1].values()) if isinstance(existing[1], dict) else list(existing[1])
+            row_values = (
+                [existing[1].get(header, "") for header in promo_headers]
+                if isinstance(existing[1], dict)
+                else list(existing[1])
+            )
         else:
             row_values = [
                 context.ticket_number,
                 context.username,
                 context.clan_tag,
+                context.source_clan_tag,
                 "",
                 context.promo_type,
                 context.thread_created,
@@ -829,16 +967,17 @@ class PromoTicketWatcher(commands.Cog):
                 str(getattr(thread, "id", 0)),
                 "",
                 context.state,
+                "",
                 created_value,
                 "",
             ]
 
-        if len(row_values) < len(PROMO_HEADERS):
-            row_values.extend(["" for _ in range(len(PROMO_HEADERS) - len(row_values))])
+        if len(row_values) < len(promo_headers):
+            row_values.extend(["" for _ in range(len(promo_headers) - len(row_values))])
 
         try:
-            created_idx = PROMO_HEADERS.index("created_at")
-            updated_idx = PROMO_HEADERS.index("updated_at")
+            created_idx = promo_headers.index("created_at")
+            updated_idx = promo_headers.index("updated_at")
         except ValueError:
             return
 
@@ -855,7 +994,7 @@ class PromoTicketWatcher(commands.Cog):
                 thread=thread,
                 user=user_ref,
                 write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_promo, row_values, PROMO_HEADERS
+                    onboarding_sheets.upsert_promo, row_values, promo_headers
                 ),
             )
         except Exception:
@@ -970,7 +1109,7 @@ class PromoTicketWatcher(commands.Cog):
         context = await self._ensure_context(after)
         if context is None:
             return
-        if context.state in {"awaiting_clan", "closed"}:
+        if context.state in {"awaiting_clan", "awaiting_source_clan", "awaiting_destination_clan", "closed"}:
             return
         if getattr(after, "id", None) in self._auto_closed_threads:
             context.state = "closed"
@@ -1075,13 +1214,24 @@ class PromoTicketWatcher(commands.Cog):
         if getattr(message.author, "bot", False):
             return
 
-        if context.state == "awaiting_clan":
+        if context.state in {"awaiting_clan", "awaiting_source_clan", "awaiting_destination_clan"}:
             candidate = (message.content or "").strip().upper()
             if not candidate:
                 return
             tags = await self._load_clan_tags()
-            if candidate not in tags:
+            valid = set(tags) | ({_NO_PLACEMENT_TAG} if context.state == "awaiting_source_clan" else set())
+            if candidate not in valid:
                 await self._send_invalid_tag_notice(thread, message.author, candidate)
+                return
+            if context.state == "awaiting_source_clan":
+                await self._set_source_clan_tag(
+                    thread,
+                    context,
+                    candidate,
+                    actor=message.author,
+                    prompt_message=None,
+                    view=None,
+                )
                 return
             await self._finalize_clan_tag(
                 thread,

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1580,6 +1580,15 @@ class ReservationDecision:
     recompute_tags: List[str]
 
 
+def _call_find_clan_row(find_clan_row: Callable[..., object], tag: str, *, force: bool = True) -> object:
+    try:
+        return find_clan_row(tag, force=force)
+    except TypeError as exc:
+        if "force" not in str(exc):
+            raise
+        return find_clan_row(tag)
+
+
 @dataclass(slots=True)
 class _ClanMathRowSnapshot:
     tag: str
@@ -1595,6 +1604,7 @@ def _determine_reservation_decision(
     final_is_real: bool,
     consume_open_spot: bool = True,
     previous_final: str | None = None,
+    previous_is_real: bool = True,
 ) -> ReservationDecision:
     normalized_final = (final_tag or "").strip().upper()
     normalized_previous = (previous_final or "").strip().upper()
@@ -1603,7 +1613,8 @@ def _determine_reservation_decision(
 
     if reservation_row is None:
         if (
-            normalized_previous
+            previous_is_real
+            and normalized_previous
             and normalized_previous != no_placement_tag
             and normalized_previous != normalized_final
         ):
@@ -1638,6 +1649,14 @@ def _determine_reservation_decision(
     if reservation_tag and reservation_tag_key == final_tag_key:
         label = "same"
         status = "closed_same_clan"
+        if (
+            previous_is_real
+            and normalized_previous
+            and normalized_previous != no_placement_tag
+            and _normalize_clan_tag_key(normalized_previous) != final_tag_key
+        ):
+            open_deltas[normalized_previous] = open_deltas.get(normalized_previous, 0) + 1
+            recompute.append(normalized_previous)
         recompute.append(reservation_tag)
         return ReservationDecision(label, status, open_deltas, recompute)
 
@@ -1646,6 +1665,14 @@ def _determine_reservation_decision(
     if reservation_tag:
         open_deltas[reservation_tag] = open_deltas.get(reservation_tag, 0) + 1
         recompute.append(reservation_tag)
+    if (
+        previous_is_real
+        and normalized_previous
+        and normalized_previous != no_placement_tag
+        and _normalize_clan_tag_key(normalized_previous) not in {reservation_tag_key, final_tag_key}
+    ):
+        open_deltas[normalized_previous] = open_deltas.get(normalized_previous, 0) + 1
+        recompute.append(normalized_previous)
     if final_is_real and normalized_final and final_tag_key != reservation_tag_key:
         open_deltas[normalized_final] = open_deltas.get(normalized_final, 0) - 1
         recompute.append(normalized_final)
@@ -1688,6 +1715,7 @@ async def cleanup_reservation_for_ticket_close(
     update_reservation_status_fn: Callable[..., Awaitable[None]] | None = None,
     adjust_manual_open_spots_fn: Callable[..., Awaitable[int]] | None = None,
     recompute_clan_availability_fn: Callable[..., Awaitable[None]] | None = None,
+    require_source_for_open_spot_math: bool = False,
 ) -> ReservationCleanupResult:
     """Apply the shared welcome-close reservation cleanup path.
 
@@ -1760,6 +1788,23 @@ async def cleanup_reservation_for_ticket_close(
             None, "none", None, None, False, False, {}, {}, [], [], True, True, True, reason, decision_line
         )
 
+    if require_source_for_open_spot_math and normalized_final != _NO_PLACEMENT_TAG and not normalized_previous:
+        reason = "source_clan_missing"
+        decision_line = (
+            "decision: "
+            f"final_tag={normalized_final or '-'} • previous_final=- • "
+            "reservation=unknown • consume_open_spot=False • final_is_real=False • "
+            "decision_result=skipped_open_delta • skip_reason=source_clan_missing • "
+            "action_required=prompt_for_source_clan"
+        )
+        event_log.warning(
+            "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • source_clan_tag=- • result=skip • reason=%s • action_required=prompt_for_source_clan",
+            normalized_scope, ticket, user_label or "-", user_id or "-", normalized_final or "-", reason,
+        )
+        return ReservationCleanupResult(
+            reservation_row, "source_missing", old_status, None, False, False, {}, {}, [], [], True, True, True, reason, decision_line
+        )
+
     clans_fresh = await ensure_fresh(
         actor=f"{normalized_scope}_placement", ticket=ticket, user=user_label
     )
@@ -1781,7 +1826,7 @@ async def cleanup_reservation_for_ticket_close(
 
     try:
         final_entry = (
-            await asyncio.to_thread(find_clan_row, normalized_final, force=True)
+            await asyncio.to_thread(_call_find_clan_row, find_clan_row, normalized_final, force=True)
             if normalized_final != _NO_PLACEMENT_TAG
             else None
         )
@@ -1792,6 +1837,19 @@ async def cleanup_reservation_for_ticket_close(
             normalized_scope, ticket, user_label or "-", user_id or "-", normalized_final or "-",
         )
         final_is_real = False
+
+    previous_is_real = False
+    if normalized_previous and normalized_previous != _NO_PLACEMENT_TAG:
+        try:
+            previous_is_real = await asyncio.to_thread(_call_find_clan_row, find_clan_row, normalized_previous, force=True) is not None
+        except Exception:
+            event_log.exception(
+                "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • source_clan_tag=%s • result=partial • reason=source_clan_lookup_failed",
+                normalized_scope, ticket, user_label or "-", user_id or "-", normalized_previous or "-",
+            )
+            previous_is_real = False
+    elif normalized_previous == _NO_PLACEMENT_TAG:
+        previous_is_real = False
 
     consume_open_spot = bool(
         normalized_final
@@ -1809,6 +1867,7 @@ async def cleanup_reservation_for_ticket_close(
         final_is_real=final_is_real,
         consume_open_spot=consume_open_spot,
         previous_final=previous_final or "",
+        previous_is_real=previous_is_real,
     )
     new_status = decision.status
 

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -47,6 +47,7 @@ PROMO_HEADERS: List[str] = [
     "ticket number",
     "username",
     "clantag",
+    "source_clan_tag",
     "date closed",
     "type",
     "thread created",
@@ -64,6 +65,51 @@ PROMO_HEADERS: List[str] = [
     "created_at",
     "updated_at",
 ]
+PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY = "PROMO_SOURCE_CLAN_TAG_HEADER"
+_PROMO_SOURCE_CLAN_TAG_HEADER_DEFAULT_SLOT = 3
+
+
+def get_promo_source_clan_tag_header(*, force: bool = False) -> str:
+    """Return the Config-driven Promo source clan header.
+
+    This is intentionally required. Promo move close math must not silently fall
+    back to destination-only behavior if the source column mapping is absent.
+    """
+
+    if force:
+        _load_config(force=True)
+    header = _config_lookup(PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY)
+    cleaned = str(header or "").strip()
+    if not cleaned:
+        raise RuntimeError(
+            "Onboarding Config missing PROMO_SOURCE_CLAN_TAG_HEADER for Promo source clan header"
+        )
+    return cleaned
+
+
+def get_promo_headers(*, force: bool = False) -> List[str]:
+    """Return Promo headers with the source-clan column resolved from Config."""
+
+    headers = list(PROMO_HEADERS)
+    headers[_PROMO_SOURCE_CLAN_TAG_HEADER_DEFAULT_SLOT] = (
+        get_promo_source_clan_tag_header(force=force)
+    )
+    return headers
+
+
+def require_promo_source_clan_header(headers: Sequence[str]) -> str:
+    """Validate that ``headers`` include the Config-resolved source header."""
+
+    source_header = get_promo_source_clan_tag_header()
+    normalized_source = _normalize_header_name(source_header)
+    normalized_headers = {_normalize_header_name(header) for header in headers}
+    if normalized_source not in normalized_headers:
+        raise RuntimeError(
+            "Promo sheet/header mapping missing configured source clan header "
+            f"{PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY}={source_header!r}"
+        )
+    return source_header
+
 WELCOME_TICKET_INDEX = 0
 WELCOME_CLAN_TAG_INDEX = 2
 WELCOME_DATE_CLOSED_INDEX = 3
@@ -262,6 +308,30 @@ def _ensure_headers(ws, headers: Sequence[str]) -> List[str]:
         core.call_with_backoff(ws.update, "A1", [list(headers)])
         return list(headers)
     return list(existing) if existing else list(headers)
+
+
+def _ensure_promo_headers(ws) -> List[str]:
+    """Ensure Promo headers without silently adding a missing source column.
+
+    Empty worksheets are initialized, but an existing Promo header row must
+    already contain the Config-resolved source clan header so row data cannot be
+    shifted accidentally.
+    """
+
+    desired = get_promo_headers()
+    source_header = get_promo_source_clan_tag_header()
+    try:
+        existing = core.call_with_backoff(ws.row_values, 1)
+    except Exception:
+        existing = []
+    if existing:
+        normalized_existing = {_normalize_header_name(header) for header in existing}
+        if _normalize_header_name(source_header) not in normalized_existing:
+            raise RuntimeError(
+                "Promo sheet missing configured source clan header "
+                f"{PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY}={source_header!r}"
+            )
+    return _ensure_headers(ws, desired)
 
 
 def _fmt_ticket(ticket: str | None) -> str:
@@ -728,15 +798,19 @@ def upsert_promo(
 ) -> str:
     """Insert or update a promo ticket row based on its ticket number."""
 
+    resolved_headers = list(headers or get_promo_headers())
+    require_promo_source_clan_header(resolved_headers)
     ws = _worksheet(_promo_tab())
+    _ensure_promo_headers(ws)
     keys = [("ticket number", _fmt_ticket)]
-    return _upsert(ws, keys, row_values, headers)
+    return _upsert(ws, keys, row_values, resolved_headers)
 
 
 def append_promo_ticket_row(
     ticket: str,
     username: str,
     clan_tag: str,
+    source_clan_tag: str,
     promo_type: str,
     thread_created: str,
     year: str,
@@ -755,7 +829,8 @@ def append_promo_ticket_row(
 ) -> str:
     sheet_id, tab = _resolve_onboarding_and_promo_tab()
     ws = core.get_worksheet(sheet_id, tab)
-    header = _ensure_headers(ws, PROMO_HEADERS)
+    header = _ensure_promo_headers(ws)
+    source_header = require_promo_source_clan_header(header)
     ticket_value = _fmt_ticket(ticket)
     created, updated = _normalize_ticket_timestamps(created_at, updated_at)
 
@@ -765,6 +840,7 @@ def append_promo_ticket_row(
         "ticketid": ticket_value,
         "username": str(username or "").strip(),
         "clantag": str(clan_tag or "").strip(),
+        _normalize_header_name(source_header): str(source_clan_tag or "").strip(),
         "dateclosed": "",
         "type": str(promo_type or "").strip(),
         "threadcreated": str(thread_created or "").strip(),
@@ -851,7 +927,8 @@ def find_promo_row(ticket: str | None) -> Optional[Tuple[int, Dict[str, str]]]:
         return None
 
     ws = _worksheet(_promo_tab())
-    header = _ensure_headers(ws, PROMO_HEADERS)
+    header = _ensure_promo_headers(ws)
+    require_promo_source_clan_header(header)
     ticket_col = _column_index(header, "ticket number")
     target = _fmt_ticket(ticket)
 

--- a/tests/onboarding/test_promo_close_clan_prompt.py
+++ b/tests/onboarding/test_promo_close_clan_prompt.py
@@ -4,8 +4,18 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 from modules.onboarding.watcher_promo import PromoTicketContext, PromoTicketWatcher
 from shared.sheets.reservations import ReservationRow
+
+
+@pytest.fixture(autouse=True)
+def _promo_source_header_config(monkeypatch):
+    monkeypatch.setattr(
+        "shared.sheets.onboarding.get_promo_source_clan_tag_header",
+        lambda **_kwargs: "source_clan_tag",
+    )
 
 
 class DummyThread:
@@ -34,7 +44,7 @@ class DummyBot:
     user = SimpleNamespace(id=111)
 
 
-def _context(state="open", clan_tag=""):
+def _context(state="open", clan_tag="", source_clan_tag="NONE"):
     return PromoTicketContext(
         thread_id=1,
         ticket_number="R1234",
@@ -45,6 +55,7 @@ def _context(state="open", clan_tag=""):
         month="January",
         state=state,
         clan_tag=clan_tag,
+        source_clan_tag=source_clan_tag,
     )
 
 
@@ -198,10 +209,10 @@ def test_promo_close_with_no_active_reservation_skips_cleanup(monkeypatch, caplo
             )
         )
     assert "scope=promo" in caplog.text
-    assert "skip_reason=no_active_reservation" in caplog.text
+    assert "decision_result=applied_open_delta" in caplog.text
     assert "promo_reservation_cleanup" in caplog.text
-    adjust.assert_not_awaited()
-    recompute.assert_not_awaited()
+    adjust.assert_awaited_once()
+    recompute.assert_awaited_once()
     thread.edit.assert_awaited()
     assert any("Logged clan tag" in (content or "") for content, _ in thread.sent)
 

--- a/tests/onboarding/test_promo_source_schema.py
+++ b/tests/onboarding/test_promo_source_schema.py
@@ -1,0 +1,258 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from modules.onboarding import watcher_promo
+from shared.sheets import onboarding as onboarding_sheets
+
+
+class FakeWorksheet:
+    id = 1
+
+    def __init__(self):
+        self.rows: list[list[str]] = []
+
+    def row_values(self, _idx):
+        return self.rows[0] if self.rows else []
+
+    def get_all_values(self):
+        return self.rows
+
+    def update(self, cell_range, values):
+        if cell_range == "A1":
+            self.rows[:1] = [list(values[0])]
+            return
+        row_label = cell_range.split(":", 1)[0]
+        row_number = int("".join(ch for ch in row_label if ch.isdigit()) or "1")
+        while len(self.rows) < row_number:
+            self.rows.append([])
+        self.rows[row_number - 1] = list(values[0])
+
+    def append_row(self, row, value_input_option=None):
+        self.rows.append(list(row))
+
+
+@pytest.fixture
+def promo_config(monkeypatch):
+    monkeypatch.setattr(
+        onboarding_sheets,
+        "_config_lookup",
+        lambda key, default=None: "source_clan_tag"
+        if str(key).upper() == "PROMO_SOURCE_CLAN_TAG_HEADER"
+        else default,
+    )
+
+
+def _install_fake_sheet(monkeypatch):
+    worksheet = FakeWorksheet()
+    monkeypatch.setattr(
+        onboarding_sheets.core,
+        "call_with_backoff",
+        lambda func, *args, **kwargs: func(*args, **kwargs),
+    )
+    monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "Promo"))
+    monkeypatch.setattr(onboarding_sheets, "_worksheet", lambda tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    return worksheet
+
+
+def test_promo_source_header_resolves_from_config(monkeypatch):
+    monkeypatch.setattr(
+        onboarding_sheets,
+        "_config_lookup",
+        lambda key, default=None: "previous_clan_tag"
+        if str(key).upper() == "PROMO_SOURCE_CLAN_TAG_HEADER"
+        else default,
+    )
+
+    assert onboarding_sheets.get_promo_source_clan_tag_header() == "previous_clan_tag"
+    assert onboarding_sheets.get_promo_headers()[3] == "previous_clan_tag"
+
+
+def test_missing_promo_source_header_config_fails_clearly(monkeypatch):
+    monkeypatch.setattr(onboarding_sheets, "_config_lookup", lambda key, default=None: default)
+
+    with pytest.raises(RuntimeError, match="PROMO_SOURCE_CLAN_TAG_HEADER"):
+        onboarding_sheets.get_promo_headers()
+
+
+def test_missing_resolved_promo_source_header_fails_clearly(monkeypatch, promo_config):
+    headers = list(onboarding_sheets.PROMO_HEADERS)
+    headers[3] = "wrong_source_column"
+
+    with pytest.raises(RuntimeError, match="source clan header"):
+        onboarding_sheets.require_promo_source_clan_header(headers)
+
+
+def test_promo_open_row_alignment(monkeypatch, promo_config):
+    worksheet = _install_fake_sheet(monkeypatch)
+    created = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+    onboarding_sheets.append_promo_ticket_row(
+        "M0352",
+        "Lucifer",
+        "F-IT",
+        "C1CV",
+        "player move request",
+        "2026-06-08 00:00:00",
+        "2026",
+        "June",
+        "",
+        "",
+        "",
+        thread_name="M0352-Lucifer",
+        user_id=12345,
+        thread_id=999,
+        panel_message_id=444,
+        status="open",
+        created_at=created,
+        updated_at=created,
+    )
+
+    header, row = worksheet.rows[0], worksheet.rows[1]
+    assert header[3] == "source_clan_tag"
+    assert row[0] == "M0352"
+    assert row[2] == "F-IT"
+    assert row[3] == "C1CV"
+    assert row[4] == ""
+    assert row[5] == "player move request"
+    assert row[6] == "2026-06-08 00:00:00"
+    assert row[17] == ""
+    assert row[18] == created.isoformat()
+    assert row[19] == created.isoformat()
+
+
+def test_promo_close_row_alignment(monkeypatch, promo_config):
+    worksheet = _install_fake_sheet(monkeypatch)
+    headers = onboarding_sheets.get_promo_headers()
+    row_values = [
+        "M0352",
+        "Lucifer",
+        "F-IT",
+        "C1CV",
+        "2026-06-08",
+        "player move request",
+        "2026-06-08 00:00:00",
+        "2026",
+        "June",
+        "",
+        "",
+        "",
+    ]
+
+    onboarding_sheets.upsert_promo(row_values, headers)
+
+    row = worksheet.rows[1]
+    assert row[0] == "M0352"
+    assert row[3] == "C1CV"
+    assert row[4] == "2026-06-08"
+    assert row[5] == "player move request"
+    assert row[6] == "2026-06-08 00:00:00"
+
+
+def test_promo_reminder_touch_fallback_alignment(monkeypatch, promo_config):
+    captured: dict[str, list[str]] = {}
+
+    async def fake_log_sheet_write(**kwargs):
+        return await kwargs["write_coro"]()
+
+    def fake_upsert(row_values, headers):
+        captured["row"] = list(row_values)
+        captured["headers"] = list(headers)
+        return "inserted"
+
+    monkeypatch.setattr(watcher_promo, "log_sheet_write", fake_log_sheet_write)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda ticket: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "upsert_promo", fake_upsert)
+    watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace())
+    context = watcher_promo.PromoTicketContext(
+        thread_id=999,
+        ticket_number="M0352",
+        username="Lucifer",
+        promo_type="player move request",
+        thread_created="2026-06-08 00:00:00",
+        year="2026",
+        month="June",
+        clan_tag="F-IT",
+        source_clan_tag="C1CV",
+        state="open",
+        user_id=12345,
+    )
+    thread = SimpleNamespace(id=999, name="M0352-Lucifer")
+    created = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+    asyncio.run(
+        watcher._touch_promo_sheet_for_reminder(
+            phase="reminder",
+            thread=thread,
+            context=context,
+            created_at=created,
+            user_ref="Lucifer",
+        )
+    )
+
+    row = captured["row"]
+    assert captured["headers"][3] == "source_clan_tag"
+    assert row[3] == "C1CV"
+    assert row[4] == ""
+    assert row[5] == "player move request"
+    assert row[12] == "M0352-Lucifer"
+    assert row[16] == "open"
+    assert row[17] == ""
+    assert row[18] == created.isoformat()
+    assert row[19]
+
+
+def test_existing_promo_sheet_missing_source_header_fails_safely(monkeypatch, promo_config):
+    worksheet = _install_fake_sheet(monkeypatch)
+    worksheet.rows.append([
+        "ticket number",
+        "username",
+        "clantag",
+        "date closed",
+        "type",
+        "thread created",
+    ])
+
+    with pytest.raises(RuntimeError, match="missing configured source clan header"):
+        onboarding_sheets.append_promo_ticket_row(
+            "M0352",
+            "Lucifer",
+            "F-IT",
+            "C1CV",
+            "player move request",
+            "2026-06-08 00:00:00",
+            "2026",
+            "June",
+            "",
+            "",
+            "",
+        )
+
+
+def test_existing_promo_row_with_blank_source_keeps_later_columns_aligned(monkeypatch, promo_config):
+    worksheet = _install_fake_sheet(monkeypatch)
+    headers = onboarding_sheets.get_promo_headers()
+    worksheet.rows.append(headers)
+    worksheet.rows.append([
+        "M0352",
+        "Lucifer",
+        "F-IT",
+        "",
+        "2026-06-08",
+        "player move request",
+        "2026-06-08 00:00:00",
+        "2026",
+        "June",
+    ])
+
+    found = onboarding_sheets.find_promo_row("M0352")
+
+    assert found is not None
+    _row_idx, mapping = found
+    assert mapping["source_clan_tag"] == ""
+    assert mapping["date closed"] == "2026-06-08"
+    assert mapping["type"] == "player move request"
+    assert mapping["thread created"] == "2026-06-08 00:00:00"

--- a/tests/onboarding/test_promo_watcher.py
+++ b/tests/onboarding/test_promo_watcher.py
@@ -4,11 +4,20 @@ from types import SimpleNamespace
 
 import pytest
 
+
 from modules.onboarding.constants import CLAN_TAG_PROMPT_HELPER
 from modules.onboarding import thread_scopes
 from modules.onboarding import watcher_promo
 from modules.onboarding.watcher_welcome import parse_promo_thread_name
 from shared.sheets import onboarding as onboarding_sheets
+
+
+@pytest.fixture(autouse=True)
+def _promo_source_header_config(monkeypatch):
+    monkeypatch.setattr(
+        "shared.sheets.onboarding.get_promo_source_clan_tag_header",
+        lambda **_kwargs: "source_clan_tag",
+    )
 
 
 class DummyMessage:
@@ -82,8 +91,8 @@ def promo_setup(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(onboarding_sheets, "upsert_promo", _fake_upsert)
 
-    def _fake_append(ticket, username, clan_tag, promo_type, thread_created, year, month, join_month, clan_name, progression, **_kwargs):
-        row = [ticket, username, clan_tag, "", promo_type, thread_created, year, month, join_month, clan_name, progression]
+    def _fake_append(ticket, username, clan_tag, source_clan_tag, promo_type, thread_created, year, month, join_month, clan_name, progression, **_kwargs):
+        row = [ticket, username, clan_tag, source_clan_tag, "", promo_type, thread_created, year, month, join_month, clan_name, progression]
         return _fake_upsert(row, onboarding_sheets.PROMO_HEADERS)
 
     monkeypatch.setattr(onboarding_sheets, "append_promo_ticket_row", _fake_append)
@@ -233,6 +242,9 @@ def test_promo_watcher_close_flow_updates_sheet(promo_setup, monkeypatch: pytest
         await watcher.on_message(close_message)
 
         assert thread.sent, "expected prompt to be sent"
+        source_message = SimpleNamespace(content="NONE", author=DummyAuthor(bot=False), channel=thread)
+        await watcher.on_message(source_message)
+
         clan_message = SimpleNamespace(content="C1CE", author=DummyAuthor(bot=False), channel=thread)
         await watcher.on_message(clan_message)
 
@@ -264,9 +276,10 @@ def _patch_promo_close_dependencies(monkeypatch: pytest.MonkeyPatch, *, open_spo
         return list(reservations or [])
 
     def find_clan_row(tag, force=False):
-        if str(tag).strip().upper() != "F-IT":
+        normalized = str(tag).strip().upper()
+        if normalized not in {"F-IT", "C1CV"}:
             return None
-        return (7, ["", "", "F-IT", "", str(state["open_spots"]), "0", "0", ""])
+        return (7, ["", "", normalized, "", str(state["open_spots"]), "0", "0", ""])
 
     async def adjust(tag, delta):
         deltas.append((tag, delta))
@@ -316,6 +329,7 @@ def test_promo_move_close_preserves_full_ticket_id_and_consumes_unreserved_spot(
         year="2026",
         month="June",
         clan_tag="F-IT",
+        source_clan_tag="C1CV",
         user_id=12345,
     )
 
@@ -331,11 +345,10 @@ def test_promo_move_close_preserves_full_ticket_id_and_consumes_unreserved_spot(
     assert calls["upserts"][-1][0][0] != "0352"
     assert thread.name == "Closed-M0352-Lucifer-F-IT"
     assert thread.edits[-1]["name"] == "Closed-M0352-Lucifer-F-IT"
-    assert deltas == [("F-IT", -1)]
-    assert state["open_spots"] == 1
+    assert sorted(deltas) == [("C1CV", 1), ("F-IT", -1)]
+    assert state["open_spots"] == 2
     assert log_messages, "expected logging-channel open spot delta entry"
-    assert "M0352 • Lucifer → F-IT" in log_messages[-1]
-    assert "open_spots: 2 → 1" in log_messages[-1]
+    assert "M0352 • Lucifer: C1CV → F-IT" in log_messages[-1]
     assert "F-IT:-1" in log_messages[-1]
 
 
@@ -369,6 +382,7 @@ def test_reserved_promo_move_same_clan_does_not_double_consume_open_spot(
         year="2026",
         month="June",
         clan_tag="F-IT",
+        source_clan_tag="C1CV",
         user_id=12345,
     )
 
@@ -380,11 +394,11 @@ def test_reserved_promo_move_same_clan_does_not_double_consume_open_spot(
     asyncio.run(run())
 
     assert thread.name == "Closed-M0352-Lucifer-F-IT"
-    assert deltas == []
-    assert state["open_spots"] == 2
+    assert deltas == [("C1CV", 1)]
+    assert state["open_spots"] == 3
     assert log_messages
     assert "reservation=same" in log_messages[-1]
-    assert "skipped_open_delta" in log_messages[-1]
+    assert "C1CV:+1" in log_messages[-1]
 
 def test_promo_watcher_respects_feature_flags(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(watcher_promo, "get_promo_channel_id", lambda: 1)

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -12,6 +12,7 @@ from modules.onboarding.watcher_welcome import (
     WelcomeTicketWatcher,
     _NO_PLACEMENT_TAG,
     _determine_reservation_decision,
+    cleanup_reservation_for_ticket_close,
     parse_welcome_thread_name,
     rename_thread_to_reserved,
     _clan_math_column_indices,
@@ -2046,3 +2047,68 @@ def test_finalize_preflight_failure_applies_no_discord_actions(monkeypatch) -> N
     assert "result=error" in log_messages[-1]
     assert "reason=open_delta_preflight_failed" in log_messages[-1]
     assert "action_state=no_discord_member_action_applied" in log_messages[-1]
+
+
+def test_promo_move_decision_releases_source_and_consumes_destination() -> None:
+    decision = _determine_reservation_decision(
+        "F-IT",
+        None,
+        no_placement_tag=_NO_PLACEMENT_TAG,
+        final_is_real=True,
+        previous_final="C1CV",
+        previous_is_real=True,
+    )
+    assert decision.open_deltas == {"C1CV": 1, "F-IT": -1}
+
+
+def test_promo_move_decision_same_source_destination_noop() -> None:
+    decision = _determine_reservation_decision(
+        "F-IT",
+        None,
+        no_placement_tag=_NO_PLACEMENT_TAG,
+        final_is_real=True,
+        consume_open_spot=False,
+        previous_final="F-IT",
+        previous_is_real=True,
+    )
+    assert decision.open_deltas == {}
+
+
+def test_promo_move_destination_reservation_still_releases_source() -> None:
+    row = _make_reservation("F-IT")
+    decision = _determine_reservation_decision(
+        "F-IT",
+        row,
+        no_placement_tag=_NO_PLACEMENT_TAG,
+        final_is_real=True,
+        previous_final="C1CV",
+        previous_is_real=True,
+    )
+    assert decision.label == "same"
+    assert decision.open_deltas == {"C1CV": 1}
+
+
+def test_promo_move_missing_source_skips_open_spot_math() -> None:
+    applied = []
+
+    async def run() -> None:
+        result = await cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="M0352",
+            user="Lucifer",
+            user_id=None,
+            final_tag="F-IT",
+            previous_final="",
+            require_source_for_open_spot_math=True,
+            ensure_fresh_fn=lambda **_kwargs: asyncio.sleep(0, result=True),
+            find_active_reservations_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=[]),
+            find_clan_row_fn=lambda *_args, **_kwargs: (10, []),
+            adjust_manual_open_spots_fn=lambda tag, delta: applied.append((tag, delta)) or asyncio.sleep(0, result=0),
+            recompute_clan_availability_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=None),
+        )
+        assert result.skipped is True
+        assert result.reason == "source_clan_missing"
+        assert "skip_reason=source_clan_missing" in result.decision_line
+
+    asyncio.run(run())
+    assert applied == []


### PR DESCRIPTION
### Motivation
- Prevent silent loss of source-clan information on promo/move tickets so source open spots are released correctly during closes. 
- Make the Promo sheet source column configurable and required to avoid accidental column shifts or destination-only math. 
- Prompt for and persist the source clan in the close flow so reservation cleanup can make correct open-spot decisions.

### Description
- Add configurable Promo source header plumbing in `shared.sheets.onboarding` (`PROMO_SOURCE_CLAN_TAG_HEADER`, `get_promo_source_clan_tag_header`, `get_promo_headers`, `require_promo_source_clan_header`, `_ensure_promo_headers`) and use it when `upsert_promo`, `append_promo_ticket_row`, and `find_promo_row` operate. 
- Extend promo row schema to include `source_clan_tag` and ensure header alignment when writing and reading Promo rows, failing fast if the configured source header is missing. 
- Update `modules/onboarding/watcher_promo.py` to track `source_clan_tag` in `PromoTicketContext`, prompt first for source then destination in the close UI, read/write the source column, and include source-aware logging and sheet writes. 
- Adjust reservation cleanup and decision logic (`modules/onboarding/watcher_welcome.py`) to consider `previous_final`/`previous_is_real` and add `require_source_for_open_spot_math` to skip open-spot math when a source is required but missing. 
- Update user-facing docs (`docs/ops/Config.md`, `docs/ops/PromoTickets.md`) to document the new `source_clan_tag` column and the `PROMO_SOURCE_CLAN_TAG_HEADER` config key. 
- Add and update unit tests to cover header resolution, sheet alignment, new prompt flow, and reservation math; tests include `tests/onboarding/test_promo_source_schema.py`, `tests/onboarding/test_promo_watcher.py`, `tests/onboarding/test_promo_close_clan_prompt.py`, and adjustments to `tests/onboarding/test_welcome_reservations.py`.

### Testing
- Ran the onboarding test suite with `pytest tests/onboarding` including added `test_promo_source_schema.py` and modified `test_promo_watcher.py`, `test_promo_close_clan_prompt.py`, and `test_welcome_reservations.py`; all tests passed. 
- Exercised the promo close flow unit tests that simulate thread messages and interactions to validate source+destination prompt behavior and sheet writes, which succeeded. 
- Ran header/worksheet unit tests that validate alignment and failure modes for missing configured source header, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26e418d2c0832399b15a59f021b73a)