### PR TITLE
Fix promo source clan close math

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -109,6 +109,27 @@ async def _ensure_fresh_clans_for_placement(*, actor: str, ticket: str, user: st
     return True
 
 
+def _find_promo_clan_row(clan_tag: str, *, force: bool = False) -> tuple[int, List[str]] | None:
+    """Resolve promo clans with the same configured bot_info tag column used by availability writes."""
+
+    try:
+        headers = availability._resolve_availability_headers()  # type: ignore[attr-defined]
+        return availability._find_availability_clan_row(clan_tag, headers)  # type: ignore[attr-defined]
+    except Exception:
+        log.debug(
+            "promo clan lookup falling back to recruitment.find_clan_row",
+            exc_info=True,
+            extra={"clan_tag": clan_tag},
+        )
+    try:
+        return recruitment_sheets.find_clan_row(clan_tag, force=force)
+    except TypeError:
+        return recruitment_sheets.find_clan_row(clan_tag)
+
+
+_find_promo_clan_row.lookup_mode = "availability_configured_clan_tag_header_with_recruitment_fallback"  # type: ignore[attr-defined]
+
+
 async def _send_runtime(message: str) -> None:
     try:
         await rt.send_log_message(message)
@@ -794,7 +815,7 @@ class PromoTicketWatcher(commands.Cog):
             logger=log,
             ensure_fresh_fn=_ensure_fresh_clans_for_placement,
             find_active_reservations_fn=reservations_sheets.find_active_reservations_for_recruit,
-            find_clan_row_fn=recruitment_sheets.find_clan_row,
+            find_clan_row_fn=_find_promo_clan_row,
             update_reservation_status_fn=reservations_sheets.update_reservation_status,
             adjust_manual_open_spots_fn=availability.adjust_manual_open_spots,
             recompute_clan_availability_fn=availability.recompute_clan_availability,
@@ -885,11 +906,17 @@ class PromoTicketWatcher(commands.Cog):
         release_source_open_spot = cleanup.applied_open_deltas.get(source_tag, 0) > 0
         consume_destination_open_spot = cleanup.applied_open_deltas.get(final_tag, 0) < 0
         log.info(
-            "promo_close_debug — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • source_clan_tag=%s • destination_clan_tag=%s • reservation_status=%s • consume_destination_open_spot=%s • release_source_open_spot=%s • open_spots_before=%s • open_spots_after=%s • open_spots_before_by_clan=%s • open_spots_after_by_clan=%s • channel_name_before=%s • channel_name_after=%s • logging_channel_result=%s",
+            "promo_close_debug — workflow_type=promo/move • ticket_id_raw=%s • ticket_id_final=%s • player_name=%s • source_clan_tag=%s • source_clan_lookup_key=%s • source_clan_row_found=%s • source_clan_row_number=%s • previous_is_real=%s • reason_if_not_real=%s • source_clan_lookup_mode=%s • destination_clan_tag=%s • reservation_status=%s • consume_destination_open_spot=%s • release_source_open_spot=%s • open_spots_before=%s • open_spots_after=%s • open_spots_before_by_clan=%s • open_spots_after_by_clan=%s • channel_name_before=%s • channel_name_after=%s • logging_channel_result=%s",
             ticket_id_raw,
             ticket_id_final,
             context.username,
             source_tag or "-",
+            cleanup.source_clan_lookup_key or "-",
+            cleanup.source_clan_row_found,
+            cleanup.source_clan_row_number if cleanup.source_clan_row_number is not None else "-",
+            cleanup.previous_is_real,
+            cleanup.source_clan_not_real_reason or "-",
+            cleanup.source_clan_lookup_mode or "-",
             final_tag or "-",
             cleanup.reservation_label or "none",
             consume_destination_open_spot,

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1616,7 +1616,7 @@ def _determine_reservation_decision(
             previous_is_real
             and normalized_previous
             and normalized_previous != no_placement_tag
-            and normalized_previous != normalized_final
+            and _normalize_clan_tag_key(normalized_previous) != _normalize_clan_tag_key(normalized_final)
         ):
             open_deltas[normalized_previous] = (
                 open_deltas.get(normalized_previous, 0) + 1
@@ -1696,6 +1696,12 @@ class ReservationCleanupResult:
     skipped: bool
     reason: str | None
     decision_line: str
+    source_clan_lookup_key: str = ""
+    source_clan_row_found: bool = False
+    source_clan_row_number: int | None = None
+    previous_is_real: bool = False
+    source_clan_not_real_reason: str | None = None
+    source_clan_lookup_mode: str = ""
 
 
 async def cleanup_reservation_for_ticket_close(
@@ -1839,25 +1845,84 @@ async def cleanup_reservation_for_ticket_close(
         final_is_real = False
 
     previous_is_real = False
+    source_clan_lookup_key = _normalize_clan_tag_key(normalized_previous)
+    source_clan_row_found = False
+    source_clan_row_number: int | None = None
+    source_clan_not_real_reason: str | None = None
+    source_clan_lookup_mode = str(getattr(find_clan_row, "lookup_mode", ""))
+    if not source_clan_lookup_mode:
+        lookup_module = getattr(find_clan_row, "__module__", "unknown")
+        lookup_name = getattr(
+            find_clan_row,
+            "__qualname__",
+            getattr(find_clan_row, "__name__", "unknown"),
+        )
+        source_clan_lookup_mode = f"{lookup_module}.{lookup_name}"
     if normalized_previous and normalized_previous != _NO_PLACEMENT_TAG:
         try:
-            previous_is_real = await asyncio.to_thread(_call_find_clan_row, find_clan_row, normalized_previous, force=True) is not None
+            previous_entry = await asyncio.to_thread(
+                _call_find_clan_row, find_clan_row, normalized_previous, force=True
+            )
+            source_clan_row_found = previous_entry is not None
+            if previous_entry is not None:
+                previous_is_real = True
+                try:
+                    source_clan_row_number = int(previous_entry[0])  # type: ignore[index]
+                except (TypeError, ValueError, IndexError):
+                    source_clan_row_number = None
+            else:
+                previous_is_real = False
+                source_clan_not_real_reason = "source_clan_row_not_found"
         except Exception:
+            source_clan_not_real_reason = "source_clan_lookup_exception"
             event_log.exception(
                 "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • source_clan_tag=%s • result=partial • reason=source_clan_lookup_failed",
                 normalized_scope, ticket, user_label or "-", user_id or "-", normalized_previous or "-",
             )
             previous_is_real = False
     elif normalized_previous == _NO_PLACEMENT_TAG:
+        source_clan_not_real_reason = "source_clan_none"
         previous_is_real = False
+    else:
+        source_clan_not_real_reason = "source_clan_blank"
 
+    event_log.info(
+        "reservation_cleanup_source_lookup — scope=%s • ticket=%s • user=%s • source_clan_tag=%s • source_clan_lookup_key=%s • source_clan_row_found=%s • source_clan_row_number=%s • previous_is_real=%s • reason_if_not_real=%s • available_lookup_mode=%s",
+        normalized_scope,
+        ticket,
+        user_label or "-",
+        normalized_previous or "-",
+        source_clan_lookup_key or "-",
+        source_clan_row_found,
+        source_clan_row_number if source_clan_row_number is not None else "-",
+        previous_is_real,
+        source_clan_not_real_reason or "-",
+        source_clan_lookup_mode,
+    )
+    if (
+        normalized_scope == "promo"
+        and normalized_previous
+        and normalized_previous != _NO_PLACEMENT_TAG
+        and not source_clan_row_found
+    ):
+        event_log.warning(
+            "promo_source_clan_lookup_failed — source_clan_tag=%s • source_clan_lookup_key=%s • ticket=%s • player=%s • available_lookup_mode=%s",
+            normalized_previous,
+            source_clan_lookup_key or "-",
+            ticket,
+            user_label or "-",
+            source_clan_lookup_mode,
+        )
+
+    normalized_previous_key = _normalize_clan_tag_key(normalized_previous)
+    normalized_final_key = _normalize_clan_tag_key(normalized_final)
     consume_open_spot = bool(
         normalized_final
         and normalized_final != _NO_PLACEMENT_TAG
         and (
             not normalized_previous
             or normalized_previous == _NO_PLACEMENT_TAG
-            or normalized_previous != normalized_final
+            or normalized_previous_key != normalized_final_key
         )
     )
     decision = _determine_reservation_decision(
@@ -1961,6 +2026,12 @@ async def cleanup_reservation_for_ticket_close(
         False,
         reason,
         decision_line,
+        source_clan_lookup_key,
+        source_clan_row_found,
+        source_clan_row_number,
+        previous_is_real,
+        source_clan_not_real_reason,
+        source_clan_lookup_mode,
     )
 
 
@@ -1996,17 +2067,30 @@ def _normalize_clan_math_targets(tags: set[str]) -> OrderedDict[str, str]:
 
 def _clan_math_column_indices() -> Dict[str, int]:
     header_map = recruitment_sheets.get_clan_header_map()
-    required = ("open_spots", "inactives", "reservation_count", "reservation_summary")
-    missing = [key for key in required if header_map.get(key) is None]
+    fallback_open = getattr(recruitment_sheets, "FALLBACK_OPEN_SPOTS_INDEX", 31)
+    fallback_inactives = getattr(recruitment_sheets, "FALLBACK_INACTIVES_INDEX", 32)
+    # Bot-info logging is visibility-only; do not fail close math just because
+    # optional display columns are absent from the cached header map.
+    fallback_reservation_count = 33  # Column AH
+    fallback_reservation_summary = getattr(recruitment_sheets, "FALLBACK_RESERVED_INDEX", 34)  # Column AI
+    missing = [
+        key
+        for key in ("open_spots", "inactives", "reservation_count", "reservation_summary")
+        if header_map.get(key) is None
+    ]
     if missing:
-        missing_text = ", ".join(missing)
-        raise ValueError(
-            f"clan header missing required columns for logging: {missing_text}"
+        log.warning(
+            "clan math logging using fallback bot_info columns",
+            extra={"missing_columns": missing, "header_map": dict(header_map)},
         )
-    open_index = int(header_map["open_spots"])
-    inactives_index = int(header_map["inactives"])
-    reservation_count_index = int(header_map["reservation_count"])
-    reservation_summary_index = int(header_map["reservation_summary"])
+    open_index = int(header_map.get("open_spots", fallback_open))
+    inactives_index = int(header_map.get("inactives", fallback_inactives))
+    reservation_count_index = int(
+        header_map.get("reservation_count", header_map.get("reserved", fallback_reservation_count))
+    )
+    reservation_summary_index = int(
+        header_map.get("reservation_summary", fallback_reservation_summary)
+    )
     return {
         "open_spots": open_index,
         "AF": open_index,
@@ -2037,7 +2121,11 @@ def _capture_clan_snapshots(
         if entry is None:
             continue
         sheet_row, row_values = entry
-        tag_cell = row_values[2] if len(row_values) > 2 else tag
+        try:
+            tag_index = recruitment_sheets.get_clan_header_map().get("clan_tag", 2)
+        except Exception:
+            tag_index = 2
+        tag_cell = row_values[tag_index] if len(row_values) > tag_index else tag
         display_tag = (tag_cell or tag or "").strip() or tag
         values: Dict[str, str] = {}
         for label, index in column_map.items():

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -68,6 +68,12 @@ def _column_aliases(*aliases: str) -> tuple[str, ...]:
 
 
 HEADER_MAP: Dict[str, tuple[str, ...]] = {
+    "clan_tag": _column_aliases(
+        "clan tag",
+        "clantag",
+        "clan_tag",
+        "tag",
+    ),
     "manual_open_spots": _column_aliases(
         "manual open spots",
         "manual_open_spots",
@@ -683,10 +689,11 @@ def _normalize_tag(tag: str | None) -> str:
 
 def _build_tag_index(rows: List[List[str]]) -> Dict[str, List[str]]:
     index: Dict[str, List[str]] = {}
+    tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
     for row in rows:
-        if len(row) < 3:
+        if tag_index >= len(row):
             continue
-        normalized = _normalize_tag(row[2])
+        normalized = _normalize_tag(row[tag_index])
         if not normalized:
             continue
         index[normalized] = row
@@ -718,10 +725,11 @@ def get_clan_by_tag(tag: str, *, force: bool = False) -> List[str] | None:
 
     # Index unavailable — fall back to a lightweight scan of cached rows.
     rows = fetch_clans(force=False)
+    tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
     for row in rows:
-        if len(row) < 3:
+        if tag_index >= len(row):
             continue
-        if _normalize_tag(row[2]) == normalized:
+        if _normalize_tag(row[tag_index]) == normalized:
             return row
     return None
 
@@ -736,10 +744,11 @@ def find_clan_row(
         return None
 
     rows = fetch_clans(force=force)
+    tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
     for idx, row in enumerate(rows):
-        if len(row) < 3:
+        if tag_index >= len(row):
             continue
-        if _normalize_tag(row[2]) == normalized:
+        if _normalize_tag(row[tag_index]) == normalized:
             sheet_row = idx + 4  # Account for the three summary/header rows.
             return sheet_row, list(row)
     return None
@@ -763,7 +772,8 @@ def update_cached_clan_row(sheet_row: int, row_values: Sequence[str]) -> None:
         _CLAN_ROWS_TS = now
 
     if _CLAN_TAG_INDEX is not None:
-        tag = normalized_row[2] if len(normalized_row) > 2 else ""
+        tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
+        tag = normalized_row[tag_index] if len(normalized_row) > tag_index else ""
         normalized_tag = _normalize_tag(tag)
         if normalized_tag:
             _CLAN_TAG_INDEX[normalized_tag] = list(normalized_row)

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -95,13 +95,18 @@ def test_clan_math_column_indices_resolve_by_header(monkeypatch) -> None:
     assert resolved == {"open_spots": 22, "AF": 22, "AG": 8, "AH": 41, "AI": 3}
 
 
-def test_clan_math_column_indices_missing_required_header_raises(monkeypatch) -> None:
+def test_clan_math_column_indices_missing_visibility_header_uses_fallback(monkeypatch) -> None:
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
         lambda: {"open_spots": 22, "inactives": 8, "reservation_count": 41},
     )
-    with pytest.raises(ValueError, match="required columns"):
-        _clan_math_column_indices()
+    assert _clan_math_column_indices() == {
+        "open_spots": 22,
+        "AF": 22,
+        "AG": 8,
+        "AH": 41,
+        "AI": 34,
+    }
 
 
 def test_parse_thread_name_open_without_w_prefix() -> None:
@@ -2112,3 +2117,88 @@ def test_promo_move_missing_source_skips_open_spot_math() -> None:
 
     asyncio.run(run())
     assert applied == []
+
+
+def test_promo_source_lookup_failure_warns_and_records_debug(caplog) -> None:
+    applied = []
+
+    async def run() -> None:
+        caplog.set_level(logging.INFO)
+        result = await cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="M0361",
+            user="Caillean",
+            user_id=None,
+            final_tag="C1CD",
+            previous_final="C1CB",
+            require_source_for_open_spot_math=True,
+            ensure_fresh_fn=lambda **_kwargs: asyncio.sleep(0, result=True),
+            find_active_reservations_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=[]),
+            find_clan_row_fn=lambda tag, **_kwargs: (20, []) if tag == "C1CD" else None,
+            adjust_manual_open_spots_fn=lambda tag, delta: applied.append((tag, delta)) or asyncio.sleep(0, result=0),
+            recompute_clan_availability_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=None),
+        )
+        assert result.source_clan_lookup_key == "C1CB"
+        assert result.source_clan_row_found is False
+        assert result.previous_is_real is False
+        assert result.source_clan_not_real_reason == "source_clan_row_not_found"
+
+    asyncio.run(run())
+    assert applied == [("C1CD", -1)]
+    assert "promo_source_clan_lookup_failed" in caplog.text
+    assert "source_clan_tag=C1CB" in caplog.text
+    assert "source_clan_lookup_key=C1CB" in caplog.text
+    assert "source_clan_row_found=False" in caplog.text
+    assert "previous_is_real=False" in caplog.text
+
+
+def test_promo_source_none_only_consumes_destination() -> None:
+    applied = []
+
+    async def run() -> None:
+        result = await cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="M0361",
+            user="Caillean",
+            user_id=None,
+            final_tag="C1CD",
+            previous_final=_NO_PLACEMENT_TAG,
+            require_source_for_open_spot_math=True,
+            ensure_fresh_fn=lambda **_kwargs: asyncio.sleep(0, result=True),
+            find_active_reservations_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=[]),
+            find_clan_row_fn=lambda tag, **_kwargs: (20, []) if tag == "C1CD" else None,
+            adjust_manual_open_spots_fn=lambda tag, delta: applied.append((tag, delta)) or asyncio.sleep(0, result=0),
+            recompute_clan_availability_fn=lambda *_args, **_kwargs: asyncio.sleep(0, result=None),
+        )
+        assert result.requested_open_deltas == {"C1CD": -1}
+        assert result.source_clan_not_real_reason == "source_clan_none"
+
+    asyncio.run(run())
+    assert applied == [("C1CD", -1)]
+
+
+def test_promo_same_source_destination_normalized_no_delta() -> None:
+    decision = _determine_reservation_decision(
+        "C1-CD",
+        None,
+        no_placement_tag=_NO_PLACEMENT_TAG,
+        final_is_real=True,
+        consume_open_spot=False,
+        previous_final="C1CD",
+        previous_is_real=True,
+    )
+    assert decision.open_deltas == {}
+
+
+def test_clan_math_column_indices_uses_fallbacks_for_missing_visibility_columns(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: {"open_spots": 4},
+    )
+    assert _clan_math_column_indices() == {
+        "open_spots": 4,
+        "AF": 4,
+        "AG": 32,
+        "AH": 33,
+        "AI": 34,
+    }


### PR DESCRIPTION
### Motivation
- A promo move (e.g. M0361 C1CB → C1CD) failed to release the source clan because the source clan lookup and validation path could silently drop the source delta.  
- The code assumed clan-tag lived in a fixed column and compared raw tags instead of normalized keys, causing same-clan/no-op and lookup-edge cases to misbehave.  
- Bot-side before/after snapshot logging could fail the close path when optional visibility columns were absent, leaving log rows empty.

### Description
- Add a promo-aware lookup `_find_promo_clan_row` that first resolves clans via the availability-configured `bot_info` header path and falls back to `recruitment.find_clan_row`, and use it for promo closes by passing `find_clan_row_fn=_find_promo_clan_row`.  
- Extend `cleanup_reservation_for_ticket_close` to record and return explicit source lookup diagnostics (`source_clan_lookup_key`, `source_clan_row_found`, `source_clan_row_number`, `previous_is_real`, `source_clan_not_real_reason`, `source_clan_lookup_mode`) and emit a clear `promo_source_clan_lookup_failed` warning when a selected source cannot be resolved.  
- Ensure source/destination equality is tested using normalized keys via `_normalize_clan_tag_key` so same-normalized-clan closes produce no net delta while truly different tags (format variants) still release/consume correctly.  
- Make clan-math snapshot/logging tolerant of missing optional visibility columns by falling back to legacy column indices and logging a warning (no fatal error) so close flows still complete and row details are attempted where possible.  
- Update recruitment sheet helpers to honor a configurable `clan_tag` header when indexing/looking up clan rows (instead of assuming column 2), and adjust `_capture_clan_snapshots` to use resolved `clan_tag` header for display.  
- Add/adjust unit tests exercising: promo source lookup failure, source `NONE` behavior, same-normalized-clan no-op, reservation behaviors, and fallback snapshot behavior (`tests/onboarding/test_welcome_reservations.py`).

### Testing
- Ran the targeted unit suites with `pytest -q tests/onboarding/test_welcome_reservations.py tests/onboarding/test_promo_watcher.py` and the suites passed.  
- Verified module syntax/typing by compiling with `python -m py_compile modules/onboarding/watcher_welcome.py modules/onboarding/watcher_promo.py shared/sheets/recruitment.py` which completed without errors.  
- Added new tests covering promo source lookup diagnostics and snapshot fallback behavior which were executed as part of the above test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271c646768832385fc9159c77791d9)