### PR TITLE
Add staff-only !finishplacement fallback command for onboarding tickets

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1192,6 +1192,7 @@ class Runtime:
         from modules.onboarding import watcher_welcome as onboarding_welcome
         from modules.onboarding import watcher_promo as onboarding_promo
         from modules.onboarding import cmd_resume as onboarding_cmd_resume
+        from modules.onboarding import cmd_finishplacement as onboarding_cmd_finishplacement
         from modules.ops import permissions_ui as ops_permissions
         from c1c_coreops import ops as ops_cog
 
@@ -1361,6 +1362,12 @@ class Runtime:
             log.info("modules: onboarding_resume enabled")
         else:
             log.info("modules: onboarding_resume disabled")
+
+        if toggles.welcome_watcher_enabled or toggles.promo_watcher_enabled:
+            await onboarding_cmd_finishplacement.setup(self.bot)
+            log.info("modules: onboarding_finishplacement enabled")
+        else:
+            log.info("modules: onboarding_finishplacement disabled")
 
         await ops_cog.setup(self.bot)
 

--- a/modules/onboarding/cmd_finishplacement.py
+++ b/modules/onboarding/cmd_finishplacement.py
@@ -1,0 +1,600 @@
+"""Staff-only fallback command for manually finishing onboarding placements."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import is_admin_member, is_recruiter, is_staff_member
+from modules.onboarding import thread_scopes
+from modules.onboarding.watcher_welcome import (
+    TicketContext,
+    WelcomeTicketWatcher,
+    _NO_PLACEMENT_TAG,
+    parse_promo_thread_name,
+    parse_welcome_thread_name,
+)
+from modules.onboarding.watcher_promo import PromoTicketContext, PromoTicketWatcher
+from shared.sheets import onboarding as onboarding_sheets
+from shared.sheets import onboarding_sessions
+
+log = logging.getLogger("c1c.onboarding.finishplacement")
+
+Flow = Literal["welcome", "promo"]
+
+
+@dataclass(slots=True)
+class FinishPlacementContext:
+    flow: Flow
+    ticket_id: str
+    username: str
+    user_id: int | None = None
+    prompt_message_id: int | None = None
+    promo_type: str = ""
+    thread_created: str = ""
+    year: str = ""
+    month: str = ""
+    join_month: str = ""
+    clan_name: str = ""
+    progression: str = ""
+    existing_clan_tag: str = ""
+    existing_source_clan_tag: str = ""
+    status: str = ""
+    date_closed: str = ""
+    source: str = ""
+    lookup_keys: list[str] | None = None
+
+
+def _upper_tag(value: str | None) -> str:
+    return str(value or "").strip().upper()
+
+
+def _is_none_source(value: str | None) -> bool:
+    return _upper_tag(value) in {"", _NO_PLACEMENT_TAG}
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None or str(value).strip() == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _merge_finalized_state_from_ticket(
+    ctx: FinishPlacementContext,
+) -> FinishPlacementContext:
+    """Best-effort idempotency refresh by full ticket id before finalization."""
+
+    try:
+        if ctx.flow == "welcome":
+            found = onboarding_sheets.find_welcome_row(ctx.ticket_id)
+            if found:
+                _row, values = found
+                header = list(getattr(onboarding_sheets, "WELCOME_HEADERS", []))
+                mapped = {
+                    header[idx]: values[idx] if idx < len(values) else ""
+                    for idx in range(len(header))
+                }
+                ctx.existing_clan_tag = (
+                    ctx.existing_clan_tag or str(mapped.get("clantag") or "").strip()
+                )
+                ctx.status = ctx.status or str(mapped.get("status") or "").strip()
+                ctx.date_closed = (
+                    ctx.date_closed or str(mapped.get("date_closed") or "").strip()
+                )
+        else:
+            found = onboarding_sheets.find_promo_row(ctx.ticket_id)
+            if found:
+                _row, mapped = found
+                ctx.existing_clan_tag = (
+                    ctx.existing_clan_tag or str(mapped.get("clantag") or "").strip()
+                )
+                ctx.status = ctx.status or str(mapped.get("status") or "").strip()
+                ctx.date_closed = (
+                    ctx.date_closed
+                    or str(
+                        mapped.get("date closed") or mapped.get("date_closed") or ""
+                    ).strip()
+                )
+    except Exception:
+        log.exception(
+            "finishplacement idempotency ticket refresh failed",
+            extra={"ticket_id": ctx.ticket_id, "flow": ctx.flow},
+        )
+    return ctx
+
+
+def _is_finalized(ctx: FinishPlacementContext) -> bool:
+    if str(ctx.status or "").strip().lower() in {
+        "closed",
+        "complete",
+        "completed",
+        "finalized",
+    }:
+        return True
+    if str(ctx.date_closed or "").strip() and _upper_tag(ctx.existing_clan_tag):
+        return True
+    return False
+
+
+def _welcome_row_context(thread_id: int) -> FinishPlacementContext | None:
+    found = onboarding_sheets.find_welcome_row_by_thread_id(thread_id)
+    if not found:
+        return None
+    _row_number, values = found
+    return FinishPlacementContext(
+        flow="welcome",
+        ticket_id=str(
+            values.get("ticket_number") or values.get("ticket") or ""
+        ).strip(),
+        username=str(values.get("username") or "").strip(),
+        user_id=_safe_int(values.get("user_id")),
+        prompt_message_id=_safe_int(values.get("panel_message_id")),
+        existing_clan_tag=str(values.get("clantag") or "").strip(),
+        status=str(values.get("status") or "").strip(),
+        date_closed=str(
+            values.get("date_closed") or values.get("dateclosed") or ""
+        ).strip(),
+        source="sheet_thread_id",
+        lookup_keys=[f"welcome.thread_id={thread_id}"],
+    )
+
+
+def _promo_row_context(thread_id: int) -> FinishPlacementContext | None:
+    found = onboarding_sheets.find_promo_row_by_thread_id(thread_id)
+    if not found:
+        return None
+    _row_number, values = found
+    source_header = ""
+    try:
+        source_header = onboarding_sheets.get_promo_source_clan_tag_header()
+    except Exception:
+        source_header = "source_clan_tag"
+    return FinishPlacementContext(
+        flow="promo",
+        ticket_id=str(
+            values.get("ticket number")
+            or values.get("ticket_number")
+            or values.get("ticket")
+            or ""
+        ).strip(),
+        username=str(values.get("username") or "").strip(),
+        user_id=_safe_int(values.get("user_id")),
+        prompt_message_id=_safe_int(values.get("panel_message_id")),
+        promo_type=str(values.get("type") or "").strip(),
+        thread_created=str(
+            values.get("thread created") or values.get("thread_created") or ""
+        ).strip(),
+        year=str(values.get("year") or "").strip(),
+        month=str(values.get("month") or "").strip(),
+        join_month=str(values.get("join_month") or "").strip(),
+        clan_name=str(values.get("clan name") or values.get("clan_name") or "").strip(),
+        progression=str(values.get("progression") or "").strip(),
+        existing_clan_tag=str(values.get("clantag") or "").strip(),
+        existing_source_clan_tag=str(
+            values.get(source_header) or values.get("source_clan_tag") or ""
+        ).strip(),
+        status=str(values.get("status") or "").strip(),
+        date_closed=str(
+            values.get("date closed") or values.get("date_closed") or ""
+        ).strip(),
+        source="sheet_thread_id",
+        lookup_keys=[f"promo.thread_id={thread_id}"],
+    )
+
+
+def _session_context(
+    thread: discord.Thread, flow: Flow
+) -> FinishPlacementContext | None:
+    row = onboarding_sessions.get_by_thread_id(getattr(thread, "id", None))
+    if not row:
+        return None
+    thread_name = str(row.get("thread_name") or getattr(thread, "name", "") or "")
+    if flow == "promo":
+        parts = parse_promo_thread_name(thread_name)
+        if not parts:
+            return None
+        return FinishPlacementContext(
+            flow="promo",
+            ticket_id=parts.ticket_code,
+            username=parts.username,
+            user_id=_safe_int(row.get("user_id")),
+            prompt_message_id=_safe_int(row.get("panel_message_id")),
+            promo_type=parts.promo_type,
+            source="onboarding_session_thread_id",
+            lookup_keys=[f"sessions.thread_id={getattr(thread, 'id', None)}"],
+        )
+    parts = parse_welcome_thread_name(thread_name)
+    if not parts:
+        return None
+    return FinishPlacementContext(
+        flow="welcome",
+        ticket_id=parts.ticket_code,
+        username=parts.username,
+        user_id=_safe_int(row.get("user_id")),
+        prompt_message_id=_safe_int(row.get("panel_message_id")),
+        source="onboarding_session_thread_id",
+        lookup_keys=[f"sessions.thread_id={getattr(thread, 'id', None)}"],
+    )
+
+
+def _thread_name_context(
+    thread: discord.Thread, flow: Flow
+) -> FinishPlacementContext | None:
+    now = getattr(thread, "created_at", None) or dt.datetime.now(dt.timezone.utc)
+    if flow == "promo":
+        parts = parse_promo_thread_name(getattr(thread, "name", None))
+        if not parts:
+            return None
+        return FinishPlacementContext(
+            flow="promo",
+            ticket_id=parts.ticket_code,
+            username=parts.username,
+            promo_type=parts.promo_type,
+            thread_created=now.isoformat(),
+            year=str(now.year),
+            month=now.strftime("%B"),
+            existing_clan_tag=parts.clan_tag or "",
+            source="thread_name",
+            lookup_keys=[f"thread.name={getattr(thread, 'name', '')}"],
+        )
+    parts = parse_welcome_thread_name(getattr(thread, "name", None))
+    if not parts:
+        return None
+    return FinishPlacementContext(
+        flow="welcome",
+        ticket_id=parts.ticket_code,
+        username=parts.username,
+        existing_clan_tag=parts.clan_tag or "",
+        source="thread_name",
+        lookup_keys=[f"thread.name={getattr(thread, 'name', '')}"],
+    )
+
+
+class FinishPlacementCog(commands.Cog):
+    """Staff fallback command that delegates to the normal close finalizers."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    def _authorized(self, member: Any) -> bool:
+        return bool(
+            is_staff_member(member) or is_admin_member(member) or is_recruiter(member)
+        )
+
+    async def _valid_tags(self) -> set[str]:
+        tags = await asyncio.to_thread(onboarding_sheets.load_clan_tags)
+        return {
+            str(tag or "").strip().upper() for tag in tags if str(tag or "").strip()
+        }
+
+    async def _resolve_context(
+        self, thread: discord.Thread, flow: Flow
+    ) -> FinishPlacementContext | None:
+        lookup_keys = [f"thread_id={getattr(thread, 'id', None)}"]
+        if flow == "welcome":
+            watcher = self.bot.get_cog("WelcomeTicketWatcher")
+            if isinstance(watcher, WelcomeTicketWatcher):
+                existing = watcher._tickets.get(thread.id)
+                if existing is not None:
+                    return FinishPlacementContext(
+                        flow="welcome",
+                        ticket_id=existing.ticket_number,
+                        username=existing.username,
+                        user_id=existing.recruit_id,
+                        prompt_message_id=existing.prompt_message_id,
+                        existing_clan_tag=existing.final_clan or "",
+                        status=existing.state,
+                        source="memory_thread_id",
+                        lookup_keys=lookup_keys,
+                    )
+            for resolver in (_welcome_row_context,):
+                ctx = await asyncio.to_thread(resolver, thread.id)
+                if ctx:
+                    return ctx
+        else:
+            watcher = self.bot.get_cog("PromoTicketWatcher")
+            if isinstance(watcher, PromoTicketWatcher):
+                existing = watcher._tickets.get(thread.id)
+                if existing is not None:
+                    return FinishPlacementContext(
+                        flow="promo",
+                        ticket_id=existing.ticket_number,
+                        username=existing.username,
+                        user_id=existing.user_id,
+                        prompt_message_id=existing.prompt_message_id,
+                        promo_type=existing.promo_type,
+                        thread_created=existing.thread_created,
+                        year=existing.year,
+                        month=existing.month,
+                        join_month=existing.join_month,
+                        clan_name=existing.clan_name,
+                        progression=existing.progression,
+                        existing_clan_tag=existing.clan_tag,
+                        existing_source_clan_tag=existing.source_clan_tag,
+                        status=existing.state,
+                        source="memory_thread_id",
+                        lookup_keys=lookup_keys,
+                    )
+            ctx = await asyncio.to_thread(_promo_row_context, thread.id)
+            if ctx:
+                return ctx
+
+        ctx = await asyncio.to_thread(_session_context, thread, flow)
+        if ctx:
+            return ctx
+        # Ticket helper/log table currently shares the Welcome sheet in this codebase;
+        # the sheet-by-thread lookup above covers it when thread_id is present.
+        return _thread_name_context(thread, flow)
+
+    @tier("staff")
+    @help_metadata(
+        function_group="recruitment", section="onboarding", access_tier="staff"
+    )
+    @commands.command(
+        name="finishplacement",
+        usage="<source_clan_tag|NONE> <destination_clan_tag>",
+        help="Staff fallback: manually finish a welcome or promo placement in the current ticket thread.",
+        brief="Manually finish placement for the current onboarding ticket.",
+    )
+    async def finishplacement(
+        self,
+        ctx: commands.Context,
+        source_clan_tag: str | None = None,
+        destination_clan_tag: str | None = None,
+    ) -> None:
+        thread = ctx.channel if isinstance(ctx.channel, discord.Thread) else None
+        actor_id = getattr(getattr(ctx, "author", None), "id", None)
+        log.info(
+            "finishplacement_invoked",
+            extra={"thread_id": getattr(thread, "id", None), "actor_id": actor_id},
+        )
+
+        if not self._authorized(getattr(ctx, "author", None)):
+            log.info(
+                "finishplacement_unauthorized",
+                extra={"thread_id": getattr(thread, "id", None), "actor_id": actor_id},
+            )
+            await ctx.reply("Staff only.", mention_author=False)
+            return
+
+        if source_clan_tag is None or destination_clan_tag is None:
+            await ctx.reply(
+                "Usage: `!finishplacement <source_clan_tag|NONE> <destination_clan_tag>`",
+                mention_author=False,
+            )
+            return
+
+        if thread is None:
+            log.info(
+                "finishplacement_wrong_thread_type",
+                extra={
+                    "channel_id": getattr(ctx.channel, "id", None),
+                    "actor_id": actor_id,
+                },
+            )
+            await ctx.reply(
+                "Use this inside a welcome or promo ticket thread.",
+                mention_author=False,
+            )
+            return
+
+        if thread_scopes.is_welcome_parent(thread):
+            flow: Flow = "welcome"
+        elif thread_scopes.is_promo_parent(thread):
+            flow = "promo"
+        else:
+            log.info(
+                "finishplacement_wrong_thread_type",
+                extra={
+                    "thread_id": thread.id,
+                    "parent_channel_id": getattr(thread, "parent_id", None),
+                    "actor_id": actor_id,
+                },
+            )
+            await ctx.reply(
+                "Use this inside a welcome or promo ticket thread.",
+                mention_author=False,
+            )
+            return
+
+        source_tag = _upper_tag(source_clan_tag)
+        destination_tag = _upper_tag(destination_clan_tag)
+        if not destination_tag or destination_tag == _NO_PLACEMENT_TAG:
+            await ctx.reply("Destination clan tag is required.", mention_author=False)
+            return
+
+        valid_tags = await self._valid_tags()
+        if destination_tag not in valid_tags or (
+            not _is_none_source(source_tag) and source_tag not in valid_tags
+        ):
+            await ctx.reply(
+                "Unknown clan tag. Please use configured clan tags or `NONE` for source.",
+                mention_author=False,
+            )
+            return
+
+        if flow == "welcome" and not _is_none_source(source_tag):
+            log.warning(
+                "finishplacement_wrong_thread_type welcome_source_rejected",
+                extra={
+                    "thread_id": thread.id,
+                    "source_clan_tag": source_tag,
+                    "destination_clan_tag": destination_tag,
+                    "actor_id": actor_id,
+                },
+            )
+            await ctx.reply(
+                "Welcome tickets only support `NONE` as the source clan.",
+                mention_author=False,
+            )
+            return
+
+        context = await self._resolve_context(thread, flow)
+        if context is None or not context.ticket_id or not context.username:
+            attempted = [
+                f"thread_id={thread.id}",
+                f"channel_name={getattr(thread, 'name', '')}",
+                "memory",
+                "sheet_thread_id",
+                "onboarding_session",
+                "ticket_helper",
+                "thread_name",
+            ]
+            log.error(
+                "finishplacement_context_unresolved",
+                extra={
+                    "thread_id": thread.id,
+                    "channel_name": getattr(thread, "name", ""),
+                    "parent_channel_id": getattr(thread, "parent_id", None),
+                    "actor_id": actor_id,
+                    "attempted_lookup_keys": attempted,
+                    "reason": "missing_ticket_or_username",
+                },
+            )
+            await ctx.reply(
+                "I couldn't resolve this ticket context. Please verify the thread name or sheet row and try again.",
+                mention_author=False,
+            )
+            return
+
+        context = await asyncio.to_thread(_merge_finalized_state_from_ticket, context)
+        log.info(
+            "finishplacement_context_resolved",
+            extra={
+                "thread_id": thread.id,
+                "ticket_id": context.ticket_id,
+                "flow": flow,
+                "source": context.source,
+            },
+        )
+        if _is_finalized(context):
+            log.info(
+                "finishplacement_already_finalized",
+                extra={
+                    "thread_id": thread.id,
+                    "ticket_id": context.ticket_id,
+                    "flow": flow,
+                },
+            )
+            await ctx.reply(
+                "This ticket already appears finalized.", mention_author=False
+            )
+            return
+
+        log.info(
+            "finishplacement_started",
+            extra={
+                "thread_id": thread.id,
+                "ticket_id": context.ticket_id,
+                "flow": flow,
+                "source_clan_tag": source_tag,
+                "destination_clan_tag": destination_tag,
+            },
+        )
+        if flow == "welcome":
+            watcher = self.bot.get_cog("WelcomeTicketWatcher")
+            if not isinstance(watcher, WelcomeTicketWatcher):
+                await ctx.reply(
+                    "Welcome ticket finalizer is unavailable.", mention_author=False
+                )
+                return
+            ticket_context = watcher._tickets.get(thread.id) or TicketContext(
+                thread_id=thread.id,
+                ticket_number=context.ticket_id,
+                username=context.username,
+                recruit_id=context.user_id,
+                recruit_display=context.username,
+                prompt_message_id=context.prompt_message_id,
+            )
+            ticket_context.close_source = "finishplacement"
+            watcher._tickets[thread.id] = ticket_context
+            await watcher._finalize_clan_tag(
+                thread,
+                ticket_context,
+                destination_tag,
+                actor=getattr(ctx, "author", None),
+                source="finishplacement",
+                prompt_message=None,
+                view=None,
+                notify=False,
+                rename_thread=True,
+                sheet_phase="finishplacement",
+            )
+            if ticket_context.state == "closed":
+                await ctx.reply(
+                    f"Placement finalized: **{destination_tag}**.", mention_author=False
+                )
+                log.info(
+                    "finishplacement_completed",
+                    extra={
+                        "thread_id": thread.id,
+                        "ticket_id": context.ticket_id,
+                        "flow": flow,
+                    },
+                )
+            return
+
+        watcher = self.bot.get_cog("PromoTicketWatcher")
+        if not isinstance(watcher, PromoTicketWatcher):
+            await ctx.reply(
+                "Promo ticket finalizer is unavailable.", mention_author=False
+            )
+            return
+        now = getattr(thread, "created_at", None) or dt.datetime.now(dt.timezone.utc)
+        promo_context = watcher._tickets.get(thread.id) or PromoTicketContext(
+            thread_id=thread.id,
+            ticket_number=context.ticket_id,
+            username=context.username,
+            promo_type=context.promo_type or "promo.m",
+            thread_created=context.thread_created or now.isoformat(),
+            year=context.year or str(now.year),
+            month=context.month or now.strftime("%B"),
+            join_month=context.join_month,
+            clan_name=context.clan_name,
+            progression=context.progression,
+            user_id=context.user_id,
+            prompt_message_id=context.prompt_message_id,
+        )
+        promo_context.ticket_number = context.ticket_id
+        promo_context.username = context.username
+        promo_context.source_clan_tag = (
+            _NO_PLACEMENT_TAG if _is_none_source(source_tag) else source_tag
+        )
+        promo_context.clan_tag = destination_tag
+        promo_context.state = "awaiting_destination_clan"
+        watcher._tickets[thread.id] = promo_context
+        await watcher._complete_close(
+            thread,
+            promo_context,
+            progression=promo_context.progression,
+            clan_name=promo_context.clan_name,
+            phase="finishplacement",
+            previous_final=promo_context.source_clan_tag,
+        )
+        if promo_context.state == "closed":
+            await ctx.reply(
+                f"Placement finalized: **{source_tag or _NO_PLACEMENT_TAG}** → **{destination_tag}**.",
+                mention_author=False,
+            )
+            log.info(
+                "finishplacement_completed",
+                extra={
+                    "thread_id": thread.id,
+                    "ticket_id": context.ticket_id,
+                    "flow": flow,
+                },
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(FinishPlacementCog(bot))

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -773,6 +773,71 @@ def append_welcome_ticket_row(
     return _upsert(ws, key_columns, row_values, header, search_values=search_values)
 
 
+def _row_map(header: Sequence[str], row: Sequence[str]) -> Dict[str, str]:
+    """Return a header-to-value mapping for a sheet row."""
+
+    return {
+        str(name): (row[idx] if idx < len(row) else "")
+        for idx, name in enumerate(header)
+    }
+
+
+def _find_row_by_thread_id(
+    *, tab: str, headers: Sequence[str], thread_id: int | str | None
+) -> Optional[Tuple[int, Dict[str, str]]]:
+    """Return the (1-indexed) row number and mapped values for ``thread_id``."""
+
+    if thread_id is None:
+        return None
+    target = str(thread_id).strip()
+    if not target:
+        return None
+
+    ws = _worksheet(tab)
+    if tab == _promo_tab():
+        header = _ensure_promo_headers(ws)
+    else:
+        header = _ensure_headers(ws, headers)
+    normalized_header = [_normalize_header_name(col) for col in header]
+    thread_indexes = [
+        idx
+        for idx, name in enumerate(normalized_header)
+        if name in {"threadid", "thread"}
+    ]
+    if not thread_indexes:
+        return None
+
+    values = core.call_with_backoff(ws.get_all_values)
+    for row_idx, row in enumerate(values[1:], start=2):
+        for col_idx in thread_indexes:
+            current = row[col_idx] if col_idx < len(row) else ""
+            if str(current or "").strip() == target:
+                return row_idx, _row_map(header, row)
+    return None
+
+
+def find_welcome_row_by_thread_id(
+    thread_id: int | str | None,
+) -> Optional[Tuple[int, Dict[str, str]]]:
+    """Return the Welcome row matching ``thread_id`` if present."""
+
+    return _find_row_by_thread_id(
+        tab=_welcome_tab(), headers=WELCOME_HEADERS, thread_id=thread_id
+    )
+
+
+def find_promo_row_by_thread_id(
+    thread_id: int | str | None,
+) -> Optional[Tuple[int, Dict[str, str]]]:
+    """Return the Promo row matching ``thread_id`` if present."""
+
+    result = _find_row_by_thread_id(
+        tab=_promo_tab(), headers=PROMO_HEADERS, thread_id=thread_id
+    )
+    if result is not None:
+        require_promo_source_clan_header(list(result[1].keys()))
+    return result
+
 def find_welcome_row(ticket: str | None) -> Optional[Tuple[int, List[str]]]:
     """Return the (1-indexed) row number and values for ``ticket`` if present."""
 

--- a/tests/onboarding/test_finishplacement_command.py
+++ b/tests/onboarding/test_finishplacement_command.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
+
+import pytest
+
+from modules.onboarding import cmd_finishplacement as fp
+from modules.onboarding.watcher_promo import PromoTicketContext, PromoTicketWatcher
+from modules.onboarding.watcher_welcome import TicketContext, WelcomeTicketWatcher
+
+
+class DummyThread:
+    def __init__(self, *, thread_id=123, name="W0919-player", parent_id=10):
+        self.id = thread_id
+        self.name = name
+        self.parent_id = parent_id
+        self.guild = SimpleNamespace(id=1)
+        self.created_at = None
+        self.edited = []
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append((content, kwargs))
+        return SimpleNamespace(id=999, content=content)
+
+    async def edit(self, **kwargs):
+        self.edited.append(kwargs)
+        if "name" in kwargs:
+            self.name = kwargs["name"]
+
+
+class DummyCtx:
+    def __init__(self, channel, *, author=None):
+        self.channel = channel
+        self.author = author or SimpleNamespace(id=42)
+        self.replies = []
+
+    async def reply(self, content, **kwargs):
+        self.replies.append((content, kwargs))
+
+
+class DummyBot:
+    def __init__(self, **cogs):
+        self._cogs = cogs
+
+    def get_cog(self, name):
+        return self._cogs.get(name)
+
+
+@pytest.fixture(autouse=True)
+def _common(monkeypatch):
+    monkeypatch.setattr(fp.discord, "Thread", DummyThread)
+    monkeypatch.setattr(fp, "is_staff_member", lambda member: True)
+    monkeypatch.setattr(fp, "is_admin_member", lambda member: False)
+    monkeypatch.setattr(fp, "is_recruiter", lambda member: False)
+    monkeypatch.setattr(
+        fp.onboarding_sheets, "load_clan_tags", lambda: ["C1CB", "C1CD"]
+    )
+    monkeypatch.setattr(
+        fp.thread_scopes, "is_welcome_parent", lambda thread: thread.parent_id == 10
+    )
+    monkeypatch.setattr(
+        fp.thread_scopes, "is_promo_parent", lambda thread: thread.parent_id == 20
+    )
+    monkeypatch.setattr(fp.onboarding_sessions, "get_by_thread_id", lambda *_: None)
+    monkeypatch.setattr(
+        fp.onboarding_sheets, "find_welcome_row_by_thread_id", lambda *_: None
+    )
+    monkeypatch.setattr(
+        fp.onboarding_sheets, "find_promo_row_by_thread_id", lambda *_: None
+    )
+    monkeypatch.setattr(fp.onboarding_sheets, "find_welcome_row", lambda *_: None)
+    monkeypatch.setattr(fp.onboarding_sheets, "find_promo_row", lambda *_: None)
+
+
+def test_staff_can_finish_welcome_ticket(monkeypatch):
+    watcher = WelcomeTicketWatcher(SimpleNamespace())
+    watcher._finalize_clan_tag = AsyncMock(
+        side_effect=lambda _thread, context, *_args, **_kwargs: setattr(
+            context, "state", "closed"
+        )
+    )
+    cog = fp.FinishPlacementCog(DummyBot(WelcomeTicketWatcher=watcher))
+    thread = DummyThread(name="W0919-player", parent_id=10)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "C1CD")
+    )
+
+    watcher._finalize_clan_tag.assert_awaited_once()
+    called_context = watcher._finalize_clan_tag.await_args.args[1]
+    assert called_context.ticket_number == "W0919"
+    assert called_context.username == "player"
+    assert watcher._finalize_clan_tag.await_args.args[2] == "C1CD"
+    assert ctx.replies[-1][0] == "Placement finalized: **C1CD**."
+
+
+def test_staff_can_finish_promo_move_ticket(monkeypatch):
+    watcher = PromoTicketWatcher(SimpleNamespace())
+    watcher._complete_close = AsyncMock(
+        side_effect=lambda _thread, context, *_args, **_kwargs: setattr(
+            context, "state", "closed"
+        )
+    )
+    cog = fp.FinishPlacementCog(DummyBot(PromoTicketWatcher=watcher))
+    thread = DummyThread(name="M0354-player", parent_id=20)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "C1CB", "C1CD")
+    )
+
+    watcher._complete_close.assert_awaited_once()
+    promo_context = watcher._complete_close.await_args.args[1]
+    assert promo_context.ticket_number == "M0354"
+    assert promo_context.source_clan_tag == "C1CB"
+    assert promo_context.clan_tag == "C1CD"
+    assert watcher._complete_close.await_args.kwargs["previous_final"] == "C1CB"
+    assert ctx.replies[-1][0] == "Placement finalized: **C1CB** → **C1CD**."
+
+
+def test_promo_none_source_passes_none_to_shared_finalizer(monkeypatch):
+    watcher = PromoTicketWatcher(SimpleNamespace())
+    watcher._complete_close = AsyncMock(
+        side_effect=lambda _thread, context, *_args, **_kwargs: setattr(
+            context, "state", "closed"
+        )
+    )
+    cog = fp.FinishPlacementCog(DummyBot(PromoTicketWatcher=watcher))
+    thread = DummyThread(name="M0354-player", parent_id=20)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "C1CD")
+    )
+
+    promo_context = watcher._complete_close.await_args.args[1]
+    assert promo_context.source_clan_tag == "NONE"
+    assert watcher._complete_close.await_args.kwargs["previous_final"] == "NONE"
+
+
+def test_non_staff_is_rejected(monkeypatch):
+    monkeypatch.setattr(fp, "is_staff_member", lambda member: False)
+    monkeypatch.setattr(fp, "is_admin_member", lambda member: False)
+    monkeypatch.setattr(fp, "is_recruiter", lambda member: False)
+    watcher = WelcomeTicketWatcher(SimpleNamespace())
+    watcher._finalize_clan_tag = AsyncMock()
+    cog = fp.FinishPlacementCog(DummyBot(WelcomeTicketWatcher=watcher))
+    ctx = DummyCtx(DummyThread(parent_id=10))
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "C1CD")
+    )
+
+    watcher._finalize_clan_tag.assert_not_awaited()
+    assert ctx.replies == [("Staff only.", {"mention_author": False})]
+
+
+def test_wrong_thread_type_is_rejected():
+    watcher = WelcomeTicketWatcher(SimpleNamespace())
+    watcher._finalize_clan_tag = AsyncMock()
+    cog = fp.FinishPlacementCog(DummyBot(WelcomeTicketWatcher=watcher))
+    ctx = DummyCtx(DummyThread(parent_id=999))
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "C1CD")
+    )
+
+    watcher._finalize_clan_tag.assert_not_awaited()
+    assert ctx.replies[-1][0] == "Use this inside a welcome or promo ticket thread."
+
+
+def test_already_finalized_ticket_does_not_call_finalizer():
+    watcher = PromoTicketWatcher(SimpleNamespace())
+    watcher._tickets[123] = PromoTicketContext(
+        thread_id=123,
+        ticket_number="M0354",
+        username="player",
+        promo_type="promo.m",
+        thread_created="",
+        year="2026",
+        month="June",
+        clan_tag="C1CD",
+        source_clan_tag="C1CB",
+        state="closed",
+    )
+    watcher._complete_close = AsyncMock()
+    cog = fp.FinishPlacementCog(DummyBot(PromoTicketWatcher=watcher))
+    ctx = DummyCtx(DummyThread(thread_id=123, name="M0354-player", parent_id=20))
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "C1CB", "C1CD")
+    )
+
+    watcher._complete_close.assert_not_awaited()
+    assert ctx.replies[-1][0] == "This ticket already appears finalized."
+
+
+def test_welcome_real_source_is_rejected_safely():
+    watcher = WelcomeTicketWatcher(SimpleNamespace())
+    watcher._finalize_clan_tag = AsyncMock()
+    cog = fp.FinishPlacementCog(DummyBot(WelcomeTicketWatcher=watcher))
+    ctx = DummyCtx(DummyThread(parent_id=10))
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "C1CB", "C1CD")
+    )
+
+    watcher._finalize_clan_tag.assert_not_awaited()
+    assert (
+        ctx.replies[-1][0] == "Welcome tickets only support `NONE` as the source clan."
+    )


### PR DESCRIPTION
### Motivation
- Provide a staff-operated fallback to trigger the final placement/finalization flow when automatic close detection fails or a controlled manual action is needed. 
- Support both welcome and promo/move ticket flows while preserving the exact ticket id/prefix and reusing the existing placement/reservation logic. 
- Ensure safety: staff-only access, thread-scope validation, clan-tag validation, and idempotency to avoid double-releasing reservations or double-adjusting open spots. 

### Description
- Added a new Cog `FinishPlacementCog` implementing `!finishplacement <source_clan_tag|NONE> <destination_clan_tag>` in `modules/onboarding/cmd_finishplacement.py`; it enforces staff/recruiter/admin RBAC, validates tags, and rejects use outside welcome/promo threads. 
- Context resolution follows the required order (in-memory watcher, sheet row by `thread_id`, onboarding session by `thread_id`, then thread-name parsing) and preserves full ticket ids when renaming/confirming. 
- The command delegates to existing finalizers instead of duplicating logic: welcome paths call `WelcomeTicketWatcher._finalize_clan_tag`, promo paths call `PromoTicketWatcher._complete_close`, and `NONE` source for promo is preserved to indicate no previous clan. 
- Added idempotency preflight that refreshes ticket row state (`_merge_finalized_state_from_ticket`) and returns a short reply if already finalized, preventing duplicate reservation releases/open-spot adjustments/log posts. 
- Added sheet helpers to look up Welcome/Promo rows by `thread_id` in `shared/sheets/onboarding.py` to support robust context recovery. 
- Wired the new command to the onboarding bootstrap so it is registered when welcome or promo watchers are enabled (`modules/common/runtime.py`). 
- Tests and test helpers: added `tests/onboarding/test_finishplacement_command.py` covering welcome and promo flows, NONE source handling, non-staff rejection, wrong-thread rejection, already-finalized idempotency, and welcome-source rejection. 

### Testing
- Unit tests: `pytest -q tests/onboarding/test_finishplacement_command.py` — all tests passed. 
- Targeted integration/unit checks: ran subset including `tests/onboarding/test_welcome_reservations.py::test_promo_move_decision_releases_source_and_consumes_destination`, `tests/onboarding/test_welcome_reservations.py::test_promo_source_none_only_consumes_destination`, `tests/onboarding/test_welcome_reservations.py::test_promo_same_source_destination_normalized_no_delta`, and `tests/onboarding/test_promo_close_clan_prompt.py::test_after_clan_confirm_progression_still_completes` — all passed. 
- Compiled changed modules with `python -m compileall modules/onboarding/cmd_finishplacement.py shared/sheets/onboarding.py modules/common/runtime.py` to confirm syntax. 

No config, sheet tab, or column migrations are required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281481db8883239f1c23f6a26cebbd)