### PR TITLE
Preserve Discord usernames in reservation thread renames

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -82,6 +82,7 @@ _PROMO_TYPE_MAP = {
     "M": "player move request",
     "L": "clan lead move request",
 }
+_DISCORD_THREAD_NAME_LIMIT = 100
 
 
 async def _ensure_fresh_clans_for_placement(
@@ -383,6 +384,21 @@ async def resolve_subject_user_id(
 def build_reserved_thread_name(ticket_code: str, username: str, clan_tag: str) -> str:
     tag = (clan_tag or "").strip().upper()
     return f"Res-{ticket_code}-{username}-{tag}".strip("-")
+
+
+def _truncate_reserved_thread_name(
+    ticket_code: str, username: str, clan_tag: str
+) -> tuple[str, str | None]:
+    original_name = build_reserved_thread_name(ticket_code, username, clan_tag)
+    if len(original_name) <= _DISCORD_THREAD_NAME_LIMIT:
+        return original_name, None
+
+    tag = (clan_tag or "").strip().upper()
+    prefix = f"Res-{ticket_code}-"
+    suffix = f"-{tag}" if tag else ""
+    max_username_length = max(0, _DISCORD_THREAD_NAME_LIMIT - len(prefix) - len(suffix))
+    truncated_name = f"{prefix}{username[:max_username_length]}{suffix}"
+    return truncated_name, original_name
 
 
 def build_closed_thread_name(ticket_code: str, username: str, clan_tag: str) -> str:
@@ -1411,31 +1427,49 @@ async def _process_promo_thread(
 
 
 def _parse_reservable_ticket_thread_name(name: str | None) -> Optional[ThreadNameParts]:
-    """Parse welcome or promo ticket thread names for reservation renames."""
-
-    parts = parse_welcome_thread_name(name)
-    if parts is not None:
-        return parts
+    """Parse ticket thread names for reservation renames without rewriting usernames."""
 
     normalized = (name or "").strip()
-    prefix_match = re.match(
-        r"^(?P<prefix>res|closed)[-_\s]+", normalized, re.IGNORECASE
-    )
-    state_prefix = prefix_match.group("prefix") if prefix_match else None
-    promo_name = normalized[prefix_match.end() :] if prefix_match else normalized
-    promo_parts = parse_promo_thread_name(promo_name)
-    if promo_parts is None:
+    if not normalized:
         return None
-    username = promo_parts.username
-    clan_tag = promo_parts.clan_tag
-    if state_prefix and clan_tag is None:
-        username_parts = re.split(r"[-_\s]+", username)
-        possible_tag = username_parts[-1] if len(username_parts) > 1 else ""
-        if re.fullmatch(r"[A-Z0-9]+", possible_tag or ""):
-            clan_tag = possible_tag
-            username = "-".join(part for part in username_parts[:-1] if part)
+
+    state_prefix: str | None = None
+    ticket_name = normalized
+    prefix_match = re.match(r"^(?P<prefix>res|closed)-", normalized, re.IGNORECASE)
+    if prefix_match:
+        state_prefix = prefix_match.group("prefix")
+        ticket_name = normalized[prefix_match.end() :].strip()
+
+    ticket_id, separator, remainder = ticket_name.partition("-")
+    if not separator:
+        return None
+
+    ticket_id = ticket_id.strip()
+    username = remainder.strip()
+    if not ticket_id or not username:
+        return None
+
+    if ticket_id[:1].upper() in _PROMO_TYPE_MAP:
+        valid_ticket = _normalize_promo_ticket(ticket_id)
+    else:
+        valid_ticket = _normalize_ticket_code(ticket_id)
+    if not valid_ticket:
+        return None
+
+    clan_tag = None
+    if state_prefix:
+        username_value, tag_separator, possible_tag = username.rpartition("-")
+        if tag_separator:
+            possible_tag = possible_tag.strip()
+            if re.fullmatch(r"[A-Za-z0-9]+", possible_tag or ""):
+                clan_tag = possible_tag
+                username = username_value.strip()
+
+    if not username:
+        return None
+
     return ThreadNameParts(
-        ticket_code=promo_parts.ticket_code,
+        ticket_code=ticket_id,
         username=username,
         prefix=state_prefix,
         clan_tag=clan_tag,
@@ -1477,9 +1511,27 @@ async def rename_thread_to_reserved(thread: discord.Thread, clan_tag: str) -> bo
         )
         return False
 
-    new_name = build_reserved_thread_name(
+    new_name, original_target_name = _truncate_reserved_thread_name(
         parts.ticket_code, parts.username, normalized_tag
     )
+    if original_target_name is not None:
+        log.warning(
+            "reservation_thread_name_truncated",
+            extra={
+                "original_target_name": original_target_name,
+                "truncated_target_name": new_name,
+                "thread_id": getattr(thread, "id", None),
+                "ticket": parts.ticket_code,
+            },
+        )
+        human_log.human(
+            "warning",
+            (
+                "⚠️ reservation_thread_name_truncated "
+                f"• original_target_name={original_target_name} "
+                f"• truncated_target_name={new_name}"
+            ),
+        )
     if getattr(thread, "name", None) == new_name:
         log.info(
             "✅ welcome_reserve_rename — ticket=%s • user=%s • tag=%s • result=already_reserved",

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -1888,6 +1888,54 @@ def test_rename_thread_to_reserved_promo_ticket_success() -> None:
     assert thread.renames == ["Res-M0351-Debido-C1CK"]
 
 
+def test_rename_thread_to_reserved_preserves_discord_accepted_username() -> None:
+    thread = _RenameThread("M0363-[C1C] SoulAnon")
+
+    async def runner() -> None:
+        await rename_thread_to_reserved(thread, "C1CM")
+
+    asyncio.run(runner())
+
+    assert thread.name == "Res-M0363-[C1C] SoulAnon-C1CM"
+    assert thread.renames == ["Res-M0363-[C1C] SoulAnon-C1CM"]
+
+
+def test_rename_thread_to_reserved_truncates_only_when_discord_limit_requires(
+    monkeypatch, caplog
+) -> None:
+    username = "[C1C] " + "SoulAnon" * 20
+    original_target_name = f"Res-M0363-{username}-C1CM"
+    thread = _RenameThread(f"M0363-{username}")
+    human_calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.human_log",
+        SimpleNamespace(
+            human=lambda level, message: human_calls.append((level, message))
+        ),
+    )
+    caplog.set_level(logging.WARNING, logger="c1c.onboarding.welcome_watcher")
+
+    async def runner() -> None:
+        await rename_thread_to_reserved(thread, "C1CM")
+
+    asyncio.run(runner())
+
+    assert len(thread.name) == 100
+    assert thread.name.startswith("Res-M0363-[C1C] SoulAnon")
+    assert thread.name.endswith("-C1CM")
+    assert " " in thread.name
+    assert "[C1C]" in thread.name
+    assert any(
+        record.getMessage() == "reservation_thread_name_truncated"
+        and getattr(record, "original_target_name", None) == original_target_name
+        and getattr(record, "truncated_target_name", None) == thread.name
+        for record in caplog.records
+    )
+    assert human_calls
+    assert human_calls[0][0] == "warning"
+    assert "reservation_thread_name_truncated" in human_calls[0][1]
+
 def test_rename_thread_to_reserved_updates_existing_reserved_clan() -> None:
     thread = _RenameThread("Res-M0351-Debido-C1CD")
 


### PR DESCRIPTION
### Motivation
- Ticket thread rename logic was over-sanitizing / rewriting the username segment and could change Discord-accepted display names such as `M0363-[C1C] SoulAnon`, which breaks parity with Ticket Tool and recruiter expectations.
- The intent is to preserve the username portion exactly (except trimming surrounding whitespace) and only alter the thread name to add reservation metadata or truncate for Discord limits.

### Description
- Update parsing for reservation renames in `modules/onboarding/watcher_welcome.py` to split on the first dash only and treat everything after that dash as the username, trimming only leading/trailing whitespace (`_parse_reservable_ticket_thread_name`).
- Stop sanitizing/replacing spaces, brackets, punctuation or clan tags inside the username and preserve the exact Discord-accepted username when building reserved names (`rename_thread_to_reserved` / `build_reserved_thread_name`).
- Add a truncation helper `_truncate_reserved_thread_name` honoring a `_DISCORD_THREAD_NAME_LIMIT = 100` and only truncating the username when the full `Res-<ticket>-<username>-<CLAN>` would exceed the limit.
- Emit a `reservation_thread_name_truncated` log (and a human-facing warning via `human_log.human`) with `original_target_name` and `truncated_target_name` when truncation occurs, and add tests covering preserved usernames and truncation behavior.

### Testing
- Ran the updated unit tests `pytest tests/onboarding/test_welcome_reservations.py -q`, which passed.
- Ran the combined suite `pytest tests/placement/test_reserve_command.py tests/onboarding/test_welcome_reservations.py -q`, which passed.
- Added regression tests exercising `M0363-[C1C] SoulAnon` preservation and truncation logging, and those tests passed under the above runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a282272078883239371fbc6a8250ea0)