### PR TITLE
Improve welcome ticket repair logging, review reasoning, and alert formatting

### DIFF
--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -7,7 +7,7 @@ import os
 import re
 import time
 from datetime import datetime, timezone
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from shared.sheets import core
 from shared.sheets.async_core import afetch_values
@@ -447,13 +447,18 @@ def _looks_like_ticket(value: str) -> bool:
     return bool(_WELCOME_TICKET_RE.match(_fmt_ticket(value)))
 
 
-def repair_welcome_rows(ws) -> dict[str, int]:
+def repair_welcome_rows(ws) -> dict[str, Any]:
     header = _ensure_headers(ws, get_welcome_headers())
     norm = [_normalize_header_name(col) for col in header]
     idx = {name: pos for pos, name in enumerate(norm)}
     required = {"ticketnumber", "username"}
-    if not required.issubset(idx):
-        return {"repaired": 0, "flagged": 0, "scanned": 0}
+    missing_required = sorted(required - set(idx))
+    if missing_required:
+        log.error(
+            "welcome ticket metadata check skipped: missing required header",
+            extra={"missing_headers": missing_required},
+        )
+        return {"repaired": 0, "flagged": 0, "scanned": 0, "config_error": "missing_required_header"}
 
     values = core.call_with_backoff(ws.get_all_values)
     repaired = 0
@@ -463,6 +468,8 @@ def repair_welcome_rows(ws) -> dict[str, int]:
     welcome_rows = 0
     reservation_rows = 0
     malformed_rows = 0
+    review_detail_rows = 0
+    app_logged_review_details = 0
     ticket_identity: dict[str, dict[str, set[str]]] = {}
     for row in values[1:]:
         row_values = list(row) + [""] * (len(header) - len(row))
@@ -554,20 +561,36 @@ def repair_welcome_rows(ws) -> dict[str, int]:
         if invalid and status_idx is not None:
             status_value = str(row_values[status_idx] or "").strip().lower()
             if len(identity["thread_ids"]) > 1:
-                row_values[status_idx] = "needs_review"
-                if review_idx is not None:
-                    row_values[review_idx] = "conflicting thread IDs"
-                changed = True
+                review_reason = "conflicting thread IDs"
             elif len(identity["user_ids"]) > 1:
+                review_reason = "conflicting user IDs"
+            else:
+                review_reason = "no matching ticket source found"
+
+            if status_value not in {"invalid", "needs_review", "closed"}:
                 row_values[status_idx] = "needs_review"
-                if review_idx is not None:
-                    row_values[review_idx] = "conflicting user IDs"
                 changed = True
-            elif status_value not in {"invalid", "needs_review", "closed"}:
-                row_values[status_idx] = "needs_review"
-                if review_idx is not None:
-                    row_values[review_idx] = "no matching ticket source found"
+            if review_idx is not None and not str(row_values[review_idx] or "").strip():
+                row_values[review_idx] = review_reason
                 changed = True
+            if review_idx is not None and str(row_values[review_idx] or "").strip():
+                review_detail_rows += 1
+
+            log.warning(
+                "welcome ticket metadata check needs attention",
+                extra={
+                    "ticket": ticket_key,
+                    "row_number": row_number,
+                    "username": username,
+                    "thread_id": thread_id or None,
+                    "user_id": user_id or None,
+                    "review_reason": str(row_values[review_idx] or "").strip() if review_idx is not None else review_reason,
+                    "review_reason_persisted": bool(
+                        review_idx is not None and str(row_values[review_idx] or "").strip()
+                    ),
+                },
+            )
+            app_logged_review_details += 1
             flagged += 1
         elif status_idx is not None and str(row_values[status_idx] or "").strip().lower() == "needs_review":
             # keep explicit invalid marker untouched
@@ -585,28 +608,54 @@ def repair_welcome_rows(ws) -> dict[str, int]:
             core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row_values[: len(header)]])
             repaired += 1
 
-    return {"repaired": repaired, "flagged": flagged, "scanned": scanned, "legacy_rows": legacy_rows, "welcome_rows": welcome_rows, "reservation_rows": reservation_rows, "malformed_rows": malformed_rows}
+    return {"repaired": repaired, "flagged": flagged, "scanned": scanned, "legacy_rows": legacy_rows, "welcome_rows": welcome_rows, "reservation_rows": reservation_rows, "malformed_rows": malformed_rows, "review_detail_rows": review_detail_rows, "app_logged_review_details": app_logged_review_details}
 
 
-def _queue_welcome_repair_alert(summary: dict[str, int]) -> None:
-    global _WELCOME_REPAIR_ALERT_LAST_TS, _WELCOME_REPAIR_ALERT_PENDING
+def _format_welcome_repair_alert(summary: dict[str, Any]) -> str | None:
+    if summary.get("config_error"):
+        return "⚠️ Welcome ticket metadata check skipped: required sheet configuration is missing."
+
     flagged = int(summary.get("flagged", 0) or 0)
-    if flagged <= 0:
-        return
     repaired = int(summary.get("repaired", 0) or 0)
+    welcome_rows = int(summary.get("welcome_rows", 0) or 0)
+    review_detail_rows = int(summary.get("review_detail_rows", 0) or 0)
+    app_logged_review_details = int(summary.get("app_logged_review_details", 0) or 0)
+
+    if flagged <= 0 and repaired <= 0:
+        return f"✅ Welcome ticket metadata check: no repair needed. {welcome_rows} welcome tickets checked."
+    if flagged <= 0:
+        return f"✅ Welcome ticket metadata check: {repaired} repaired, none need review."
+    if review_detail_rows >= flagged:
+        return (
+            "⚠️ Welcome ticket metadata check: "
+            f"{flagged} tickets need review, {repaired} repaired. "
+            "See review_reason in the configured onboarding sheet."
+        )
+    if app_logged_review_details >= flagged:
+        return (
+            "⚠️ Welcome ticket metadata check: "
+            f"{flagged} ticket records could not be auto-repaired. Details in app logs."
+        )
+    log.error(
+        "welcome ticket metadata check found records without review visibility",
+        extra={"flagged": flagged, "repaired": repaired, "welcome_rows": welcome_rows},
+    )
+    return None
+
+
+def _queue_welcome_repair_alert(summary: dict[str, Any]) -> None:
+    global _WELCOME_REPAIR_ALERT_LAST_TS, _WELCOME_REPAIR_ALERT_PENDING
+    message = _format_welcome_repair_alert(summary)
+    if not message:
+        return
+    flagged = int(summary.get("flagged", 0) or 0)
+    if flagged <= 0 and int(summary.get("repaired", 0) or 0) <= 0:
+        return
     now_ts = time.time()
     if (now_ts - _WELCOME_REPAIR_ALERT_LAST_TS) < 3600:
         return
     _WELCOME_REPAIR_ALERT_LAST_TS = now_ts
-    legacy_rows = int(summary.get("legacy_rows", 0) or 0)
-    welcome_rows = int(summary.get("welcome_rows", 0) or 0)
-    reservation_rows = int(summary.get("reservation_rows", 0) or 0)
-    malformed_rows = int(summary.get("malformed_rows", 0) or 0)
-    _WELCOME_REPAIR_ALERT_PENDING = (
-        "Welcome ticket metadata repair: "
-        f"{repaired} repaired, {flagged} flagged for review "
-        f"(welcome={welcome_rows}, reservations={reservation_rows}, legacy={legacy_rows}, malformed={malformed_rows}, open_spots_repair=not_performed)"
-    )
+    _WELCOME_REPAIR_ALERT_PENDING = message
 
 
 def consume_welcome_repair_alert() -> str | None:
@@ -715,7 +764,7 @@ def _normalize_ticket_timestamps(
 
 
 
-def run_welcome_ticket_repair_pass(*, min_interval_sec: float = 3600) -> dict[str, int]:
+def run_welcome_ticket_repair_pass(*, min_interval_sec: float = 3600) -> dict[str, Any]:
     """Run a repair/flag sweep on the Welcome ticket tab using config-resolved sheet/tab."""
 
     global _WELCOME_REPAIR_LAST_RUN

--- a/tests/onboarding/test_onboarding_repair_logic.py
+++ b/tests/onboarding/test_onboarding_repair_logic.py
@@ -1,4 +1,4 @@
-import datetime as dt
+import logging
 
 from shared.sheets import onboarding
 
@@ -18,9 +18,10 @@ class _WS:
         self.updated.append((rng, payload))
 
 
-def _run(values, monkeypatch):
+def _run(values, monkeypatch, *, expected_headers=None):
     ws = _WS(values)
     monkeypatch.setattr(onboarding.core, "call_with_backoff", lambda fn, *a, **k: fn(*a, **k))
+    monkeypatch.setattr(onboarding, "get_welcome_headers", lambda: list(expected_headers or values[0]))
     summary = onboarding.repair_welcome_rows(ws)
     return ws, summary
 
@@ -65,20 +66,162 @@ def test_legacy_rows_not_flagged(monkeypatch):
     assert ws.updated == []
 
 
-def test_repair_alert_mentions_open_spots_not_performed():
+def test_repair_alert_no_repair_needed_is_short_without_noisy_counters():
+    message = onboarding._format_welcome_repair_alert(
+        {
+            "repaired": 0,
+            "flagged": 0,
+            "welcome_rows": 41,
+            "reservation_rows": 0,
+            "legacy_rows": 0,
+            "malformed_rows": 1098,
+        }
+    )
+
+    assert message == "✅ Welcome ticket metadata check: no repair needed. 41 welcome tickets checked."
+    assert "malformed" not in message
+    assert "open_spots" not in message
+
+
+def test_repair_alert_repaired_without_flags_reports_repair_done():
+    message = onboarding._format_welcome_repair_alert(
+        {
+            "repaired": 2,
+            "flagged": 0,
+            "welcome_rows": 41,
+            "reservation_rows": 0,
+            "legacy_rows": 0,
+            "malformed_rows": 1098,
+        }
+    )
+
+    assert message == "✅ Welcome ticket metadata check: 2 repaired, none need review."
+    assert "no repair needed" not in message
+    assert "malformed" not in message
+    assert "open_spots" not in message
+
+
+def test_repair_alert_review_needed_with_persisted_details_points_to_sheet():
     onboarding._WELCOME_REPAIR_ALERT_LAST_TS = 0
     onboarding._WELCOME_REPAIR_ALERT_PENDING = None
     onboarding._queue_welcome_repair_alert(
         {
-            "repaired": 0,
-            "flagged": 1,
-            "welcome_rows": 1,
-            "reservation_rows": 0,
-            "legacy_rows": 0,
-            "malformed_rows": 0,
+            "repaired": 3,
+            "flagged": 9,
+            "welcome_rows": 41,
+            "review_detail_rows": 9,
+            "app_logged_review_details": 9,
+            "malformed_rows": 1098,
         }
     )
+
     message = onboarding.consume_welcome_repair_alert()
     assert message is not None
-    assert "metadata repair" in message
-    assert "open_spots_repair=not_performed" in message
+    assert "9 tickets need review, 3 repaired" in message
+    assert "review_reason" in message
+    assert "flagged for review" not in message
+    assert "malformed" not in message
+    assert "open_spots" not in message
+
+
+def test_repair_alert_review_needed_without_sheet_details_points_to_app_logs():
+    message = onboarding._format_welcome_repair_alert(
+        {
+            "repaired": 0,
+            "flagged": 2,
+            "welcome_rows": 4,
+            "review_detail_rows": 0,
+            "app_logged_review_details": 2,
+        }
+    )
+
+    assert message == (
+        "⚠️ Welcome ticket metadata check: "
+        "2 ticket records could not be auto-repaired. Details in app logs."
+    )
+    assert "flagged for review" not in message
+
+
+def test_repair_alert_without_review_visibility_suppresses_count_and_logs_defect(caplog):
+    caplog.set_level(logging.ERROR, logger=onboarding.__name__)
+
+    message = onboarding._format_welcome_repair_alert(
+        {
+            "repaired": 0,
+            "flagged": 2,
+            "welcome_rows": 4,
+            "review_detail_rows": 0,
+            "app_logged_review_details": 0,
+        }
+    )
+
+    assert message is None
+    assert "flagged for review" not in caplog.text
+    assert "without review visibility" in caplog.text
+
+
+def test_existing_needs_review_row_gets_review_reason_and_structured_log(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger=onboarding.__name__)
+    header = onboarding.WELCOME_HEADERS
+    values = [
+        header,
+        ["W0882", "user", "", "", "", "", "", "", "needs_review", "", "2026-04-02T00:00:00+00:00", ""],
+    ]
+
+    ws, summary = _run(values, monkeypatch)
+
+    assert summary["flagged"] == 1
+    assert summary["review_detail_rows"] == 1
+    updated_row = ws.updated[-1][1][0]
+    assert updated_row[8] == "needs_review"
+    assert updated_row[9] == "no matching ticket source found"
+    records = [r for r in caplog.records if r.message == "welcome ticket metadata check needs attention"]
+    assert records
+    assert records[-1].ticket == "W0882"
+    assert records[-1].row_number == 2
+    assert records[-1].review_reason == "no matching ticket source found"
+
+
+def test_missing_review_header_uses_app_log_message_without_review_claim(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger=onboarding.__name__)
+    header = [h for h in onboarding.WELCOME_HEADERS if h != "review_reason"]
+    values = [
+        header,
+        ["W0883", "user", "", "", "", "", "", "", "open", "2026-04-02T00:00:00+00:00", ""],
+    ]
+    ws, summary = _run(values, monkeypatch, expected_headers=header)
+
+    assert summary["flagged"] == 1
+    assert summary["review_detail_rows"] == 0
+    assert summary["app_logged_review_details"] == 1
+    message = onboarding._format_welcome_repair_alert(summary)
+    assert "Details in app logs" in message
+    assert "flagged for review" not in message
+    assert ws.updated
+    assert "welcome ticket metadata check needs attention" in caplog.text
+
+
+def test_malformed_noise_stays_out_of_discord_summary():
+    message = onboarding._format_welcome_repair_alert(
+        {"repaired": 0, "flagged": 0, "welcome_rows": 1, "malformed_rows": 1098}
+    )
+
+    assert message is not None
+    assert "malformed" not in message
+    assert "1098" not in message
+
+
+def test_missing_required_header_logs_and_skips_safely(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR, logger=onboarding.__name__)
+    header = ["ticket_number", "status", "created_at"]
+    values = [header, ["W0884", "open", "2026-04-02T00:00:00+00:00"]]
+
+    ws, summary = _run(values, monkeypatch, expected_headers=header)
+
+    assert summary["config_error"] == "missing_required_header"
+    assert summary["flagged"] == 0
+    assert ws.updated == []
+    assert "missing required header" in caplog.text
+    assert onboarding._format_welcome_repair_alert(summary) == (
+        "⚠️ Welcome ticket metadata check skipped: required sheet configuration is missing."
+    )

--- a/tests/onboarding/test_open_spot_visibility_logging.py
+++ b/tests/onboarding/test_open_spot_visibility_logging.py
@@ -222,10 +222,11 @@ def test_welcome_reads_previous_final_before_overwrite(monkeypatch):
     asyncio.run(run())
 
 
-def test_repair_alert_mentions_not_performed():
-    onboarding_sheets._queue_welcome_repair_alert({'repaired':0,'flagged':1,'legacy_rows':0,'welcome_rows':1,'reservation_rows':0,'malformed_rows':0})
+def test_repair_alert_omits_open_spots_when_not_part_of_metadata_check():
+    onboarding_sheets._WELCOME_REPAIR_ALERT_LAST_TS = 0
+    onboarding_sheets._queue_welcome_repair_alert({'repaired':0,'flagged':1,'legacy_rows':0,'welcome_rows':1,'reservation_rows':0,'malformed_rows':0,'review_detail_rows':1,'app_logged_review_details':1})
     msg = onboarding_sheets.consume_welcome_repair_alert()
-    assert 'open_spots_repair=not_performed' in (msg or '')
+    assert 'open_spots_repair=not_performed' not in (msg or '')
 
 
 def test_promo_first_time_placement_decrements_once(monkeypatch, caplog):


### PR DESCRIPTION
### Motivation

- Make the Welcome ticket repair pass provide clearer, less noisy alerts and structured logs when records need manual review. 
- Surface why records are flagged via `review_reason` when possible and fall back to app logs when sheet columns are missing. 

### Description

- Add tracking fields `review_detail_rows` and `app_logged_review_details` and return a richer summary from `repair_welcome_rows` and `run_welcome_ticket_repair_pass` by using `dict[str, Any]` return types. 
- Populate `review_reason` for flagged rows when available and write it to the sheet, and emit structured `log.warning` records with ticket/row/reason details for audit. 
- Add `_format_welcome_repair_alert` to craft concise user-facing messages that omit noisy counters (like malformed counts) and distinguish between sheet-visible review details and app-only logs, and wire `_queue_welcome_repair_alert` to use it. 
- Handle missing required headers by logging an error, returning a `config_error` in the summary, and skipping the repair pass safely. 
- Minor typing import change (`Any` added) and non-functional test updates to exercise the new behavior and messages.

### Testing

- Ran the onboarding repair unit tests in `tests/onboarding/test_onboarding_repair_logic.py`, which validate duplicate identity repair, conflicting identity handling, missing header behavior, alert message variants, and structured logging; all tests passed. 
- Ran the open-spot visibility test change in `tests/onboarding/test_open_spot_visibility_logging.py` that asserts the updated alert wording omits unrelated open-spots text; the test passed. 
- Logging-related assertions were exercised with `caplog` to verify structured `warning`/`error` output; those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28656e763083239b288228a00617df)