### PR TITLE
Make Statistics sheet parsing header-driven, preserve bracket order, and add tests

### DIFF
--- a/modules/recruitment/reporting/daily_recruiter_update.py
+++ b/modules/recruitment/reporting/daily_recruiter_update.py
@@ -72,6 +72,14 @@ def _role_mentions() -> Sequence[str]:
 
 
 HeadersMap = Dict[str, int]
+_REPORT_REQUIRED_HEADERS = (
+    "h1 headline",
+    "h2 headline",
+    "key",
+    "open spots",
+    "inactives",
+    "reserved spots",
+)
 
 
 def _normalize_header(label: str) -> str:
@@ -100,7 +108,9 @@ def _parse_int(text: str) -> int:
         return 0
 
 
-def _find_row_equals(rows: Sequence[Sequence[str]], column: int, needle: str) -> int:
+def _find_row_equals(rows: Sequence[Sequence[str]], column: int | None, needle: str) -> int:
+    if column is None:
+        return -1
     target = (needle or "").strip().lower()
     for idx, row in enumerate(rows):
         value = str(row[column] if column < len(row) else "").strip().lower()
@@ -113,14 +123,14 @@ def _collect_block(
     rows: Sequence[Sequence[str]],
     *,
     start_row: int,
-    stop_column: int,
+    stop_column: int | None,
     stop_value: str,
 ) -> List[Sequence[str]]:
     collected: List[Sequence[str]] = []
     stop_normalized = (stop_value or "").strip().lower()
     for idx in range(start_row + 1, len(rows)):
         row = rows[idx]
-        value = str(row[stop_column] if stop_column < len(row) else "").strip().lower()
+        value = _column(row, stop_column).strip().lower()
         if value == stop_normalized:
             break
         collected.append(row)
@@ -131,40 +141,67 @@ def _collect_bracket_sections(
     rows: Sequence[Sequence[str]],
     *,
     start_row: int,
-) -> Tuple[Dict[str, List[Sequence[str]]], Dict[str, Tuple[int, int, int]]]:
-    wanted = [
-        "elite end game",
-        "early end game",
-        "late game",
-        "mid game",
-        "early game",
-        "beginners",
-    ]
-    sections: Dict[str, List[Sequence[str]]] = {label: [] for label in wanted}
-    totals: Dict[str, Tuple[int, int, int]] = {label: (0, 0, 0) for label in wanted}
-    active: Optional[str] = None
-    for idx in range(start_row, len(rows)):
-        row = rows[idx]
-        group = str(row[1] if len(row) > 1 else "").strip().lower()
-        if group in sections:
-            active = group
-            open_total = _parse_int(row[3] if len(row) > 3 else "0")
-            inactive_total = _parse_int(row[4] if len(row) > 4 else "0")
-            reserved_total = _parse_int(row[5] if len(row) > 5 else "0")
-            totals[group] = (open_total, inactive_total, reserved_total)
-            continue
-        if active is None:
-            continue
+    headers: HeadersMap,
+) -> List[Tuple[str, List[Sequence[str]]]]:
+    """Collect Bracket Details groups in the same order they appear in the sheet.
+
+    The Statistics sheet marks Bracket Details groups in the configured
+    ``H2_Headline`` column, then lists clan rows below each heading using the
+    configured ``Key`` column. Do not hardcode bracket names or column
+    positions here; the sheet layout is allowed to reorder columns as long as
+    the existing header row supplies the schema.
+    """
+
+    h1_index = _resolve_index(headers, "h1 headline")
+    h2_index = _resolve_index(headers, "h2 headline")
+    key_index = _resolve_index(headers, "key")
+    if h2_index is None or key_index is None:
+        return []
+
+    sections: List[Tuple[str, List[Sequence[str]]]] = []
+    active_index: int | None = None
+
+    for row in rows[start_row:]:
         if not any(str(cell).strip() for cell in row):
-            active = None
+            active_index = None
             continue
-        sections[active].append(row)
-    return sections, totals
+
+        section_label = _column(row, h1_index).strip()
+        bracket_label = _column(row, h2_index).strip()
+        key_label = _column(row, key_index).strip()
+
+        if section_label and not bracket_label and not key_label:
+            active_index = None
+            continue
+
+        if bracket_label and not key_label:
+            sections.append((bracket_label, []))
+            active_index = len(sections) - 1
+            continue
+
+        if active_index is None or not key_label:
+            continue
+
+        sections[active_index][1].append(row)
+
+    return sections
 
 
 def _resolve_index(headers: HeadersMap, name: str) -> Optional[int]:
     normalized = _normalize_header(name)
     return headers.get(normalized)
+
+
+def _require_report_headers(headers: HeadersMap) -> None:
+    missing = [
+        name
+        for name in _REPORT_REQUIRED_HEADERS
+        if _resolve_index(headers, name) is None
+    ]
+    if missing:
+        raise ValueError(
+            f"Statistics report missing required header(s): {', '.join(missing)}"
+        )
 
 
 def _format_line(
@@ -223,13 +260,16 @@ async def _fetch_report_rows() -> Tuple[List[List[str]], HeadersMap]:
 def _extract_report_sections(
     rows: Sequence[Sequence[str]], headers: HeadersMap
 ) -> ReportSections:
-    general_index = _find_row_equals(rows, 0, "general overview")
-    per_bracket_index = _find_row_equals(rows, 0, "per bracket")
-    details_index = _find_row_equals(rows, 0, "bracket details")
+    _require_report_headers(headers)
+    h1_index = _resolve_index(headers, "h1 headline")
+    key_index = _resolve_index(headers, "key")
+    general_index = _find_row_equals(rows, h1_index, "general overview")
+    per_bracket_index = _find_row_equals(rows, h1_index, "per bracket")
+    details_index = _find_row_equals(rows, h1_index, "bracket details")
 
     general_lines: List[str] = []
     if general_index != -1:
-        stop_column = 0
+        stop_column = h1_index
         if per_bracket_index != -1:
             stop_value = "per bracket"
         elif details_index != -1:
@@ -242,7 +282,6 @@ def _extract_report_sections(
             stop_column=stop_column,
             stop_value=stop_value,
         )
-        key_index = _resolve_index(headers, "key")
         always_visible = {"overall", "top 10", "top 5"}
         for row in block:
             label = _column(row, key_index).strip().lower() if key_index is not None else ""
@@ -256,10 +295,9 @@ def _extract_report_sections(
         block = _collect_block(
             rows,
             start_row=per_bracket_index,
-            stop_column=0,
+            stop_column=h1_index,
             stop_value=stop_value,
         )
-        key_index = _resolve_index(headers, "key")
         for row in block:
             label = _column(row, key_index).strip() if key_index is not None else ""
             if not label:
@@ -274,24 +312,21 @@ def _extract_report_sections(
     elif per_bracket_index != -1:
         details_start = per_bracket_index + 1
 
-    sections: Dict[str, List[Sequence[str]]] = {}
+    sections: List[Tuple[str, List[Sequence[str]]]] = []
     if details_start > 0 and details_start < len(rows):
-        sections, _ = _collect_bracket_sections(rows, start_row=details_start)
+        sections = _collect_bracket_sections(
+            rows, start_row=details_start, headers=headers
+        )
 
-    order = [
-        "elite end game",
-        "early end game",
-        "late game",
-        "mid game",
-        "early game",
-        "beginners",
-    ]
     detail_blocks: List[Tuple[str, List[str]]] = []
-    for key in order:
-        entries = sections.get(key) or []
-        formatted = [line for row in entries if (line := _format_line(headers, row))]
+    for label, entries in sections:
+        formatted = [
+            line
+            for row in entries
+            if (line := _format_line(headers, row, always=True))
+        ]
         if formatted:
-            detail_blocks.append((key, formatted))
+            detail_blocks.append((label, formatted))
 
     return ReportSections(
         general_lines=general_lines,
@@ -514,11 +549,16 @@ async def post_daily_recruiter_update(bot: discord.Client) -> Tuple[bool, str]:
         fetch_error = _format_error(exc)
         log.warning("failed to fetch recruiter report rows", exc_info=True)
 
-    sections = _extract_report_sections(rows, headers)
-    summary_embed = _build_summary_embed(sections)
+    try:
+        sections = _extract_report_sections(rows, headers)
+        summary_embed = _build_summary_embed(sections)
+        pager_view = OpenSpotsPager(sections)
+    except Exception as exc:
+        log.warning("failed to build recruiter report", exc_info=True)
+        return False, _format_error(exc)
+
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     content = _report_content(today)
-    pager_view = OpenSpotsPager(sections)
 
     try:
         await channel.send(content=content, embeds=[summary_embed], view=pager_view)

--- a/tests/recruitment/test_daily_recruiter_update.py
+++ b/tests/recruitment/test_daily_recruiter_update.py
@@ -8,20 +8,28 @@ from cogs.recruitment_reporting import RecruitmentReporting
 
 def _sample_rows():
     return [
-        ["Key", "Grouping", "Open Spots", "Inactives", "Reserved Spots"],
-        ["General Overview", "", "", "", ""],
-        ["Ops Summary", "", "3", "1", "0"],
-        ["Ops Idle", "", "0", "0", "0"],
-        ["Per Bracket", "", "", "", ""],
-        ["Elite End Game", "", "2", "0", "1"],
-        ["Mid Game", "", "0", "0", "0"],
-        ["Bracket Details", "", "", "", ""],
-        ["", "Elite End Game", "", "", ""],
-        ["Clan Alpha", "", "5", "0", "1"],
-        ["Clan Beta", "", "0", "0", "0"],
-        ["", "", "", "", ""],
-        ["", "Mid Game", "", "", ""],
-        ["Clan Delta", "", "2", "2", "0"],
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["General Overview", "", "", "", "", ""],
+        ["", "", "Ops Summary", "3", "1", "0"],
+        ["", "", "Ops Idle", "0", "0", "0"],
+        ["Per Bracket", "", "", "", "", ""],
+        ["", "", "Elite End Game", "2", "0", "1"],
+        ["", "", "Mid Game", "0", "0", "0"],
+        ["Bracket Details", "", "", "", "", ""],
+        ["", "Elite End Game", "", "", "", ""],
+        ["", "", "Clan Alpha", "5", "0", "1"],
+        ["", "", "Elders", "0", "0", "0"],
+        ["", "", "Cambions", "0", "0", "0"],
+        ["", "", "", "", "", ""],
+        ["", "Mid Game", "", "", "", ""],
+        ["", "", "Clan Delta", "2", "2", "0"],
     ]
 
 
@@ -58,12 +66,79 @@ def test_build_embeds_from_rows_filters_and_groups():
     assert elite_end_game.name == "Elite End Game"
     assert elite_end_game.inline is False
     assert "🔹 **Clan Alpha:** open 5 | inactives 0 | reserved 1" in elite_end_game.value
-    assert "Clan Beta" not in elite_end_game.value
+    assert "🔹 **Elders:** open 0 | inactives 0 | reserved 0" in elite_end_game.value
+    assert "🔹 **Cambions:** open 0 | inactives 0 | reserved 0" in elite_end_game.value
 
     mid_game = details_embed.fields[1]
     assert mid_game.name == "Mid Game"
     assert mid_game.inline is False
     assert "🔹 **Clan Delta:** open 2 | inactives 2 | reserved 0" in mid_game.value
+
+
+def test_bracket_details_include_zero_rows_and_preserve_sheet_order():
+    rows = [
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["Bracket Details", "", "", "", "", ""],
+        ["", "First Sheet Bracket", "", "", "", ""],
+        ["", "", "Island Arena", "0", "0", "0"],
+        ["", "", "Active Clan", "4", "1", "2"],
+        ["", "Second Sheet Bracket", "", "", "", ""],
+        ["", "", "Vindicators", "0", "0", "0"],
+        ["", "", "Warlords", "0", "0", "0"],
+        ["", "", "Eff-It", "0", "0", "0"],
+    ]
+    headers = dru._headers_map(rows[0])
+
+    sections = dru._extract_report_sections(rows, headers)
+    details_embed = dru._build_details_embed(sections)
+
+    assert [field.name for field in details_embed.fields] == [
+        "First Sheet Bracket",
+        "Second Sheet Bracket",
+    ]
+    first_value = details_embed.fields[0].value
+    assert "🔹 **Island Arena:** open 0 | inactives 0 | reserved 0" in first_value
+    assert "🔹 **Active Clan:** open 4 | inactives 1 | reserved 2" in first_value
+    assert first_value.index("Island Arena") < first_value.index("Active Clan")
+    second_value = details_embed.fields[1].value
+    assert "🔹 **Vindicators:** open 0 | inactives 0 | reserved 0" in second_value
+    assert "🔹 **Warlords:** open 0 | inactives 0 | reserved 0" in second_value
+    assert "🔹 **Eff-It:** open 0 | inactives 0 | reserved 0" in second_value
+
+
+def test_live_headers_drive_sections_brackets_and_clan_names_without_grouping():
+    rows = [
+        [
+            "reserved_spots",
+            "H2_Headline",
+            "inactives",
+            "Key",
+            "H1_Headline",
+            "open_spots",
+        ],
+        ["", "", "", "", "Bracket Details", ""],
+        ["", "Configured H2 Bracket", "", "", "", ""],
+        ["0", "", "0", "Key Clan Zero", "", "0"],
+        ["3", "", "1", "Key Clan Active", "", "2"],
+    ]
+    headers = dru._headers_map(rows[0])
+
+    assert "grouping" not in headers
+    sections = dru._extract_report_sections(rows, headers)
+    details_embed = dru._build_details_embed(sections)
+
+    assert len(details_embed.fields) == 1
+    assert details_embed.fields[0].name == "Configured H2 Bracket"
+    value = details_embed.fields[0].value
+    assert "🔹 **Key Clan Zero:** open 0 | inactives 0 | reserved 0" in value
+    assert "🔹 **Key Clan Active:** open 2 | inactives 1 | reserved 3" in value
 
 
 def test_open_spots_pager_switches_pages():


### PR DESCRIPTION
### Motivation
- Make the recruitment Statistics sheet parsing resilient to column reordering and avoid hardcoded column positions and bracket names. 
- Ensure bracket detail groups preserve the order from the sheet and include zero-count clan rows. 
- Fail fast when required headers are missing to surface misconfigured sheets earlier.

### Description
- Replace hardcoded column indices and bracket name lists with header-driven lookups via `_headers_map`, `_resolve_index`, and a new `_REPORT_REQUIRED_HEADERS` check enforced by `_require_report_headers`.
- Rework `_collect_bracket_sections` to detect H1/H2/Key columns from the live header row, preserve sheet ordering, return an ordered list of `(label, rows)`, and include zero rows; remove the old totals map and hardcoded bracket ordering.
- Update `_collect_block`, `_find_row_equals`, `_format_line`, and `_extract_report_sections` to use resolved header indices and to raise a clear error when required headers are missing; adjust function signatures accordingly and add defensive checks.
- Add header-driven tests and adjust existing tests in `tests/recruitment/test_daily_recruiter_update.py` to match the new schema, and add new tests verifying zero-row inclusion, sheet-order preservation, and that arbitrary header ordering still works.
- Improve error handling in `post_daily_recruiter_update` so report-building failures are logged and returned instead of proceeding to send incomplete payloads.

### Testing
- Ran `pytest tests/recruitment/test_daily_recruiter_update.py` which covers the summary/details builders and pager behavior, and the updated/added tests for header-driven parsing, and they passed. 
- Executed the recruitment reporting unit tests locally and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29a80526248323bfb68867ef486427)