### PR TITLE
Persist Promo ticket metadata to live Promo headers and bound startup backfill

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -54,7 +54,7 @@ log = logging.getLogger("c1c.onboarding.promo_watcher")
 
 def _promo_headers_for_write(*, ticket: str | None = None) -> list[str]:
     try:
-        return onboarding_sheets.get_promo_headers()
+        return onboarding_sheets.get_live_promo_headers()
     except Exception:
         log.exception(
             "promo source clan header mapping unavailable; cannot write Promo row",
@@ -89,6 +89,13 @@ def _promo_finalization_state(row_values: dict[str, str] | list[str] | None) -> 
         return onboarding_sheets.get_ticket_finalization_state("promo", row_values)
     except Exception:
         log.exception("promo finalization state unavailable")
+        if isinstance(row_values, dict):
+            return {
+                "finalization_status": str(row_values.get("finalization_status", "") or "").strip(),
+                "reservation_status": str(row_values.get("reservation_status", "") or "").strip(),
+                "clan_update_status": str(row_values.get("clan_update_status", "") or "").strip(),
+                "finalization_note": str(row_values.get("finalization_note", "") or "").strip(),
+            }
         return {}
 
 
@@ -108,6 +115,13 @@ _PROMO_TRIGGER_LABELS: Dict[str, str] = {
     "promo.m": "Player move request",
     "promo.l": "Clan lead move request",
 }
+PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS = 48
+_PROMO_BACKFILL_TIMESTAMP_HEADERS = (
+    "date closed",
+    "updated_at",
+    "created_at",
+    "thread created",
+)
 
 
 async def _ensure_fresh_clans_for_placement(*, actor: str, ticket: str, user: str) -> bool:
@@ -244,6 +258,37 @@ def _promo_trigger_from_content(content: str | None) -> Tuple[str | None, str | 
     for marker, flow in _PROMO_TRIGGER_MAP.items():
         if marker in text:
             return marker, flow
+    return None, None
+
+
+def _parse_backfill_timestamp(value: object) -> dt.datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    candidates = [text]
+    if " " in text and "T" not in text:
+        candidates.append(text.replace(" ", "T", 1))
+    if len(text) >= 10:
+        candidates.append(text[:10])
+    for candidate in candidates:
+        try:
+            if len(candidate) == 10 and candidate[4] == "-" and candidate[7] == "-":
+                parsed = dt.datetime.combine(dt.date.fromisoformat(candidate), dt.time.min)
+            else:
+                parsed = dt.datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    return None
+
+
+def _backfill_row_timestamp(values: dict[str, str]) -> tuple[dt.datetime | None, str | None]:
+    for header in _PROMO_BACKFILL_TIMESTAMP_HEADERS:
+        parsed = _parse_backfill_timestamp(values.get(header))
+        if parsed is not None:
+            return parsed, header
     return None, None
 
 
@@ -500,6 +545,62 @@ class PromoTicketWatcher(commands.Cog):
                 context.username,
                 exc,
             )
+        await self._patch_ticket_metadata(
+            phase="created_metadata",
+            thread=thread,
+            context=context,
+            user_id=user_id,
+            status="open",
+            created_at=created,
+        )
+
+    async def _patch_ticket_metadata(
+        self,
+        *,
+        phase: str,
+        thread: discord.Thread,
+        context: PromoTicketContext,
+        user_id: int | str | None = None,
+        panel_message_id: int | str | None = None,
+        status: str | None = None,
+        review_reason: str | None = None,
+        created_at: dt.datetime | None = None,
+        updated_at: dt.datetime | None = None,
+    ) -> str | None:
+        resolved_user_id = user_id if user_id is not None else context.user_id
+        reason = review_reason
+        if resolved_user_id is None and not reason:
+            reason = "user_id unresolved from Ticket Tool intro message"
+            log.warning(
+                "promo metadata user_id unresolved",
+                extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
+            )
+        try:
+            result = await asyncio.to_thread(
+                onboarding_sheets.patch_promo_ticket_metadata,
+                ticket=context.ticket_number,
+                thread_id=getattr(thread, "id", None),
+                thread_name=getattr(thread, "name", ""),
+                username=context.username,
+                user_id=resolved_user_id,
+                panel_message_id=panel_message_id,
+                status=status or context.state or "open",
+                review_reason=reason,
+                created_at=created_at or getattr(thread, "created_at", None),
+                updated_at=updated_at,
+            )
+        except Exception:
+            log.exception(
+                "promo metadata write failed",
+                extra={"phase": phase, "ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
+            )
+            return None
+        log.info(
+            "promo metadata write %s",
+            result,
+            extra={"phase": phase, "ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
+        )
+        return result
 
     async def _ensure_row_initialized(self, thread: discord.Thread, context: PromoTicketContext) -> None:
         try:
@@ -591,6 +692,14 @@ class PromoTicketWatcher(commands.Cog):
             return
         view.message = message
         context.prompt_message_id = message.id
+        await self._patch_ticket_metadata(
+            phase="close_prompt_metadata",
+            thread=thread,
+            context=context,
+            panel_message_id=message.id,
+            status="prompt_required",
+            updated_at=getattr(message, "created_at", None),
+        )
         log.info("close_prompt_started", extra={"flow": "promo", "trigger": trigger, "thread_id": getattr(thread, "id", None), "ticket": context.ticket_number})
         await _send_placement_log_line(flow="promo", outcome="prompt", ticket=context.ticket_number, player=context.username, trigger=trigger, finalization_status="prompt_required", reason="missing_source_destination", action="prompted_staff")
 
@@ -822,21 +931,35 @@ class PromoTicketWatcher(commands.Cog):
             await thread.send("⚠️ Promo source clan header mapping is missing. Please fix Config before closing this promo ticket.")
             return
 
+        row_map = {
+            "ticketnumber": context.ticket_number,
+            "username": context.username,
+            "clantag": context.clan_tag,
+            "sourceclantag": context.source_clan_tag,
+            "dateclosed": timestamp,
+            "type": context.promo_type,
+            "threadcreated": context.thread_created,
+            "year": context.year,
+            "month": context.month,
+            "joinmonth": context.join_month,
+            "clanname": clan_name,
+            "progression": progression,
+        }
         row = [
-            context.ticket_number,
-            context.username,
-            context.clan_tag,
-            context.source_clan_tag,
-            timestamp,
-            context.promo_type,
-            context.thread_created,
-            context.year,
-            context.month,
-            context.join_month,
-            clan_name,
-            progression,
+            row_map.get(
+                "".join(ch for ch in str(header or "").lower() if ch.isalnum()),
+                "",
+            )
+            for header in promo_headers
         ]
         try:
+            await self._patch_ticket_metadata(
+                phase="finalization_metadata",
+                thread=thread,
+                context=context,
+                panel_message_id=context.prompt_message_id,
+                status="closed",
+            )
             result = await log_sheet_write(
                 flow="promo",
                 phase=phase or "close",
@@ -1047,90 +1170,16 @@ class PromoTicketWatcher(commands.Cog):
         created_at: dt.datetime,
         user_ref: str,
     ) -> None:
-        created_value = created_at.isoformat()
-        updated_value = dt.datetime.now(UTC).isoformat()
-        try:
-            promo_headers = _promo_headers_for_write(ticket=context.ticket_number)
-        except Exception:
-            log.warning(
-                "promo reminder: source clan header mapping missing; skipping sheet touch",
-                extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
-            )
-            return
-
-        try:
-            existing = await asyncio.to_thread(
-                onboarding_sheets.find_promo_row, context.ticket_number
-            )
-        except Exception:
-            log.debug(
-                "promo reminder: failed to load promo row for sheet logging",
-                exc_info=True,
-                extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
-            )
-            existing = None
-
-        if existing:
-            row_values = (
-                [existing[1].get(header, "") for header in promo_headers]
-                if isinstance(existing[1], dict)
-                else list(existing[1])
-            )
-        else:
-            row_values = [
-                context.ticket_number,
-                context.username,
-                context.clan_tag,
-                context.source_clan_tag,
-                "",
-                context.promo_type,
-                context.thread_created,
-                context.year,
-                context.month,
-                context.join_month,
-                context.clan_name,
-                context.progression,
-                getattr(thread, "name", ""),
-                str(context.user_id or ""),
-                str(getattr(thread, "id", 0)),
-                "",
-                context.state,
-                "",
-                created_value,
-                "",
-            ]
-
-        if len(row_values) < len(promo_headers):
-            row_values.extend(["" for _ in range(len(promo_headers) - len(row_values))])
-
-        try:
-            created_idx = promo_headers.index("created_at")
-            updated_idx = promo_headers.index("updated_at")
-        except ValueError:
-            return
-
-        if not row_values[created_idx]:
-            row_values[created_idx] = created_value
-        row_values[updated_idx] = updated_value
-
-        try:
-            await log_sheet_write(
-                flow="promo",
-                phase=phase,
-                tab="Promo",
-                logger=log,
-                thread=thread,
-                user=user_ref,
-                write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_promo, row_values, promo_headers
-                ),
-            )
-        except Exception:
-            log.debug(
-                "promo reminder: sheet touch failed",
-                exc_info=True,
-                extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
-            )
+        _ = user_ref
+        await self._patch_ticket_metadata(
+            phase=phase,
+            thread=thread,
+            context=context,
+            panel_message_id=context.prompt_message_id,
+            status=context.state or "open",
+            created_at=created_at,
+            updated_at=dt.datetime.now(UTC),
+        )
 
     async def auto_close_ticket(
         self, thread: discord.Thread, context: PromoTicketContext
@@ -1343,6 +1392,14 @@ class PromoTicketWatcher(commands.Cog):
                 flow=flow_key,
                 trigger_message=message,
             )
+            if getattr(outcome, "panel_message_id", None):
+                await self._patch_ticket_metadata(
+                    phase="panel_metadata",
+                    thread=thread,
+                    context=context,
+                    panel_message_id=outcome.panel_message_id,
+                    status="open",
+                )
             self._log_panel_outcome(
                 message.author,
                 thread,
@@ -1414,6 +1471,14 @@ class PromoTicketWatcher(commands.Cog):
             flow=flow_key,
             trigger_message=message,
         )
+        if getattr(outcome, "panel_message_id", None):
+            await self._patch_ticket_metadata(
+                phase="panel_metadata",
+                thread=thread,
+                context=context,
+                panel_message_id=outcome.panel_message_id,
+                status="open",
+            )
         self._log_panel_outcome(
             message.author,
             thread,
@@ -1502,7 +1567,17 @@ class PromoTicketWatcher(commands.Cog):
         # Startup watcher status is included in the global startup summary.
 
     async def run_close_backfill(self) -> dict[str, int]:
-        summary = {"scanned": 0, "finalized": 0, "prompt_required": 0, "already_done": 0, "unresolved": 0, "error": 0}
+        summary = {
+            "scanned": 0,
+            "finalized": 0,
+            "prompt_required": 0,
+            "already_done": 0,
+            "unresolved": 0,
+            "error": 0,
+            "skipped_old": 0,
+            "skipped_no_timestamp": 0,
+        }
+        cutoff = dt.datetime.now(UTC) - dt.timedelta(hours=PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS)
         try:
             rows = await asyncio.to_thread(onboarding_sheets.list_ticket_rows_for_finalization_backfill, "promo")
         except Exception:
@@ -1517,6 +1592,28 @@ class PromoTicketWatcher(commands.Cog):
             thread_id = str(values.get("thread_id") or values.get("thread") or "").strip()
             if status != "closed" and not thread_id:
                 continue
+            stamp, stamp_source = _backfill_row_timestamp(values)
+            ticket = values.get("ticket number") or values.get("ticket_number") or values.get("ticket")
+            if stamp is None:
+                summary["skipped_no_timestamp"] += 1
+                log.info(
+                    "close_backfill_skip_no_timestamp",
+                    extra={"flow": "promo", "thread_id": thread_id, "ticket": ticket},
+                )
+                continue
+            if stamp < cutoff:
+                summary["skipped_old"] += 1
+                log.debug(
+                    "close_backfill_skip_old",
+                    extra={
+                        "flow": "promo",
+                        "thread_id": thread_id,
+                        "ticket": ticket,
+                        "timestamp_source": stamp_source,
+                        "lookback_hours": PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS,
+                    },
+                )
+                continue
             summary["scanned"] += 1
             thread = None
             if thread_id:
@@ -1527,7 +1624,6 @@ class PromoTicketWatcher(commands.Cog):
                         thread = await self.bot.fetch_channel(tid)
                 except Exception:
                     thread = None
-            ticket = values.get("ticket number") or values.get("ticket_number") or values.get("ticket")
             player = values.get("username") or "unknown"
             sheet_closed = status == "closed"
             thread_closed = bool(thread is not None and _is_closed_thread(thread))

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -372,27 +372,36 @@ def _ensure_headers(ws, headers: Sequence[str]) -> List[str]:
 
 
 def _ensure_promo_headers(ws) -> List[str]:
-    """Ensure Promo headers without silently adding a missing source column.
+    """Return the live Promo header row without mutating it.
 
-    Empty worksheets are initialized, but an existing Promo header row must
-    already contain the Config-resolved source clan header so row data cannot be
-    shifted accidentally.
+    Promo column order is operator-owned. Existing headers are the source of
+    truth; callers must map writes by matching header names only.
     """
 
-    desired = get_promo_headers()
-    source_header = get_promo_source_clan_tag_header()
     try:
         existing = core.call_with_backoff(ws.row_values, 1)
     except Exception:
         existing = []
-    if existing:
-        normalized_existing = {_normalize_header_name(header) for header in existing}
-        if _normalize_header_name(source_header) not in normalized_existing:
-            raise RuntimeError(
-                "Promo sheet missing configured source clan header "
-                f"{PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY}={source_header!r}"
-            )
-    return _ensure_headers(ws, desired)
+    header = [str(value or "").strip() for value in existing]
+    if not any(header):
+        raise RuntimeError("Promo sheet header row missing; refusing to write")
+
+    source_header = get_promo_source_clan_tag_header()
+    normalized_existing = {_normalize_header_name(col) for col in header}
+    if _normalize_header_name(source_header) not in normalized_existing:
+        raise RuntimeError(
+            "Promo sheet missing configured source clan header "
+            f"{PROMO_SOURCE_CLAN_TAG_HEADER_CONFIG_KEY}={source_header!r}"
+        )
+    return header
+
+
+def get_live_promo_headers() -> List[str]:
+    """Return the operator-owned live Promo header row."""
+
+    sheet_id, tab = _resolve_onboarding_and_promo_tab()
+    ws = core.get_worksheet(sheet_id, tab)
+    return _ensure_promo_headers(ws)
 
 
 def _fmt_ticket(ticket: str | None) -> str:
@@ -1000,12 +1009,182 @@ def upsert_promo(
     existing_map = existing[1] if existing else {}
     if len(incoming) < len(resolved_headers):
         incoming.extend("" for _ in range(len(resolved_headers) - len(incoming)))
+    for idx, header in enumerate(resolved_headers):
+        if idx >= len(incoming):
+            continue
+        if str(incoming[idx] or "").strip():
+            continue
+        existing_value = existing_map.get(header, "")
+        if str(existing_value or "").strip():
+            incoming[idx] = existing_value
     for field, header in final_headers.items():
         col = _column_index(resolved_headers, header, default=-1)
         if col >= 0 and not str(incoming[col] or "").strip():
             incoming[col] = existing_map.get(header, "") or ("pending" if field != "finalization_note" else "")
     keys = [("ticket number", _fmt_ticket)]
     return _upsert(ws, keys, incoming, resolved_headers)
+
+
+PROMO_METADATA_REQUIRED_HEADERS = {
+    "ticketnumber": "ticket number",
+    "threadid": "thread_id",
+}
+PROMO_METADATA_FIELDS = {
+    "ticketnumber",
+    "username",
+    "threadname",
+    "userid",
+    "threadid",
+    "panelmessageid",
+    "status",
+    "reviewreason",
+    "createdat",
+    "updatedat",
+}
+PROMO_METADATA_PRESERVE_FIELDS = {
+    "ticketnumber",
+    "username",
+    "clantag",
+    "sourceclantag",
+    "dateclosed",
+    "type",
+    "threadcreated",
+    "finalizationstatus",
+    "reservationstatus",
+    "clanupdatestatus",
+    "finalizationnote",
+    "year",
+    "month",
+    "joinmonth",
+    "clanname",
+    "progression",
+}
+
+
+def patch_promo_ticket_metadata(
+    *,
+    ticket: str | None,
+    thread_id: int | str | None = None,
+    thread_name: str | None = None,
+    username: str | None = None,
+    user_id: int | str | None = None,
+    panel_message_id: int | str | None = None,
+    status: str | None = None,
+    review_reason: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> str:
+    """Patch Promo ticket metadata using the live sheet headers.
+
+    Existing nonblank values are preserved unless the incoming value is a
+    lifecycle update that is expected to be newer (status, panel id, updated_at,
+    review_reason). Business and finalization columns are never changed here.
+    """
+
+    sheet_id, tab = _resolve_onboarding_and_promo_tab()
+    ws = core.get_worksheet(sheet_id, tab)
+    header = _ensure_promo_headers(ws)
+    normalized_header = [_normalize_header_name(col) for col in header]
+    idx = {name: pos for pos, name in enumerate(normalized_header)}
+
+    missing = [
+        label
+        for normalized, label in PROMO_METADATA_REQUIRED_HEADERS.items()
+        if normalized not in idx
+    ]
+    if missing:
+        log.warning(
+            "promo metadata skipped: missing required header",
+            extra={"missing_headers": missing, "ticket": _fmt_ticket(ticket), "thread_id": thread_id},
+        )
+        return "skipped_missing_header"
+
+    ticket_value = _fmt_ticket(ticket)
+    thread_value = str(thread_id or "").strip()
+    if not ticket_value and not thread_value:
+        log.warning("promo metadata skipped: missing ticket and thread_id")
+        return "skipped_missing_key"
+
+    values = core.call_with_backoff(ws.get_all_values)
+    row_number: int | None = None
+    row_values: list[str] | None = None
+
+    thread_idx = idx.get("threadid")
+    ticket_idx = idx.get("ticketnumber")
+
+    if thread_value and thread_idx is not None:
+        for current_idx, row in enumerate(values[1:], start=2):
+            current = row[thread_idx] if thread_idx < len(row) else ""
+            if str(current or "").strip() == thread_value:
+                row_number = current_idx
+                row_values = list(row)
+                break
+
+    if row_number is None and ticket_value and ticket_idx is not None:
+        for current_idx, row in enumerate(values[1:], start=2):
+            current = row[ticket_idx] if ticket_idx < len(row) else ""
+            if _fmt_ticket(current) == ticket_value:
+                row_number = current_idx
+                row_values = list(row)
+                break
+
+    if row_values is None:
+        row_values = ["" for _ in header]
+    elif len(row_values) < len(header):
+        row_values.extend("" for _ in range(len(header) - len(row_values)))
+
+    now = updated_at or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    created = created_at
+    if created is not None and created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+
+    incoming = {
+        "ticketnumber": ticket_value,
+        "username": str(username or "").strip(),
+        "threadname": str(thread_name or "").strip(),
+        "userid": str(user_id).strip() if user_id is not None else "",
+        "threadid": thread_value,
+        "panelmessageid": str(panel_message_id).strip() if panel_message_id is not None else "",
+        "status": str(status or "").strip(),
+        "reviewreason": str(review_reason or "").strip(),
+        "createdat": created.isoformat() if created is not None else "",
+        "updatedat": now.isoformat(),
+    }
+
+    changed = False
+    for field, value in incoming.items():
+        if field not in idx or field not in PROMO_METADATA_FIELDS:
+            continue
+        if not value:
+            continue
+        current = str(row_values[idx[field]] or "").strip()
+        if field in PROMO_METADATA_PRESERVE_FIELDS and current:
+            continue
+        if field in {"threadid", "userid", "threadname", "createdat"} and current:
+            continue
+        if field == "reviewreason" and current and current == value:
+            continue
+        if field == "panelmessageid" and current == value:
+            continue
+        if field == "status" and current == value:
+            continue
+        if field == "updatedat" and current == value:
+            continue
+        row_values[idx[field]] = value
+        changed = True
+
+    if not changed:
+        return "unchanged"
+
+    if row_number is None:
+        core.call_with_backoff(ws.append_row, row_values[: len(header)], value_input_option="RAW")
+        return "inserted"
+
+    end_col = _col_to_a1(len(header) - 1)
+    core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row_values[: len(header)]])
+    return "updated"
 
 
 def append_promo_ticket_row(

--- a/tests/onboarding/test_promo_metadata_persistence.py
+++ b/tests/onboarding/test_promo_metadata_persistence.py
@@ -1,0 +1,302 @@
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from modules.onboarding import watcher_promo
+from shared.sheets import onboarding as onboarding_sheets
+
+LIVE_PROMO_HEADERS = [
+    "ticket number",
+    "username",
+    "clantag",
+    "source_clan_tag",
+    "date closed",
+    "type",
+    "thread created",
+    "thread_name",
+    "user_id",
+    "thread_id",
+    "panel_message_id",
+    "status",
+    "review_reason",
+    "created_at",
+    "updated_at",
+    "finalization_status",
+    "reservation_status",
+    "clan_update_status",
+    "finalization_note",
+    "year",
+    "month",
+    "join_month",
+    "clan name",
+    "progression",
+]
+
+
+class FakeWorksheet:
+    id = 1
+
+    def __init__(self, headers=None):
+        self.rows = [list(headers or LIVE_PROMO_HEADERS)]
+        self.header_updates = []
+
+    def row_values(self, idx):
+        return self.rows[idx - 1] if len(self.rows) >= idx else []
+
+    def get_all_values(self):
+        return self.rows
+
+    def update(self, cell_range, values):
+        if cell_range == "A1":
+            self.header_updates.append(list(values[0]))
+        row_label = cell_range.split(":", 1)[0]
+        row_number = int("".join(ch for ch in row_label if ch.isdigit()) or "1")
+        while len(self.rows) < row_number:
+            self.rows.append([])
+        self.rows[row_number - 1] = list(values[0])
+
+    def append_row(self, row, value_input_option=None):
+        self.rows.append(list(row))
+
+
+@pytest.fixture
+def promo_sheet(monkeypatch):
+    worksheet = FakeWorksheet()
+    monkeypatch.setattr(onboarding_sheets.core, "call_with_backoff", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "PromoFromConfig"))
+    monkeypatch.setattr(onboarding_sheets, "_worksheet", lambda tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
+    monkeypatch.setattr(onboarding_sheets, "get_finalization_headers", lambda flow, **kwargs: {
+        "finalization_status": "finalization_status",
+        "reservation_status": "reservation_status",
+        "clan_update_status": "clan_update_status",
+        "finalization_note": "finalization_note",
+    })
+    return worksheet
+
+
+def _row_map(ws, row_idx=1):
+    return dict(zip(ws.rows[0], ws.rows[row_idx]))
+
+
+def test_patch_promo_metadata_writes_existing_headers_and_preserves_order(promo_sheet):
+    created = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0370",
+        username="Pastor Coco",
+        thread_name="M0370-Pastor-Coco",
+        user_id=123456789012345678,
+        thread_id=987654321098765432,
+        status="open",
+        created_at=created,
+        updated_at=created,
+    )
+
+    assert result == "inserted"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    assert promo_sheet.header_updates == []
+    row = _row_map(promo_sheet)
+    assert row["ticket number"] == "M0370"
+    assert row["thread_name"] == "M0370-Pastor-Coco"
+    assert row["user_id"] == "123456789012345678"
+    assert row["thread_id"] == "987654321098765432"
+    assert row["status"] == "open"
+    assert row["created_at"] == created.isoformat()
+    assert row["updated_at"] == created.isoformat()
+
+
+def test_patch_promo_metadata_panel_id_no_header_change(promo_sheet):
+    promo_sheet.rows.append(["M0370", "Pastor", "C1CE", "C1CV", "", "player move request", "2026", "M0370-Pastor", "", "777", "", "open", "", "old", "old", "pending", "none", "pending", "", "2026", "June", "", "", ""])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0370",
+        thread_id=777,
+        panel_message_id=444,
+        updated_at=dt.datetime(2026, 6, 14, 13, 0, tzinfo=dt.timezone.utc),
+    )
+
+    assert result == "updated"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    row = _row_map(promo_sheet)
+    assert row["panel_message_id"] == "444"
+    assert row["clantag"] == "C1CE"
+    assert row["finalization_status"] == "pending"
+
+
+def test_patch_promo_metadata_finalization_preserves_business_and_no_blank_overwrite(promo_sheet):
+    promo_sheet.rows.append(["M0370", "Pastor", "C1CE", "C1CV", "2026-06-14", "player move request", "2026-06-14 12:00", "M0370-Pastor", "111", "777", "333", "open", "", "created", "updated", "done", "released", "done", "final", "2026", "June", "", "Clan", "TH15"])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0370",
+        thread_id=777,
+        thread_name="",
+        user_id=None,
+        panel_message_id=None,
+        status="closed",
+        updated_at=dt.datetime(2026, 6, 14, 14, 0, tzinfo=dt.timezone.utc),
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["thread_name"] == "M0370-Pastor"
+    assert row["user_id"] == "111"
+    assert row["panel_message_id"] == "333"
+    assert row["status"] == "closed"
+    assert row["clantag"] == "C1CE"
+    assert row["source_clan_tag"] == "C1CV"
+    assert row["finalization_status"] == "done"
+    assert row["finalization_note"] == "final"
+    assert row["progression"] == "TH15"
+
+
+def test_patch_promo_metadata_missing_user_id_sets_review_reason(promo_sheet):
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0371",
+        username="No Mention",
+        thread_name="M0371-No-Mention",
+        thread_id=778,
+        status="open",
+        review_reason="user_id unresolved from Ticket Tool intro message",
+    )
+
+    assert result == "inserted"
+    row = _row_map(promo_sheet)
+    assert row["thread_name"] == "M0371-No-Mention"
+    assert row["thread_id"] == "778"
+    assert row["user_id"] == ""
+    assert row["review_reason"] == "user_id unresolved from Ticket Tool intro message"
+
+
+def test_patch_promo_metadata_missing_required_header_skips_without_header_rewrite(monkeypatch):
+    worksheet = FakeWorksheet(headers=[h for h in LIVE_PROMO_HEADERS if h != "thread_id"])
+    monkeypatch.setattr(onboarding_sheets.core, "call_with_backoff", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "PromoFromConfig"))
+    monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(ticket="M0372", thread_id=779)
+
+    assert result == "skipped_missing_header"
+    assert len(worksheet.rows) == 1
+    assert worksheet.header_updates == []
+
+
+def test_promo_close_backfill_runs_on_startup_with_bounded_runner(monkeypatch):
+    calls = []
+    monkeypatch.setattr(watcher_promo, "get_promo_channel_id", lambda: 1)
+    monkeypatch.setattr(watcher_promo, "get_ticket_tool_bot_id", lambda: 2)
+    monkeypatch.setattr(watcher_promo.feature_flags, "is_enabled", lambda name: True)
+    monkeypatch.setattr(watcher_promo, "_channel_readable_label", lambda bot, cid: "promo")
+
+    async def fake_backfill(self):
+        calls.append("backfill")
+        return {"scanned": 0}
+
+    monkeypatch.setattr(watcher_promo.PromoTicketWatcher, "run_close_backfill", fake_backfill)
+    watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace())
+
+    import asyncio
+    asyncio.run(watcher.on_ready())
+
+    assert calls == ["backfill"]
+
+
+def test_startup_backfill_includes_recent_unresolved_closed_promo(monkeypatch):
+    now = dt.datetime.now(dt.timezone.utc)
+    updates = []
+    logs = []
+    row = {
+        "ticket number": "M0401",
+        "username": "Recent",
+        "status": "closed",
+        "thread_id": "444401",
+        "updated_at": (now - dt.timedelta(hours=1)).isoformat(),
+        "finalization_status": "pending",
+        "thread_name": "Closed-M0401-Recent-C1CE",
+    }
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "list_ticket_rows_for_finalization_backfill", lambda flow: [(2, row)])
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *args, **kwargs: updates.append(kwargs) or "updated")
+
+    async def fake_log(**kwargs):
+        logs.append(kwargs)
+
+    monkeypatch.setattr(watcher_promo, "_send_placement_log_line", fake_log)
+    bot = SimpleNamespace(get_channel=lambda tid: None)
+    watcher = watcher_promo.PromoTicketWatcher(bot=bot)
+
+    import asyncio
+    summary = asyncio.run(watcher.run_close_backfill())
+
+    assert summary["scanned"] == 1
+    assert summary["unresolved"] == 1
+    assert updates and updates[0]["finalization_status"] == "skipped_unresolved"
+    assert logs and logs[0]["trigger"] == "startup_backfill"
+
+
+def test_startup_backfill_skips_closed_promo_older_than_48_hours(monkeypatch):
+    old = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=49)
+    updates = []
+    row = {
+        "ticket number": "M0402",
+        "username": "Old",
+        "status": "closed",
+        "thread_id": "444402",
+        "date closed": old.isoformat(),
+        "finalization_status": "pending",
+    }
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "list_ticket_rows_for_finalization_backfill", lambda flow: [(2, row)])
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *args, **kwargs: updates.append(kwargs) or "updated")
+    watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace(get_channel=lambda tid: None))
+
+    import asyncio
+    summary = asyncio.run(watcher.run_close_backfill())
+
+    assert summary["scanned"] == 0
+    assert summary["skipped_old"] == 1
+    assert updates == []
+
+
+def test_startup_backfill_skips_done_inside_48_hours(monkeypatch):
+    row = {
+        "ticket number": "M0403",
+        "username": "Done",
+        "status": "closed",
+        "thread_id": "444403",
+        "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "finalization_status": "done",
+    }
+    updates = []
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "list_ticket_rows_for_finalization_backfill", lambda flow: [(2, row)])
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *args, **kwargs: updates.append(kwargs) or "updated")
+    watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace(get_channel=lambda tid: None))
+
+    import asyncio
+    summary = asyncio.run(watcher.run_close_backfill())
+
+    assert summary["already_done"] == 1
+    assert summary["scanned"] == 0
+    assert updates == []
+
+
+def test_startup_backfill_skips_closed_promo_with_no_usable_timestamp(monkeypatch):
+    row = {
+        "ticket number": "M0404",
+        "username": "NoTime",
+        "status": "closed",
+        "thread_id": "444404",
+        "finalization_status": "pending",
+    }
+    updates = []
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "list_ticket_rows_for_finalization_backfill", lambda flow: [(2, row)])
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *args, **kwargs: updates.append(kwargs) or "updated")
+    watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace(get_channel=lambda tid: None))
+
+    import asyncio
+    summary = asyncio.run(watcher.run_close_backfill())
+
+    assert summary["skipped_no_timestamp"] == 1
+    assert summary["scanned"] == 0
+    assert updates == []


### PR DESCRIPTION
### Motivation

- Ensure the Promo watcher writes lifecycle metadata without mutating operator-owned Promo column order and avoid overwriting business/finalization data. 
- Make startup backfill safer by only attempting to finalize recently-closed promos and by robustly parsing posted timestamps.
- Centralize and preserve ticket metadata updates so lifecycle events (panel creation, prompts, closes) consistently update the sheet.

### Description

- Introduced `get_live_promo_headers()` and changed callers to read the live Promo header row rather than mutating header order, and updated `_promo_headers_for_write` to use it. 
- Added `patch_promo_ticket_metadata()` in `shared.sheets.onboarding` to upsert/patch lifecycle metadata (thread id, panel id, status, created/updated timestamps, etc.) while preserving business and finalization columns; added related constants to control required and preserved fields. 
- Updated `upsert_promo()` to preserve existing non-blank values when empty values are supplied by older callers. 
- Added metadata plumbing in `modules.onboarding.watcher_promo.PromoTicketWatcher` via `_patch_ticket_metadata()` and replaced direct sheet touch logic with calls to that method in relevant places (create, prompt, finalization, panel post, reminders). 
- Added robust backfill parsing helpers `_parse_backfill_timestamp()` and `_backfill_row_timestamp()` and bounded the startup backfill to `PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS = 48`, adding logic to skip rows with no usable timestamp or older than the cutoff in `run_close_backfill()`. 
- Added tests in `tests/onboarding/test_promo_metadata_persistence.py` covering metadata patching behavior, header preservation, and backfill bounding and selection.

### Testing

- Added `tests/onboarding/test_promo_metadata_persistence.py` which exercises `patch_promo_ticket_metadata`, backfill timestamp handling, and `run_close_backfill` behavior. 
- Ran the new unit tests (`pytest tests/onboarding/test_promo_metadata_persistence.py`) and the assertions in the file passed. 
- No automated test failures observed for the modified behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f16f46b2c8323ae652a3afc349cbc)