### PR TITLE
Fix Promo header-safe metadata persistence and bounded backfill

### DIFF
--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -759,6 +759,87 @@ def _ticket_key_columns(
     return key_columns, search_values
 
 
+
+
+def _promo_header_index(header: Sequence[str]) -> dict[str, int]:
+    return {_normalize_header_name(name): idx for idx, name in enumerate(header)}
+
+
+def _promo_find_row_in_values(
+    header: Sequence[str],
+    values: Sequence[Sequence[str]],
+    *,
+    ticket: str | None = None,
+    thread_id: int | str | None = None,
+) -> tuple[int | None, list[str] | None]:
+    idx = _promo_header_index(header)
+    target_thread = str(thread_id or "").strip()
+    thread_col = idx.get("threadid")
+    if target_thread and thread_col is not None:
+        for row_idx, row in enumerate(values[1:], start=2):
+            current = row[thread_col] if thread_col < len(row) else ""
+            if str(current or "").strip() == target_thread:
+                return row_idx, list(row)
+
+    target_ticket = _fmt_ticket(ticket) if ticket else ""
+    ticket_col = idx.get("ticketnumber")
+    if target_ticket and ticket_col is not None:
+        for row_idx, row in enumerate(values[1:], start=2):
+            current = row[ticket_col] if ticket_col < len(row) else ""
+            if _fmt_ticket(current) == target_ticket:
+                return row_idx, list(row)
+    return None, None
+
+
+def _promo_update_data_row(ws, header: Sequence[str], row_number: int, row_values: Sequence[str]) -> None:
+    end_col = _col_to_a1(len(header) - 1)
+    core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [list(row_values)[: len(header)]])
+
+
+def _promo_safe_upsert_mapped(
+    ws,
+    header: Sequence[str],
+    incoming: dict[str, str],
+    *,
+    ticket: str | None = None,
+    thread_id: int | str | None = None,
+    preserve_existing: bool = True,
+) -> str:
+    """Insert/update a Promo data row without touching row 1."""
+
+    idx = _promo_header_index(header)
+    if "ticketnumber" not in idx:
+        raise RuntimeError("Promo sheet missing required header: ticket number")
+    values = core.call_with_backoff(ws.get_all_values)
+    row_number, row = _promo_find_row_in_values(header, values, ticket=ticket, thread_id=thread_id)
+    if row is None:
+        row = ["" for _ in header]
+    elif len(row) < len(header):
+        row.extend("" for _ in range(len(header) - len(row)))
+
+    changed = False
+    for normalized, value in incoming.items():
+        col = idx.get(_normalize_header_name(normalized))
+        if col is None:
+            continue
+        text = str(value or "").strip()
+        if not text:
+            continue
+        if preserve_existing and str(row[col] or "").strip():
+            continue
+        if row[col] != text:
+            row[col] = text
+            changed = True
+
+    if row_number is None:
+        core.call_with_backoff(ws.append_row, row[: len(header)], value_input_option="RAW")
+        return "inserted"
+    if not changed:
+        return "unchanged"
+    _promo_update_data_row(ws, header, row_number, row)
+    return "updated"
+
+
 def _normalize_ticket_timestamps(
     created_at: datetime | None, updated_at: datetime | None
 ) -> tuple[datetime, datetime]:
@@ -1021,8 +1102,23 @@ def upsert_promo(
         col = _column_index(resolved_headers, header, default=-1)
         if col >= 0 and not str(incoming[col] or "").strip():
             incoming[col] = existing_map.get(header, "") or ("pending" if field != "finalization_note" else "")
-    keys = [("ticket number", _fmt_ticket)]
-    return _upsert(ws, keys, incoming, resolved_headers)
+    actual_idx = _promo_header_index(actual_headers)
+    resolved_idx = {_normalize_header_name(name): pos for pos, name in enumerate(resolved_headers)}
+    incoming_map: dict[str, str] = {}
+    for normalized, actual_pos in actual_idx.items():
+        source_pos = resolved_idx.get(normalized)
+        value = incoming[source_pos] if source_pos is not None and source_pos < len(incoming) else ""
+        if str(value or "").strip():
+            incoming_map[normalized] = str(value)
+    thread_value = incoming_map.get("threadid") or incoming_map.get("thread")
+    return _promo_safe_upsert_mapped(
+        ws,
+        actual_headers,
+        incoming_map,
+        ticket=ticket_value,
+        thread_id=thread_value,
+        preserve_existing=False,
+    )
 
 
 PROMO_METADATA_REQUIRED_HEADERS = {
@@ -1246,9 +1342,14 @@ def append_promo_ticket_row(
     value_map[_normalize_header_name(final_headers["clan_update_status"])] = "pending"
     value_map[_normalize_header_name(final_headers["finalization_note"])] = ""
 
-    row_values = _build_ticket_row(header, value_map)
-    key_columns, search_values = _ticket_key_columns(header, ticket_value, thread_id)
-    return _upsert(ws, key_columns, row_values, header, search_values=search_values)
+    return _promo_safe_upsert_mapped(
+        ws,
+        header,
+        value_map,
+        ticket=ticket_value,
+        thread_id=thread_id,
+        preserve_existing=False,
+    )
 
 
 def append_onboarding_session_row(
@@ -1368,19 +1469,27 @@ def update_ticket_finalization_state(
     header = _ensure_promo_headers(ws) if normalized == "promo" else _ensure_headers(ws, desired_headers)
     final_headers = require_finalization_headers(normalized, header)
     values = core.call_with_backoff(ws.get_all_values)
-    ticket_col = _column_index(header, ticket_header)
-    thread_col = next((idx for idx, name in enumerate(_normalize_header_name(h) for h in header) if name in {"threadid", "thread"}), -1)
     target_ticket = _fmt_ticket(ticket) if ticket else ""
     target_thread = str(thread_id or "").strip()
-    row_number = None
-    row = None
-    for idx, current in enumerate(values[1:], start=2):
-        ticket_match = bool(target_ticket) and ticket_col < len(current) and _fmt_ticket(current[ticket_col]) == target_ticket
-        thread_match = bool(target_thread) and thread_col >= 0 and thread_col < len(current) and str(current[thread_col] or "").strip() == target_thread
-        if ticket_match or thread_match:
-            row_number = idx
-            row = list(current)
-            break
+    if normalized == "promo":
+        row_number, row = _promo_find_row_in_values(
+            header,
+            values,
+            ticket=target_ticket,
+            thread_id=target_thread,
+        )
+    else:
+        ticket_col = _column_index(header, ticket_header)
+        thread_col = next((idx for idx, name in enumerate(_normalize_header_name(h) for h in header) if name in {"threadid", "thread"}), -1)
+        row_number = None
+        row = None
+        for idx, current in enumerate(values[1:], start=2):
+            ticket_match = bool(target_ticket) and ticket_col < len(current) and _fmt_ticket(current[ticket_col]) == target_ticket
+            thread_match = bool(target_thread) and thread_col >= 0 and thread_col < len(current) and str(current[thread_col] or "").strip() == target_thread
+            if ticket_match or thread_match:
+                row_number = idx
+                row = list(current)
+                break
     if row_number is None or row is None:
         raise RuntimeError(f"{normalized} finalization row not found for ticket={ticket or '-'} thread_id={thread_id or '-'}")
     if len(row) < len(header):

--- a/tests/onboarding/test_promo_metadata_persistence.py
+++ b/tests/onboarding/test_promo_metadata_persistence.py
@@ -66,6 +66,7 @@ def promo_sheet(monkeypatch):
     monkeypatch.setattr(onboarding_sheets.core, "call_with_backoff", lambda func, *args, **kwargs: func(*args, **kwargs))
     monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "PromoFromConfig"))
     monkeypatch.setattr(onboarding_sheets, "_worksheet", lambda tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets, "_promo_tab", lambda: "PromoFromConfig")
     monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
     monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
     monkeypatch.setattr(onboarding_sheets, "get_finalization_headers", lambda flow, **kwargs: {
@@ -300,3 +301,125 @@ def test_startup_backfill_skips_closed_promo_with_no_usable_timestamp(monkeypatc
     assert summary["skipped_no_timestamp"] == 1
     assert summary["scanned"] == 0
     assert updates == []
+
+
+def test_append_promo_ticket_row_preserves_header_order_and_places_values(promo_sheet):
+    created = dt.datetime(2026, 6, 14, 12, 0, tzinfo=dt.timezone.utc)
+    result = onboarding_sheets.append_promo_ticket_row(
+        "M0500",
+        "Player One",
+        "C1CE",
+        "C1CV",
+        "move",
+        "2026-06-14 12:00",
+        "2026",
+        "June",
+        "June",
+        "Clan One",
+        "TH16",
+        thread_name="M0500-Player-One",
+        user_id=111,
+        thread_id=222,
+        panel_message_id=333,
+        status="open",
+        created_at=created,
+        updated_at=created,
+    )
+
+    assert result == "inserted"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    assert promo_sheet.header_updates == []
+    row = _row_map(promo_sheet)
+    expected = {
+        "ticket number": "M0500",
+        "username": "Player One",
+        "clantag": "C1CE",
+        "source_clan_tag": "C1CV",
+        "date closed": "",
+        "type": "move",
+        "thread created": "2026-06-14 12:00",
+        "thread_name": "M0500-Player-One",
+        "user_id": "111",
+        "thread_id": "222",
+        "panel_message_id": "333",
+        "status": "open",
+        "review_reason": "",
+        "created_at": created.isoformat(),
+        "updated_at": created.isoformat(),
+        "finalization_status": "pending",
+        "reservation_status": "pending",
+        "clan_update_status": "pending",
+        "finalization_note": "",
+        "year": "2026",
+        "month": "June",
+        "join_month": "June",
+        "clan name": "Clan One",
+        "progression": "TH16",
+    }
+    assert row == expected
+
+
+def test_upsert_promo_preserves_header_and_existing_metadata(promo_sheet):
+    promo_sheet.rows.append(["M0501", "Old", "C1CA", "C1CB", "", "move", "old thread", "thread-name", "111", "222", "333", "open", "keep", "created", "updated", "pending", "pending", "pending", "", "2026", "May", "May", "Clan", "TH15"])
+    incoming = [""] * len(LIVE_PROMO_HEADERS)
+    values = dict(zip(LIVE_PROMO_HEADERS, incoming))
+    values.update({
+        "ticket number": "M0501",
+        "username": "New",
+        "clantag": "C1CE",
+        "source_clan_tag": "C1CV",
+        "type": "move",
+        "year": "2026",
+        "month": "June",
+        "clan name": "Clan New",
+    })
+    row_values = [values[h] for h in LIVE_PROMO_HEADERS]
+
+    result = onboarding_sheets.upsert_promo(row_values, LIVE_PROMO_HEADERS)
+
+    assert result == "updated"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    assert promo_sheet.header_updates == []
+    row = _row_map(promo_sheet)
+    assert row["thread_name"] == "thread-name"
+    assert row["user_id"] == "111"
+    assert row["panel_message_id"] == "333"
+    assert row["finalization_status"] == "pending"
+    assert row["username"] == "New"
+    assert row["clantag"] == "C1CE"
+
+
+def test_update_ticket_finalization_state_promo_preserves_header_and_metadata(promo_sheet):
+    promo_sheet.rows.append(["M0502", "Player", "C1CE", "C1CV", "", "move", "created thread", "thread-name", "111", "222", "333", "closed", "reason", "created", "updated", "pending", "pending", "pending", "", "2026", "June", "June", "Clan", "TH16"])
+
+    result = onboarding_sheets.update_ticket_finalization_state(
+        "promo",
+        ticket="M0502",
+        thread_id=222,
+        finalization_status="done",
+        reservation_status="released",
+        clan_update_status="done",
+        finalization_note="finalized",
+    )
+
+    assert result == "updated"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    assert promo_sheet.header_updates == []
+    row = _row_map(promo_sheet)
+    assert row["thread_name"] == "thread-name"
+    assert row["user_id"] == "111"
+    assert row["panel_message_id"] == "333"
+    assert row["finalization_status"] == "done"
+    assert row["reservation_status"] == "released"
+    assert row["clan_update_status"] == "done"
+    assert row["finalization_note"] == "finalized"
+
+
+def test_list_ticket_rows_for_promo_backfill_does_not_mutate_header(promo_sheet):
+    promo_sheet.rows.append(["M0503", "Player", "", "", "", "", "", "", "", "222", "", "closed", "", "", dt.datetime.now(dt.timezone.utc).isoformat(), "pending", "", "", "", "", "", "", "", ""])
+
+    rows = onboarding_sheets.list_ticket_rows_for_finalization_backfill("promo")
+
+    assert rows[0][1]["ticket number"] == "M0503"
+    assert promo_sheet.rows[0] == LIVE_PROMO_HEADERS
+    assert promo_sheet.header_updates == []

--- a/tests/onboarding/test_promo_source_schema.py
+++ b/tests/onboarding/test_promo_source_schema.py
@@ -8,6 +8,15 @@ from modules.onboarding import watcher_promo
 from shared.sheets import onboarding as onboarding_sheets
 
 
+_CONFIG_HEADERS = {
+    "PROMO_SOURCE_CLAN_TAG_HEADER": "source_clan_tag",
+    "PROMO_FINALIZATION_STATUS_HEADER": "finalization_status",
+    "PROMO_RESERVATION_STATUS_HEADER": "reservation_status",
+    "PROMO_CLAN_UPDATE_STATUS_HEADER": "clan_update_status",
+    "PROMO_FINALIZATION_NOTE_HEADER": "finalization_note",
+}
+
+
 class FakeWorksheet:
     id = 1
 
@@ -39,9 +48,7 @@ def promo_config(monkeypatch):
     monkeypatch.setattr(
         onboarding_sheets,
         "_config_lookup",
-        lambda key, default=None: "source_clan_tag"
-        if str(key).upper() == "PROMO_SOURCE_CLAN_TAG_HEADER"
-        else default,
+        lambda key, default=None: _CONFIG_HEADERS.get(str(key).upper(), default),
     )
 
 
@@ -55,6 +62,7 @@ def _install_fake_sheet(monkeypatch):
     monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "Promo"))
     monkeypatch.setattr(onboarding_sheets, "_worksheet", lambda tab: worksheet)
     monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    worksheet.rows.append(onboarding_sheets.get_promo_headers())
     return worksheet
 
 
@@ -62,9 +70,7 @@ def test_promo_source_header_resolves_from_config(monkeypatch):
     monkeypatch.setattr(
         onboarding_sheets,
         "_config_lookup",
-        lambda key, default=None: "previous_clan_tag"
-        if str(key).upper() == "PROMO_SOURCE_CLAN_TAG_HEADER"
-        else default,
+        lambda key, default=None: ({**_CONFIG_HEADERS, "PROMO_SOURCE_CLAN_TAG_HEADER": "previous_clan_tag"}).get(str(key).upper(), default),
     )
 
     assert onboarding_sheets.get_promo_source_clan_tag_header() == "previous_clan_tag"
@@ -158,14 +164,13 @@ def test_promo_reminder_touch_fallback_alignment(monkeypatch, promo_config):
     async def fake_log_sheet_write(**kwargs):
         return await kwargs["write_coro"]()
 
-    def fake_upsert(row_values, headers):
-        captured["row"] = list(row_values)
-        captured["headers"] = list(headers)
-        return "inserted"
+    def fake_patch(**kwargs):
+        captured["metadata"] = dict(kwargs)
+        return "updated"
 
     monkeypatch.setattr(watcher_promo, "log_sheet_write", fake_log_sheet_write)
     monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda ticket: None)
-    monkeypatch.setattr(watcher_promo.onboarding_sheets, "upsert_promo", fake_upsert)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_ticket_metadata", fake_patch)
     watcher = watcher_promo.PromoTicketWatcher(bot=SimpleNamespace())
     context = watcher_promo.PromoTicketContext(
         thread_id=999,
@@ -193,28 +198,25 @@ def test_promo_reminder_touch_fallback_alignment(monkeypatch, promo_config):
         )
     )
 
-    row = captured["row"]
-    assert captured["headers"][3] == "source_clan_tag"
-    assert row[3] == "C1CV"
-    assert row[4] == ""
-    assert row[5] == "player move request"
-    assert row[12] == "M0352-Lucifer"
-    assert row[16] == "open"
-    assert row[17] == ""
-    assert row[18] == created.isoformat()
-    assert row[19]
+    metadata = captured["metadata"]
+    assert metadata["ticket"] == "M0352"
+    assert metadata["thread_id"] == 999
+    assert metadata["thread_name"] == "M0352-Lucifer"
+    assert metadata["user_id"] == 12345
+    assert metadata["status"] == "open"
+    assert metadata["created_at"] == created
 
 
 def test_existing_promo_sheet_missing_source_header_fails_safely(monkeypatch, promo_config):
     worksheet = _install_fake_sheet(monkeypatch)
-    worksheet.rows.append([
+    worksheet.rows = [[
         "ticket number",
         "username",
         "clantag",
         "date closed",
         "type",
         "thread created",
-    ])
+    ]]
 
     with pytest.raises(RuntimeError, match="missing configured source clan header"):
         onboarding_sheets.append_promo_ticket_row(
@@ -235,7 +237,7 @@ def test_existing_promo_sheet_missing_source_header_fails_safely(monkeypatch, pr
 def test_existing_promo_row_with_blank_source_keeps_later_columns_aligned(monkeypatch, promo_config):
     worksheet = _install_fake_sheet(monkeypatch)
     headers = onboarding_sheets.get_promo_headers()
-    worksheet.rows.append(headers)
+    worksheet.rows = [headers]
     worksheet.rows.append([
         "M0352",
         "Lucifer",

--- a/tests/onboarding/test_promo_watcher.py
+++ b/tests/onboarding/test_promo_watcher.py
@@ -156,6 +156,20 @@ def test_upsert_promo_inserts_and_updates(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(onboarding_sheets, "_worksheet", lambda tab: FakeWorksheet())
     monkeypatch.setattr(onboarding_sheets, "_promo_tab", lambda: "PromoTickets")
     monkeypatch.setattr(onboarding_sheets, "_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
+    monkeypatch.setattr(onboarding_sheets, "get_finalization_headers", lambda flow, **kwargs: {
+        "finalization_status": "finalization_status",
+        "reservation_status": "reservation_status",
+        "clan_update_status": "clan_update_status",
+        "finalization_note": "finalization_note",
+    })
+    live_headers = list(onboarding_sheets.PROMO_HEADERS) + [
+        "finalization_status",
+        "reservation_status",
+        "clan_update_status",
+        "finalization_note",
+    ]
+    rows.append(live_headers)
 
     base_row = [
         "R0001",
@@ -171,15 +185,15 @@ def test_upsert_promo_inserts_and_updates(monkeypatch: pytest.MonkeyPatch) -> No
         "",
     ]
 
-    result_insert = onboarding_sheets.upsert_promo(base_row, onboarding_sheets.PROMO_HEADERS)
+    result_insert = onboarding_sheets.upsert_promo(base_row, live_headers)
     assert result_insert == "inserted"
-    assert rows[0] == onboarding_sheets.PROMO_HEADERS
+    assert rows[0] == live_headers
     assert len(rows) == 2
     assert rows[1][:5] == base_row[:5]
 
     updated_row = base_row[:]
     updated_row[2] = "C1CE"
-    result_update = onboarding_sheets.upsert_promo(updated_row, onboarding_sheets.PROMO_HEADERS)
+    result_update = onboarding_sheets.upsert_promo(updated_row, live_headers)
     assert result_update == "updated"
     assert len(rows) == 2
     assert rows[1][2] == "C1CE"

--- a/tests/onboarding/test_ticket_close_finalization.py
+++ b/tests/onboarding/test_ticket_close_finalization.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime as dt
 from types import SimpleNamespace
 
 from modules.onboarding import watcher_promo, watcher_welcome
@@ -258,6 +259,7 @@ def test_welcome_backfill_closed_row_fetch_fails_marks_skipped_unresolved(monkey
         "username": "ClosedUser",
         "thread_id": "123",
         "status": "closed",
+        "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "finalization_status": "pending",
     }
     updates = []
@@ -283,6 +285,7 @@ def test_promo_backfill_closed_row_fetch_fails_marks_skipped_unresolved(monkeypa
         "username": "ClosedUser",
         "thread_id": "123",
         "status": "closed",
+        "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "finalization_status": "pending",
     }
     updates = []
@@ -328,6 +331,7 @@ def test_promo_backfill_open_row_fetched_archived_thread_triggers_prompt(monkeyp
         "username": "ArchivedUser",
         "thread_id": "123",
         "status": "open",
+        "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "finalization_status": "pending",
     }
     prompted = []


### PR DESCRIPTION
### Motivation
- Root cause: Promo write paths were still delegating to the shared `_upsert` which calls `_ensure_headers`, and `_ensure_headers` rewrites `A1` when the live header differs from expectations, causing operator-owned Promo row 1 to be reordered or rewritten.  
- Intent: ensure the bot never mutates the Promo header row and always maps writes to the live header row, persisting required metadata reliably.  
- Preserve business/finalization columns and keep startup close backfill strictly bounded to 48 hours to avoid touching historical rows.  

### Description
- Added Promo-safe data-row helpers that read the live header row and never touch row 1: `_promo_header_index`, `_promo_find_row_in_values`, `_promo_update_data_row`, and `_promo_safe_upsert_mapped` in `shared/sheets/onboarding.py`.  
- Rewrote Promo write flows to use the live header mapping and Promo-safe helpers instead of `_upsert`, including `upsert_promo`, `append_promo_ticket_row`, and `update_ticket_finalization_state` in `shared/sheets/onboarding.py`, and preserved existing metadata/business fields when appropriate.  
- Hardened `patch_promo_ticket_metadata` to find rows by `thread_id` first, fall back to ticket number, avoid blank overwrites, and only update data ranges or append rows (never `A1`).  
- Restored/clarified bounded startup backfill in `modules/onboarding/watcher_promo.py` with `PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS = 48` and timestamp parsing/priority logic to skip rows without a usable timestamp or older than 48 hours.  
- Tests added/updated to assert exact Promo header order is preserved and to validate metadata placement, preservation rules, finalization writes, and bounded backfill behavior (see tests below).  

### Testing
- Ran targeted unit tests covering Promo behavior and ticket finalization: `pytest -q tests/onboarding/test_promo_metadata_persistence.py tests/onboarding/test_promo_watcher.py::test_upsert_promo_inserts_and_updates tests/onboarding/test_promo_source_schema.py tests/onboarding/test_ticket_close_finalization.py`, and compiled modules with `python -m py_compile shared/sheets/onboarding.py modules/onboarding/watcher_promo.py`; these completed successfully.  
- Local test runs exercising the modified code completed with the modified tests passing (Promo metadata persistence, header-safety assertions, upsert/append/finalization flows, and bounded startup backfill).  

Files / primary functions changed (key items):
- `shared/sheets/onboarding.py`: added `_promo_header_index`, `_promo_find_row_in_values`, `_promo_update_data_row`, `_promo_safe_upsert_mapped`; updated `upsert_promo`, `append_promo_ticket_row`, `patch_promo_ticket_metadata`, `update_ticket_finalization_state`, and `list_ticket_rows_for_finalization_backfill` to use Promo-safe paths and live headers.  
- `modules/onboarding/watcher_promo.py`: ensured `PROMO_CLOSE_BACKFILL_LOOKBACK_HOURS = 48`, tightened `_backfill_row_timestamp` usage and `run_close_backfill` behavior to respect the 48-hour bound and timestamp priority.  
- Tests: `tests/onboarding/test_promo_metadata_persistence.py`, `tests/onboarding/test_promo_source_schema.py`, `tests/onboarding/test_promo_watcher.py`, `tests/onboarding/test_ticket_close_finalization.py` — updated/added assertions to verify header-preservation and metadata placement.  

Notes
- The Promo header row is now only read (via `_ensure_promo_headers` / `get_live_promo_headers`) and will not be written by any Promo code path; all Promo writes update only data rows (or append rows) and map columns by normalized header name.  
- No new Promo columns were introduced, and the change is intentionally minimal and focused to avoid impact on Welcome flows except where necessary for shared safety (tests cover regression scenarios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f273dcecc832385b5ec4ff81be7e6)