### PR TITLE
Add 'Members with only @everyone' audit, persist Fusion role-cleanup summaries, and improve report rendering

### DIFF
--- a/docs/audits/housekeeping_role_visitor_audit.md
+++ b/docs/audits/housekeeping_role_visitor_audit.md
@@ -1,0 +1,254 @@
+# Housekeeping Role & Visitor Audit Investigation
+
+## Scope
+
+Investigated the current implementation of the daily Role & Visitor Audit / housekeeping report, why Discord members with no roles or no meaningful roles are not appearing in that report, and all currently discoverable code paths that can remove Discord roles from members. This investigation is documentation-only and does not change runtime behavior or sheet schema.
+
+## Current Daily Report Behavior
+
+The daily Role & Visitor Audit is run as part of the Daily Recruiter Update bundle. `scheduler_daily_recruiter_update()` calls `run_full_recruiter_reports(bot, actor="scheduled")`, which posts the recruiter report, then calls `run_role_and_visitor_audit(..., dry_run=True)`, then posts the open-ticket report.
+
+The audit resolves these required inputs before scanning: `RAID_ROLE_ID`, `WANDERING_SOULS_ROLE_ID`, `VISITOR_ROLE_ID`, `CLAN_ROLE_IDS`, an audit destination (`ADMIN_AUDIT_DEST_ID`, falling back to log channel IDs), and at least one ticket channel (`WELCOME_CHANNEL_ID` or `PROMO_CHANNEL_ID`). It scans allowed guilds from `GUILD_IDS` when configured, otherwise all bot guilds.
+
+For each guild, `_audit_guild()` fetches all members, fetches welcome/promo ticket threads, builds a member-to-ticket map, and evaluates each member for these buckets:
+
+1. **Stray members**: members with Raid, no configured clan role, and no Wandering Souls role. In scheduled/dry-run mode the report says it would remove Raid and add Wandering Souls; it does not actually mutate roles.
+2. **Existing Wanderers that still have Raid but no clan role**: members with Raid and Wandering Souls, but no configured clan role. In scheduled/dry-run mode the report says it would remove Raid and keep Wandering Souls.
+3. **Manual review: Wandering Souls with clan tags**: members with Wandering Souls and at least one configured clan role.
+4. **Visitors without any ticket**: members with the configured Visitor role and no fetched ticket thread membership.
+5. **Visitors with only closed tickets**: members with the Visitor role whose fetched tickets are all closed/archived.
+6. **Visitors with extra roles**: members with the Visitor role plus any role other than Visitor and `@everyone`.
+
+The report renderer only adds sections when a bucket has at least one line. If no detected sections or action sections exist, the embed description is empty and only the footer shows the checked member count.
+
+## Roleless / No-Role Member Check
+
+* **Does the current audit check for members who only have `@everyone`?** No. The audit scans all fetched members, but there is no classification or report bucket for members whose role set is only the guild `@everyone` role.
+* **Does it check for members with no clan tag role, no visitor role, no raid role, no Wandering Souls role, and no other configured allowed role?** No. There is no general "no meaningful roles" or "allowed role" concept in the current audit. The only configured role sets used by the audit are Raid, Wandering Souls, Visitor, and configured clan roles.
+* **What exact criteria does the code currently use?** `_classify_roles()` computes only three meaningful non-ok role states:
+  * `stray`: has Raid, does not have any configured clan role, and does not have Wandering Souls.
+  * `drop_raid`: has Raid and Wandering Souls, but does not have any configured clan role.
+  * `wander_with_clan`: has Wandering Souls and at least one configured clan role.
+  * Everything else is `ok`.
+
+  Visitor checks only run when the member has the configured Visitor role. A Visitor's "extra roles" are every role except Visitor and `@everyone`.
+* **If roleless members are not checked, say that clearly.** Roleless/no-role members are not checked by the current daily Role & Visitor Audit.
+
+## Why Roleless Members Are Missing From The Report
+
+* **Are they filtered out?** They are not filtered out before the scan; they are included in the fetched member list and counted in the footer's checked-member total. However, the classification logic returns `ok` for roleless/no-role members because they do not have Raid, Wandering Souls, a configured clan role, or Visitor.
+* **Is the report section missing?** Yes. There is no report section for "roleless", "only @everyone", "no meaningful roles", or "no configured allowed roles" members.
+* **Is the audit only checking bad combinations of known roles?** Yes. The role audit checks known problematic combinations involving Raid, Wandering Souls, configured clan roles, and Visitor/ticket state. It does not do a broad membership hygiene check for absence of roles.
+* **Is the report capped/truncated?** The current renderer does not implement an explicit per-section cap/truncation. Discord embed description length still applies at send time, so a very large report could fail to send, but roleless members are missing because they are never collected into a report bucket, not because a cap hides them.
+* **Is there a difference in code between "no roles" and "no clan roles"?** Yes. "No clan roles" means the member lacks any role ID from `CLAN_ROLE_IDS`; it is only meaningful to the current role-classification logic when combined with Raid and/or Wandering Souls. "No roles" / "only @everyone" has no separate logic and falls through as `ok`.
+
+## Relevant Files And Functions
+
+* **Scheduled housekeeping / daily job**
+  * `modules/recruitment/reporting/daily_recruiter_update.py`
+    * `_scheduled_time()` reads `REPORT_DAILY_POST_TIME`.
+    * `scheduler_daily_recruiter_update()` is the daily task loop entrypoint.
+    * `ensure_scheduler_started()` starts/cancels the daily task based on the `recruitment_reports` feature toggle and report destination.
+    * `run_full_recruiter_reports()` runs the recruiter report, role/visitor audit, and open-ticket report.
+  * `modules/common/runtime.py`
+    * Startup/scheduler registration imports housekeeping modules and schedules cleanup/keepalive jobs under the `housekeeping_enabled` toggle. The Role & Visitor Audit itself is coupled to the recruitment daily report scheduler, not the cleanup watcher.
+* **Role/visitor audit**
+  * `modules/housekeeping/role_audit.py`
+    * `resolve_audit_destination()` resolves `ADMIN_AUDIT_DEST_ID` with log-channel fallbacks.
+    * `_member_roles()` extracts member role IDs.
+    * `_classify_roles()` classifies Raid/Wandering/clan-role combinations.
+    * `_extra_roles()` calculates Visitor extra roles.
+    * `_audit_guild()` scans guild members and builds all audit buckets.
+    * `_apply_role_changes()` performs role mutations only when non-dry-run and actor is not scheduled/background/startup-like.
+    * `_render_report()` renders the Discord embed sections.
+    * `run_role_and_visitor_audit()` resolves config, aggregates guild results, and sends the embed.
+    * `preview_role_audit_mutations()` recomputes a dry-run mutation snapshot for the admin command.
+* **Report rendering / command access**
+  * `modules/housekeeping/role_audit.py::_render_report()` renders detected/action sections.
+  * `cogs/recruitment_reporting.py::RecruitmentReporting.report_group()` exposes `!report recruiters [all]`.
+  * `cogs/recruitment_reporting.py::RecruitmentReporting.roleaudit()` exposes `!roleaudit preview` and `!roleaudit apply CONFIRM [override]`.
+* **Config loading used by the audit**
+  * `shared/config.py` functions imported by `modules/housekeeping/role_audit.py`: `get_admin_audit_dest_id`, `get_log_channel_id`, `get_logging_channel_id`, `get_allowed_guild_ids`, `get_clan_role_ids`, `get_promo_channel_id`, `get_raid_role_id`, `get_visitor_role_id`, `get_wandering_souls_role_id`, and `get_welcome_channel_id`.
+  * `modules/common/feature_flags.py` is used by the daily recruiter report feature gate through `feature_enabled()`.
+  * Ticket data comes from `modules/common/tickets.py::fetch_ticket_threads()` and `TicketThread`.
+
+## Automatic Role Removal Investigation
+
+Searches performed included `remove_roles`, `member.remove_roles`, role edits via `roles=`, role cleanup, visitor cleanup, clan role cleanup, Wandering Souls handling, pruning, scheduled cleanup, startup/backfill/repair, watcher tasks, button flows, ticket close flows, and admin commands.
+
+### Role-removal paths found
+
+#### 1. Role & Visitor Audit apply path
+
+* **File/function:** `modules/housekeeping/role_audit.py::_apply_role_changes()`, called by `_audit_guild()` and `run_role_and_visitor_audit()`.
+* **Trigger/entrypoint:** `!roleaudit apply CONFIRM [override]` via `cogs/recruitment_reporting.py::RecruitmentReporting.roleaudit()`.
+* **Which roles can be removed:** The configured Raid role.
+* **Conditions for removal:**
+  * `stray`: member has Raid, no configured clan role, and no Wandering Souls; apply removes Raid and adds Wandering Souls.
+  * `drop_raid`: member has Raid and Wandering Souls, but no configured clan role; apply removes Raid.
+* **Automatic or staff/admin action:** Staff/admin action only for actual mutation. Scheduled/background/startup-like actors and dry runs are explicitly report-only and skip mutations.
+
+#### 2. Daily scheduled Role & Visitor Audit dry-run
+
+* **File/function:** `modules/recruitment/reporting/daily_recruiter_update.py::run_full_recruiter_reports()` calls `modules/housekeeping/role_audit.py::run_role_and_visitor_audit()`.
+* **Trigger/entrypoint:** Daily scheduler at `REPORT_DAILY_POST_TIME`, plus manual `!report recruiters all`.
+* **Which roles can be removed:** None in current scheduled behavior.
+* **Conditions for removal:** Not applicable. The call uses `dry_run=True`, and `_apply_role_changes()` also refuses to mutate for scheduled/background/startup-like actors.
+* **Automatic or staff/admin action:** Automatic report only; no role removal.
+
+#### 3. Clan role remove command
+
+* **File/function:** `cogs/clanrole_management.py::ClanRoleManagementCog.apply_clan_removal_cleanup()`.
+* **Trigger/entrypoint:** Staff command `!clanrole remove <member query>`, including a selection view when multiple members or clan roles match.
+* **Which roles can be removed:** One selected configured clan role; also the configured Raid role if the member has no remaining configured clan roles after the selected clan role is removed.
+* **Conditions for removal:** Caller must pass the command authorization check. If exactly one clan role is selected, the command removes it. If no other configured clan roles remain and Raid is present, Raid is removed. The command may add Wandering Souls afterward.
+* **Automatic or staff/admin action:** Staff/admin action only.
+
+#### 4. Fusion opt-out button
+
+* **File/function:** `modules/community/fusion/opt_in_view.py` button handler.
+* **Trigger/entrypoint:** User presses the Fusion opt-out button.
+* **Which roles can be removed:** The configured Fusion opt-in role for that fusion panel.
+* **Conditions for removal:** The user is a guild member, the role exists, the button action is opt-out, and the member currently has the role.
+* **Automatic or staff/admin action:** User self-service action, not automatic.
+
+#### 5. Fusion ended-role cleanup
+
+* **File/function:** `modules/community/fusion/role_cleanup.py::process_ended_fusion_role_cleanup()`.
+* **Trigger/entrypoint:** Fusion scheduler/cleanup processing for fusions returned by `fusion_sheets.get_ended_fusions()`.
+* **Which roles can be removed:** A fusion row's configured opt-in role (`opt_in_role_id`).
+* **Conditions for removal:** Fusion is ended, an opt-in role ID exists, the cleanup dedupe key has not already been marked sent, the guild and role resolve, and members are present in `role.members`.
+* **Automatic or staff/admin action:** Automatic scheduled cleanup.
+
+#### 6. Shard reminder opt-out button
+
+* **File/function:** `modules/community/shard_tracker/cog.py` reminder role update handler.
+* **Trigger/entrypoint:** User presses shard reminder opt-out UI.
+* **Which roles can be removed:** The selected clan shard reminder opt-in role.
+* **Conditions for removal:** Selected config has an opt-in role ID, the guild/member/role resolve, action is opt-out, and the member has the role.
+* **Automatic or staff/admin action:** User self-service action, not automatic.
+
+#### 7. Reaction-role revoke
+
+* **File/function:** `modules/community/reaction_roles.py` reaction-role event handler.
+* **Trigger/entrypoint:** A configured reaction-role event where `grant` is false, typically reaction removal.
+* **Which roles can be removed:** The configured reaction-role row's role ID.
+* **Conditions for removal:** The reaction payload matches configured row location, the role exists, and the member currently has the role.
+* **Automatic or staff/admin action:** Event-driven user self-service action; automatic in response to the reaction event.
+
+#### 8. Reset reminder opt-out button
+
+* **File/function:** `modules/community/reset_reminders/views.py::ResetReminderView` button callback.
+* **Trigger/entrypoint:** User presses reset reminder opt-out UI.
+* **Which roles can be removed:** The configured reset reminder role for the view.
+* **Conditions for removal:** Guild/member/role resolve and action is opt-out.
+* **Automatic or staff/admin action:** User self-service action, not automatic.
+
+### Searched but no role-removal path found
+
+* **Visitor cleanup:** No code path was found that automatically removes Visitor roles as part of housekeeping or ticket close handling.
+* **Clan role cleanup outside staff command:** No automatic clan-role removal path was found outside `!clanrole remove`.
+* **Wandering Souls removal:** No current path was found that removes Wandering Souls. The role audit may add Wandering Souls in manual apply mode; the clan-role command may add Wandering Souls after a clan removal.
+* **Ticket close flows:** Welcome/promo close handlers update sheets, reservations/open spots, thread names, prompts, and logs. No member role removal was found in those ticket close paths.
+* **Startup repair/backfill:** Welcome/promo close backfill finalizes sheet/ticket state; no member role removal was found there.
+* **Housekeeping cleanup watcher:** Deletes messages from configured cleanup threads; does not remove roles.
+* **Pruning:** No Discord member-pruning role-removal implementation was found.
+
+## Role Removal Logging
+
+#### 1. Role & Visitor Audit apply path
+
+* **Discord ops/admin logs:** The manual apply sends the Role & Visitor Audit embed to the audit destination. When `dry_run=False`, `_render_report()` includes action sections for roles removed/added and failures/skips.
+* **App logs:** `_apply_role_changes()` logs successful mutations with before/after role names, removed roles, added roles, actor, member ID/name, and reason. Permission/API failures are warning logs with member/error context.
+* **Silent?** Not silent for the admin command path because it replies to the command and posts the audit/action report. Scheduled runs are dry-run only and log that mutations were skipped.
+* **Deduped/suppressed?** No dedupe for the audit report was found.
+* **Failures logged clearly?** Yes, failures are logged and included in the report's failed/skipped action section when apply mode is used.
+
+#### 2. Clan role remove command
+
+* **Discord ops/admin logs:** The command replies in-channel with the removal/cleanup result, but no separate ops-log post was found for the mutation.
+* **App logs:** Successful clan role removal, Raid removal, and Wandering Souls add are logged with member/actor context. Failures log exceptions.
+* **Silent?** Not silent to the command invoker, but not necessarily visible in a centralized admin ops log unless the command channel itself is monitored.
+* **Deduped/suppressed?** No dedupe found.
+* **Failures logged clearly?** Yes to app logs and command response.
+
+#### 3. Fusion opt-out button
+
+* **Discord ops/admin logs:** Failures call `fusion_logs.send_ops_alert(...)`. Successful self-service opt-outs do not appear to send an ops/admin log.
+* **App logs:** Failures are logged with exception/context. Success is acknowledged ephemerally to the user; no success app log was found in the inspected snippet.
+* **Silent?** Successful removals are silent to admins, but user-initiated and limited to Fusion opt-in roles.
+* **Deduped/suppressed?** Failure ops alerts use dedupe keys.
+* **Failures logged clearly?** Yes; failure alerts and app logs exist.
+
+#### 4. Fusion ended-role cleanup
+
+* **Discord ops/admin logs:** Failures for loading ended fusions, status transitions, dedupe state, and iteration failures call `fusion_logs.send_ops_alert(...)`. Per-member removal failures are only app logged. Successful automatic removals do not appear to send an admin-visible summary.
+* **App logs:** Missing guild/role and per-member failures are logged. Successful removals are not individually logged in the inspected code.
+* **Silent?** Yes. This is an automatic role-removal path, and successful role removals can occur without an admin-visible success log or summary.
+* **Deduped/suppressed?** Cleanup uses a sheet dedupe key so each ended fusion cleanup is only processed once; failure ops alerts use dedupe keys.
+* **Failures logged clearly?** Some failures are visible via ops alerts; per-member removal failures are app-log-only.
+
+#### 5. Shard reminder opt-out button
+
+* **Discord ops/admin logs:** None found for success or failure.
+* **App logs:** Generic exception logs for unexpected failures; `discord.Forbidden` only replies to the user and does not log in the inspected snippet.
+* **Silent?** Successful removals are silent to admins, but user-initiated and limited to reminder opt-in roles.
+* **Deduped/suppressed?** No dedupe found.
+* **Failures logged clearly?** Unexpected failures are app logged; forbidden failures are user-visible but not app/ops logged in the inspected snippet.
+
+#### 6. Reaction-role revoke
+
+* **Discord ops/admin logs:** None found for success or failure in the inspected code path.
+* **App logs:** Failures log exceptions with action/key/role/user context. Success logs an info entry after applying rows.
+* **Silent?** Admin-visible Discord logs were not found; revokes are event-driven and user-triggered by reaction removal.
+* **Deduped/suppressed?** No dedupe found.
+* **Failures logged clearly?** Failures are app logged.
+
+#### 7. Reset reminder opt-out button
+
+* **Discord ops/admin logs:** None found.
+* **App logs:** Missing role warns; forbidden and unexpected failures log exceptions with context.
+* **Silent?** Successful removals are silent to admins, but user-initiated and limited to reset reminder roles.
+* **Deduped/suppressed?** No dedupe found.
+* **Failures logged clearly?** Yes in app logs for missing role, forbidden, and unexpected failures.
+
+## Findings Summary
+
+1. **Are roleless/no-role members currently checked?** No. They are scanned and counted, but no roleless/no-meaningful-role condition is evaluated or reported.
+2. **Why are they missing from the report?** The audit has no section for roleless/no-meaningful-role members. Members without Raid, Wandering Souls, Visitor, or configured clan roles fall through `_classify_roles()` as `ok`, and Visitor checks are skipped unless the member has Visitor.
+3. **Can the bot remove roles automatically?** Yes, but not through the daily Role & Visitor Audit. The confirmed automatic role-removal path is Fusion ended-role cleanup, which removes ended fusion opt-in roles. Reaction-role revocation is also event-driven and can remove roles in response to reaction events. The daily Role & Visitor Audit runs as dry-run/report-only.
+4. **Are automatic role removals visible in admin logs?** Not consistently. Fusion ended-role cleanup can successfully remove roles without an admin-visible success summary. Some failures are sent to Fusion ops alerts, but successful removals and per-member failures are not consistently admin-visible. User self-service opt-outs generally acknowledge the user and may log failures, but do not post admin-visible success logs.
+5. **What behavior is confirmed safe?** The scheduled daily Role & Visitor Audit is confirmed report-only: it passes `dry_run=True`, and `_apply_role_changes()` refuses to mutate roles for scheduled/background/startup-like actors. Ticket close/backfill and housekeeping message cleanup were not found to remove member roles.
+6. **What behavior needs follow-up?** Add a roleless/no-meaningful-role reporting bucket if admins want those members visible. Add admin-visible logging/summaries for any automatic role removals, especially Fusion ended-role cleanup, before treating automatic removals as operationally transparent.
+
+## Recommended Follow-Up
+
+Do not implement code yet. Safest follow-up design:
+
+* **Add roleless/no-role members to the existing Role & Visitor Audit report.** This belongs in the current audit because it already scans all guild members and posts to the admin audit destination.
+* **Suggested report section name:** `Roleless / no meaningful roles` or `Members with only @everyone`. If the check becomes broader than literal `@everyone` only, use `Members with no configured allowed roles`.
+* **Make the check sheet/config-driven.** Avoid hard-coding what counts as "meaningful" beyond `@everyone`. Admin expectations may include staff roles, bot roles, event opt-in roles, muted roles, or other non-clan roles.
+* **Possible config needed later:**
+  * A config key or sheet row for enabled/disabled state, for example `roleless_member_audit_enabled`.
+  * A configured allowed-role list, for example `ROLELESS_AUDIT_ALLOWED_ROLE_IDS` or a sheet-backed `AllowedRoles`/`RoleAuditAllowedRoles` tab.
+  * Optional ignore role IDs, ignore user IDs, ignore bot accounts, minimum account age/join age, and max rows to display.
+  * A display label/notes column if using a sheet tab, so admins can document why a role is allowed/ignored.
+* **Suggested criteria if implemented later:**
+  * Literal roleless bucket: member role IDs minus the guild `@everyone` role is empty.
+  * Broader no-meaningful-role bucket: member has no configured clan role, no Visitor, no Raid, no Wandering Souls, and no role in a configured allowed-role list. Decide explicitly whether bot accounts are excluded.
+* **Logging for automatic role removals:**
+  * Every automatic role-removal job should post an admin-visible summary to the relevant ops/audit destination with job name, role IDs/names, member count, success count, skipped count, failure count, and dedupe key/status.
+  * Per-member details should be available in the summary or an attached/truncated detail section when counts are small.
+  * Failures should always be both app-logged and admin-visible, including permission/hierarchy failures.
+  * Success logs should not be entirely silent for automatic removals. If noise is a concern, aggregate summaries are safer than per-member spam.
+
+## Implementation Follow-Up (2026-06-20)
+
+This follow-up implemented the audit changes recommended by the investigation without adding sheet tabs, sheet columns, or new config keys.
+
+* Members whose only role is the guild `@everyone` role are now collected in the existing Role & Visitor Audit and rendered in a `Members with only @everyone` section. Bot accounts are excluded from this section so automated service users do not create noise in the human housekeeping list.
+* The scheduled Role & Visitor Audit remains report-only/dry-run for role mutations.
+* Fusion ended-role cleanup now persists compact unreported cleanup summaries in the existing Fusion reminder/dedupe storage, while retaining runtime state only as a fallback. The scheduled Role & Visitor Audit reads those summaries and renders them in a `Fusion role cleanup` section using the existing audit destination.
+* Cleanup summaries are marked reported only after the scheduled Role & Visitor Audit successfully sends; manual audit/report runs do not clear scheduled cleanup visibility.
+* No separate Fusion cleanup report or standalone daily Fusion cleanup message was added.
+* No report result counts are capped. The audit renderer can split oversized output across multiple embeds/messages while preserving all section lines.

--- a/modules/community/fusion/role_cleanup.py
+++ b/modules/community/fusion/role_cleanup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from dataclasses import dataclass, field
 
 import discord
 from discord.ext import commands
@@ -16,6 +17,129 @@ log = logging.getLogger("c1c.community.fusion.role_cleanup")
 
 _ROLE_CLEANUP_EVENT_ID = "__fusion_role_cleanup__"
 _ROLE_CLEANUP_TYPE = "ended"
+_ROLE_CLEANUP_DEDUPE_KEY = (_ROLE_CLEANUP_EVENT_ID, _ROLE_CLEANUP_TYPE)
+
+
+@dataclass(slots=True)
+class FusionRoleCleanupSummary:
+    fusion_id: str
+    fusion_name: str
+    role_id: int | None
+    role_name: str | None = None
+    members_found: int = 0
+    removed_count: int = 0
+    failed_count: int = 0
+    skipped_count: int = 0
+    dedupe_key: str = f"{_ROLE_CLEANUP_EVENT_ID}:{_ROLE_CLEANUP_TYPE}"
+    status: str = "processed"
+    already_processed: bool = False
+    failure_reasons: list[str] = field(default_factory=list)
+    row_number: int | None = None
+
+
+_RECENT_ROLE_CLEANUP_SUMMARIES: list[FusionRoleCleanupSummary] = []
+
+
+def get_recent_role_cleanup_summaries() -> list[FusionRoleCleanupSummary]:
+    return list(_RECENT_ROLE_CLEANUP_SUMMARIES)
+
+
+def clear_recent_role_cleanup_summaries() -> None:
+    _RECENT_ROLE_CLEANUP_SUMMARIES.clear()
+
+
+def _record_summary(summary: FusionRoleCleanupSummary) -> None:
+    for idx, existing in enumerate(_RECENT_ROLE_CLEANUP_SUMMARIES):
+        if existing.fusion_id == summary.fusion_id and existing.dedupe_key == summary.dedupe_key:
+            if summary.already_processed and not existing.already_processed:
+                return
+            _RECENT_ROLE_CLEANUP_SUMMARIES[idx] = summary
+            return
+    _RECENT_ROLE_CLEANUP_SUMMARIES.append(summary)
+
+
+def _summary_to_payload(summary: FusionRoleCleanupSummary) -> dict[str, object]:
+    return {
+        "fusion_id": summary.fusion_id,
+        "fusion_name": summary.fusion_name,
+        "role_id": summary.role_id,
+        "role_name": summary.role_name,
+        "members_found": summary.members_found,
+        "removed_count": summary.removed_count,
+        "failed_count": summary.failed_count,
+        "skipped_count": summary.skipped_count,
+        "dedupe_key": summary.dedupe_key,
+        "status": summary.status,
+        "already_processed": summary.already_processed,
+        "failure_reasons": list(summary.failure_reasons),
+    }
+
+
+def _summary_from_payload(payload: dict[str, object]) -> FusionRoleCleanupSummary:
+    def _to_int(value: object) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    role_id_value = payload.get("role_id")
+    role_id = None if role_id_value in (None, "") else _to_int(role_id_value)
+    failure_reasons = payload.get("failure_reasons")
+    if not isinstance(failure_reasons, list):
+        failure_reasons = []
+    return FusionRoleCleanupSummary(
+        fusion_id=str(payload.get("fusion_id") or ""),
+        fusion_name=str(payload.get("fusion_name") or ""),
+        role_id=role_id,
+        role_name=str(payload.get("role_name") or "") or None,
+        members_found=_to_int(payload.get("members_found")),
+        removed_count=_to_int(payload.get("removed_count")),
+        failed_count=_to_int(payload.get("failed_count")),
+        skipped_count=_to_int(payload.get("skipped_count")),
+        dedupe_key=str(payload.get("dedupe_key") or f"{_ROLE_CLEANUP_EVENT_ID}:{_ROLE_CLEANUP_TYPE}"),
+        status=str(payload.get("status") or "processed"),
+        already_processed=bool(payload.get("already_processed")),
+        failure_reasons=[str(reason) for reason in failure_reasons],
+        row_number=_to_int(payload.get("_row_number")) or None,
+    )
+
+
+async def _persist_summary(summary: FusionRoleCleanupSummary, *, sent_at: dt.datetime) -> None:
+    try:
+        await fusion_sheets.upsert_role_cleanup_summary(
+            summary.fusion_id,
+            payload=_summary_to_payload(summary),
+            sent_at=sent_at,
+        )
+    except Exception as exc:
+        context = {"fusion_id": summary.fusion_id, "role_id": summary.role_id}
+        log.exception("fusion role cleanup summary persist failed", extra=context)
+        try:
+            await fusion_logs.send_ops_alert(
+                component="role_cleanup",
+                summary="summary_persist_failed",
+                dedupe_key=f"fusion:role_cleanup:summary:{summary.fusion_id}",
+                error=exc,
+                fields=context,
+            )
+        except Exception:
+            log.exception("fusion role cleanup summary persist alert failed", extra=context)
+
+
+async def load_unreported_role_cleanup_summaries() -> list[FusionRoleCleanupSummary]:
+    payloads = await fusion_sheets.get_unreported_role_cleanup_summaries()
+    if payloads:
+        return [_summary_from_payload(dict(payload)) for payload in payloads]
+    return get_recent_role_cleanup_summaries()
+
+
+async def mark_role_cleanup_summaries_reported(
+    summaries: list[FusionRoleCleanupSummary],
+) -> None:
+    row_numbers = [summary.row_number for summary in summaries if summary.row_number]
+    if row_numbers:
+        await fusion_sheets.mark_role_cleanup_summaries_reported(row_numbers)
+    clear_recent_role_cleanup_summaries()
 
 
 def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
@@ -93,30 +217,68 @@ async def process_ended_fusion_role_cleanup(
             )
             continue
 
-        cleanup_key = (_ROLE_CLEANUP_EVENT_ID, _ROLE_CLEANUP_TYPE)
-        if cleanup_key in sent_keys:
+        if _ROLE_CLEANUP_DEDUPE_KEY in sent_keys:
+            try:
+                if await fusion_sheets.has_role_cleanup_summary(target.fusion_id):
+                    continue
+            except Exception:
+                log.warning(
+                    "fusion role cleanup summary state lookup failed",
+                    exc_info=True,
+                    extra={"fusion_id": target.fusion_id},
+                )
+            summary = FusionRoleCleanupSummary(
+                fusion_id=target.fusion_id,
+                fusion_name=target.fusion_name,
+                role_id=target.opt_in_role_id,
+                status="skipped",
+                already_processed=True,
+                skipped_count=1,
+            )
+            _record_summary(summary)
+            await _persist_summary(summary, sent_at=reference)
             continue
 
+        summary = FusionRoleCleanupSummary(
+            fusion_id=target.fusion_id,
+            fusion_name=target.fusion_name,
+            role_id=target.opt_in_role_id,
+        )
         try:
             guild = await _resolve_cleanup_guild(bot, target)
             if guild is None:
+                summary.status = "skipped"
+                summary.skipped_count += 1
+                summary.failure_reasons.append("guild unavailable")
                 log.warning(
                     "fusion role cleanup skipped; guild unavailable",
                     extra={"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id},
                 )
+                _record_summary(summary)
+                await _persist_summary(summary, sent_at=reference)
                 continue
 
             role = guild.get_role(target.opt_in_role_id)
             if role is None:
+                summary.status = "skipped"
+                summary.skipped_count += 1
+                summary.failure_reasons.append("role missing")
                 log.warning(
                     "fusion role cleanup role missing",
                     extra={"fusion_id": target.fusion_id, "guild_id": guild.id, "role_id": target.opt_in_role_id},
                 )
             else:
+                summary.role_name = getattr(role, "name", None)
+                summary.members_found = len(list(getattr(role, "members", [])))
                 for member in list(role.members):
                     try:
                         await member.remove_roles(role, reason=f"Fusion ended: {target.fusion_id}")
+                        summary.removed_count += 1
                     except Exception:
+                        summary.failed_count += 1
+                        summary.failure_reasons.append(
+                            f"member {getattr(member, 'id', 'unknown')}: permission/hierarchy/API failure"
+                        )
                         log.exception(
                             "fusion role cleanup failed for member",
                             extra={
@@ -133,8 +295,17 @@ async def process_ended_fusion_role_cleanup(
                 reminder_type=_ROLE_CLEANUP_TYPE,
                 sent_at=reference,
             )
+            if summary.failed_count:
+                summary.status = "partial_failure"
+            _record_summary(summary)
+            await _persist_summary(summary, sent_at=reference)
         except Exception as exc:
             context = {"fusion_id": target.fusion_id, "role_id": target.opt_in_role_id}
+            summary.status = "failed"
+            summary.failed_count += 1
+            summary.failure_reasons.append(str(exc))
+            _record_summary(summary)
+            await _persist_summary(summary, sent_at=reference)
             log.exception(
                 "fusion role cleanup iteration failed",
                 extra=context,
@@ -148,4 +319,11 @@ async def process_ended_fusion_role_cleanup(
             )
 
 
-__all__ = ["process_ended_fusion_role_cleanup"]
+__all__ = [
+    "FusionRoleCleanupSummary",
+    "clear_recent_role_cleanup_summaries",
+    "get_recent_role_cleanup_summaries",
+    "load_unreported_role_cleanup_summaries",
+    "mark_role_cleanup_summaries_reported",
+    "process_ended_fusion_role_cleanup",
+]

--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -10,6 +10,7 @@ from typing import Iterable, Sequence
 import discord
 from discord.ext import commands
 
+from modules.community.fusion import role_cleanup as fusion_role_cleanup
 from modules.common.embeds import get_embed_colour
 from modules.common.tickets import TicketThread, fetch_ticket_threads
 from shared.config import (
@@ -51,6 +52,8 @@ class AuditResult:
     visitors_no_ticket: list[discord.Member] | None = None
     visitors_closed_only: list[tuple[discord.Member, list[TicketThread]]] | None = None
     visitors_extra_roles: list[tuple[discord.Member, list[discord.Role], list[TicketThread]]] | None = None
+    members_only_everyone: list[discord.Member] | None = None
+    fusion_role_cleanup: list[fusion_role_cleanup.FusionRoleCleanupSummary] | None = None
     proposed_role_mutations: list[tuple[discord.Member, list[discord.Role], list[discord.Role]]] | None = None
     action_roles_removed: list[str] | None = None
     action_roles_added: list[str] | None = None
@@ -88,6 +91,17 @@ def _extra_roles(member: discord.Member, visitor_role_id: int) -> list[discord.R
     return extras
 
 
+def _is_only_everyone_member(member: discord.Member) -> bool:
+    """Return True for non-bot members whose only role is the guild @everyone role."""
+    if getattr(member, "bot", False):
+        return False
+    guild_id = getattr(getattr(member, "guild", None), "id", None)
+    role_ids = _member_roles(member)
+    if guild_id is not None:
+        role_ids.discard(int(guild_id))
+    return not role_ids
+
+
 def _format_member(member: discord.Member) -> str:
     mention = getattr(member, "mention", None)
     if mention:
@@ -96,6 +110,13 @@ def _format_member(member: discord.Member) -> str:
     if name:
         return f"{name} ({getattr(member, 'id', 'unknown')})"
     return str(getattr(member, "id", "unknown"))
+
+
+def _format_member_with_username(member: discord.Member) -> str:
+    name = getattr(member, "display_name", None) or getattr(member, "name", None)
+    if not name:
+        name = str(getattr(member, "id", "unknown"))
+    return f"{_format_member(member)} – {name}"
 
 
 def _format_roles(roles: Iterable[discord.Role]) -> str:
@@ -214,6 +235,7 @@ async def _audit_guild(
         visitors_no_ticket=[],
         visitors_closed_only=[],
         visitors_extra_roles=[],
+        members_only_everyone=[],
         proposed_role_mutations=[],
         action_roles_removed=[],
         action_roles_added=[],
@@ -223,6 +245,8 @@ async def _audit_guild(
 
     for member in members:
         member_roles = _member_roles(member)
+        if _is_only_everyone_member(member):
+            result.members_only_everyone.append(member)
 
         classification = _classify_roles(
             member_roles,
@@ -309,17 +333,33 @@ def _format_joined_date(member: discord.abc.User) -> str:
     return joined_at.strftime("%Y-%m-%d")
 
 
-def _render_report(
+def _build_fusion_cleanup_lines(
+    summaries: Sequence[fusion_role_cleanup.FusionRoleCleanupSummary],
+) -> list[str]:
+    lines: list[str] = []
+    for item in summaries:
+        role_label = item.role_name or "unknown"
+        status = "already processed/skipped" if item.already_processed else item.status
+        lines.append(
+            "• "
+            f"{item.fusion_name or item.fusion_id} (`{item.fusion_id}`) – "
+            f"role `{role_label}` ({item.role_id or 'missing'}); "
+            f"found={item.members_found}, removed={item.removed_count}, "
+            f"failed={item.failed_count}, skipped={item.skipped_count}; "
+            f"dedupe=`{item.dedupe_key}` {status}"
+        )
+        for reason in item.failure_reasons:
+            lines.append(f"  ◦ failure: {reason}")
+    return lines
+
+
+def _build_report_sections(
     *,
     summary: AuditResult,
     raid_role_name: str,
     wanderer_role_name: str,
     dry_run: bool = True,
-) -> discord.Embed:
-    date_text = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-
-    parts: list[str] = []
-
+) -> tuple[list[tuple[str, list[str]]], list[tuple[str, list[str]]]]:
     stray_action = "Would remove" if dry_run else "Removed"
     stray_add_action = "would add" if dry_run else "added"
     wanderer_action = "Would remove" if dry_run else "Removed"
@@ -364,6 +404,17 @@ def _render_report(
     if visitor_extra_roles:
         detected_sections.append(("5) Visitors with extra roles", visitor_extra_roles))
 
+    only_everyone_lines = [
+        f"• {_format_member_with_username(member)}"
+        for member in (summary.members_only_everyone or [])
+    ]
+    if only_everyone_lines:
+        detected_sections.append(("6) Members with only @everyone", only_everyone_lines))
+
+    fusion_lines = _build_fusion_cleanup_lines(summary.fusion_role_cleanup or [])
+    if fusion_lines:
+        detected_sections.append(("7) Fusion role cleanup", fusion_lines))
+
     if summary.action_roles_removed:
         action_sections.append(("6) Roles removed", summary.action_roles_removed))
     if summary.action_roles_added:
@@ -373,30 +424,110 @@ def _render_report(
     if summary.action_failed_or_skipped:
         action_sections.append(("9) Failed / skipped actions", summary.action_failed_or_skipped))
 
+    return detected_sections, action_sections
+
+
+_SAFE_DESCRIPTION_LIMIT = 3800
+
+
+def _section_blocks(sections: Sequence[tuple[str, list[str]]], *, heading: str) -> list[list[str]]:
+    if not sections:
+        return []
+    blocks: list[list[str]] = [["━━━━━━━━━━━━", heading, "━━━━━━━━━━━━", ""]]
+    for idx, (title, lines) in enumerate(sections):
+        section_lines = _render_section(title, lines)
+        if idx < len(sections) - 1:
+            section_lines.append("")
+        blocks.append(section_lines)
+    return blocks
+
+
+def _split_report_parts(blocks: Sequence[Sequence[str]]) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+
+    def _joined_len(lines: Sequence[str]) -> int:
+        return len("\n".join(lines).strip())
+
+    for block in blocks:
+        block_lines = list(block)
+        if current and _joined_len([*current, *block_lines]) > _SAFE_DESCRIPTION_LIMIT:
+            parts.append("\n".join(current).strip())
+            current = []
+        if _joined_len(block_lines) <= _SAFE_DESCRIPTION_LIMIT:
+            current.extend(block_lines)
+            continue
+
+        header = block_lines[:1]
+        entries = block_lines[1:]
+        if not current:
+            current.extend(header)
+        for line in entries:
+            if current and _joined_len([*current, line]) > _SAFE_DESCRIPTION_LIMIT:
+                parts.append("\n".join(current).strip())
+                current = header.copy()
+            current.append(line)
+    if current or not parts:
+        parts.append("\n".join(current).strip())
+    return parts
+
+
+def _render_report_embeds(
+    *,
+    summary: AuditResult,
+    raid_role_name: str,
+    wanderer_role_name: str,
+    dry_run: bool = True,
+) -> list[discord.Embed]:
+    date_text = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    detected_sections, action_sections = _build_report_sections(
+        summary=summary,
+        raid_role_name=raid_role_name,
+        wanderer_role_name=wanderer_role_name,
+        dry_run=dry_run,
+    )
+    blocks: list[list[str]] = []
     if detected_sections:
-        parts.extend(["━━━━━━━━━━━━", "DETECTED ISSUES", "━━━━━━━━━━━━", ""])
-        for idx, (title, lines) in enumerate(detected_sections):
-            parts.extend(_render_section(title, lines))
-            if idx < len(detected_sections) - 1:
-                parts.append("")
+        blocks.extend(_section_blocks(detected_sections, heading="DETECTED ISSUES"))
 
     if action_sections:
-        if parts:
-            parts.append("")
-        parts.extend(["━━━━━━━━━━━━", "ACTIONS PERFORMED", "━━━━━━━━━━━━", ""])
-        for idx, (title, lines) in enumerate(action_sections):
-            parts.extend(_render_section(title, lines))
-            if idx < len(action_sections) - 1:
-                parts.append("")
+        if blocks:
+            blocks.append([""])
+        blocks.extend(_section_blocks(action_sections, heading="ACTIONS PERFORMED"))
 
-    embed = discord.Embed(
-        title="🧹 Role & Visitor Audit",
-        description="\n".join(parts).strip(),
-        colour=get_embed_colour("admin"),
-    )
-    embed.set_footer(text=f"Date: {date_text} • Checked: {summary.checked} members")
+    parts = _split_report_parts(blocks)
+    embeds: list[discord.Embed] = []
+    for idx, description in enumerate(parts, start=1):
+        total = len(parts)
+        title = "🧹 Role & Visitor Audit"
+        if total > 1:
+            title = f"{title} ({idx}/{total})"
+        embed = discord.Embed(
+            title=title,
+            description=description,
+            colour=get_embed_colour("admin"),
+        )
+        footer = f"Date: {date_text} • Checked: {summary.checked} members"
+        if total > 1:
+            footer = f"{footer} • Part {idx}/{total}"
+        embed.set_footer(text=footer)
+        embeds.append(embed)
+    return embeds
 
-    return embed
+
+def _render_report(
+    *,
+    summary: AuditResult,
+    raid_role_name: str,
+    wanderer_role_name: str,
+    dry_run: bool = True,
+) -> discord.Embed:
+    return _render_report_embeds(
+        summary=summary,
+        raid_role_name=raid_role_name,
+        wanderer_role_name=wanderer_role_name,
+        dry_run=dry_run,
+    )[0]
 
 
 async def run_role_and_visitor_audit(
@@ -426,6 +557,13 @@ async def run_role_and_visitor_audit(
 
     raid_role_name = "Raid"
     wanderer_role_name = "Wandering Souls"
+    actor_normalized = (actor or "").strip().lower()
+    scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
+    try:
+        fusion_cleanup_summaries = await fusion_role_cleanup.load_unreported_role_cleanup_summaries()
+    except Exception:
+        log.warning("failed to load fusion role cleanup summaries", exc_info=True)
+        fusion_cleanup_summaries = fusion_role_cleanup.get_recent_role_cleanup_summaries()
     aggregated = AuditResult(
         checked=0,
         auto_fixed_strays=[],
@@ -434,6 +572,8 @@ async def run_role_and_visitor_audit(
         visitors_no_ticket=[],
         visitors_closed_only=[],
         visitors_extra_roles=[],
+        members_only_everyone=[],
+        fusion_role_cleanup=fusion_cleanup_summaries,
         proposed_role_mutations=[],
         action_roles_removed=[],
         action_roles_added=[],
@@ -471,6 +611,7 @@ async def run_role_and_visitor_audit(
         aggregated.visitors_no_ticket.extend(result.visitors_no_ticket or [])
         aggregated.visitors_closed_only.extend(result.visitors_closed_only or [])
         aggregated.visitors_extra_roles.extend(result.visitors_extra_roles or [])
+        aggregated.members_only_everyone.extend(result.members_only_everyone or [])
         aggregated.proposed_role_mutations.extend(result.proposed_role_mutations or [])
         aggregated.action_roles_removed.extend(result.action_roles_removed or [])
         aggregated.action_roles_added.extend(result.action_roles_added or [])
@@ -482,8 +623,6 @@ async def run_role_and_visitor_audit(
 
     proposed_adds = len(aggregated.auto_fixed_strays or [])
     proposed_removes = len(aggregated.auto_fixed_strays or []) + len(aggregated.auto_fixed_wanderers or [])
-    actor_normalized = (actor or "").strip().lower()
-    scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
     if dry_run or actor_normalized in scheduled_actors:
         log.info(
             "role audit mutations skipped",
@@ -533,7 +672,7 @@ async def run_role_and_visitor_audit(
         },
     )
 
-    embed = _render_report(
+    embeds = _render_report_embeds(
         summary=aggregated,
         raid_role_name=raid_role_name,
         wanderer_role_name=wanderer_role_name,
@@ -541,10 +680,16 @@ async def run_role_and_visitor_audit(
     )
 
     try:
-        await channel.send(embed=embed)
+        for embed in embeds:
+            await channel.send(embed=embed)
     except Exception as exc:
         log.warning("failed to send role audit report", exc_info=True)
         return False, f"send:{type(exc).__name__}"
+    if actor_normalized == "scheduled":
+        try:
+            await fusion_role_cleanup.mark_role_cleanup_summaries_reported(fusion_cleanup_summaries)
+        except Exception:
+            log.warning("failed to mark fusion role cleanup summaries reported", exc_info=True)
 
     return True, "-"
 
@@ -570,6 +715,7 @@ async def preview_role_audit_mutations(
         visitors_no_ticket=[],
         visitors_closed_only=[],
         visitors_extra_roles=[],
+        members_only_everyone=[],
         proposed_role_mutations=[],
         action_roles_removed=[],
         action_roles_added=[],

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -28,6 +29,8 @@ _LAST_FUSION_PARSE_ERRORS: dict[str, str] = {}
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
 _FUSION_REMINDER_SETTINGS_TAB_KEY = "FUSION_REMINDER_SETTINGS_TAB"
+_FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED = "__fusion_role_cleanup_summary_unreported__"
+_FUSION_ROLE_CLEANUP_SUMMARY_REPORTED = "__fusion_role_cleanup_summary_reported__"
 _FUSION_REMINDER_SETTINGS_COLUMN_HEADERS: dict[str, tuple[str, ...]] = {
     "setting_key": ("setting_key",),
     "value": ("value",),
@@ -1105,6 +1108,152 @@ async def mark_reminder_sent(
     )
 
 
+async def upsert_role_cleanup_summary(
+    fusion_id: str,
+    *,
+    payload: Mapping[str, object],
+    sent_at: dt.datetime,
+) -> None:
+    """Persist an unreported Fusion role-cleanup summary in existing reminder storage."""
+
+    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        raise RuntimeError(
+            "Fusion reminder sheet is empty "
+            f"(tab={tab_name}, key={_FUSION_REMINDER_TAB_KEY})"
+        )
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    event_idx = index_by_field["event_id"]
+    reminder_idx = index_by_field["reminder_type"]
+    sent_at_idx = index_by_field["sent_at_utc"]
+    target_fusion = str(fusion_id or "").strip()
+    payload_text = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+    sent_token = sent_at.astimezone(dt.timezone.utc).isoformat()
+
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    for row_idx, row in enumerate(matrix[1:], start=2):
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_event = str(row[event_idx] if event_idx < len(row) else "").strip()
+        if row_fusion != target_fusion or row_event != _FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED:
+            continue
+        await acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(reminder_idx)}{row_idx}",
+            [[payload_text]],
+            value_input_option="RAW",
+        )
+        await acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(sent_at_idx)}{row_idx}",
+            [[sent_token]],
+            value_input_option="RAW",
+        )
+        return
+
+    row_values = [""] * len(header)
+    row_values[fusion_idx] = target_fusion
+    row_values[event_idx] = _FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED
+    row_values[reminder_idx] = payload_text
+    row_values[sent_at_idx] = sent_token
+    await acall_with_backoff(
+        worksheet.append_row,
+        row_values,
+        value_input_option="RAW",
+    )
+
+
+async def get_unreported_role_cleanup_summaries() -> list[dict[str, object]]:
+    """Read unreported Fusion role-cleanup summaries from existing reminder storage."""
+
+    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return []
+
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    event_idx = index_by_field["event_id"]
+    reminder_idx = index_by_field["reminder_type"]
+    sent_at_idx = index_by_field["sent_at_utc"]
+    results: list[dict[str, object]] = []
+    for row_idx, row in enumerate(matrix[1:], start=2):
+        row_event = str(row[event_idx] if event_idx < len(row) else "").strip()
+        if row_event != _FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED:
+            continue
+        payload_text = str(row[reminder_idx] if reminder_idx < len(row) else "").strip()
+        try:
+            payload = json.loads(payload_text) if payload_text else {}
+        except json.JSONDecodeError:
+            payload = {"status": "failed", "failure_reasons": ["summary payload malformed"]}
+        if not isinstance(payload, dict):
+            payload = {"status": "failed", "failure_reasons": ["summary payload malformed"]}
+        payload.setdefault("fusion_id", str(row[fusion_idx] if fusion_idx < len(row) else "").strip())
+        payload["_row_number"] = row_idx
+        payload["_sent_at_utc"] = str(row[sent_at_idx] if sent_at_idx < len(row) else "").strip()
+        results.append(payload)
+    return results
+
+
+async def has_role_cleanup_summary(fusion_id: str) -> bool:
+    """Return True when a cleanup summary row already exists for a fusion."""
+
+    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return False
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = {
+        field: _resolve_header_index(tab_name=tab_name, header=header, field=field)
+        for field in required_fields
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    event_idx = index_by_field["event_id"]
+    target_fusion = str(fusion_id or "").strip()
+    summary_events = {
+        _FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED,
+        _FUSION_ROLE_CLEANUP_SUMMARY_REPORTED,
+    }
+    for row in matrix[1:]:
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_event = str(row[event_idx] if event_idx < len(row) else "").strip()
+        if row_fusion == target_fusion and row_event in summary_events:
+            return True
+    return False
+
+
+async def mark_role_cleanup_summaries_reported(row_numbers: list[int]) -> None:
+    """Mark persisted Fusion role-cleanup summary rows as reported."""
+
+    if not row_numbers:
+        return
+    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        return
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    event_idx = _resolve_header_index(tab_name=tab_name, header=header, field="event_id")
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    for row_number in sorted({int(row) for row in row_numbers if int(row) > 1}):
+        cell = f"{_column_label(event_idx)}{row_number}"
+        await acall_with_backoff(
+            worksheet.update,
+            cell,
+            [[_FUSION_ROLE_CLEANUP_SUMMARY_REPORTED]],
+            value_input_option="RAW",
+        )
+
+
 def _normalize_progress_status(value: object) -> str:
     status = str(value or "").strip().lower()
     if status in _PROGRESS_ALLOWED_STATUSES:
@@ -1609,13 +1758,17 @@ __all__ = [
     "get_last_fusion_parse_errors",
     "get_fusion_events",
     "get_sent_reminder_keys",
+    "get_unreported_role_cleanup_summaries",
+    "has_role_cleanup_summary",
     "reminder_dedupe_backend_metadata",
     "get_user_event_progress",
     "get_progress_sheet_diagnostics",
     "get_upcoming_events",
     "get_fusion_reminder_settings",
     "get_last_reminder_sent_at",
+    "mark_role_cleanup_summaries_reported",
     "mark_reminder_sent",
+    "upsert_role_cleanup_summary",
     "upsert_user_event_progress",
     "update_fusion_publication",
     "update_fusion_announcement_refresh_state",

--- a/tests/community/test_fusion_role_cleanup.py
+++ b/tests/community/test_fusion_role_cleanup.py
@@ -44,6 +44,7 @@ class _Member:
 class _Role:
     def __init__(self, role_id: int, members: list[_Member]) -> None:
         self.id = role_id
+        self.name = "Fusion Ping"
         self.members = members
 
 
@@ -58,6 +59,7 @@ class _Guild:
 
 def test_ended_fusion_triggers_role_cleanup(monkeypatch):
     async def _run() -> None:
+        role_cleanup.clear_recent_role_cleanup_summaries()
         members = [_Member(1), _Member(2)]
         role = _Role(777, members)
         guild = _Guild(role)
@@ -68,6 +70,7 @@ def test_ended_fusion_triggers_role_cleanup(monkeypatch):
         monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "upsert_role_cleanup_summary", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
         monkeypatch.setattr(role_cleanup, "_resolve_cleanup_guild", AsyncMock(return_value=guild))
 
@@ -77,12 +80,18 @@ def test_ended_fusion_triggers_role_cleanup(monkeypatch):
             member.remove_roles.assert_awaited_once_with(role, reason="Fusion ended: f-ended")
         fusion_sheets.transition_fusion_to_ended.assert_awaited_once_with("f-ended")
         fusion_sheets.mark_reminder_sent.assert_awaited_once()
+        summaries = role_cleanup.get_recent_role_cleanup_summaries()
+        assert len(summaries) == 1
+        assert summaries[0].members_found == 2
+        assert summaries[0].removed_count == 2
+        assert summaries[0].failed_count == 0
 
     asyncio.run(_run())
 
 
 def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
     async def _run() -> None:
+        role_cleanup.clear_recent_role_cleanup_summaries()
         member = _Member(1)
         role = _Role(777, [member])
         guild = _Guild(role)
@@ -97,6 +106,8 @@ def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
             AsyncMock(return_value={("__fusion_role_cleanup__", "ended")}),
         )
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "upsert_role_cleanup_summary", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "has_role_cleanup_summary", AsyncMock(return_value=False))
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
 
         await role_cleanup.process_ended_fusion_role_cleanup(bot)
@@ -104,6 +115,10 @@ def test_cleanup_is_one_shot_via_dedupe(monkeypatch):
         member.remove_roles.assert_not_awaited()
         fusion_sheets.transition_fusion_to_ended.assert_awaited_once_with("f-ended")
         fusion_sheets.mark_reminder_sent.assert_not_awaited()
+        summaries = role_cleanup.get_recent_role_cleanup_summaries()
+        assert len(summaries) == 1
+        assert summaries[0].already_processed is True
+        assert summaries[0].skipped_count == 1
 
     asyncio.run(_run())
 
@@ -118,18 +133,24 @@ def test_missing_role_is_handled_safely(monkeypatch):
         monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "upsert_role_cleanup_summary", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
         monkeypatch.setattr(role_cleanup, "_resolve_cleanup_guild", AsyncMock(return_value=guild))
 
         await role_cleanup.process_ended_fusion_role_cleanup(bot)
 
         fusion_sheets.mark_reminder_sent.assert_awaited_once()
+        summaries = role_cleanup.get_recent_role_cleanup_summaries()
+        assert summaries[-1].status == "skipped"
+        assert summaries[-1].skipped_count == 1
+        assert summaries[-1].failure_reasons == ["role missing"]
 
     asyncio.run(_run())
 
 
 def test_partial_member_failure_does_not_abort(monkeypatch):
     async def _run() -> None:
+        role_cleanup.clear_recent_role_cleanup_summaries()
         members = [_Member(1, fail=True), _Member(2, fail=False)]
         role = _Role(777, members)
         guild = _Guild(role)
@@ -140,6 +161,7 @@ def test_partial_member_failure_does_not_abort(monkeypatch):
         monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=True))
         monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
         monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+        monkeypatch.setattr(fusion_sheets, "upsert_role_cleanup_summary", AsyncMock())
         monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
 
         await role_cleanup.process_ended_fusion_role_cleanup(bot)
@@ -147,5 +169,96 @@ def test_partial_member_failure_does_not_abort(monkeypatch):
         assert members[0].remove_roles.await_count == 1
         assert members[1].remove_roles.await_count == 1
         fusion_sheets.mark_reminder_sent.assert_awaited_once()
+        summaries = role_cleanup.get_recent_role_cleanup_summaries()
+        assert summaries[-1].members_found == 2
+        assert summaries[-1].removed_count == 1
+        assert summaries[-1].failed_count == 1
+        assert summaries[-1].status == "partial_failure"
+
+    asyncio.run(_run())
+
+
+def test_loads_persisted_unreported_cleanup_summary(monkeypatch):
+    async def _run() -> None:
+        monkeypatch.setattr(
+            fusion_sheets,
+            "get_unreported_role_cleanup_summaries",
+            AsyncMock(
+                return_value=[
+                    {
+                        "fusion_id": "f-ended",
+                        "fusion_name": "Old Fusion",
+                        "role_id": 777,
+                        "role_name": "Fusion Ping",
+                        "members_found": 3,
+                        "removed_count": 2,
+                        "failed_count": 1,
+                        "skipped_count": 0,
+                        "status": "partial_failure",
+                        "failure_reasons": ["member 1: permission/hierarchy/API failure"],
+                        "_row_number": 12,
+                    }
+                ]
+            ),
+        )
+
+        summaries = await role_cleanup.load_unreported_role_cleanup_summaries()
+
+        assert len(summaries) == 1
+        assert summaries[0].fusion_id == "f-ended"
+        assert summaries[0].removed_count == 2
+        assert summaries[0].failed_count == 1
+        assert summaries[0].row_number == 12
+
+    asyncio.run(_run())
+
+
+def test_mark_reported_uses_persisted_rows_and_clears_runtime(monkeypatch):
+    async def _run() -> None:
+        marker = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "mark_role_cleanup_summaries_reported", marker)
+        role_cleanup.clear_recent_role_cleanup_summaries()
+        runtime_summary = role_cleanup.FusionRoleCleanupSummary(
+            fusion_id="f-ended",
+            fusion_name="Old Fusion",
+            role_id=777,
+            row_number=12,
+        )
+        role_cleanup._record_summary(runtime_summary)
+
+        await role_cleanup.mark_role_cleanup_summaries_reported([runtime_summary])
+
+        marker.assert_awaited_once_with([12])
+        assert role_cleanup.get_recent_role_cleanup_summaries() == []
+
+    asyncio.run(_run())
+
+
+def test_dedupe_does_not_recreate_summary_after_reported(monkeypatch):
+    async def _run() -> None:
+        role_cleanup.clear_recent_role_cleanup_summaries()
+        member = _Member(1)
+        role = _Role(777, [member])
+        guild = _Guild(role)
+        channel = SimpleNamespace(guild=guild)
+        bot = SimpleNamespace(guilds=[guild])
+
+        monkeypatch.setattr(fusion_sheets, "get_ended_fusions", AsyncMock(return_value=[_fusion_row()]))
+        monkeypatch.setattr(fusion_sheets, "transition_fusion_to_ended", AsyncMock(return_value=False))
+        monkeypatch.setattr(
+            fusion_sheets,
+            "get_sent_reminder_keys",
+            AsyncMock(return_value={("__fusion_role_cleanup__", "ended")}),
+        )
+        upsert = AsyncMock()
+        monkeypatch.setattr(fusion_sheets, "upsert_role_cleanup_summary", upsert)
+        monkeypatch.setattr(fusion_sheets, "has_role_cleanup_summary", AsyncMock(return_value=True))
+        monkeypatch.setattr(role_cleanup, "resolve_announcement_channel", AsyncMock(return_value=channel))
+
+        await role_cleanup.process_ended_fusion_role_cleanup(bot)
+
+        member.remove_roles.assert_not_awaited()
+        upsert.assert_not_awaited()
+        assert role_cleanup.get_recent_role_cleanup_summaries() == []
 
     asyncio.run(_run())

--- a/tests/housekeeping/test_role_audit.py
+++ b/tests/housekeeping/test_role_audit.py
@@ -128,3 +128,116 @@ def test_render_report_dry_run_wording_and_footer():
     assert embed.footer.text is not None
     assert "Date:" in embed.footer.text
     assert "Checked: 9 members" in embed.footer.text
+
+
+def test_only_everyone_section_includes_non_bot_member():
+    guild = SimpleNamespace(id=100)
+    everyone = DummyRole(id=100, name="@everyone")
+    member = DummyMember(id=1, name="roleless", display_name="Role Less", guild=guild, roles=[everyone], bot=False)
+    summary = role_audit.AuditResult(checked=1, members_only_everyone=[member])
+
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+
+    description = embed.description or ""
+    assert "Members with only @everyone" in description
+    assert "<@1>" in description
+    assert "Role Less" in description
+
+
+def test_only_everyone_helper_excludes_members_with_other_roles_and_bots():
+    guild = SimpleNamespace(id=100)
+    everyone = DummyRole(id=100, name="@everyone")
+    other = DummyRole(id=200, name="Member")
+    human_only_everyone = DummyMember(id=1, guild=guild, roles=[everyone], bot=False)
+    human_with_role = DummyMember(id=2, guild=guild, roles=[everyone, other], bot=False)
+    bot_only_everyone = DummyMember(id=3, guild=guild, roles=[everyone], bot=True)
+
+    assert role_audit._is_only_everyone_member(human_only_everyone) is True
+    assert role_audit._is_only_everyone_member(human_with_role) is False
+    assert role_audit._is_only_everyone_member(bot_only_everyone) is False
+
+
+def test_render_report_large_roleless_set_splits_without_omitting_members():
+    guild = SimpleNamespace(id=100)
+    everyone = DummyRole(id=100, name="@everyone")
+    members = [
+        DummyMember(
+            id=idx,
+            name=f"roleless-{idx}",
+            display_name=f"Roleless Member {idx}",
+            guild=guild,
+            roles=[everyone],
+            bot=False,
+        )
+        for idx in range(1, 220)
+    ]
+    summary = role_audit.AuditResult(checked=len(members), members_only_everyone=members)
+
+    embeds = role_audit._render_report_embeds(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+    combined = "\n".join(embed.description or "" for embed in embeds)
+
+    assert len(embeds) > 1
+    for member in members:
+        assert f"<@{member.id}>" in combined
+    assert all(len(embed.description or "") <= 4096 for embed in embeds)
+
+
+def test_scheduled_role_audit_apply_changes_remains_report_only():
+    member = DummyMember(id=1, roles=[])
+    role = DummyRole(id=2, name="Raid")
+    called = False
+
+    async def _remove_roles(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    member.remove_roles = _remove_roles
+
+    import asyncio
+
+    changed, error = asyncio.run(
+        role_audit._apply_role_changes(
+            member,
+            actor="scheduled",
+            dry_run=False,
+            remove=(role,),
+        )
+    )
+
+    assert changed is True
+    assert error is None
+    assert called is False
+
+
+def test_fusion_cleanup_section_renders_summary_counts():
+    summary = role_audit.AuditResult(
+        checked=0,
+        fusion_role_cleanup=[
+            role_audit.fusion_role_cleanup.FusionRoleCleanupSummary(
+                fusion_id="f-ended",
+                fusion_name="Old Fusion",
+                role_id=777,
+                role_name="Fusion Ping",
+                members_found=3,
+                removed_count=2,
+                failed_count=1,
+                skipped_count=0,
+                status="partial_failure",
+                failure_reasons=["member 1: permission/hierarchy/API failure"],
+            )
+        ],
+    )
+
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+    description = embed.description or ""
+
+    assert "Fusion role cleanup" in description
+    assert "Old Fusion" in description
+    assert "found=3, removed=2, failed=1, skipped=0" in description
+    assert "permission/hierarchy/API failure" in description


### PR DESCRIPTION
### Motivation

- Ensure roleless/hygiene users are visible in the existing Role & Visitor Audit by surfacing members whose only role is `@everyone` while excluding bot accounts. 
- Make automatic Fusion ended-role cleanup operations operationally transparent by persisting compact per-fusion cleanup summaries and surfacing them in the daily audit. 
- Avoid losing large audits to Discord embed length limits by splitting oversized reports across multiple embeds and preserve all detected lines.

### Description

- Added detection for non-bot members whose only role is the guild `@everyone` via `_is_only_everyone_member()` and collect them in `AuditResult.members_only_everyone` during `_audit_guild()` in `modules/housekeeping/role_audit.py`.
- Rendered a new `Members with only @everyone` section in the Role & Visitor Audit and included `Fusion role cleanup` summary lines; added helper formatting and a stable multi-embed renderer that splits long reports (`_render_report_embeds`, `_split_report_parts`) and preserves footers/parts.
- Introduced `FusionRoleCleanupSummary` dataclass and an in-memory list plus persistence helpers in `modules/community/fusion/role_cleanup.py` to record, dedupe, and persist compact cleanup summaries; process now records removed/failed/skipped counts and failure reasons and attempts to persist them to sheets.
- Added sheet-backed storage helpers in `shared/sheets/fusion.py` to `upsert_role_cleanup_summary`, `get_unreported_role_cleanup_summaries`, `has_role_cleanup_summary`, and `mark_role_cleanup_summaries_reported` using the existing fusion reminder sheet layout.
- The scheduled audit attempts to load unreported Fusion cleanup summaries and mark persisted summaries as reported after the scheduled send; manual runs do not clear persisted visibility.
- Existing scheduled/dry-run semantics for role mutations are preserved and `_apply_role_changes()` still refuses to mutate for scheduled/background actors.
- Tests updated/added to cover the new behavior and persistence API changes in `tests/community/test_fusion_role_cleanup.py` and `tests/housekeeping/test_role_audit.py`.

### Testing

- Updated and added unit tests in `tests/community/test_fusion_role_cleanup.py` to validate summary recording, persistence interactions, dedupe behavior, partial failures, and loading persisted summaries, and in `tests/housekeeping/test_role_audit.py` to validate the `only @everyone` section, helper exclusion rules, multi-embed splitting, scheduled no-op applies, and Fusion cleanup section rendering. 
- Ran the test suite (pytest); all added and existing unit tests related to the changes passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36585e3b588323803adc6b3af4b142)