### PR TITLE
Add staff `!setopenspots` command with availability wrapper and tests

### DIFF
--- a/cogs/recruitment_open_spots.py
+++ b/cogs/recruitment_open_spots.py
@@ -1,0 +1,138 @@
+"""Emergency recruitment open-spots correction command."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import is_admin_member, is_staff_member, ops_only
+from modules.common import runtime as runtime_helpers
+from modules.recruitment import availability
+
+log = logging.getLogger(__name__)
+
+USAGE = "!setopenspots <clan_tag_or_name> <open_spots> <reason>"
+
+
+def _display_name(author: object) -> str:
+    return str(
+        getattr(author, "display_name", None)
+        or getattr(author, "name", None)
+        or getattr(author, "id", "Unknown")
+    )
+
+
+def _parse_whole_number(value: str | None) -> Optional[int]:
+    if value is None or not re.fullmatch(r"\d+", str(value).strip()):
+        return None
+    parsed = int(str(value).strip())
+    return parsed if parsed >= 0 else None
+
+
+class RecruitmentOpenSpotsCog(commands.Cog):
+    """Staff/admin emergency overrides for recruitment availability."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("staff")
+    @help_metadata(
+        function_group="recruitment", section="recruitment", access_tier="staff"
+    )
+    @commands.command(
+        name="setopenspots",
+        usage="<clan_tag_or_name> <open_spots> <reason>",
+        help="Emergency staff/admin correction for configured clan open spots.",
+        brief="Corrects configured clan open spots.",
+    )
+    @ops_only()
+    async def setopenspots(
+        self,
+        ctx: commands.Context,
+        clan_tag_or_name: Optional[str] = None,
+        open_spots: Optional[str] = None,
+        *,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Manually correct a clan's configured open-spots availability value."""
+
+        if not (is_staff_member(ctx) or is_admin_member(ctx)):
+            await ctx.reply(
+                "You do not have permission to use this command.", mention_author=False
+            )
+            return
+
+        if (
+            not clan_tag_or_name
+            or open_spots is None
+            or not reason
+            or not reason.strip()
+        ):
+            await ctx.reply(f"Usage: {USAGE}", mention_author=False)
+            return
+
+        new_value = _parse_whole_number(open_spots)
+        if new_value is None:
+            await ctx.reply(
+                "open_spots must be a whole number >= 0.", mention_author=False
+            )
+            return
+
+        try:
+            old_value, corrected_value, resolved_clan = (
+                await availability.set_manual_open_spots(clan_tag_or_name, new_value)
+            )
+        except ValueError as exc:
+            message = str(exc).lower()
+            if "ambiguous" in message or "multiple clans" in message:
+                await ctx.reply(
+                    "That clan input matches multiple clans; please use the clan tag.",
+                    mention_author=False,
+                )
+                return
+            if "unknown clan" in message or "row_not_found" in message:
+                await ctx.reply("The clan could not be found.", mention_author=False)
+                return
+            log.exception("setopenspots configuration/header resolution failed")
+            await runtime_helpers.send_log_message(
+                f"⚠️ Open spots correction failed: recruitment sheet configuration invalid for {clan_tag_or_name}."
+            )
+            await ctx.reply(
+                "The correction could not be applied because recruitment sheet configuration is incomplete or invalid.",
+                mention_author=False,
+            )
+            return
+        except Exception:
+            log.exception("setopenspots sheet update failed")
+            await runtime_helpers.send_log_message(
+                f"⚠️ Open spots correction failed: recruitment sheet configuration invalid for {clan_tag_or_name}."
+            )
+            await ctx.reply(
+                "The correction could not be applied because recruitment sheet configuration is incomplete or invalid.",
+                mention_author=False,
+            )
+            return
+
+        actor = _display_name(ctx.author)
+        actor_id = getattr(ctx.author, "id", None)
+        await ctx.reply(
+            "**Open spots corrected**\n\n"
+            f"Clan: {resolved_clan}\n"
+            f"Open spots: {old_value} → {corrected_value}\n"
+            f"Reason: {reason.strip()}\n"
+            f"Updated by: {actor}",
+            mention_author=False,
+        )
+        id_suffix = f" ({actor_id})" if actor_id is not None else ""
+        await runtime_helpers.send_log_message(
+            f"🛠️ Open spots corrected: {resolved_clan} {old_value} → {corrected_value} by {actor}{id_suffix}\n"
+            f"Reason: {reason.strip()}"
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RecruitmentOpenSpotsCog(bot))

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -56,6 +56,8 @@ from modules.community import COMMUNITY_EXTENSIONS
 log = logging.getLogger("c1c.runtime")
 
 _ACTIVE_RUNTIME: "Runtime | None" = None
+
+
 @dataclass(slots=True)
 class StartupPreloadReport:
     rows: list[dict[str, object]]
@@ -97,7 +99,8 @@ async def create_app(*, runtime: "Runtime | None" = None) -> web.Application:
 
     @web.middleware
     async def tracing_middleware(
-        request: web.Request, handler: Callable[[web.Request], Awaitable[web.StreamResponse]]
+        request: web.Request,
+        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
     ) -> web.StreamResponse:
         trace = set_trace_id()
         started = time.perf_counter()
@@ -208,7 +211,9 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
     bucket_names = cache_telemetry.list_buckets()
     if not bucket_names:
         log.info("Cache preloader skipped: no cache buckets registered")
-        return StartupPreloadReport(rows=[], total_s=0.0, error="no cache buckets registered")
+        return StartupPreloadReport(
+            rows=[], total_s=0.0, error="no cache buckets registered"
+        )
 
     rows: list[RefreshEmbedRow] = []
     total_ms = 0
@@ -277,7 +282,10 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
 
     startup_rows: list[dict[str, object]] = []
     for bucket in refresh_bucket_results(refresh_results):
-        details: list[str] = [f"{bucket.duration_s:.1f}s", str(bucket.item_count if bucket.item_count is not None else "?")]
+        details: list[str] = [
+            f"{bucket.duration_s:.1f}s",
+            str(bucket.item_count if bucket.item_count is not None else "?"),
+        ]
         if bucket.ttl_ok is True:
             details.append("ttl")
         if bucket.ttl_expired_before_refresh is True:
@@ -316,7 +324,9 @@ def get_active_runtime() -> "Runtime | None":
     return _ACTIVE_RUNTIME
 
 
-def schedule_startup_preload(bot: commands.Bot | None = None) -> asyncio.Task[StartupPreloadReport]:
+def schedule_startup_preload(
+    bot: commands.Bot | None = None,
+) -> asyncio.Task[StartupPreloadReport]:
     """Ensure the startup cache preload task has been scheduled and return it."""
 
     global _PRELOAD_TASK
@@ -327,7 +337,9 @@ def schedule_startup_preload(bot: commands.Bot | None = None) -> asyncio.Task[St
         try:  # pragma: no cover - defensive logging
             task.result()
         except Exception:
-            log.debug("previous cache preloader task completed with error", exc_info=True)
+            log.debug(
+                "previous cache preloader task completed with error", exc_info=True
+            )
     _PRELOAD_TASK = asyncio.create_task(
         _startup_preload(bot), name="cache_startup_preload"
     )
@@ -871,7 +883,10 @@ class Scheduler:
                         coro.close()
                     except Exception:
                         pass
-                    log.debug("scheduler spawn skipped duplicate task", extra={"task_name": name})
+                    log.debug(
+                        "scheduler spawn skipped duplicate task",
+                        extra={"task_name": name},
+                    )
                     return existing
         if name is not None:
             task = asyncio.create_task(coro, name=name)
@@ -899,7 +914,10 @@ class Scheduler:
         if name is not None:
             for existing in self._jobs:
                 if existing.name == name:
-                    log.debug("scheduler registration skipped duplicate job", extra={"job_name": name})
+                    log.debug(
+                        "scheduler registration skipped duplicate job",
+                        extra={"job_name": name},
+                    )
                     return existing
         total_seconds = float(hours) * 3600.0 + float(minutes) * 60.0 + float(seconds)
         if total_seconds <= 0:
@@ -1047,10 +1065,14 @@ class Runtime:
             "keepalive_sec": keepalive,
             "connected": snapshot.connected,
             "disconnect_age": (
-                None if snapshot.disconnect_age is None else round(snapshot.disconnect_age, 3)
+                None
+                if snapshot.disconnect_age is None
+                else round(snapshot.disconnect_age, 3)
             ),
             "last_ready_age": (
-                None if snapshot.last_ready_age is None else round(snapshot.last_ready_age, 3)
+                None
+                if snapshot.last_ready_age is None
+                else round(snapshot.last_ready_age, 3)
             ),
         }
         return payload, healthy
@@ -1074,9 +1096,7 @@ class Runtime:
     async def shutdown_health_server(self) -> None:
         await self.shutdown_webserver()
 
-    async def send_log_message(
-        self, message: str
-    ) -> None:
+    async def send_log_message(self, message: str) -> None:
         try:
             channel_id = get_log_channel_id()
             if not channel_id:
@@ -1151,7 +1171,9 @@ class Runtime:
     ) -> asyncio.Task:
         times_list = _parse_times(times or get_refresh_times())
         if not times_list:
-            log.warning("no valid refresh times supplied; defaulting to hourly schedule")
+            log.warning(
+                "no valid refresh times supplied; defaulting to hourly schedule"
+            )
             times_list = [dt_time(hour=0, minute=0)]
         tz_name = timezone or get_refresh_timezone()
         tz = _resolve_timezone(tz_name)
@@ -1192,7 +1214,9 @@ class Runtime:
         from modules.onboarding import watcher_welcome as onboarding_welcome
         from modules.onboarding import watcher_promo as onboarding_promo
         from modules.onboarding import cmd_resume as onboarding_cmd_resume
-        from modules.onboarding import cmd_finishplacement as onboarding_cmd_finishplacement
+        from modules.onboarding import (
+            cmd_finishplacement as onboarding_cmd_finishplacement,
+        )
         from modules.ops import permissions_ui as ops_permissions
         from c1c_coreops import ops as ops_cog
 
@@ -1289,9 +1313,7 @@ class Runtime:
                     extra=extra_info,
                 )
                 try:
-                    await self.send_log_message(
-                        f"❌ {module_path}.setup failed: {exc}"
-                    )
+                    await self.send_log_message(f"❌ {module_path}.setup failed: {exc}")
                 except Exception:
                     pass
                 raise
@@ -1325,9 +1347,11 @@ class Runtime:
 
         await clanrole_management.setup(self.bot)
         log.info("modules: clanrole_management enabled")
-        await _load_feature_module(
-            "cogs.recruitment_welcome", ("recruitment_welcome",)
-        )
+        await _load_feature_module("cogs.recruitment_welcome", ("recruitment_welcome",))
+        from cogs import recruitment_open_spots
+
+        await recruitment_open_spots.setup(self.bot)
+        log.info("modules: recruitment_open_spots enabled")
         await _load_feature_module(
             "modules.recruitment.reports", ("recruitment_reports",)
         )
@@ -1537,7 +1561,10 @@ class Runtime:
             _startup_phase_log("scheduler registration", "ok")
 
     async def _register_ready_schedulers_inner(self) -> None:
-        from shared.sheets.cache_scheduler import ensure_cache_registration, register_refresh_job
+        from shared.sheets.cache_scheduler import (
+            ensure_cache_registration,
+            register_refresh_job,
+        )
         from modules.housekeeping import cleanup as housekeeping_cleanup
         from modules.housekeeping import keepalive as housekeeping_keepalive
         from modules.housekeeping import mirralith_overview as housekeeping_mirralith
@@ -1545,7 +1572,9 @@ class Runtime:
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
         from modules.community.shard_tracker.scheduler import schedule_shard_jobs
-        from modules.community.reset_reminders.scheduler import schedule_reset_reminder_jobs
+        from modules.community.reset_reminders.scheduler import (
+            schedule_reset_reminder_jobs,
+        )
 
         toggles = shared_config.features
         ensure_cache_registration()
@@ -1581,7 +1610,12 @@ class Runtime:
 
             cleanup_job.do(cleanup_runner)
             successes.append(
-                (SimpleNamespace(bucket="cleanup", cadence_label=f"{cleanup_interval}h"), cleanup_job)
+                (
+                    SimpleNamespace(
+                        bucket="cleanup", cadence_label=f"{cleanup_interval}h"
+                    ),
+                    cleanup_job,
+                )
             )
         else:
             log.info("housekeeping cleanup disabled via feature toggle")
@@ -1602,12 +1636,16 @@ class Runtime:
             mirralith_job.do(mirralith_runner)
             successes.append(
                 (
-                    SimpleNamespace(bucket="mirralith_overview", cadence_label=mirralith_cron),
+                    SimpleNamespace(
+                        bucket="mirralith_overview", cadence_label=mirralith_cron
+                    ),
                     mirralith_job,
                 )
             )
         elif mirralith_cron:
-            log.info("Mirralith overview disabled via feature toggle; skipping schedule")
+            log.info(
+                "Mirralith overview disabled via feature toggle; skipping schedule"
+            )
         else:
             log.info("Mirralith overview job disabled; MIRRALITH_POST_CRON is not set.")
 
@@ -1620,13 +1658,16 @@ class Runtime:
             )
 
             async def keepalive_runner() -> None:
-                await housekeeping_keepalive.run_keepalive(
-                    self.bot, keepalive_logger
-                )
+                await housekeeping_keepalive.run_keepalive(self.bot, keepalive_logger)
 
             keepalive_job.do(keepalive_runner)
             successes.append(
-                (SimpleNamespace(bucket="housekeeping_keepalive", cadence_label="24h"), keepalive_job)
+                (
+                    SimpleNamespace(
+                        bucket="housekeeping_keepalive", cadence_label="24h"
+                    ),
+                    keepalive_job,
+                )
             )
         else:
             log.info("housekeeping keepalive disabled via feature toggle")

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -478,6 +478,35 @@ async def preflight_manual_open_spots_adjustment(
     )
 
 
+async def set_manual_open_spots(clan_tag: str, open_spots: int) -> tuple[int, int, str]:
+    """Set visible open spots using the existing manual adjustment semantics.
+
+    The existing manual adjustment flow writes the configured visible open-spots
+    value and the manual-open-spots seen marker. It intentionally does not
+    overwrite the manual baseline or reservation-derived fields. This wrapper
+    computes the delta needed to reach the requested exact value, then delegates
+    the actual write to ``adjust_manual_open_spots`` so emergency corrections do
+    not invent a separate sheet mutation pattern.
+    """
+
+    if open_spots < 0:
+        raise ValueError("open_spots must be >= 0")
+
+    plan = await preflight_manual_open_spots_adjustment(clan_tag, 0)
+    old_value = plan.current_available
+    delta = open_spots - plan.new_value
+    new_value = await adjust_manual_open_spots(clan_tag, delta)
+
+    tag_index = plan.headers.header_map.get("clan_tag")
+    resolved_tag = clan_tag
+    if tag_index is not None and tag_index < len(plan.row):
+        candidate = str(plan.row[tag_index]).strip()
+        if candidate:
+            resolved_tag = candidate
+
+    return old_value, new_value, resolved_tag
+
+
 async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
     """Adjust manual open spots for ``clan_tag`` and return the new value."""
     plan: ManualOpenSpotAdjustmentPlan | None = None

--- a/packages/c1c-coreops/src/c1c_coreops/cop.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cop.py
@@ -18,6 +18,7 @@ from cogs.recruitment_clan_profile import ClanProfileCog
 from cogs.recruitment_member import RecruitmentMember
 from cogs.recruitment_recruiter import RecruiterPanelCog
 from cogs.recruitment_welcome import WelcomeBridge
+from cogs.recruitment_open_spots import RecruitmentOpenSpotsCog
 from cogs.clanrole_management import ClanRoleManagementCog
 from modules.ops.permissions_ui import PermissionsUICog
 from shared.testing.environment import apply_required_test_environment
@@ -49,7 +50,14 @@ class HelpSurfaceSection:
 class _HelpContext:
     """Minimal context object that captures replies from ``CoreOpsCog``."""
 
-    __slots__ = ("bot", "author", "guild", "command", "_replies", "_coreops_suppress_denials")
+    __slots__ = (
+        "bot",
+        "author",
+        "guild",
+        "command",
+        "_replies",
+        "_coreops_suppress_denials",
+    )
 
     def __init__(self, bot: commands.Bot, author: object) -> None:
         self.bot = bot
@@ -73,7 +81,14 @@ class _HelpContext:
 
 
 class _DummyMember:
-    __slots__ = ("display_name", "id", "roles", "guild_permissions", "_is_admin", "_is_staff")
+    __slots__ = (
+        "display_name",
+        "id",
+        "roles",
+        "guild_permissions",
+        "_is_admin",
+        "_is_staff",
+    )
 
     def __init__(self, *, is_admin: bool = False, is_staff: bool = False) -> None:
         self.display_name = "Member"
@@ -124,7 +139,11 @@ def _patched_help_guards() -> Iterator[None]:
     _swap(rbac, "get_admin_role_ids", lambda: set())
     _swap(rbac, "get_staff_role_ids", lambda: set())
     _swap(rbac, "_resolve_member", _resolve_member)
-    _swap(rbac, "_member_has_admin_role", lambda member: bool(getattr(member, "_is_admin", False)))
+    _swap(
+        rbac,
+        "_member_has_admin_role",
+        lambda member: bool(getattr(member, "_is_admin", False)),
+    )
     _swap(
         rbac,
         "_has_administrator_permission",
@@ -132,7 +151,11 @@ def _patched_help_guards() -> Iterator[None]:
             getattr(getattr(member, "guild_permissions", None), "administrator", False)
         ),
     )
-    _swap(rbac, "is_admin_member", lambda target: bool(getattr(_resolve_member(target), "_is_admin", False)))
+    _swap(
+        rbac,
+        "is_admin_member",
+        lambda target: bool(getattr(_resolve_member(target), "_is_admin", False)),
+    )
     _swap(
         rbac,
         "is_staff_member",
@@ -141,14 +164,28 @@ def _patched_help_guards() -> Iterator[None]:
             or getattr(_resolve_member(target), "_is_admin", False)
         ),
     )
-    _swap(rbac, "is_recruiter", lambda target: bool(getattr(_resolve_member(target), "_is_staff", False)))
-    _swap(rbac, "is_lead", lambda target: bool(getattr(_resolve_member(target), "_is_staff", False)))
+    _swap(
+        rbac,
+        "is_recruiter",
+        lambda target: bool(getattr(_resolve_member(target), "_is_staff", False)),
+    )
+    _swap(
+        rbac,
+        "is_lead",
+        lambda target: bool(getattr(_resolve_member(target), "_is_staff", False)),
+    )
     _swap(
         rbac,
         "ops_gate",
-        lambda member: bool(getattr(member, "_is_admin", False) or getattr(member, "_is_staff", False)),
+        lambda member: bool(
+            getattr(member, "_is_admin", False) or getattr(member, "_is_staff", False)
+        ),
     )
-    _swap(rbac, "can_view_admin", lambda target: bool(getattr(_resolve_member(target), "_is_admin", False)))
+    _swap(
+        rbac,
+        "can_view_admin",
+        lambda target: bool(getattr(_resolve_member(target), "_is_admin", False)),
+    )
     _swap(
         rbac,
         "can_view_staff",
@@ -189,6 +226,7 @@ async def _setup_help_bot() -> commands.Bot:
     await bot.add_cog(PermissionsUICog(bot))
     await bot.add_cog(RecruiterPanelCog(bot))
     await bot.add_cog(WelcomeBridge(bot))
+    await bot.add_cog(RecruitmentOpenSpotsCog(bot))
     await bot.add_cog(RecruitmentMember(bot))
     await bot.add_cog(ClanProfileCog(bot))
     await bot.add_cog(ClanRoleManagementCog())
@@ -229,14 +267,18 @@ async def build_admin_help_surface_async(
     raise RuntimeError("Admin help surface not available")
 
 
-def build_admin_help_surface(*, allowlist: str | None = None) -> tuple[HelpSurfaceSection, ...]:
+def build_admin_help_surface(
+    *, allowlist: str | None = None
+) -> tuple[HelpSurfaceSection, ...]:
     """Synchronously gather the admin help surface sections."""
 
     return asyncio.run(build_admin_help_surface_async(allowlist=allowlist))
 
 
 @contextlib.asynccontextmanager
-async def _help_bot_context(*, allowlist: str | None) -> AsyncIterator[list[discord.Embed]]:
+async def _help_bot_context(
+    *, allowlist: str | None
+) -> AsyncIterator[list[discord.Embed]]:
     if allowlist is None:
         manager = contextlib.nullcontext()
     else:

--- a/tests/recruitment/test_set_open_spots_command.py
+++ b/tests/recruitment/test_set_open_spots_command.py
@@ -1,0 +1,353 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from cogs import recruitment_open_spots as command_module
+from cogs.recruitment_open_spots import RecruitmentOpenSpotsCog
+
+
+class FakeAuthor:
+    def __init__(self, member_id=123, display_name="Caillean"):
+        self.id = member_id
+        self.display_name = display_name
+        self.name = display_name
+
+
+class FakeContext:
+    def __init__(self):
+        self.author = FakeAuthor()
+        self.guild = SimpleNamespace(id=1)
+        self.replies = []
+
+    async def reply(self, content=None, **kwargs):
+        self.replies.append((content, kwargs))
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_staff_can_set_open_spots_successfully(monkeypatch):
+    ctx = FakeContext()
+    logs = []
+    writes = []
+
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+
+    async def fake_set(clan, value):
+        writes.append((clan, value))
+        return 3, value, "C1CC"
+
+    async def fake_log(message):
+        logs.append(message)
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", fake_log)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(
+        cog.setopenspots.callback(
+            cog, ctx, "C1CC", "4", reason="missed promo close correction"
+        )
+    )
+
+    assert writes == [("C1CC", 4)]
+    assert "Open spots corrected" in ctx.replies[0][0]
+    assert "Open spots: 3 → 4" in ctx.replies[0][0]
+    assert "Reason: missed promo close correction" in ctx.replies[0][0]
+    assert "Updated by: Caillean" in ctx.replies[0][0]
+    assert logs
+    assert "Caillean" in logs[0]
+    assert "123" in logs[0]
+    assert "C1CC 3 → 4" in logs[0]
+    assert "missed promo close correction" in logs[0]
+
+
+def test_non_staff_cannot_run(monkeypatch):
+    ctx = FakeContext()
+    setter = AsyncMock()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4", reason="reason"))
+
+    assert "do not have permission" in ctx.replies[0][0]
+    setter.assert_not_awaited()
+
+
+def test_missing_reason_fails(monkeypatch):
+    ctx = FakeContext()
+    setter = AsyncMock()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4", reason=None))
+
+    assert "Usage: !setopenspots" in ctx.replies[0][0]
+    setter.assert_not_awaited()
+
+
+def test_invalid_open_spots_fails(monkeypatch):
+    ctx = FakeContext()
+    setter = AsyncMock()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4.5", reason="reason"))
+
+    assert "whole number >= 0" in ctx.replies[0][0]
+    setter.assert_not_awaited()
+
+
+def test_negative_open_spots_fails(monkeypatch):
+    ctx = FakeContext()
+    setter = AsyncMock()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "-1", reason="reason"))
+
+    assert "whole number >= 0" in ctx.replies[0][0]
+    setter.assert_not_awaited()
+
+
+def test_unknown_clan_fails(monkeypatch):
+    ctx = FakeContext()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+
+    async def fake_set(_clan, _value):
+        raise ValueError("Unknown clan tag: nope")
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "NOPE", "4", reason="reason"))
+
+    assert "could not be found" in ctx.replies[0][0]
+
+
+def test_ambiguous_clan_fails(monkeypatch):
+    ctx = FakeContext()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+
+    async def fake_set(_clan, _value):
+        raise ValueError("ambiguous clan input")
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1C", "4", reason="reason"))
+
+    assert "matches multiple clans" in ctx.replies[0][0]
+
+
+def test_config_resolution_failure_fails_safely_and_logs(monkeypatch):
+    ctx = FakeContext()
+    logs = []
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+
+    async def fake_set(_clan, _value):
+        raise ValueError("missing required Config key: clans_header_open_spots")
+
+    async def fake_log(message):
+        logs.append(message)
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", fake_log)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4", reason="reason"))
+
+    assert "configuration is incomplete or invalid" in ctx.replies[0][0]
+    assert logs and "configuration invalid" in logs[0]
+
+
+def test_set_manual_open_spots_uses_existing_adjustment_writes_only(monkeypatch):
+    from modules.recruitment import availability
+
+    updates = []
+
+    class Worksheet:
+        async def update(self, write_range, values, **kwargs):
+            updates.append((write_range, values, kwargs))
+            return {"ok": True}
+
+    class Headers:
+        tab_name = "configured-tab"
+        header_map = {
+            "clan_tag": 0,
+            "manual_open_spots": 2,
+            "open_spots": 5,
+            "manual_open_spots_seen": 7,
+            "reservation_count": 8,
+            "reservation_summary": 9,
+        }
+
+    class Plan:
+        clan_tag = "C1CC"
+        sheet_row = 12
+        row = ("C1CC", "Clan", "5", "x", "y", "3", "z", "5", "2", "A, B")
+        manual_open_index = 2
+        open_index = 5
+        seen_index = 7
+        manual_open = 5
+        current_available = 3
+        seen_manual_open = 5
+        tab_key = "clans_tab"
+        tab_name = "configured-tab"
+        manual_header_key = "manual_open_spots"
+        manual_header_name = "Manual Open Spots"
+        open_range = "CustomOpen12"
+        seen_range = "CustomSeen12"
+        combined_range = None
+        headers = Headers()
+
+        def __init__(self, delta=0):
+            self.delta = delta
+            self.new_value = self.current_available + delta
+
+    async def fake_preflight(clan, delta):
+        assert clan == "C1CC"
+        return Plan(delta)
+
+    async def fake_worksheet(sheet_id, tab_name):
+        assert sheet_id == "sheet-id"
+        assert tab_name == "configured-tab"
+        return Worksheet()
+
+    async def fake_backoff(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+
+    cached = []
+    monkeypatch.setattr(
+        availability, "preflight_manual_open_spots_adjustment", fake_preflight
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id"
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "find_clan_row",
+        lambda clan, force=True: (12, list(Plan.row)),
+    )
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_worksheet)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_backoff)
+    monkeypatch.setattr(
+        availability.recruitment,
+        "update_cached_clan_row",
+        lambda row, values: cached.append((row, values)),
+    )
+
+    old_value, new_value, clan = _run(availability.set_manual_open_spots("C1CC", 4))
+
+    assert (old_value, new_value, clan) == (3, 4, "C1CC")
+    assert [item[0] for item in updates] == ["CustomOpen12", "CustomSeen12"]
+    assert updates[0][1] == [["4"]]
+    assert updates[1][1] == [["5"]]
+    assert cached and cached[0][0] == 12
+    updated_row = cached[0][1]
+    assert updated_row[2] == "5"  # manual baseline preserved
+    assert updated_row[5] == "4"  # visible open spots corrected
+    assert updated_row[7] == "5"  # seen marker follows existing adjustment flow
+    assert updated_row[8] == "2"  # reservation count untouched
+    assert updated_row[9] == "A, B"  # reservation summary untouched
+
+
+def test_existing_adjustment_flow_still_decrements_after_manual_correction(monkeypatch):
+    from modules.recruitment import availability
+
+    updates = []
+    state = {"row": ["C1CC", "Clan", "5", "x", "y", "3", "z", "5"]}
+
+    class Worksheet:
+        async def update(self, write_range, values, **kwargs):
+            updates.append((write_range, values))
+            return {"ok": True}
+
+    class Headers:
+        tab_name = "configured-tab"
+        header_map = {"clan_tag": 0}
+
+    class Plan:
+        clan_tag = "C1CC"
+        sheet_row = 12
+        manual_open_index = 2
+        open_index = 5
+        seen_index = 7
+        tab_key = "clans_tab"
+        tab_name = "configured-tab"
+        manual_header_key = "manual_open_spots"
+        manual_header_name = "Manual Open Spots"
+        open_range = "Open12"
+        seen_range = "Seen12"
+        combined_range = None
+        headers = Headers()
+
+        def __init__(self, delta=0):
+            self.delta = delta
+            self.row = tuple(state["row"])
+            self.manual_open = int(state["row"][self.manual_open_index])
+            self.current_available = int(state["row"][self.open_index])
+            self.seen_manual_open = int(state["row"][self.seen_index])
+            base_available = (
+                self.manual_open
+                if self.manual_open != self.seen_manual_open
+                else self.current_available
+            )
+            self.new_value = max(base_available + delta, 0)
+
+    async def fake_preflight(_clan, delta):
+        return Plan(delta)
+
+    async def fake_worksheet(_sheet_id, _tab_name):
+        return Worksheet()
+
+    async def fake_backoff(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+
+    def fake_cache_update(_row_number, values):
+        state["row"] = list(values)
+
+    monkeypatch.setattr(
+        availability, "preflight_manual_open_spots_adjustment", fake_preflight
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id"
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "find_clan_row",
+        lambda clan, force=True: (12, list(state["row"])),
+    )
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_worksheet)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_backoff)
+    monkeypatch.setattr(
+        availability.recruitment, "update_cached_clan_row", fake_cache_update
+    )
+
+    assert _run(availability.set_manual_open_spots("C1CC", 4)) == (3, 4, "C1CC")
+    assert state["row"][2] == "5"
+    assert state["row"][5] == "4"
+    assert state["row"][7] == "5"
+
+    updates.clear()
+    assert _run(availability.adjust_manual_open_spots("C1CC", -1)) == 3
+
+    assert updates == [("Open12", [["3"]]), ("Seen12", [["5"]])]
+    assert state["row"][2] == "5"
+    assert state["row"][5] == "3"
+    assert state["row"][7] == "5"


### PR DESCRIPTION
### Motivation

- Provide an emergency staff/admin command to correct a clan's visible recruitment open-spots without changing existing reservation/baseline semantics.
- Reuse the existing manual-adjustment flow so corrections follow the same sheet mutation pattern and audit logging.
- Wire the new command into the runtime and help surfaces so it is available to operators.

### Description

- Add `cogs/recruitment_open_spots.py` implementing a `setopenspots` command with validation, RBAC checks, user feedback, and logging via `runtime_helpers.send_log_message`.
- Add `modules/recruitment/availability.set_manual_open_spots` which computes the required delta and delegates to the existing `adjust_manual_open_spots` to perform sheet updates, returning the old/new values and resolved clan tag.
- Register and load the new cog in the runtime (`modules/common/runtime.py`) and include it in the CoreOps help builder (`packages/c1c-coreops/src/c1c_coreops/cop.py`).
- Apply minor formatting and defensive logging/tuple/list formatting cleanups in `modules/common/runtime.py` and `packages/c1c-coreops/src/c1c_coreops/cop.py` to keep style consistent.
- Add comprehensive unit tests in `tests/recruitment/test_set_open_spots_command.py` covering success, permission denial, input validation, error cases, and verifying that `set_manual_open_spots` only writes the expected fields and preserves existing adjustment semantics.

### Testing

- Ran the new unit tests with `pytest tests/recruitment/test_set_open_spots_command.py` and they all passed. 
- Existing behavior of the manual adjustment flow was exercised by tests that simulate worksheet updates and cache updates, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e9bf593c8323937ee97748f99e07)