### PR TITLE
Add C1C recruitment ad job, command, scheduler, docs, and tests

### DIFF
--- a/cogs/housekeeping_c1c_ad.py
+++ b/cogs/housekeeping_c1c_ad.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import ops_only
+from modules.housekeeping.c1c_ad import run_c1c_ad_job
+
+log = logging.getLogger("c1c.housekeeping.c1c_ad.cog")
+
+
+class C1CAdCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("staff")
+    @help_metadata(
+        function_group="operational", section="utilities", access_tier="staff"
+    )
+    @commands.command(
+        name="c1cad",
+        help="Post or refresh the C1C recruitment ad.",
+        brief="Post or refresh the C1C recruitment ad.",
+    )
+    @ops_only()
+    async def c1cad(self, ctx: commands.Context) -> None:
+        try:
+            result = await run_c1c_ad_job(self.bot, trigger="manual", force=True)
+        except Exception:
+            log.exception("C1C ad manual refresh failed")
+            await ctx.send(
+                "C1C ad update failed. Please check the bot logs for details."
+            )
+            return
+        if result.status == "success":
+            await ctx.send("C1C recruitment ad refreshed.")
+        elif result.message == "feature toggle off":
+            await ctx.send("C1C recruitment ad is disabled by feature toggle.")
+        else:
+            await ctx.send(f"C1C recruitment ad skipped: {result.message}.")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(C1CAdCog(bot))

--- a/docs/modules/housekeeping_mirralith_overview.md
+++ b/docs/modules/housekeeping_mirralith_overview.md
@@ -36,3 +36,38 @@ Each message includes its label token so the bot can find and update it on subse
 - If logs show `Mirralith spec missing tab or range; skipping`, the bot could not read the Config tab for the listed key; ensure the KV rows exist and the deployment includes the latest config loader.
 
 Doc last updated: 2025-12-04 (v0.9.8.2)
+
+## C1C recruitment ad posting
+
+The `!c1cad` command and `c1c_ad` scheduled job intentionally reuse the Mirralith overview export pattern: Config-tab keys resolve the source tab/range, `get_tab_gid` resolves the worksheet gid, and `export_pdf_as_png` renders the configured range as a PNG.
+
+### Migration rows
+
+Config tab rows:
+
+```text
+C1C_AD_TAB = C1C_AD
+C1C_AD_IMAGE_RANGE = A1:V42
+C1C_AD_TEXT_TAB = C1C_AD_TEXT
+C1C_AD_TEXT_ROW = 2
+C1C_AD_TARGET_THREAD_ID = 1324313499731755039
+C1C_AD_REFRESH_DAYS = 7
+```
+
+FeatureToggles row:
+
+```text
+c1c_ad,TRUE
+```
+
+Create the `C1C_AD_TEXT` tab with row 1 headers:
+
+```text
+ad_text | last_posted_at_utc | last_image_message_id | last_text_message_id | last_post_status | last_post_error | updated_at_utc
+```
+
+### Operation
+
+- Manual refresh: `!c1cad` (admin-gated) checks `c1c_ad`, renders `C1C_AD!A1:V42`, reads `ad_text` from configured row 2, deletes prior stored bot message IDs, posts image then text, and writes the new message IDs/status back to the header-driven row.
+- Scheduled refresh: every configured `C1C_AD_REFRESH_DAYS`; it checks `last_posted_at_utc` before posting so restarts do not duplicate the ad.
+- Safe skips/failures: missing toggle/config/header, empty text, render failure, or missing target thread logs a short reason and does not post partial image-only or text-only ads.

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -346,6 +346,7 @@ Feature Toggles:
   SERVER_MAP,TRUE
   housekeeping_enabled,TRUE
   mirralith_overview_enabled,TRUE
+  c1c_ad,TRUE
   ops_permissions_enabled,TRUE
   welcome_watcher_enabled,TRUE
   promo_watcher_enabled,TRUE
@@ -355,6 +356,28 @@ Feature Toggles:
   PROMO_ENABLED,TRUE
   ENABLE_PROMO_HOOK,TRUE
   ```
+
+
+### C1C recruitment ad Config rows
+
+Add these rows to the Mirralith workbook `Config` tab before enabling the `c1c_ad` feature:
+
+```text
+C1C_AD_TAB = C1C_AD
+C1C_AD_IMAGE_RANGE = A1:V42
+C1C_AD_TEXT_TAB = C1C_AD_TEXT
+C1C_AD_TEXT_ROW = 2
+C1C_AD_TARGET_THREAD_ID = 1324313499731755039
+C1C_AD_REFRESH_DAYS = 7
+```
+
+Add the `C1C_AD_TEXT` worksheet with row 1 headers:
+
+```text
+ad_text | last_posted_at_utc | last_image_message_id | last_text_message_id | last_post_status | last_post_error | updated_at_utc
+```
+
+The bot treats row 2 as the single active recruitment ad row and resolves all state columns by header name.
 
 **Behavior**
 

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1209,6 +1209,7 @@ class Runtime:
         from c1c_coreops import cog as coreops_cog
         from cogs import app_admin
         from cogs import housekeeping_mirralith
+        from cogs import housekeeping_c1c_ad
         from modules.onboarding import ops_check as onboarding_ops_check
         from modules.onboarding import reaction_fallback as onboarding_reaction_fallback
         from modules.onboarding import watcher_welcome as onboarding_welcome
@@ -1244,6 +1245,9 @@ class Runtime:
             log.info("modules: mirralith_overview enabled")
         else:
             log.info("modules: mirralith_overview disabled")
+
+        await housekeeping_c1c_ad.setup(self.bot)
+        log.info("modules: c1c_ad command registered")
 
         async def _load_feature_module(
             module_path: str, feature_keys: Sequence[str]
@@ -1568,6 +1572,8 @@ class Runtime:
         from modules.housekeeping import cleanup as housekeeping_cleanup
         from modules.housekeeping import keepalive as housekeeping_keepalive
         from modules.housekeeping import mirralith_overview as housekeeping_mirralith
+        from modules.housekeeping import c1c_ad as housekeeping_c1c_ad
+        from shared.sheets import recruitment as recruitment_sheets
         from modules.ops import server_map as server_map_module
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
@@ -1648,6 +1654,37 @@ class Runtime:
             )
         else:
             log.info("Mirralith overview job disabled; MIRRALITH_POST_CRON is not set.")
+
+        try:
+            c1c_refresh_days_raw = recruitment_sheets.get_config_value("C1C_AD_REFRESH_DAYS", None)
+            c1c_refresh_days = int(c1c_refresh_days_raw) if c1c_refresh_days_raw else None
+        except Exception:
+            c1c_refresh_days = None
+            log.exception("C1C ad refresh interval lookup failed; skipping schedule")
+
+        if c1c_refresh_days and c1c_refresh_days > 0:
+            c1c_ad_job = self.scheduler.every(
+                hours=float(c1c_refresh_days) * 24.0,
+                tag="c1c_ad",
+                name="c1c_ad",
+            )
+
+            async def c1c_ad_runner() -> None:
+                await housekeeping_c1c_ad.run_c1c_ad_job(
+                    self.bot, trigger="scheduled", force=False
+                )
+
+            c1c_ad_job.do(c1c_ad_runner)
+            successes.append(
+                (
+                    SimpleNamespace(
+                        bucket="c1c_ad", cadence_label=f"{c1c_refresh_days}d"
+                    ),
+                    c1c_ad_job,
+                )
+            )
+        else:
+            log.info("C1C ad job disabled; C1C_AD_REFRESH_DAYS is not configured.")
 
         if toggles.housekeeping_enabled:
             keepalive_logger = logging.getLogger("c1c.housekeeping.keepalive")

--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import datetime as dt
+import io
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import discord
+
+from modules.common import feature_flags
+from shared.sheets import core as sheets_core
+from shared.sheets import recruitment
+from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
+
+log = logging.getLogger("c1c.housekeeping.c1c_ad")
+
+FEATURE_KEY = "c1c_ad"
+CONFIG_KEYS = (
+    "C1C_AD_TAB",
+    "C1C_AD_IMAGE_RANGE",
+    "C1C_AD_TEXT_TAB",
+    "C1C_AD_TEXT_ROW",
+    "C1C_AD_TARGET_THREAD_ID",
+    "C1C_AD_REFRESH_DAYS",
+)
+REQUIRED_HEADERS = (
+    "ad_text",
+    "last_posted_at_utc",
+    "last_image_message_id",
+    "last_text_message_id",
+    "last_post_status",
+    "last_post_error",
+    "updated_at_utc",
+)
+
+
+@dataclass(frozen=True)
+class C1CAdConfig:
+    image_tab: str
+    image_range: str
+    text_tab: str
+    text_row: int
+    target_thread_id: int
+    refresh_days: int
+
+
+@dataclass(frozen=True)
+class C1CAdResult:
+    status: str
+    message: str
+    posted: bool = False
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _timestamp(now: dt.datetime | None = None) -> str:
+    return (now or _utc_now()).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _column_letter(index: int) -> str:
+    label = ""
+    value = index
+    while value > 0:
+        value, rem = divmod(value - 1, 26)
+        label = chr(ord("A") + rem) + label
+    return label
+
+
+def _header_map(headers: list[Any]) -> dict[str, int]:
+    return {
+        str(cell or "").strip(): idx
+        for idx, cell in enumerate(headers, start=1)
+        if str(cell or "").strip()
+    }
+
+
+def _resolve_config() -> tuple[C1CAdConfig | None, str | None]:
+    values: dict[str, str] = {}
+    for key in CONFIG_KEYS:
+        value = recruitment.get_config_value(key, None)
+        if not value:
+            return None, f"missing Config key {key}"
+        values[key] = value
+    try:
+        text_row = int(values["C1C_AD_TEXT_ROW"])
+        thread_id = int(values["C1C_AD_TARGET_THREAD_ID"])
+        refresh_days = int(values["C1C_AD_REFRESH_DAYS"])
+    except ValueError as exc:
+        return None, f"invalid Config value {exc}"
+    if text_row < 2:
+        return None, "C1C_AD_TEXT_ROW must be 2 or greater"
+    if refresh_days < 1:
+        return None, "C1C_AD_REFRESH_DAYS must be positive"
+    return (
+        C1CAdConfig(
+            image_tab=values["C1C_AD_TAB"],
+            image_range=values["C1C_AD_IMAGE_RANGE"],
+            text_tab=values["C1C_AD_TEXT_TAB"],
+            text_row=text_row,
+            target_thread_id=thread_id,
+            refresh_days=refresh_days,
+        ),
+        None,
+    )
+
+
+def _get_sheet_id() -> tuple[str | None, str | None]:
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    if not sheet_id:
+        return None, "Recruitment sheet ID missing"
+    return sheet_id, None
+
+
+def _read_text_row(
+    sheet_id: str, config: C1CAdConfig
+) -> tuple[dict[str, str] | None, dict[str, int] | None, str | None]:
+    values = (
+        sheets_core.sheets_read(sheet_id, f"{config.text_tab}!1:{config.text_row}")
+        or []
+    )
+    if not values:
+        return None, None, "missing C1C_AD_TEXT headers"
+    headers = _header_map(list(values[0]))
+    missing = [header for header in REQUIRED_HEADERS if header not in headers]
+    if missing:
+        return None, headers, f"missing C1C_AD_TEXT header {missing[0]}"
+    row_values = (
+        list(values[config.text_row - 1]) if len(values) >= config.text_row else []
+    )
+    row: dict[str, str] = {}
+    for header, col in headers.items():
+        row[header] = str(row_values[col - 1]).strip() if len(row_values) >= col else ""
+    return row, headers, None
+
+
+def _write_status(
+    sheet_id: str,
+    config: C1CAdConfig,
+    headers: Mapping[str, int],
+    updates: Mapping[str, str],
+) -> None:
+    worksheet = sheets_core.get_worksheet(sheet_id, config.text_tab)
+    cells = []
+    for header, value in updates.items():
+        col = headers.get(header)
+        if col is None:
+            continue
+        cells.append(
+            {"range": f"{_column_letter(col)}{config.text_row}", "values": [[value]]}
+        )
+    if cells:
+        sheets_core.call_with_backoff(worksheet.batch_update, cells)
+
+
+def _parse_timestamp(value: str) -> dt.datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _due_for_refresh(
+    row: Mapping[str, str], refresh_days: int, now: dt.datetime
+) -> bool:
+    last = _parse_timestamp(row.get("last_posted_at_utc", ""))
+    if last is None:
+        return True
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=dt.timezone.utc)
+    return now - last >= dt.timedelta(days=refresh_days)
+
+
+async def _resolve_thread(bot: discord.Client, thread_id: int) -> Any | None:
+    channel = bot.get_channel(thread_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(thread_id)
+        except Exception:
+            return None
+    if not hasattr(channel, "send"):
+        return None
+    return channel
+
+
+async def _delete_old_messages(channel: Any, row: Mapping[str, str]) -> None:
+    for key in ("last_image_message_id", "last_text_message_id"):
+        raw = str(row.get(key, "")).strip()
+        if not raw:
+            continue
+        try:
+            message_id = int(raw)
+        except ValueError:
+            log.warning("⚠️ C1C ad warning: invalid old message id %s=%s", key, raw)
+            continue
+        try:
+            message = await channel.fetch_message(message_id)
+            await message.delete()
+        except discord.NotFound:
+            log.warning(
+                "⚠️ C1C ad warning: old message already deleted message_id=%s",
+                message_id,
+            )
+        except Exception:
+            log.exception(
+                "⚠️ C1C ad warning: failed to delete old message message_id=%s",
+                message_id,
+            )
+
+
+async def run_c1c_ad_job(
+    bot: discord.Client, *, trigger: str = "scheduled", force: bool = False
+) -> C1CAdResult:
+    if not feature_flags.is_enabled(FEATURE_KEY):
+        log.info("⚠️ C1C ad skipped: feature toggle off")
+        return C1CAdResult("skipped", "feature toggle off")
+
+    config, error = _resolve_config()
+    if config is None:
+        log.warning("⚠️ C1C ad skipped: %s", error)
+        return C1CAdResult("skipped", str(error))
+    sheet_id, error = _get_sheet_id()
+    if sheet_id is None:
+        log.warning("⚠️ C1C ad skipped: %s", error)
+        return C1CAdResult("skipped", str(error))
+
+    row, headers, error = _read_text_row(sheet_id, config)
+    if row is None or headers is None:
+        log.warning("⚠️ C1C ad skipped: %s", error)
+        return C1CAdResult("skipped", str(error))
+
+    now = _utc_now()
+    if not force and not _due_for_refresh(row, config.refresh_days, now):
+        log.info("⚠️ C1C ad skipped: refresh not due")
+        return C1CAdResult("skipped", "refresh not due")
+
+    def fail(reason: str) -> C1CAdResult:
+        _write_status(
+            sheet_id,
+            config,
+            headers,
+            {
+                "last_post_status": "failed",
+                "last_post_error": reason,
+                "updated_at_utc": _timestamp(now),
+            },
+        )
+        log.error("❌ C1C ad failed: %s", reason)
+        return C1CAdResult("failed", reason)
+
+    ad_text = str(row.get("ad_text", "")).strip()
+    if not ad_text:
+        return fail("ad_text empty")
+
+    if ":" not in config.image_range:
+        return fail("image range invalid")
+    try:
+        gid = get_tab_gid(sheet_id, config.image_tab)
+        png_bytes = await export_pdf_as_png(
+            sheet_id,
+            gid,
+            config.image_range,
+            log_context={
+                "label": "[C1C_AD]",
+                "tab": config.image_tab,
+                "range": config.image_range,
+            },
+        )
+    except Exception:
+        log.exception("❌ C1C ad failed: image render exception")
+        return fail("image render failed")
+    if not png_bytes:
+        return fail("image render failed")
+
+    channel = await _resolve_thread(bot, config.target_thread_id)
+    if channel is None:
+        reason = f"target thread not found thread_id={config.target_thread_id}"
+        _write_status(
+            sheet_id,
+            config,
+            headers,
+            {
+                "last_post_status": "skipped",
+                "last_post_error": reason,
+                "updated_at_utc": _timestamp(now),
+            },
+        )
+        log.warning("⚠️ C1C ad skipped: %s", reason)
+        return C1CAdResult("skipped", reason)
+
+    await _delete_old_messages(channel, row)
+    try:
+        image_message = await channel.send(
+            file=discord.File(io.BytesIO(png_bytes), filename="c1c_recruitment_ad.png")
+        )
+        text_message = await channel.send(ad_text)
+    except Exception:
+        log.exception("❌ C1C ad failed: Discord post failed")
+        return fail("Discord post failed")
+
+    stamp = _timestamp(now)
+    _write_status(
+        sheet_id,
+        config,
+        headers,
+        {
+            "last_posted_at_utc": stamp,
+            "last_image_message_id": str(getattr(image_message, "id", "")),
+            "last_text_message_id": str(getattr(text_message, "id", "")),
+            "last_post_status": "success",
+            "last_post_error": "",
+            "updated_at_utc": stamp,
+        },
+    )
+    channel_name = getattr(channel, "name", str(config.target_thread_id))
+    log.info("✅ C1C ad refreshed: image + text posted to #%s", channel_name)
+    return C1CAdResult("success", "image + text posted", posted=True)
+
+
+__all__ = ["C1CAdConfig", "C1CAdResult", "run_c1c_ad_job"]

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -1,0 +1,260 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from modules.housekeeping import c1c_ad
+
+
+class DummyMessage:
+    def __init__(self, message_id):
+        self.id = message_id
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class DummyChannel:
+    name = "recruitment-thread"
+
+    def __init__(self):
+        self.sent = []
+        self.messages = {10: DummyMessage(10), 11: DummyMessage(11)}
+
+    async def fetch_message(self, message_id):
+        if message_id not in self.messages:
+            import discord
+
+            raise discord.NotFound(
+                SimpleNamespace(status=404, reason="missing"), "missing"
+            )
+        return self.messages[message_id]
+
+    async def send(self, content=None, file=None):
+        msg = DummyMessage(100 + len(self.sent))
+        self.sent.append((content, file, msg.id))
+        return msg
+
+
+class DummyBot:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get_channel(self, channel_id):
+        return self.channel
+
+
+def _config_values():
+    return {
+        "C1C_AD_TAB": "C1C_AD",
+        "C1C_AD_IMAGE_RANGE": "A1:V42",
+        "C1C_AD_TEXT_TAB": "C1C_AD_TEXT",
+        "C1C_AD_TEXT_ROW": "2",
+        "C1C_AD_TARGET_THREAD_ID": "1324313499731755039",
+        "C1C_AD_REFRESH_DAYS": "7",
+    }
+
+
+def _sheet_rows(ad_text="Join C1C!", last_posted=""):
+    return [
+        [
+            "ad_text",
+            "last_posted_at_utc",
+            "last_image_message_id",
+            "last_text_message_id",
+            "last_post_status",
+            "last_post_error",
+            "updated_at_utc",
+        ],
+        [ad_text, last_posted, "10", "11", "success", "", ""],
+    ]
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    config = _config_values()
+    rows = _sheet_rows()
+    updates = []
+    channel = DummyChannel()
+    monkeypatch.setattr(c1c_ad.feature_flags, "is_enabled", lambda key: True)
+    monkeypatch.setattr(
+        c1c_ad.recruitment,
+        "get_config_value",
+        lambda key, default=None: config.get(key, default),
+    )
+    monkeypatch.setattr(
+        c1c_ad.recruitment, "get_recruitment_sheet_id", lambda: "sheet123"
+    )
+    monkeypatch.setattr(
+        c1c_ad.sheets_core, "sheets_read", lambda sheet_id, a1_range: rows
+    )
+    monkeypatch.setattr(c1c_ad, "get_tab_gid", lambda sheet_id, tab_name: "456")
+
+    async def render(*args, **kwargs):
+        return b"png"
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+
+    class Worksheet:
+        def batch_update(self, cells):
+            updates.extend(cells)
+
+    monkeypatch.setattr(
+        c1c_ad.sheets_core, "get_worksheet", lambda sheet_id, tab: Worksheet()
+    )
+    monkeypatch.setattr(
+        c1c_ad.sheets_core,
+        "call_with_backoff",
+        lambda func, *args, **kwargs: func(*args, **kwargs),
+    )
+    return SimpleNamespace(
+        config=config,
+        rows=rows,
+        updates=updates,
+        channel=channel,
+        bot=DummyBot(channel),
+    )
+
+
+def test_disabled_feature_skips_without_post(monkeypatch, harness):
+    monkeypatch.setattr(c1c_ad.feature_flags, "is_enabled", lambda key: False)
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "skipped"
+    assert harness.channel.sent == []
+
+
+def test_missing_config_skips_without_post(harness):
+    del harness.config["C1C_AD_IMAGE_RANGE"]
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "skipped"
+    assert "missing Config key C1C_AD_IMAGE_RANGE" == result.message
+    assert harness.channel.sent == []
+
+
+def test_missing_header_skips_without_post(harness):
+    harness.rows[0][0] = "copy"
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "skipped"
+    assert "missing C1C_AD_TEXT header ad_text" == result.message
+    assert harness.channel.sent == []
+
+
+def test_empty_ad_text_fails_without_post(harness):
+    harness.rows[1][0] = ""
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "failed"
+    assert harness.channel.sent == []
+    assert any(cell["values"] == [["failed"]] for cell in harness.updates)
+
+
+def test_render_failure_does_not_post_text_only(monkeypatch, harness):
+    async def render(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "failed"
+    assert harness.channel.sent == []
+
+
+def test_success_deletes_old_messages_posts_and_stores_state(harness):
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "success"
+    assert harness.channel.messages[10].deleted is True
+    assert harness.channel.messages[11].deleted is True
+    assert len(harness.channel.sent) == 2
+    written_values = [cell["values"][0][0] for cell in harness.updates]
+    assert "100" in written_values
+    assert "101" in written_values
+    assert "success" in written_values
+
+
+def test_scheduled_refresh_not_due_skips_restart_spam(harness):
+    recent = (
+        (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=1))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    harness.rows[1][1] = recent
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=False))
+    assert result.status == "skipped"
+    assert result.message == "refresh not due"
+    assert harness.channel.sent == []
+
+
+def test_missing_old_messages_do_not_block_repost(harness):
+    harness.rows[1][2] = "404"
+    harness.rows[1][3] = "405"
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "success"
+    assert len(harness.channel.sent) == 2
+
+
+def test_image_range_comes_from_config(monkeypatch, harness):
+    captured = {}
+
+    async def render(sheet_id, gid, cell_range, **kwargs):
+        captured["range"] = cell_range
+        return b"png"
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+    assert result.status == "success"
+    assert captured["range"] == "A1:V42"
+
+
+def _c1cad_check():
+    from cogs.housekeeping_c1c_ad import C1CAdCog
+
+    return C1CAdCog.c1cad.checks[0]
+
+
+class DummyRole:
+    def __init__(self, role_id):
+        self.id = role_id
+
+
+class DummyMember:
+    def __init__(self, roles=(), administrator=False):
+        self.roles = [DummyRole(role_id) for role_id in roles]
+        self.guild_permissions = SimpleNamespace(administrator=administrator)
+        self.id = 123
+
+
+class DummyCtx:
+    guild = object()
+    _coreops_suppress_denials = True
+    command = SimpleNamespace(qualified_name="c1cad")
+
+    def __init__(self, author):
+        self.author = author
+
+
+@pytest.fixture
+def rbac_members(monkeypatch):
+    import c1c_coreops.rbac as rbac
+
+    monkeypatch.setattr(rbac.discord, "Member", DummyMember)
+    monkeypatch.setattr(rbac, "get_admin_role_ids", lambda: {1})
+    monkeypatch.setattr(rbac, "get_staff_role_ids", lambda: {2})
+
+
+def test_c1cad_permission_allows_admin(rbac_members):
+    predicate = _c1cad_check()
+    assert asyncio.run(predicate(DummyCtx(DummyMember(roles=[1])))) is True
+
+
+def test_c1cad_permission_allows_staff(rbac_members):
+    predicate = _c1cad_check()
+    assert asyncio.run(predicate(DummyCtx(DummyMember(roles=[2])))) is True
+
+
+def test_c1cad_permission_denies_non_staff_non_admin(rbac_members):
+    from discord.ext import commands
+
+    predicate = _c1cad_check()
+    with pytest.raises(commands.CheckFailure):
+        asyncio.run(predicate(DummyCtx(DummyMember(roles=[3]))))


### PR DESCRIPTION
### Motivation
- Add a reusable housekeeping flow to publish a C1C recruitment advertisement as an image + text to a configured Discord thread, with manual operator control and scheduled refreshes.
- Provide operator-facing docs and configuration guidance so the feature can be enabled/disabled by FeatureToggles and configured from the Mirralith recruitment sheet.

### Description
- Introduces a new housekeeping module `modules/housekeeping/c1c_ad.py` that implements `run_c1c_ad_job`, configuration resolution, sheet read/write helpers, image rendering via `export_pdf_as_png`, safe deletion of prior messages, and robust status updates to the recruitment sheet. 
- Adds an admin/staff command cog `cogs/housekeeping_c1c_ad.py` exposing the `!c1cad` command which calls `run_c1c_ad_job` with `force=True` and reports concise results to the invoking channel. 
- Registers the command cog and a periodic scheduler job in `modules/common/runtime.py` using the `C1C_AD_REFRESH_DAYS` config to enable scheduled runs, and wires feature toggle checks via the existing `FeatureToggles` mechanism. 
- Updates docs in `docs/modules/housekeeping_mirralith_overview.md` and `docs/ops/Config.md` with configuration rows, migration notes, and usage/behavior details for the C1C ad feature. 
- Adds comprehensive unit tests in `tests/test_c1c_ad.py` covering config resolution, feature toggle gating, rendering failures, message deletion/posting, scheduled refresh logic, and RBAC checks for the `!c1cad` command. 

### Testing
- Ran the new unit tests with `pytest tests/test_c1c_ad.py` and they passed. 
- The tests exercise success, failure, and skip paths for `run_c1c_ad_job` and the RBAC checks for the `C1CAdCog.c1cad` command; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f80c51208323ac7a234e4c2e3e1a)