### PR TITLE
c1c_ad: resolve OPEN_SPOTS placeholders from Statistics tab and pre-validate ad text length

### DIFF
--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -4,13 +4,14 @@ import datetime as dt
 import io
 import logging
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import discord
 
 from modules.common import feature_flags
 from shared.sheets import core as sheets_core
 from shared.sheets import recruitment
+from shared.sheets.recruitment import afetch_reports_tab
 from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
 
 log = logging.getLogger("c1c.housekeeping.c1c_ad")
@@ -24,6 +25,24 @@ CONFIG_KEYS = (
     "C1C_AD_TARGET_THREAD_ID",
     "C1C_AD_REFRESH_DAYS",
 )
+
+PLACEHOLDER_CONFIG = {
+    "OPEN_SPOTS_ENDGAME": "open_spots_endgame_brackets",
+    "OPEN_SPOTS_LATEGAME": "open_spots_lategame_brackets",
+    "OPEN_SPOTS_MIDGAME": "open_spots_midgame_brackets",
+    "OPEN_SPOTS_EARLY": "open_spots_early_brackets",
+}
+PLACEHOLDER_TOKENS = {key: f"[{key}]" for key in PLACEHOLDER_CONFIG}
+OPEN_SPOTS_EMPTY_TEXT_HEADER = "open_spots_empty_text"
+DISCORD_TEXT_LIMIT = 2000
+RESOLVED_TEXT_TOO_LONG_ERROR = "resolved ad text exceeds Discord 2000 character limit"
+STATISTICS_REQUIRED_HEADERS = (
+    "h1_headline",
+    "h2_headline",
+    "key",
+    "open_spots",
+)
+
 REQUIRED_HEADERS = (
     "ad_text",
     "last_posted_at_utc",
@@ -155,6 +174,177 @@ def _write_status(
         sheets_core.call_with_backoff(worksheet.batch_update, cells)
 
 
+def _normalize_header(label: str) -> str:
+    return " ".join(str(label or "").strip().lower().replace("_", " ").split())
+
+
+def _cell(row: Sequence[Any], index: int | None) -> str:
+    if index is None:
+        return ""
+    return str(row[index]).strip() if 0 <= index < len(row) else ""
+
+
+def _parse_int(value: Any) -> int:
+    try:
+        return int(str(value or "").strip())
+    except Exception:
+        return 0
+
+
+def _stats_header_map(rows: Sequence[Sequence[Any]]) -> dict[str, int]:
+    required = {_normalize_header(header) for header in STATISTICS_REQUIRED_HEADERS}
+    best: dict[str, int] = {}
+    best_count = 0
+    for row in rows:
+        headers: dict[str, int] = {}
+        for idx, cell in enumerate(row):
+            key = _normalize_header(str(cell or ""))
+            if key:
+                headers[key] = idx
+        count = len(required.intersection(headers))
+        if count > best_count:
+            best = headers
+            best_count = count
+        if count == len(required):
+            return headers
+    return best
+
+
+def _find_bracket_details_start(rows: Sequence[Sequence[Any]]) -> int:
+    for idx, row in enumerate(rows):
+        if any(str(cell or "").strip().lower() == "bracket details" for cell in row):
+            return idx
+    return -1
+
+
+def _open_clans_by_bracket(rows: Sequence[Sequence[Any]]) -> dict[str, list[str]]:
+    headers = _stats_header_map(rows)
+    missing = [
+        header
+        for header in STATISTICS_REQUIRED_HEADERS
+        if _normalize_header(header) not in headers
+    ]
+    if missing:
+        raise ValueError(f"Statistics headers missing {missing[0]}")
+
+    start = _find_bracket_details_start(rows)
+    if start < 0:
+        raise ValueError("Statistics Bracket Details section missing")
+
+    h1_idx = headers[_normalize_header("h1_headline")]
+    h2_idx = headers[_normalize_header("h2_headline")]
+    key_idx = headers[_normalize_header("key")]
+    open_idx = headers[_normalize_header("open_spots")]
+
+    current_bracket = ""
+    result: dict[str, list[str]] = {}
+    for row in rows[start + 1 :]:
+        if not any(str(cell or "").strip() for cell in row):
+            current_bracket = ""
+            continue
+
+        section = _cell(row, h1_idx)
+        bracket = _cell(row, h2_idx)
+        clan = _cell(row, key_idx)
+        if (
+            section
+            and section.lower() != "bracket details"
+            and not bracket
+            and not clan
+        ):
+            break
+        if bracket and not clan:
+            current_bracket = bracket
+            result.setdefault(current_bracket, [])
+            continue
+        if current_bracket and clan and _parse_int(_cell(row, open_idx)) > 0:
+            result.setdefault(current_bracket, []).append(clan)
+    return result
+
+
+def _split_brackets(value: str) -> list[str]:
+    return [part.strip() for part in str(value or "").split(",") if part.strip()]
+
+
+def _get_reports_tab_name_required() -> str:
+    tab_name = recruitment.get_config_value("REPORTS_TAB", None)
+    if not str(tab_name or "").strip():
+        raise ValueError("reports tab config missing")
+    return str(tab_name).strip()
+
+
+def _resolve_placeholder_text(
+    *,
+    placeholder: str,
+    row: Mapping[str, str],
+    open_by_bracket: Mapping[str, Sequence[str]],
+    empty_text: str,
+) -> tuple[str, int]:
+    mapping_header = PLACEHOLDER_CONFIG[placeholder]
+    brackets = _split_brackets(row.get(mapping_header, ""))
+    if not brackets:
+        log.warning(
+            "⚠️ C1C ad placeholder skipped: missing bracket mapping placeholder=%s",
+            placeholder,
+        )
+        return empty_text, 0
+
+    clans: list[str] = []
+    seen: set[str] = set()
+    bracket_names = set(brackets)
+    for bracket, open_clans in open_by_bracket.items():
+        if bracket not in bracket_names:
+            continue
+        for clan in open_clans:
+            if clan not in seen:
+                clans.append(clan)
+                seen.add(clan)
+    if not clans:
+        return empty_text, 0
+    return f"Open right now: **{', '.join(clans)}**", len(clans)
+
+
+async def _resolve_dynamic_placeholders(ad_text: str, row: Mapping[str, str]) -> str:
+    present = [
+        placeholder
+        for placeholder, token in PLACEHOLDER_TOKENS.items()
+        if token in ad_text
+    ]
+    if not present:
+        return ad_text
+
+    empty_text = str(row.get(OPEN_SPOTS_EMPTY_TEXT_HEADER, "")).strip()
+    if not empty_text:
+        raise ValueError("open_spots_empty_text empty")
+
+    tab_name = _get_reports_tab_name_required()
+    try:
+        stats_rows = await afetch_reports_tab(tab_name)
+    except Exception as exc:
+        raise ValueError("Statistics tab read failed") from exc
+    open_by_bracket = _open_clans_by_bracket(stats_rows or [])
+
+    resolved = ad_text
+    counts = {"endgame": 0, "lategame": 0, "midgame": 0, "early": 0}
+    for placeholder in present:
+        replacement, count = _resolve_placeholder_text(
+            placeholder=placeholder,
+            row=row,
+            open_by_bracket=open_by_bracket,
+            empty_text=empty_text,
+        )
+        resolved = resolved.replace(PLACEHOLDER_TOKENS[placeholder], replacement)
+        counts[placeholder.removeprefix("OPEN_SPOTS_").lower()] = count
+    log.info(
+        "✅ C1C ad placeholders resolved: endgame=%s lategame=%s midgame=%s early=%s",
+        counts["endgame"],
+        counts["lategame"],
+        counts["midgame"],
+        counts["early"],
+    )
+    return resolved
+
+
 def _parse_timestamp(value: str) -> dt.datetime | None:
     text = str(value or "").strip()
     if not text:
@@ -253,9 +443,36 @@ async def run_c1c_ad_job(
         log.error("❌ C1C ad failed: %s", reason)
         return C1CAdResult("failed", reason)
 
+    def fail_resolved_text_too_long(char_count: int) -> C1CAdResult:
+        _write_status(
+            sheet_id,
+            config,
+            headers,
+            {
+                "last_post_status": "failed",
+                "last_post_error": RESOLVED_TEXT_TOO_LONG_ERROR,
+                "updated_at_utc": _timestamp(now),
+            },
+        )
+        log.error(
+            "❌ C1C ad failed: resolved ad text exceeds Discord limit chars=%s limit=%s",
+            char_count,
+            DISCORD_TEXT_LIMIT,
+        )
+        return C1CAdResult("failed", RESOLVED_TEXT_TOO_LONG_ERROR)
+
     ad_text = str(row.get("ad_text", "")).strip()
     if not ad_text:
         return fail("ad_text empty")
+
+    try:
+        ad_text = await _resolve_dynamic_placeholders(ad_text, row)
+    except ValueError as exc:
+        return fail(str(exc))
+
+    resolved_text_length = len(ad_text)
+    if resolved_text_length > DISCORD_TEXT_LIMIT:
+        return fail_resolved_text_too_long(resolved_text_length)
 
     if ":" not in config.image_range:
         return fail("image range invalid")

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -54,6 +54,7 @@ def _config_values():
         "C1C_AD_TEXT_ROW": "2",
         "C1C_AD_TARGET_THREAD_ID": "1324313499731755039",
         "C1C_AD_REFRESH_DAYS": "7",
+        "REPORTS_TAB": "Statistics",
     }
 
 
@@ -258,3 +259,265 @@ def test_c1cad_permission_denies_non_staff_non_admin(rbac_members):
     predicate = _c1cad_check()
     with pytest.raises(commands.CheckFailure):
         asyncio.run(predicate(DummyCtx(DummyMember(roles=[3]))))
+
+
+def _extend_c1c_ad_text_headers(harness):
+    headers = harness.rows[0]
+    row = harness.rows[1]
+    extra = [
+        ("open_spots_endgame_brackets", "Elite End Game, Early End Game"),
+        ("open_spots_lategame_brackets", "Late Game"),
+        ("open_spots_midgame_brackets", "Mid Game"),
+        ("open_spots_early_brackets", "Early Game, Beginners"),
+        ("open_spots_empty_text", "Join us and we’ll help you find the right fit."),
+    ]
+    for header, value in extra:
+        if header not in headers:
+            headers.append(header)
+            row.append(value)
+
+
+def _statistics_rows():
+    return [
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["Bracket Details", "", "", "", "", ""],
+        ["", "Elite End Game", "", "", "", ""],
+        ["", "", "Torns Valhalla", "2", "99", "99"],
+        ["", "", "Closed Endgame", "0", "0", "0"],
+        ["", "Early End Game", "", "", "", ""],
+        ["", "", "Shadow Shoguns", "1", "5", "7"],
+        ["", "Late Game", "", "", "", ""],
+        ["", "", "Late Open", "3", "1", "1"],
+        ["", "Mid Game", "", "", "", ""],
+        ["", "", "Mid Open", "4", "0", "0"],
+        ["", "Early Game", "", "", "", ""],
+        ["", "", "Early Closed", "0", "0", "0"],
+        ["", "Beginners", "", "", "", ""],
+        ["", "", "Beginner Open", "5", "8", "9"],
+    ]
+
+
+def test_dynamic_placeholders_replace_all_groups(monkeypatch, harness):
+    _extend_c1c_ad_text_headers(harness)
+    harness.rows[1][0] = "\n".join(
+        [
+            "End [OPEN_SPOTS_ENDGAME]",
+            "Late [OPEN_SPOTS_LATEGAME]",
+            "Mid [OPEN_SPOTS_MIDGAME]",
+            "Early [OPEN_SPOTS_EARLY]",
+        ]
+    )
+
+    async def fetch_stats(tab_name=None):
+        return _statistics_rows()
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+    posted_text = harness.channel.sent[1][0]
+    assert "Open right now: **Torns Valhalla, Shadow Shoguns**" in posted_text
+    assert "Open right now: **Late Open**" in posted_text
+    assert "Open right now: **Mid Open**" in posted_text
+    assert "Open right now: **Beginner Open**" in posted_text
+    assert "Closed Endgame" not in posted_text
+    assert "Early Closed" not in posted_text
+    assert "open 2" not in posted_text
+    assert "99" not in posted_text
+    assert harness.rows[1][0].startswith("End [OPEN_SPOTS_ENDGAME]")
+
+
+def test_dynamic_placeholder_empty_result_uses_empty_text(monkeypatch, harness):
+    _extend_c1c_ad_text_headers(harness)
+    harness.rows[1][0] = "Early [OPEN_SPOTS_EARLY]"
+
+    async def fetch_stats(tab_name=None):
+        rows = _statistics_rows()
+        rows[-1][3] = "0"
+        return rows
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+    assert (
+        harness.channel.sent[1][0]
+        == "Early Join us and we’ll help you find the right fit."
+    )
+
+
+def test_dynamic_placeholder_missing_mapping_warns_and_uses_empty_text(
+    monkeypatch, harness, caplog
+):
+    _extend_c1c_ad_text_headers(harness)
+    mapping_col = harness.rows[0].index("open_spots_endgame_brackets")
+    harness.rows[1][mapping_col] = ""
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+
+    async def fetch_stats(tab_name=None):
+        return _statistics_rows()
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+    assert (
+        harness.channel.sent[1][0]
+        == "End Join us and we’ll help you find the right fit."
+    )
+    assert "missing bracket mapping placeholder=OPEN_SPOTS_ENDGAME" in caplog.text
+
+
+def test_dynamic_placeholder_statistics_read_failure_fails_without_post(
+    monkeypatch, harness
+):
+    _extend_c1c_ad_text_headers(harness)
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+
+    async def fetch_stats(tab_name=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "Statistics tab read failed"
+    assert harness.channel.sent == []
+    assert any(
+        cell["values"] == [["Statistics tab read failed"]] for cell in harness.updates
+    )
+
+
+def test_dynamic_placeholder_statistics_missing_header_fails_without_post(
+    monkeypatch, harness
+):
+    _extend_c1c_ad_text_headers(harness)
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+
+    async def fetch_stats(tab_name=None):
+        rows = _statistics_rows()
+        rows[0][3] = "spots"
+        return rows
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "Statistics headers missing open_spots"
+    assert harness.channel.sent == []
+
+
+def test_dynamic_placeholder_missing_empty_text_fails_without_post(
+    monkeypatch, harness
+):
+    _extend_c1c_ad_text_headers(harness)
+    empty_col = harness.rows[0].index("open_spots_empty_text")
+    harness.rows[1][empty_col] = ""
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+
+    async def fetch_stats(tab_name=None):
+        return _statistics_rows()
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "open_spots_empty_text empty"
+    assert harness.channel.sent == []
+
+
+def test_resolved_text_over_discord_limit_fails_before_delete_or_post(
+    monkeypatch, harness, caplog
+):
+    _extend_c1c_ad_text_headers(harness)
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+    long_name = "A" * 2010
+
+    async def fetch_stats(tab_name=None):
+        rows = _statistics_rows()
+        rows[3][2] = long_name
+        rows[6][3] = "0"
+        return rows
+
+    async def render(*args, **kwargs):
+        raise AssertionError("image render should not run when text is too long")
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "resolved ad text exceeds Discord 2000 character limit"
+    assert harness.channel.sent == []
+    assert harness.channel.messages[10].deleted is False
+    assert harness.channel.messages[11].deleted is False
+    assert any(
+        cell["values"] == [["resolved ad text exceeds Discord 2000 character limit"]]
+        for cell in harness.updates
+    )
+    assert "resolved ad text exceeds Discord limit chars=" in caplog.text
+    assert "limit=2000" in caplog.text
+    assert long_name not in caplog.text
+
+
+def test_plain_ad_text_over_discord_limit_fails_before_delete_or_post(
+    monkeypatch, harness
+):
+    harness.rows[1][0] = "x" * 2001
+
+    async def render(*args, **kwargs):
+        raise AssertionError("image render should not run when text is too long")
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "resolved ad text exceeds Discord 2000 character limit"
+    assert harness.channel.sent == []
+    assert harness.channel.messages[10].deleted is False
+    assert harness.channel.messages[11].deleted is False
+
+
+def test_dynamic_placeholder_uses_configured_reports_tab(harness, monkeypatch):
+    _extend_c1c_ad_text_headers(harness)
+    harness.config["REPORTS_TAB"] = "Configured Stats"
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+    captured = {}
+
+    async def fetch_stats(tab_name=None):
+        captured["tab_name"] = tab_name
+        return _statistics_rows()
+
+    monkeypatch.setattr(c1c_ad, "afetch_reports_tab", fetch_stats)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+    assert captured["tab_name"] == "Configured Stats"
+
+
+def test_dynamic_placeholder_missing_reports_tab_config_fails_without_post(harness):
+    _extend_c1c_ad_text_headers(harness)
+    del harness.config["REPORTS_TAB"]
+    harness.rows[1][0] = "End [OPEN_SPOTS_ENDGAME]"
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "reports tab config missing"
+    assert harness.channel.sent == []


### PR DESCRIPTION
### Motivation

- Add support for dynamic placeholders in the C1C ad text that list currently open clans per bracket by reading the Statistics (reports) sheet.
- Prevent expensive image rendering and posting when the resolved ad text would exceed Discord's 2000 character limit.

### Description

- Introduces constants and mappings for placeholder tokens and related configuration (`PLACEHOLDER_CONFIG`, `PLACEHOLDER_TOKENS`, `OPEN_SPOTS_EMPTY_TEXT_HEADER`, `DISCORD_TEXT_LIMIT`, `RESOLVED_TEXT_TOO_LONG_ERROR`, `STATISTICS_REQUIRED_HEADERS`).
- Adds helper functions to parse and normalize statistics sheet rows and extract open clans by bracket: `_normalize_header`, `_cell`, `_parse_int`, `_stats_header_map`, `_find_bracket_details_start`, `_open_clans_by_bracket`, and `_split_brackets`.
- Adds functions to read the configured reports tab and resolve placeholders inside ad text by calling the async sheet fetcher `afetch_reports_tab`: `_get_reports_tab_name_required`, `_resolve_placeholder_text`, and `async _resolve_dynamic_placeholders`.
- Imports `afetch_reports_tab` and wires placeholder resolution into the main `run_c1c_ad_job` flow to resolve dynamic tokens before image rendering.
- Adds a pre-flight length check and a dedicated failure path `fail_resolved_text_too_long` that writes an error status when the resolved ad text exceeds Discord's 2000 character limit, and logs the character counts (without leaking long content).
- Retains existing behaviors for sheet reads/writes, image rendering, and thread resolution while ensuring dynamic resolution errors prevent posting.

### Testing

- Ran unit tests in `tests/test_c1c_ad.py`, including multiple new cases covering full placeholder replacement, empty-result fallback to `open_spots_empty_text`, missing mappings logging, statistics read failures, missing statistics headers, missing empty-text config, resolved-text-over-limit, plain-text-over-limit, and use of configured reports tab, and all tests passed.
- Verified that tests assert no image render is attempted when text is too long and that sheet status updates contain the correct failure messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3904bcda408323b0d72807441854fe)