### PR TITLE
Fix C1C ad image export cropping

### DIFF
--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -12,7 +12,7 @@ from modules.common import feature_flags
 from shared.sheets import core as sheets_core
 from shared.sheets import recruitment
 from shared.sheets.recruitment import afetch_reports_tab
-from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
+from shared.sheets.export_utils import ImageExportError, export_pdf_as_png, get_tab_gid
 
 log = logging.getLogger("c1c.housekeeping.c1c_ad")
 
@@ -488,6 +488,8 @@ async def run_c1c_ad_job(
                 "range": config.image_range,
             },
         )
+    except ImageExportError as exc:
+        return fail(str(exc))
     except Exception:
         log.exception("❌ C1C ad failed: image render exception")
         return fail("image render failed")

--- a/shared/sheets/export_utils.py
+++ b/shared/sheets/export_utils.py
@@ -30,6 +30,10 @@ if _pdf2image_spec is not None:
 GOOGLE_EXPORT_URL = "https://docs.google.com/spreadsheets/d/{sheet_id}/export"
 
 
+class ImageExportError(RuntimeError):
+    """Raised when a sheet image export would be unsafe to post."""
+
+
 def _export_delay_seconds() -> float:
     """
     Read SHEETS_EXPORT_DELAY_MS from the environment and return the delay in seconds.
@@ -112,10 +116,19 @@ def _convert_pdf_to_png(pdf_bytes: bytes) -> bytes | None:
         return None
 
     try:
-        images = convert_from_bytes(pdf_bytes, fmt="png", single_file=True, dpi=150)
+        images = convert_from_bytes(
+            pdf_bytes,
+            fmt="png",
+            dpi=150,
+            first_page=1,
+            last_page=2,
+        )
         if not images:
             log.error("export_pdf_as_png: pdf2image returned no pages")
             return None
+        if len(images) > 1:
+            log.error("export_pdf_as_png: PDF export produced multiple pages")
+            raise ImageExportError("image export produced multiple pages")
         image = images[0]
 
         bg = Image.new(image.mode, image.size, (255, 255, 255))
@@ -126,6 +139,8 @@ def _convert_pdf_to_png(pdf_bytes: bytes) -> bytes | None:
         buffer = io.BytesIO()
         image.save(buffer, format="PNG")
         return buffer.getvalue()
+    except ImageExportError:
+        raise
     except Exception as exc:
         log.exception(
             "export_pdf_as_png: PDF rasterization failed",
@@ -160,10 +175,20 @@ def _export_pdf_as_png_sync(
             headers=headers,
             params={
                 "format": "pdf",
-                "portrait": "false",
-                "fitw": "true",
                 "gid": gid,
                 "range": cell_range,
+                # Render the configured range as a clean, single-page image source.
+                # scale=4 is Google Sheets' "fit to page" PDF option; fitw alone can
+                # still paginate tall ranges and caused cropped first-page Discord ads.
+                "scale": "4",
+                "portrait": "false",
+                "fitw": "true",
+                "size": "7",
+                "sheetnames": "false",
+                "printtitle": "false",
+                "pagenumbers": "false",
+                "gridlines": "false",
+                "fzr": "false",
             },
             timeout=20,
         )

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -521,3 +521,22 @@ def test_dynamic_placeholder_missing_reports_tab_config_fails_without_post(harne
     assert result.status == "failed"
     assert result.message == "reports tab config missing"
     assert harness.channel.sent == []
+
+
+def test_multi_page_image_export_fails_before_delete_or_post(monkeypatch, harness):
+    async def render(*args, **kwargs):
+        raise c1c_ad.ImageExportError("image export produced multiple pages")
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "image export produced multiple pages"
+    assert harness.channel.sent == []
+    assert harness.channel.messages[10].deleted is False
+    assert harness.channel.messages[11].deleted is False
+    assert any(
+        cell["values"] == [["image export produced multiple pages"]]
+        for cell in harness.updates
+    )

--- a/tests/test_export_utils.py
+++ b/tests/test_export_utils.py
@@ -1,0 +1,68 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from shared.sheets import export_utils
+
+
+def _png_image(color=(255, 255, 255)):
+    return Image.new("RGB", (8, 8), color)
+
+
+def test_convert_pdf_to_png_rejects_multiple_pages(monkeypatch):
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(
+        export_utils,
+        "convert_from_bytes",
+        lambda *args, **kwargs: [_png_image(), _png_image()],
+    )
+
+    with pytest.raises(export_utils.ImageExportError) as exc:
+        export_utils._convert_pdf_to_png(b"%PDF")
+
+    assert str(exc.value) == "image export produced multiple pages"
+
+
+def test_convert_pdf_to_png_renders_single_page(monkeypatch):
+    captured = {}
+
+    def convert(pdf_bytes, **kwargs):
+        captured.update(kwargs)
+        return [_png_image((0, 0, 0))]
+
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(export_utils, "convert_from_bytes", convert)
+
+    png = export_utils._convert_pdf_to_png(b"%PDF")
+
+    assert png is not None
+    assert captured["first_page"] == 1
+    assert captured["last_page"] == 2
+    rendered = Image.open(BytesIO(png))
+    assert rendered.size == (8, 8)
+
+
+def test_export_pdf_request_uses_single_page_fit_options(monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+        content = b"%PDF"
+
+    def get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(export_utils, "_get_service_account_headers", lambda: {"Authorization": "Bearer token"})
+    monkeypatch.setattr(export_utils.requests, "get", get)
+    monkeypatch.setattr(export_utils, "_convert_pdf_to_png", lambda pdf: b"png")
+
+    assert export_utils._export_pdf_as_png_sync("sheet123", "456", "A1:V42") == b"png"
+
+    params = captured["params"]
+    assert params["scale"] == "4"
+    assert params["portrait"] == "false"
+    assert params["gridlines"] == "false"
+    assert params["range"] == "A1:V42"


### PR DESCRIPTION
### Motivation
- Google Sheets PDF exports were paginating tall ranges and the bot converted only the first PDF page to PNG, producing cropped C1C ad images (configured range `C1C_AD!A1:V42`) and losing bottom rows and footer. 

### Description
- Add a dedicated `ImageExportError` and make PDF rasterization request up to two pages and reject multi-page outputs by raising `ImageExportError("image export produced multiple pages")` instead of silently using page 1. 
- Adjust the Google Sheets export URL parameters (e.g. `scale=4`, `portrait=false`, `fitw=true`, `size=7`, `gridlines=false`, hide print chrome) so the configured range is more likely to fit onto a single landscape PDF page. 
- Handle `ImageExportError` in the C1C ad job so a multi-page export fails early and safely: the job writes `last_post_status = failed` and `last_post_error` without deleting previous messages or posting a cropped image. 
- Add focused tests: `tests/test_export_utils.py` for single-page rendering, multi-page rejection, and export params; and a `tests/test_c1c_ad.py` regression test ensuring a multi-page export does not post or delete prior messages. No intents, OAuth scopes, permissions, access lists, or sheet IDs were changed. 

### Testing
- Ran `pytest tests/test_export_utils.py tests/test_c1c_ad.py` and all tests passed (`26 passed` plus the new export tests). 
- Ran lint/format checks with `ruff` and verified `git diff --check`; these checks passed. 
- The changes were validated to ensure the C1C ad job fails with a clear `last_post_error` when PDF export produces multiple pages and does not post a cropped image.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a390ed27ec48323a4d8507550c607bb)