### PR TITLE
Add robust PDF-to-PNG export options and handle image export errors in C1C/Mirralith jobs

### DIFF
--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -12,7 +12,7 @@ from modules.common import feature_flags
 from shared.sheets import core as sheets_core
 from shared.sheets import recruitment
 from shared.sheets.recruitment import afetch_reports_tab
-from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
+from shared.sheets.export_utils import ImageExportError, export_pdf_as_png, get_tab_gid
 
 log = logging.getLogger("c1c.housekeeping.c1c_ad")
 
@@ -487,7 +487,12 @@ async def run_c1c_ad_job(
                 "tab": config.image_tab,
                 "range": config.image_range,
             },
+            fit_range_to_one_page=True,
+            fail_on_multi_page=True,
+            crop_to_content=False,
         )
+    except ImageExportError as exc:
+        return fail(str(exc))
     except Exception:
         log.exception("❌ C1C ad failed: image render exception")
         return fail("image render failed")
@@ -512,12 +517,21 @@ async def run_c1c_ad_job(
 
     await _delete_old_messages(channel, row)
     try:
+        text_message = await channel.send(ad_text)
+    except Exception:
+        log.exception("❌ C1C ad failed: Discord text post failed")
+        return fail("Discord post failed")
+
+    try:
         image_message = await channel.send(
             file=discord.File(io.BytesIO(png_bytes), filename="c1c_recruitment_ad.png")
         )
-        text_message = await channel.send(ad_text)
     except Exception:
-        log.exception("❌ C1C ad failed: Discord post failed")
+        log.exception("❌ C1C ad failed: Discord image post failed")
+        try:
+            await text_message.delete()
+        except Exception:
+            log.warning("⚠️ C1C ad cleanup failed: new text message delete failed")
         return fail("Discord post failed")
 
     stamp = _timestamp(now)
@@ -535,8 +549,8 @@ async def run_c1c_ad_job(
         },
     )
     channel_name = getattr(channel, "name", str(config.target_thread_id))
-    log.info("✅ C1C ad refreshed: image + text posted to #%s", channel_name)
-    return C1CAdResult("success", "image + text posted", posted=True)
+    log.info("✅ C1C ad refreshed: text + image posted to #%s", channel_name)
+    return C1CAdResult("success", "text + image posted", posted=True)
 
 
 __all__ = ["C1CAdConfig", "C1CAdResult", "run_c1c_ad_job"]

--- a/modules/housekeeping/mirralith_overview.py
+++ b/modules/housekeeping/mirralith_overview.py
@@ -172,7 +172,7 @@ def export_sheet_range_to_png(spreadsheet_id: str, tab_name: str, cell_range: st
 
 def build_mirralith_message_content(label: str, description: str, updated_date: str) -> str:
     lines = [
-        f" ",
+        " ",
         f"# {description}",
         f"-# *Last updated {updated_date}  ||{label}||*",
     ]
@@ -336,6 +336,8 @@ async def run_mirralith_overview_job(bot: discord.Client, trigger: str = "schedu
                     "tab": tab_name,
                     "range": range_value,
                 },
+                fail_on_multi_page=True,
+                crop_to_content=True,
             )
         except Exception:
             record_failure("export exception")

--- a/shared/sheets/export_utils.py
+++ b/shared/sheets/export_utils.py
@@ -30,6 +30,10 @@ if _pdf2image_spec is not None:
 GOOGLE_EXPORT_URL = "https://docs.google.com/spreadsheets/d/{sheet_id}/export"
 
 
+class ImageExportError(RuntimeError):
+    """Raised when a sheet image export would be unsafe to post."""
+
+
 def _export_delay_seconds() -> float:
     """
     Read SHEETS_EXPORT_DELAY_MS from the environment and return the delay in seconds.
@@ -106,26 +110,43 @@ def get_tab_gid(sheet_id: str, tab_name: str) -> str | None:
     return str(gid) if gid is not None else None
 
 
-def _convert_pdf_to_png(pdf_bytes: bytes) -> bytes | None:
+def _convert_pdf_to_png(
+    pdf_bytes: bytes,
+    *,
+    fail_on_multi_page: bool = True,
+    crop_to_content: bool = True,
+) -> bytes | None:
     if not _HAS_PDF2IMAGE:
         log.warning("export_pdf_as_png: pdf2image not installed; skipping PDF rasterization")
         return None
 
     try:
-        images = convert_from_bytes(pdf_bytes, fmt="png", single_file=True, dpi=150)
+        images = convert_from_bytes(
+            pdf_bytes,
+            fmt="png",
+            dpi=150,
+            first_page=1,
+            last_page=2,
+        )
         if not images:
             log.error("export_pdf_as_png: pdf2image returned no pages")
             return None
+        if len(images) > 1 and fail_on_multi_page:
+            log.error("export_pdf_as_png: PDF export produced multiple pages")
+            raise ImageExportError("image export produced multiple pages")
         image = images[0]
 
-        bg = Image.new(image.mode, image.size, (255, 255, 255))
-        diff = ImageChops.difference(image, bg)
-        bbox = diff.getbbox()
-        if bbox:
-            image = image.crop(bbox)
+        if crop_to_content:
+            bg = Image.new(image.mode, image.size, (255, 255, 255))
+            diff = ImageChops.difference(image, bg)
+            bbox = diff.getbbox()
+            if bbox:
+                image = image.crop(bbox)
         buffer = io.BytesIO()
         image.save(buffer, format="PNG")
         return buffer.getvalue()
+    except ImageExportError:
+        raise
     except Exception as exc:
         log.exception(
             "export_pdf_as_png: PDF rasterization failed",
@@ -134,12 +155,49 @@ def _convert_pdf_to_png(pdf_bytes: bytes) -> bytes | None:
         return None
 
 
+def _build_pdf_export_params(
+    gid: str | int,
+    cell_range: str,
+    *,
+    fit_range_to_one_page: bool,
+) -> dict[str, str | int]:
+    params: dict[str, str | int] = {
+        "format": "pdf",
+        "gid": gid,
+        "range": cell_range,
+        "portrait": "false",
+        "fitw": "true",
+        "sheetnames": "false",
+        "printtitle": "false",
+        "pagenumbers": "false",
+        "gridlines": "false",
+        "fzr": "false",
+    }
+    if fit_range_to_one_page:
+        # Google Sheets scale=4 is "fit to page". Keep it opt-in so existing
+        # callers can preserve prior framing unless they request strict range fitting.
+        params.update(
+            {
+                "scale": "4",
+                "size": "7",
+                "top_margin": "0.25",
+                "bottom_margin": "0.25",
+                "left_margin": "0.25",
+                "right_margin": "0.25",
+            }
+        )
+    return params
+
+
 def _export_pdf_as_png_sync(
     sheet_id: str,
     gid: str | int | None,
     cell_range: str,
     *,
     log_context: dict[str, Any] | None = None,
+    fit_range_to_one_page: bool = False,
+    fail_on_multi_page: bool = True,
+    crop_to_content: bool = True,
 ) -> bytes | None:
     context = {"range": cell_range}
     context.update(log_context or {})
@@ -158,13 +216,11 @@ def _export_pdf_as_png_sync(
         response = requests.get(
             GOOGLE_EXPORT_URL.format(sheet_id=sheet_id),
             headers=headers,
-            params={
-                "format": "pdf",
-                "portrait": "false",
-                "fitw": "true",
-                "gid": gid,
-                "range": cell_range,
-            },
+            params=_build_pdf_export_params(
+                gid,
+                cell_range,
+                fit_range_to_one_page=fit_range_to_one_page,
+            ),
             timeout=20,
         )
     except Exception as exc:  # pragma: no cover - network failure
@@ -183,7 +239,11 @@ def _export_pdf_as_png_sync(
         _log_error("empty_pdf_response", log_context=context)
         return None
 
-    return _convert_pdf_to_png(pdf_content)
+    return _convert_pdf_to_png(
+        pdf_content,
+        fail_on_multi_page=fail_on_multi_page,
+        crop_to_content=crop_to_content,
+    )
 
 
 async def export_pdf_as_png(
@@ -192,6 +252,9 @@ async def export_pdf_as_png(
     cell_range: str,
     *,
     log_context: dict[str, Any] | None = None,
+    fit_range_to_one_page: bool = False,
+    fail_on_multi_page: bool = True,
+    crop_to_content: bool = True,
 ) -> bytes | None:
     label = ""
     if log_context:
@@ -204,6 +267,9 @@ async def export_pdf_as_png(
             gid,
             cell_range,
             log_context=log_context,
+            fit_range_to_one_page=fit_range_to_one_page,
+            fail_on_multi_page=fail_on_multi_page,
+            crop_to_content=crop_to_content,
         )
     finally:
         await _sleep_after_export(label)

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -34,6 +34,7 @@ class DummyChannel:
 
     async def send(self, content=None, file=None):
         msg = DummyMessage(100 + len(self.sent))
+        self.messages[msg.id] = msg
         self.sent.append((content, file, msg.id))
         return msg
 
@@ -166,10 +167,38 @@ def test_success_deletes_old_messages_posts_and_stores_state(harness):
     assert harness.channel.messages[10].deleted is True
     assert harness.channel.messages[11].deleted is True
     assert len(harness.channel.sent) == 2
+    text_content, text_file, text_id = harness.channel.sent[0]
+    image_content, image_file, image_id = harness.channel.sent[1]
+    assert text_content == "Join C1C!"
+    assert text_file is None
+    assert image_content is None
+    assert image_file is not None
+    assert text_id == 100
+    assert image_id == 101
+    written = {cell["range"]: cell["values"][0][0] for cell in harness.updates}
+    assert written["C2"] == "101"
+    assert written["D2"] == "100"
+    assert "success" in written.values()
+
+
+def test_image_send_failure_deletes_new_text_and_does_not_write_success(harness):
+    async def send(content=None, file=None):
+        if file is not None:
+            raise RuntimeError("image send failed")
+        return await DummyChannel.send(harness.channel, content=content, file=file)
+
+    harness.channel.send = send
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "Discord post failed"
+    assert len(harness.channel.sent) == 1
+    assert harness.channel.sent[0][0] == "Join C1C!"
+    assert harness.channel.messages[100].deleted is True
     written_values = [cell["values"][0][0] for cell in harness.updates]
-    assert "100" in written_values
-    assert "101" in written_values
-    assert "success" in written_values
+    assert "success" not in written_values
+    assert "Discord post failed" in written_values
 
 
 def test_scheduled_refresh_not_due_skips_restart_spam(harness):
@@ -194,17 +223,21 @@ def test_missing_old_messages_do_not_block_repost(harness):
     assert len(harness.channel.sent) == 2
 
 
-def test_image_range_comes_from_config(monkeypatch, harness):
+def test_image_range_and_export_options_come_from_config(monkeypatch, harness):
     captured = {}
 
     async def render(sheet_id, gid, cell_range, **kwargs):
         captured["range"] = cell_range
+        captured["kwargs"] = kwargs
         return b"png"
 
     monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
     result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
     assert result.status == "success"
     assert captured["range"] == "A1:V42"
+    assert captured["kwargs"]["fit_range_to_one_page"] is True
+    assert captured["kwargs"]["fail_on_multi_page"] is True
+    assert captured["kwargs"]["crop_to_content"] is False
 
 
 def _c1cad_check():
@@ -323,7 +356,7 @@ def test_dynamic_placeholders_replace_all_groups(monkeypatch, harness):
     result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
 
     assert result.status == "success"
-    posted_text = harness.channel.sent[1][0]
+    posted_text = harness.channel.sent[0][0]
     assert "Open right now: **Torns Valhalla, Shadow Shoguns**" in posted_text
     assert "Open right now: **Late Open**" in posted_text
     assert "Open right now: **Mid Open**" in posted_text
@@ -350,7 +383,7 @@ def test_dynamic_placeholder_empty_result_uses_empty_text(monkeypatch, harness):
 
     assert result.status == "success"
     assert (
-        harness.channel.sent[1][0]
+        harness.channel.sent[0][0]
         == "Early Join us and we’ll help you find the right fit."
     )
 
@@ -372,7 +405,7 @@ def test_dynamic_placeholder_missing_mapping_warns_and_uses_empty_text(
 
     assert result.status == "success"
     assert (
-        harness.channel.sent[1][0]
+        harness.channel.sent[0][0]
         == "End Join us and we’ll help you find the right fit."
     )
     assert "missing bracket mapping placeholder=OPEN_SPOTS_ENDGAME" in caplog.text
@@ -521,3 +554,22 @@ def test_dynamic_placeholder_missing_reports_tab_config_fails_without_post(harne
     assert result.status == "failed"
     assert result.message == "reports tab config missing"
     assert harness.channel.sent == []
+
+
+def test_multi_page_image_export_fails_before_delete_or_post(monkeypatch, harness):
+    async def render(*args, **kwargs):
+        raise c1c_ad.ImageExportError("image export produced multiple pages")
+
+    monkeypatch.setattr(c1c_ad, "export_pdf_as_png", render)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "failed"
+    assert result.message == "image export produced multiple pages"
+    assert harness.channel.sent == []
+    assert harness.channel.messages[10].deleted is False
+    assert harness.channel.messages[11].deleted is False
+    assert any(
+        cell["values"] == [["image export produced multiple pages"]]
+        for cell in harness.updates
+    )

--- a/tests/test_export_utils.py
+++ b/tests/test_export_utils.py
@@ -1,0 +1,128 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from shared.sheets import export_utils
+
+
+def _png_image(color=(255, 255, 255), size=(8, 8)):
+    return Image.new("RGB", size, color)
+
+
+def test_convert_pdf_to_png_rejects_multiple_pages(monkeypatch):
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(
+        export_utils,
+        "convert_from_bytes",
+        lambda *args, **kwargs: [_png_image(), _png_image()],
+    )
+
+    with pytest.raises(export_utils.ImageExportError) as exc:
+        export_utils._convert_pdf_to_png(b"%PDF")
+
+    assert str(exc.value) == "image export produced multiple pages"
+
+
+def test_convert_pdf_to_png_can_allow_first_page_when_requested(monkeypatch):
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(
+        export_utils,
+        "convert_from_bytes",
+        lambda *args, **kwargs: [_png_image((0, 0, 0)), _png_image()],
+    )
+
+    png = export_utils._convert_pdf_to_png(b"%PDF", fail_on_multi_page=False)
+
+    assert png is not None
+    rendered = Image.open(BytesIO(png))
+    assert rendered.size == (8, 8)
+
+
+def test_convert_pdf_to_png_crops_to_content_by_default(monkeypatch):
+    captured = {}
+    image = _png_image(size=(10, 10))
+    image.putpixel((4, 4), (0, 0, 0))
+
+    def convert(pdf_bytes, **kwargs):
+        captured.update(kwargs)
+        return [image]
+
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(export_utils, "convert_from_bytes", convert)
+
+    png = export_utils._convert_pdf_to_png(b"%PDF")
+
+    assert png is not None
+    assert captured["first_page"] == 1
+    assert captured["last_page"] == 2
+    rendered = Image.open(BytesIO(png))
+    assert rendered.size == (1, 1)
+
+
+def test_convert_pdf_to_png_can_preserve_page_framing(monkeypatch):
+    image = _png_image(size=(10, 10))
+    image.putpixel((4, 4), (0, 0, 0))
+
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(export_utils, "convert_from_bytes", lambda *args, **kwargs: [image])
+
+    png = export_utils._convert_pdf_to_png(b"%PDF", crop_to_content=False)
+
+    assert png is not None
+    rendered = Image.open(BytesIO(png))
+    assert rendered.size == (10, 10)
+
+
+def test_default_pdf_request_preserves_prior_non_scale_options():
+    params = export_utils._build_pdf_export_params(
+        "456", "A1:AE26", fit_range_to_one_page=False
+    )
+
+    assert params["range"] == "A1:AE26"
+    assert params["portrait"] == "false"
+    assert params["fitw"] == "true"
+    assert params["gridlines"] == "false"
+    assert "scale" not in params
+    assert "top_margin" not in params
+
+
+def test_fit_to_one_page_pdf_request_adds_strict_fit_options(monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+        content = b"%PDF"
+
+    def get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(
+        export_utils,
+        "_get_service_account_headers",
+        lambda: {"Authorization": "Bearer token"},
+    )
+    monkeypatch.setattr(export_utils.requests, "get", get)
+    monkeypatch.setattr(
+        export_utils,
+        "_convert_pdf_to_png",
+        lambda pdf, **kwargs: b"png",
+    )
+
+    assert (
+        export_utils._export_pdf_as_png_sync(
+            "sheet123", "456", "A1:V42", fit_range_to_one_page=True
+        )
+        == b"png"
+    )
+
+    params = captured["params"]
+    assert params["scale"] == "4"
+    assert params["size"] == "7"
+    assert params["portrait"] == "false"
+    assert params["gridlines"] == "false"
+    assert params["fzr"] == "false"
+    assert params["top_margin"] == "0.25"
+    assert params["range"] == "A1:V42"


### PR DESCRIPTION
### Motivation

- Improve safety and framing of Google Sheets PDF exports by detecting multi-page outputs and allowing callers to opt into fit-to-page and cropping behavior. 
- Prevent partial Discord posts when image export fails and ensure proper cleanup of text-only messages in the `C1C` ad job. 

### Description

- Add `ImageExportError` exception and extend `_convert_pdf_to_png`, `_export_pdf_as_png_sync`, and `export_pdf_as_png` with options `fit_range_to_one_page`, `fail_on_multi_page`, and `crop_to_content` to control rasterization and framing. 
- Implement multi-page detection in `_convert_pdf_to_png` and raise `ImageExportError` when `fail_on_multi_page=True`, and support optional content-cropping. 
- Add `_build_pdf_export_params` helper to assemble Google Sheets PDF export params and wire `fit_range_to_one_page` into the HTTP export request. 
- Update callers: `modules/housekeeping/c1c_ad.py` now requests `fit_range_to_one_page=True`, `fail_on_multi_page=True`, `crop_to_content=False`, catches `ImageExportError` to fail early without deleting existing messages, posts text before image and deletes the text if the image send fails; `modules/housekeeping/mirralith_overview.py` requests `fail_on_multi_page=True` and `crop_to_content=True`. 
- Update and add unit tests to reflect new behavior and options: modify `tests/test_c1c_ad.py` to assert ordering and cleanup on image-send failure and multi-page export handling, and add `tests/test_export_utils.py` covering multi-page rejection, optional first-page behavior, cropping, and PDF param building. 

### Testing

- Ran unit tests in `tests/test_c1c_ad.py` which exercise posting order, cleanup on image send failure, and handling of `ImageExportError`, and they passed. 
- Ran new unit tests in `tests/test_export_utils.py` which validate `_convert_pdf_to_png` multi-page rejection, optional allowances, content cropping, and `_build_pdf_export_params`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a390ed27ec48323a4d8507550c607bb)