### PR TITLE
Fix C1C ad export whitespace trimming

### DIFF
--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -489,7 +489,7 @@ async def run_c1c_ad_job(
             },
             fit_range_to_one_page=True,
             fail_on_multi_page=True,
-            crop_to_content=False,
+            crop_to_content=True,
         )
     except ImageExportError as exc:
         return fail(str(exc))

--- a/shared/sheets/export_utils.py
+++ b/shared/sheets/export_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 
 import importlib.util
 import requests
-from PIL import Image, ImageChops  # noqa: F401 - provided for potential downstream usage
+from PIL import Image, ImageChops
 from google.auth.transport.requests import Request
 from google.oauth2.service_account import Credentials
 
@@ -28,6 +28,38 @@ if _pdf2image_spec is not None:
     _HAS_PDF2IMAGE = callable(convert_from_bytes)
 
 GOOGLE_EXPORT_URL = "https://docs.google.com/spreadsheets/d/{sheet_id}/export"
+
+
+def _trim_outer_whitespace(image: Image.Image) -> Image.Image:
+    """Trim only the outer near-white page frame from a rasterized PDF page.
+
+    Google Sheets PDF exports render the selected range onto a white PDF page.
+    Comparing against pure white is too brittle because PDF rasterization can leave
+    anti-aliased near-white pixels around sheet content, while aggressive cropping
+    risks shaving off footer rows or side content.  Treat only pixels that are very
+    close to white as page whitespace, and keep a tiny safety pad around the
+    detected content bbox.
+    """
+
+    rgb_image = image.convert("RGB")
+    white = Image.new("RGB", rgb_image.size, (255, 255, 255))
+    diff = ImageChops.difference(rgb_image, white)
+
+    # Ignore tiny rasterization noise in the PDF page background, but consider any
+    # visible sheet fill, borders, text, or image pixels to be content.
+    threshold = 8
+    mask = diff.convert("L").point(lambda pixel: 255 if pixel > threshold else 0)
+    bbox = mask.getbbox()
+    if not bbox:
+        return image
+
+    safety_pad_px = 2
+    left, top, right, bottom = bbox
+    left = max(0, left - safety_pad_px)
+    top = max(0, top - safety_pad_px)
+    right = min(image.width, right + safety_pad_px)
+    bottom = min(image.height, bottom + safety_pad_px)
+    return image.crop((left, top, right, bottom))
 
 
 class ImageExportError(RuntimeError):
@@ -137,11 +169,7 @@ def _convert_pdf_to_png(
         image = images[0]
 
         if crop_to_content:
-            bg = Image.new(image.mode, image.size, (255, 255, 255))
-            diff = ImageChops.difference(image, bg)
-            bbox = diff.getbbox()
-            if bbox:
-                image = image.crop(bbox)
+            image = _trim_outer_whitespace(image)
         buffer = io.BytesIO()
         image.save(buffer, format="PNG")
         return buffer.getvalue()

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -237,7 +237,7 @@ def test_image_range_and_export_options_come_from_config(monkeypatch, harness):
     assert captured["range"] == "A1:V42"
     assert captured["kwargs"]["fit_range_to_one_page"] is True
     assert captured["kwargs"]["fail_on_multi_page"] is True
-    assert captured["kwargs"]["crop_to_content"] is False
+    assert captured["kwargs"]["crop_to_content"] is True
 
 
 def _c1cad_check():

--- a/tests/test_export_utils.py
+++ b/tests/test_export_utils.py
@@ -57,7 +57,32 @@ def test_convert_pdf_to_png_crops_to_content_by_default(monkeypatch):
     assert captured["first_page"] == 1
     assert captured["last_page"] == 2
     rendered = Image.open(BytesIO(png))
-    assert rendered.size == (1, 1)
+    assert rendered.size == (5, 5)
+
+
+def test_convert_pdf_to_png_trims_near_white_page_frame_without_shaving_content(monkeypatch):
+    image = _png_image(size=(20, 20))
+    # Simulate anti-aliased page-background noise that should still be treated as whitespace.
+    image.putpixel((1, 1), (252, 252, 252))
+    # Simulate rendered sheet content reaching the bottom/right of the selected range.
+    for x in range(6, 15):
+        image.putpixel((x, 5), (0, 0, 0))
+        image.putpixel((x, 14), (0, 0, 0))
+    for y in range(5, 15):
+        image.putpixel((6, y), (0, 0, 0))
+        image.putpixel((14, y), (0, 0, 0))
+
+    monkeypatch.setattr(export_utils, "_HAS_PDF2IMAGE", True)
+    monkeypatch.setattr(export_utils, "convert_from_bytes", lambda *args, **kwargs: [image])
+
+    png = export_utils._convert_pdf_to_png(b"%PDF")
+
+    assert png is not None
+    rendered = Image.open(BytesIO(png))
+    assert rendered.size == (13, 14)
+    # The detected content is padded, not clipped at the exact content boundary.
+    assert rendered.getpixel((2, 2)) == (0, 0, 0)
+    assert rendered.getpixel((10, 11)) == (0, 0, 0)
 
 
 def test_convert_pdf_to_png_can_preserve_page_framing(monkeypatch):


### PR DESCRIPTION
### Motivation
- The C1C ad PNG exports included the full white PDF page margins around the rendered range instead of a tight crop to the ad, producing large white frames around the content.  
- The fix must trim outer PDF whitespace while preserving all configured range content (no bottom-row/footer/side clipping) and keep strict one-page / multi-page failure protections.

### Description
- Add `_trim_outer_whitespace(image: Image.Image)` to `shared/sheets/export_utils.py` which detects near-white page background using a small threshold and returns a bbox-cropped image with a tiny safety pad.  
- Use `_trim_outer_whitespace` in `_convert_pdf_to_png` whenever `crop_to_content=True` instead of the previous strict difference-based crop, keeping rasterization options and multi-page rejection intact.  
- Restore `crop_to_content=True` for the C1C ad export call so `C1C_AD!A1:V42` is exported fit-to-one-page but with outer whitespace trimmed.  
- Update tests in `tests/test_export_utils.py` and `tests/test_c1c_ad.py` to assert the new cropping behavior and safety padding.

### Testing
- Ran `pytest tests/test_export_utils.py tests/test_c1c_ad.py` which passed (targeted export/C1C tests succeeded).  
- Ran the full `pytest` suite which exercised broader project tests; the broader run shows unrelated failures outside the export change surface (these failures are not caused by the export trimming adjustments).  
- Unit tests updated to validate near-white trimming preserves rendered content and that C1C ad export options include `crop_to_content=True`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3936274628832394f415fd1df0b610)