### PR TITLE
Housekeeping: restrict channel cleanup to channel's own history and update detection/docs/tests

### DIFF
--- a/docs/ops/Housekeeping.md
+++ b/docs/ops/Housekeeping.md
@@ -12,7 +12,11 @@ and long-lived threads active without manual nudges.
   `HOUSEKEEPING_CLEANUP_DRY_RUN`; missing/invalid values prevent scheduling
   without ENV fallback or hidden defaults.
 - **Targets.** Each non-empty row in the configured cleanup tab is a cleanup
-  target. Required headers are `enabled`, `target_id`, `target_type`,
+  target. `target_type=thread` cleans that thread's message history;
+  `target_type=channel` scans only the configured target channel's own message
+  history. Channel rows do not discover or traverse child threads
+  automatically; configure a thread as its own row when its history should be
+  cleaned. Required headers are `enabled`, `target_id`, `target_type`,
   `target_name`, `parent_name`, `cleanup_mode`, `min_age_hours`,
   `last_checked_at_utc`, `last_deleted_count`, `last_candidate_count`, `last_skipped_count`,
   `last_status`, and `notes`.

--- a/docs/ops/Watchers.md
+++ b/docs/ops/Watchers.md
@@ -37,7 +37,7 @@ source of truth covers every automation hook:
 
 ### Cleanup watcher
 - **Sheets.** `HOUSEKEEPING_CLEANUP_ENABLED` must be TRUE in Feature Toggles. Config keys `HOUSEKEEPING_CLEANUP_TAB`, `HOUSEKEEPING_CLEANUP_RUN_EVERY_HOURS`, and `HOUSEKEEPING_CLEANUP_DRY_RUN` drive the cleanup tab, cadence, and dry-run mode.
-- **Behavior.** On every run the watcher reads rows from the configured cleanup tab, validates each row, resolves target metadata, and applies the selected cleanup mode for supported thread targets. Pinned messages remain untouched.
+- **Behavior.** On every run the watcher reads rows from the configured cleanup tab, validates each row, resolves target metadata, and applies the selected cleanup mode to the configured target's own message history for supported thread and channel rows. Channel rows do not discover or traverse child threads automatically. Pinned messages remain untouched.
 - **Logging.** Each run emits a single summary line: `🧹 cleanup run complete: checked_rows=<N> dry_run=<bool> deleted=<M> candidates=<C> skipped=<S> errors=<E>`. WARN lines accompany missing/invalid sheet configuration, fetch, permission, or delete issues without logging every message.
 
 ### Thread keepalive

--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -47,6 +47,8 @@ BOT_WRITABLE_HEADERS = (
     "last_status",
 )
 ALLOWED_TARGET_TYPES = {"thread", "channel"}
+# ``target_type=channel`` means cleanup of the configured target's own
+# message history. Child threads are not discovered or traversed automatically.
 SUPPORTED_TARGET_TYPES = {"thread", "channel"}
 ALLOWED_CLEANUP_MODES = {
     "all_non_pinned",
@@ -194,7 +196,7 @@ async def _resolve_any(bot: commands.Bot, target_id: int) -> tuple[Any | None, s
             return None, None, "fetch_failed"
     if isinstance(channel, discord.Thread):
         return channel, "thread", None
-    if isinstance(channel, discord.TextChannel):
+    if isinstance(channel, discord.TextChannel) or callable(getattr(channel, "history", None)):
         return channel, "channel", None
     return channel, None, "invalid_target_type"
 
@@ -249,7 +251,7 @@ async def _delete_messages(messages: Sequence[discord.Message], logger: logging.
     return CleanupResult("deleted" if deleted else "ok_no_matches", deleted, len(messages), 0, 0)
 
 
-async def _scan_message_history(target: discord.Thread | discord.TextChannel, *, min_age_hours: float, mode: str, dry_run: bool, bot: commands.Bot, logger: logging.Logger) -> CleanupResult:
+async def _scan_message_history(target: Any, *, min_age_hours: float, mode: str, dry_run: bool, bot: commands.Bot, logger: logging.Logger) -> CleanupResult:
     candidates: list[discord.Message] = []
     skipped = 0
     cutoff = _utc_now() - timedelta(hours=min_age_hours)
@@ -277,7 +279,11 @@ async def _scan_thread(thread: discord.Thread, *, min_age_hours: float, mode: st
     return await _scan_message_history(thread, min_age_hours=min_age_hours, mode=mode, dry_run=dry_run, bot=bot, logger=logger)
 
 
-async def _scan_channel(channel: discord.TextChannel, *, min_age_hours: float, mode: str, dry_run: bool, bot: commands.Bot, logger: logging.Logger) -> CleanupResult:
+async def _scan_channel(channel: Any, *, min_age_hours: float, mode: str, dry_run: bool, bot: commands.Bot, logger: logging.Logger) -> CleanupResult:
+    """Clean only the configured channel target's own message history.
+
+    Child threads are not discovered or traversed automatically.
+    """
     return await _scan_message_history(channel, min_age_hours=min_age_hours, mode=mode, dry_run=dry_run, bot=bot, logger=logger)
 
 

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -225,6 +225,31 @@ def test_dry_run_writes_candidate_count_separately_from_skipped(monkeypatch):
     assert [m.deleted for m in msgs] == [False, False]
 
 
+def test_thread_cleanup_scans_configured_thread_only(monkeypatch):
+    thread_msgs = [Msg("bot", author_id=99)]
+    sibling_thread = Thread([Msg("bot", author_id=99)])
+    parent = Channel([])
+    parent.threads = [sibling_thread]
+    thread = Thread(thread_msgs)
+    thread.parent = parent
+
+    ws, msgs, target = run_with_sheet(
+        monkeypatch,
+        [active_row(target_type="thread", cleanup_mode="bot_messages_only")],
+        thread_msgs,
+        dry_run=False,
+        target_type="thread",
+        target=thread,
+    )
+
+    updates = update_map(ws)
+    assert target.history_calls == 1
+    assert sibling_thread.history_calls == 0
+    assert msgs[0].deleted is True
+    assert sibling_thread.messages[0].deleted is False
+    assert updates["C2"] == "thread"
+    assert updates["L2"] == "deleted"
+
 def test_channel_target_type_scans_channel_own_messages_not_child_threads(monkeypatch):
     channel_msgs = [Msg("bot", author_id=99)]
     thread = Thread([Msg("bot", author_id=99)])
@@ -283,6 +308,39 @@ def test_channel_cleanup_modes_match_thread_modes(monkeypatch):
     for mode, msgs, expected in cases:
         run_with_sheet(monkeypatch, [active_row(target_type="channel", cleanup_mode=mode, min_age_hours="0")], msgs, dry_run=False, target_type="channel")
         assert [m.deleted for m in msgs] == expected
+
+
+def test_channel_like_history_target_resolves_as_channel_without_child_traversal(monkeypatch):
+    class ChannelLikeTarget(HistoryTarget):
+        name = "channel-like-name"
+
+    child_thread = Thread([Msg("bot", author_id=99)])
+    target = ChannelLikeTarget([Msg("bot", author_id=99)])
+    target.threads = [child_thread]
+    bot = Bot(target)
+    monkeypatch.setattr(cleanup.discord, "Thread", Thread)
+    monkeypatch.setattr(cleanup.discord, "TextChannel", Channel)
+
+    resolved, detected_type, status = asyncio.run(cleanup._resolve_any(bot, 123))
+    result = asyncio.run(
+        cleanup._scan_channel(
+            resolved,
+            min_age_hours=0,
+            mode="bot_messages_only",
+            dry_run=False,
+            bot=bot,
+            logger=cleanup.log,
+        )
+    )
+
+    assert resolved is target
+    assert detected_type == "channel"
+    assert status is None
+    assert result.status == "deleted"
+    assert target.history_calls == 1
+    assert child_thread.history_calls == 0
+    assert target.messages[0].deleted is True
+    assert child_thread.messages[0].deleted is False
 
 
 def test_unsupported_target_type_still_applies_to_unsupported_resolved_objects(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent cleanup from accidentally traversing and deleting messages in child threads when a row is configured as `target_type=channel` by making channel rows operate only on the configured channel's own message history.
- Allow channel-like objects that expose a `history` API to be treated as channel targets while keeping thread traversal behavior explicit.
- Reflect the behavior change in operational docs so admins understand how to configure thread vs channel rows.

### Description
- Updated docs in `docs/ops/Housekeeping.md` and `docs/ops/Watchers.md` to state that `target_type=channel` scans only the configured channel's own message history and does not discover/traverse child threads automatically.
- In `modules/housekeeping/cleanup.py` added a clarifying comment and changed target detection in `_resolve_any` to treat objects with a callable `history` attribute as channel-like targets.
- Broadened history scan function signatures to accept generic targets (`Any`) and added a docstring to `_scan_channel` stating that child threads are not traversed.
- Added/updated unit tests in `tests/modules/housekeeping/test_cleanup.py` to cover: scanning only the configured thread, ensuring channel targets don't traverse child threads, and resolving channel-like history targets as channels.

### Testing
- Ran the housekeeping cleanup unit tests in `tests/modules/housekeeping/test_cleanup.py` via `pytest`, which exercised the new channel/thread behaviors and the added channel-like target resolution; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a93b2840c8323beef8e9df01c93c4)