### PR TITLE
Log promo availability summaries like welcome

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -5,6 +5,7 @@ import asyncio
 import datetime as dt
 import logging
 from dataclasses import dataclass
+from types import SimpleNamespace
 from time import monotonic
 from typing import Dict, List, Optional, Tuple
 
@@ -27,6 +28,7 @@ from modules.onboarding.watcher_welcome import (
     _channel_readable_label,
     _clan_math_column_indices,
     _NO_PLACEMENT_TAG,
+    _log_clan_math_event,
     _normalize_clan_math_targets,
     _send_placement_log_line,
     build_closed_thread_name,
@@ -1112,6 +1114,25 @@ class PromoTicketWatcher(commands.Cog):
             log.exception("promo finalization state completion update failed", extra={"ticket": ticket_id_final, "thread_id": getattr(thread, "id", None)})
         outcome = "success" if finalization_status == "done" else "partial"
         await _send_placement_log_line(flow="promo", outcome=outcome, ticket=ticket_id_final, player=context.username, source=source_tag or None, destination=final_tag or _NO_PLACEMENT_TAG, trigger=trigger, reservation=reservation_status, clan_update=clan_update_status, finalization_status=finalization_status, action=(None if outcome == "success" else "manual_check"))
+        try:
+            await _log_clan_math_event(
+                SimpleNamespace(
+                    ticket_number=ticket_id_final,
+                    username=context.username,
+                    close_source=context.close_trigger or trigger or "ticket_tool",
+                ),
+                final_display=final_tag if final_tag else _NO_PLACEMENT_TAG,
+                reservation_label=cleanup.reservation_label or "none",
+                reservation_row=cleanup.reservation_row,
+                result=("ok" if outcome == "success" else "error"),
+                reason=(None if outcome == "success" else cleanup.reason or "promo_finalization_partial"),
+                row_change_lines=row_change_lines,
+            )
+        except Exception:
+            log.exception(
+                "failed to emit promo clan math log",
+                extra={"ticket": ticket_id_final, "result": outcome},
+            )
         logging_channel_result = "ok" if logging_channel_result == "skip" else logging_channel_result
 
         channel_name_after = channel_name_before

--- a/tests/onboarding/test_open_spot_visibility_logging.py
+++ b/tests/onboarding/test_open_spot_visibility_logging.py
@@ -46,6 +46,10 @@ def _finalization_and_cache_mocks(monkeypatch):
     monkeypatch.setattr('modules.onboarding.watcher_promo.recruitment_sheets.get_clan_header_map', lambda: {'open_spots':4})
     monkeypatch.setattr("modules.onboarding.watcher_welcome.onboarding_sheets.update_ticket_finalization_state", state_update)
     monkeypatch.setattr("modules.onboarding.watcher_promo.onboarding_sheets.update_ticket_finalization_state", state_update)
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.onboarding_sheets.get_live_promo_headers",
+        lambda: ["ticketnumber", "username", "clantag", "sourceclantag"],
+    )
 
 
 
@@ -377,3 +381,42 @@ def test_promo_non_real_tag_logs_skip_reason(monkeypatch, caplog):
     asyncio.run(watcher._finalize_clan_tag(DummyThread(), ctx, 'C1CZ', actor=None, prompt_message=None, view=None))
     assert 'skip_reason=non_real_final_tag' in caplog.text
     assert 'reason=no_promo_open_spots_reconcile_currently' not in caplog.text
+
+
+def test_promo_finalize_emits_welcome_style_availability_summary(monkeypatch):
+    monkeypatch.setattr('modules.common.feature_flags.is_enabled', lambda *_: True)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.get_promo_channel_id', lambda: 1)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.get_ticket_tool_bot_id', lambda: 1)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.thread_scopes.is_promo_parent', lambda *_: True)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sheets.upsert_promo', lambda *_: 'updated')
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sessions.mark_completed', lambda *_: True)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sheets.find_promo_row', lambda *_: (2, {"clantag": ""}))
+    monkeypatch.setattr('modules.onboarding.watcher_promo.onboarding_sheets.get_live_promo_headers', lambda: ['ticketnumber', 'username', 'clantag', 'sourceclantag'])
+    row_state = {"open": "6"}
+
+    def fake_find_clan_row(tag, *args, **kwargs):
+        row = [''] * 36
+        row[2] = tag
+        row[4] = row_state["open"]
+        return (25, row) if tag == 'C1C9' else None
+
+    async def fake_adjust(tag, delta):
+        row_state["open"] = str(int(row_state["open"]) + delta)
+        return int(row_state["open"])
+
+    logs = []
+    monkeypatch.setattr('modules.onboarding.watcher_promo.recruitment_sheets.find_clan_row', fake_find_clan_row)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.availability.adjust_manual_open_spots', fake_adjust)
+    monkeypatch.setattr('modules.onboarding.watcher_promo.availability.recompute_clan_availability', lambda *a, **k: asyncio.sleep(0, result=None))
+    monkeypatch.setattr('modules.onboarding.watcher_welcome.rt.send_log_message', lambda message: logs.append(message) or asyncio.sleep(0))
+
+    watcher = PromoTicketWatcher(bot=DummyBot())
+    ctx = PromoTicketContext(thread_id=1,ticket_number='R9',username='u',promo_type='Returning',thread_created='x',year='2026',month='Jan',state='awaiting_clan')
+    watcher._load_clan_tags = lambda : asyncio.sleep(0, result=['C1C9'])
+
+    asyncio.run(watcher._finalize_clan_tag(DummyThread(), ctx, 'C1C9', actor=None, prompt_message=None, view=None))
+
+    availability_logs = [message for message in logs if 'open_spots:' in message]
+    assert len(availability_logs) == 1
+    assert 'C1C9 row 25: open_spots: 6 → 5' in availability_logs[0]
+    assert '(AF: 6 → 5, AG: - → -, AH: - → -, AI: - → -)' in availability_logs[0]


### PR DESCRIPTION
### Motivation
- Promo finalization updated availability in Sheets but did not emit the same human-readable availability summary line that `welcome` emits, making ops logs inconsistent.
- The intent is a minimal logging-parity fix: make promo use the same welcome-facing summary behavior without changing sheet layout or placement logic.

### Description
- Reused the welcome summary emitter by importing and invoking `modules.onboarding.watcher_welcome._log_clan_math_event` from `modules/onboarding/watcher_promo.py` and passing a small `SimpleNamespace` context so promo produces the same readable row/update lines as welcome.
- Added `from types import SimpleNamespace` and a guarded `try/except` around the emitter call so promo still emits its existing placement-finalized line and then emits the welcome-style availability summary without duplicating other diagnostics.
- Kept all sheet/header resolution logic and availability writes unchanged and used the existing header resolution helpers; no tabs, columns, or sheet structures were modified.
- Added a unit test `test_promo_finalize_emits_welcome_style_availability_summary` and a small test fixture mock to verify promo emits exactly one welcome-style availability summary including clan tag, bot_info row number, `open_spots` before→after, and `AF`/`AG`/`AH`/`AI` before→after values.

### Testing
- Compiled the modified module with `python3 -m compileall modules/onboarding/watcher_promo.py` and it succeeded.
- Ran the new promo test with `pytest -q tests/onboarding/test_open_spot_visibility_logging.py::test_promo_finalize_emits_welcome_style_availability_summary` and it passed.
- Ran the broader test set `pytest -q tests/onboarding/test_open_spot_visibility_logging.py tests/onboarding/test_welcome_reservations.py -q` to ensure no regressions in welcome/promo finalization flows and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae12e3b848323923dc7f4778af94b)