### PR TITLE
Add Share to Clan button on overview and detail tabs and fix share action routing

### DIFF
--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -86,7 +86,9 @@ class ShardTrackerView(discord.ui.View):
             )
 
         # Action rows depend on tab
-        if active_tab in shard_labels:
+        if active_tab == "overview":
+            self._add_share_button(active_tab)
+        elif active_tab in shard_labels:
             self._add_primary_buttons()
             self._add_legendary_button()
             self._add_last_pulls_button()
@@ -112,9 +114,12 @@ class ShardTrackerView(discord.ui.View):
                 controller=self._controller,
             )
         )
+        self._add_share_button(self.active_tab)
+
+    def _add_share_button(self, tab: str) -> None:
         self.add_item(
             _ShardButton(
-                custom_id=f"action:share:{self.active_tab}",
+                custom_id=f"action:share:{tab}",
                 label="Share to Clan",
                 emoji=None,
                 style=discord.ButtonStyle.secondary,

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -270,3 +270,112 @@ def test_share_summary_missing_destination_is_ephemeral_warning(caplog):
         assert any(getattr(record, "component", None) == "shard_tracker.share_to_clan" for record in caplog.records)
 
     asyncio.run(runner())
+
+
+def _button_labels(view):
+    return [getattr(child, "label", None) for child in view.children]
+
+
+def _button_custom_ids(view):
+    return [getattr(child, "custom_id", None) for child in view.children]
+
+
+def test_overview_button_layout_includes_share_to_clan():
+    from modules.community.shard_tracker.views import ShardTrackerView
+
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    view = ShardTrackerView(
+        owner_id=42,
+        controller=tracker,
+        active_tab="overview",
+        shard_labels={"ancient": "Ancient", "void": "Void", "sacred": "Sacred", "primal": "Primal"},
+        shard_emojis={},
+        timeout=None,
+    )
+
+    labels = _button_labels(view)
+    custom_ids = _button_custom_ids(view)
+    assert labels[0] == "Overview"
+    assert "Last Pulls" in labels
+    assert "Share to Clan" in labels
+    assert "action:share:overview" in custom_ids
+
+
+def test_detail_button_layout_still_includes_share_to_clan():
+    from modules.community.shard_tracker.views import ShardTrackerView
+
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    view = ShardTrackerView(
+        owner_id=42,
+        controller=tracker,
+        active_tab="ancient",
+        shard_labels={"ancient": "Ancient", "void": "Void", "sacred": "Sacred", "primal": "Primal"},
+        shard_emojis={},
+        timeout=None,
+    )
+
+    assert "Share to Clan" in _button_labels(view)
+    assert "action:share:ancient" in _button_custom_ids(view)
+
+
+def test_share_embed_uses_overview_payload():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+    clan = _share_clan()
+    user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+    embed = tracker._build_share_embed(user, record, clan)
+
+    assert embed.title == "Shard Snapshot — Tester"
+    assert embed.description == "Shared to `alpha`."
+    assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal"]
+
+
+def test_share_button_action_routes_overview_without_active_tab_payload():
+    async def runner():
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        tracker = ShardTracker(bot)
+        tracker._feature_enabled = lambda: True
+        tracker.store.get_config = AsyncMock(return_value=ShardTrackerConfig(sheet_id="s", tab_name="t", channel_id=999))
+        tracker.store.load_record = AsyncMock(return_value=tracker.store._new_record([], 42, "Tester"))  # type: ignore[arg-type]
+        tracker._handle_share_summary_action = AsyncMock()
+        interaction = _ShareInteraction()
+        interaction.guild = type("Guild", (), {"id": 123})()
+
+        await tracker.handle_button_interaction(
+            interaction=interaction,
+            custom_id="action:share:overview",
+            active_tab="overview",
+        )
+
+        assert "active_tab" not in tracker._handle_share_summary_action.await_args.kwargs
+
+    asyncio.run(runner())
+
+
+def test_detail_share_button_action_preserves_overview_share_behavior():
+    async def runner():
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        tracker = ShardTracker(bot)
+        tracker._feature_enabled = lambda: True
+        tracker.store.get_config = AsyncMock(return_value=ShardTrackerConfig(sheet_id="s", tab_name="t", channel_id=999))
+        tracker.store.load_record = AsyncMock(return_value=tracker.store._new_record([], 42, "Tester"))  # type: ignore[arg-type]
+        tracker._handle_share_summary_action = AsyncMock()
+        interaction = _ShareInteraction()
+        interaction.guild = type("Guild", (), {"id": 123})()
+
+        await tracker.handle_button_interaction(
+            interaction=interaction,
+            custom_id="action:share:ancient",
+            active_tab="ancient",
+        )
+
+        assert "active_tab" not in tracker._handle_share_summary_action.await_args.kwargs
+
+        record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+        clan = _share_clan()
+        embed = tracker._build_share_embed(interaction.user, record, clan)
+        assert embed.title == "Shard Snapshot — Tester"
+        assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal"]
+
+    asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Ensure the "Share to Clan" action is available from the Overview and individual shard detail tabs.  
- Fix the share button `custom_id` to reference the intended tab and preserve the existing overview share payload behavior when routing the action.  

### Description
- Add `_add_share_button(tab: str)` helper and wire it into the view so the share button is added for the `overview` tab and for shard detail tabs.  
- Adjust `_add_primary_buttons` to call `_add_share_button(self.active_tab)` so detail tabs also include the share action.  
- Update the share button `custom_id` to use the provided `tab` parameter (`f"action:share:{tab}"`) instead of `self.active_tab`.  
- Add unit tests to validate button layout, `custom_id`s, embed payload content, and that the share action routing does not pass `active_tab` into the share handler.

### Testing
- Ran the shard tracker tests with `pytest tests/community/shard_tracker -q`; the newly added tests in `tests/community/shard_tracker/test_cog.py` executed and passed.  
- Existing share-related tests were also executed and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae9ab07b083238cb2fec7db75b531)