### PR TITLE
Add Mystery Shards and Cursed Remnants (Remnant Mythical) to Shard Tracker

### DIFF
--- a/docs/ops/modules/ShardTracker.md
+++ b/docs/ops/modules/ShardTracker.md
@@ -8,8 +8,9 @@ keep a private, button-driven tracker thread.
 ## Scope & Responsibilities
 
 - Persist shard stash counts, last pulls, and mercy counters (`ancient`,
-  `void`, `sacred`, `primal`) per Discord user, including separate Legendary
-  and Mythical mercy tracks for Primals.
+  `void`, `sacred`, `primal`, `mystery`, `remnant`) per Discord user,
+  including separate Legendary and Mythical mercy tracks for Primals,
+  count-only Mystery Shards, and Mythical-only Remnant Summons.
 - Enforce channel routing: only the configured Shards & Mercy channel may run
   shard commands, and every user gets a private thread underneath that channel.
 - Surface a mobile-friendly, tabbed embed with shard-icon buttons and a
@@ -35,6 +36,10 @@ keep a private, button-driven tracker thread.
   - `SHARD_MERCY_CHANNEL_ID` — numeric ID for the dedicated Discord channel.
   - `SHARD_CLANS_TAB` — worksheet name for clan sharing + weekly reminders.
   - `SHARD_REMINDER_TAB` — worksheet for durable weekly reminder sent tracking.
+- **Shard tab emoji env/config keys:** `SHARD_EMOJI_ANCIENT`,
+  `SHARD_EMOJI_VOID`, `SHARD_EMOJI_SACRED`, `SHARD_EMOJI_PRIMAL`,
+  `SHARD_EMOJI_MYSTERY`, and `SHARD_EMOJI_REMNANT`. Only tab buttons use
+  these emojis; action buttons remain text-only.
 - **Worksheet schema:** row 1 contains the canonical headers listed below.
   `discord_id` is the primary key and all headers must remain in this order.
 
@@ -42,14 +47,21 @@ keep a private, button-driven tracker thread.
 | --- | --- |
 | `discord_id` | Snowflake ID for the Discord user. |
 | `username_snapshot` | Last display name captured when the bot touched the row. |
-| `ancients_owned`, `voids_owned`, `sacreds_owned`, `primals_owned` | Current stash counts. |
+| `ancients_owned`, `voids_owned`, `sacreds_owned`, `primals_owned` | Current shard stash counts. |
+| `mysteries_owned` | Current Mystery Shard count; count-only, no mercy. |
+| `remnants_owned` | Raw Cursed Remnant currency count. |
 | `ancients_since_lego`, `voids_since_lego`, `sacreds_since_lego`, `primals_since_lego` | Mercy counters per shard type. |
-| `primals_since_mythic` | Mythical mercy counter. |
-| `last_*_lego_iso`, `last_primal_mythic_iso`, `last_updated_iso` | UTC ISO timestamps for the last logged Legendary/Mythical and update time. |
-| `last_*_lego_depth`, `last_primal_mythic_depth` | Mercy depth at the time the pull was logged. |
+| `primals_since_mythic` | Primal Mythical mercy counter. |
+| `remnants_since_mythic` | Remnant Summons since last Mythical; this counts summons/misses, not raw Cursed Remnants. |
+| `last_*_lego_iso`, `last_primal_mythic_iso`, `last_remnant_mythic_iso`, `last_updated_iso` | UTC ISO timestamps for the last logged Legendary/Mythical and update time. |
+| `last_*_lego_depth`, `last_primal_mythic_depth`, `last_remnant_mythic_depth` | Mercy depth at the time the pull/summon was logged. |
 
-Rows are created automatically the first time a user opens the tracker; all
-fields initialize to zero and timestamps stay blank until a LEGO is recorded.
+Rows are created automatically the first time a user opens the tracker; integer
+count/counter fields initialize to zero and timestamp/depth string fields stay
+blank until a matching result is recorded. The main tracker worksheet is strict:
+row 1 must exactly match the expected ordered schema. The bot now writes rows
+through `A{row}:AA{row}`; deploy only after the sheet has the Mystery/Remnant
+columns in place.
 
 ### SHARD_CLANS_TAB schema
 
@@ -70,10 +82,13 @@ Plarium’s official mercy values:
 | Sacred Legendary | 6% | After 12 shards | +2% per shard |
 | Primal Legendary | 1% | After 75 shards | +1% per shard |
 | Primal Mythical | 0.5% | After 200 shards | +10% per shard |
+| Remnant Mythical | 2.5% | After 24 summons | +1% per summon |
 
-Chance increases after crossing the threshold and caps at 100%. Mythical pulls
-reset both primal tracks; Legendary pulls reset only the Legendary track but the
-Mythical counter continues accumulating primal shards.
+Chance increases only after crossing the threshold and caps at 100%. Mythical
+pulls reset both primal tracks; Legendary pulls reset only the Legendary track
+but the Mythical counter continues accumulating primal shards. Remnant Summons
+cost **100 Cursed Remnants** each, use Mythical-only mercy, and do not have any
+Legendary behavior.
 
 ## Commands & Buttons
 
@@ -90,15 +105,19 @@ there, and replies in the parent channel with a short pointer.
 Buttons live on every embed inside the user’s thread and are **locked to the
 thread owner**:
 
-- **Tab buttons** — Text-only Overview tab plus emoji-only shard tabs
-  (Ancient/Void/Sacred/Primal) and a text Last Pulls tab.
-- **+ Stash / - Pulls** — open numeric modals on the active shard tab only.
+- **Tab buttons** — Text-only Overview tab plus emoji-only shard/resource tabs
+  (Ancient/Void/Sacred/Primal/Mystery/Remnants) and a text Last Pulls tab.
+- **+ Stash / - Pulls / - Summons** — open numeric modals on the active tab only.
   + Stash increases stash without touching mercy; - Pulls reduces stash (floored
-  at 0) and increments mercy. Primal pull logging increments Legendary and
-  Mythical mercy separately so Mythical pulls no longer reset Legendary mercy.
-- **Got Legendary** — shard tabs only. Non-Primal resets the legendary mercy to
-  zero; Primal opens a follow-up with Legendary vs Mythical to decide whether to
-  reset only the legendary counter or both mercy tracks.
+  at 0) and increments mercy where applicable. Mystery `- Pulls` only reduces
+  the count and never touches mercy/timestamps. Remnant `- Summons` deducts
+  `summons * 100` Cursed Remnants and increments Mythical mercy by summons.
+  Primal pull logging increments Legendary and Mythical mercy separately so
+  Mythical pulls no longer reset Legendary mercy.
+- **Got Legendary / Got Mythical** — Ancient/Void/Sacred reset Legendary mercy;
+  Primal opens a follow-up with Legendary vs Mythical; Remnants expose only
+  **Got Mythical** and update only Remnant Mythical fields. Mystery has no
+  result or Last Pulls / Mercy button.
 
 Only the thread owner may press the buttons; everyone else receives a friendly
 rejection message. Button handlers write through to Sheets immediately and edit
@@ -124,16 +143,16 @@ the message in place.
   the user with a polite explanation and ping the first ADMIN_ROLE_ID inside a
   `❌` log entry.
 - All Sheets writes run through the shared async backoff helper and use a
-  single-row range update (`A{row}:V{row}`) so the schema stays intact.
+  single-row range update (`A{row}:AA{row}`) so the schema stays intact.
 
 ## Testing Expectations
 
 Automated tests cover:
 
-- Mercy math for every shard type and the primal mythic pity.
+- Mercy math for every shard type, primal mythic pity, and remnant mythical pity.
 - Sheet mapping (row ↔ dataclass) to ensure headers remain stable.
 - Command parsing helpers (`type` aliases, channel gating).
 - Thread routing unit tests verifying channel restrictions and reusing an
   existing thread before creating a new one.
 
-Doc last updated: 2025-11-20 (v0.9.8.2)
+Doc last updated: 2026-06-23 (v0.9.8.2)

--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -52,10 +52,12 @@ class ShardKind:
     key: str
     label: str
     stash_field: str
-    mercy_field: str
-    mercy_config: MercyConfig
-    timestamp_field: str
-    depth_field: str
+    mercy_field: str = ""
+    mercy_config: MercyConfig | None = None
+    timestamp_field: str = ""
+    depth_field: str = ""
+    mercy_label: str = "Legendary"
+    detail_note: str = ""
 
 
 SHARD_KINDS: Dict[str, ShardKind] = {
@@ -95,6 +97,22 @@ SHARD_KINDS: Dict[str, ShardKind] = {
         timestamp_field="last_primal_lego_iso",
         depth_field="last_primal_lego_depth",
     ),
+    "mystery": ShardKind(
+        key="mystery",
+        label="Mystery",
+        stash_field="mysteries_owned",
+    ),
+    "remnant": ShardKind(
+        key="remnant",
+        label="Remnants",
+        stash_field="remnants_owned",
+        mercy_field="remnants_since_mythic",
+        mercy_config=MERCY_CONFIGS["remnant_mythic"],
+        timestamp_field="last_remnant_mythic_iso",
+        depth_field="last_remnant_mythic_depth",
+        mercy_label="Mythical",
+        detail_note="Each summon costs 100 Cursed Remnants.",
+    ),
 }
 
 _BASE_RATES = {
@@ -103,6 +121,7 @@ _BASE_RATES = {
     "Sacred Legendary": "6%",
     "Primal Legendary": "1%",
     "Primal Mythical": "0.5%",
+    "Remnant Mythical": "2.5%",
 }
 
 _TYPE_ALIASES = {
@@ -118,6 +137,14 @@ _TYPE_ALIASES = {
     "primals": "primal",
     "myth": "mythic",
     "mythical": "mythic",
+    "mysteries": "mystery",
+    "mystery_shards": "mystery",
+    "mysteryshards": "mystery",
+    "remnants": "remnant",
+    "cursed_remnants": "remnant",
+    "cursedremnants": "remnant",
+    "remnant_summons": "remnant",
+    "remnantsummons": "remnant",
 }
 
 _FEATURE_TOGGLE_KEYS = ("shardtracker", "shard_tracker")
@@ -302,7 +329,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 return
 
             tab = action_tab or active_tab or "overview"
-            if tab not in SHARD_KINDS and action_name in {"stash", "pulls", "legendary"}:
+            if tab not in SHARD_KINDS and action_name in {"stash", "pulls", "legendary", "mythical"}:
                 await interaction.response.send_message(
                     "Pick a shard tab to use these buttons.", ephemeral=True
                 )
@@ -320,6 +347,16 @@ class ShardTracker(commands.Cog, ShardTrackerController):
 
             if action_name == "pulls":
                 modal = _PullsModal(
+                    controller=self,
+                    owner_id=ctx_author.id,
+                    shard_key=tab,
+                    active_tab=tab,
+                )
+                await interaction.response.send_modal(modal)
+                return
+
+            if action_name == "mythical" and tab == "remnant":
+                modal = _LegendaryModal(
                     controller=self,
                     owner_id=ctx_author.id,
                     shard_key=tab,
@@ -350,9 +387,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                     owner_id=ctx_author.id,
                     shard_key=tab,
                     active_tab=tab,
-                    legendary_mercy=max(
-                        0, getattr(record, kind.mercy_field, 0)
-                    ),
+                    legendary_mercy=max(0, getattr(record, kind.mercy_field, 0)) if kind.mercy_field else 0,
                     mythical_mercy=max(0, record.primals_since_mythic),
                 )
                 await interaction.response.send_modal(modal)
@@ -525,7 +560,10 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 await self._notify_admins(str(exc))
                 return
 
-            self._apply_pull_usage(record, kind, amount)
+            ok, message = self._apply_pull_usage(record, kind, amount)
+            if not ok:
+                await interaction.response.send_message(message or "Unable to log pulls.", ephemeral=True)
+                return
             record.snapshot_name(interaction.user.display_name or interaction.user.name)
             await self.store.save_record(config, record)
 
@@ -580,7 +618,22 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             legendary_before = max(0, record.primals_since_lego)
             mythical_before = max(0, record.primals_since_mythic)
 
-            self._apply_pull_usage(record, kind, total_pulls)
+            ok, message = self._apply_pull_usage(record, kind, total_pulls)
+            if not ok:
+                await interaction.response.send_message(message or "Unable to log pulls.", ephemeral=True)
+                return
+
+            if kind.key == "remnant":
+                depth = max(0, record.remnants_since_mythic - after_champion)
+                record.last_remnant_mythic_depth = depth
+                record.last_remnant_mythic_iso = self._now_iso()
+                record.remnants_since_mythic = max(0, after_champion)
+                record.snapshot_name(interaction.user.display_name or interaction.user.name)
+                await self.store.save_record(config, record)
+                embed, view = self._build_panel(interaction.user, record, interaction.channel, active_tab)
+                await interaction.response.edit_message(embed=embed, view=view)
+                await self._log_action("remnant_mythical_reset", interaction.user, interaction.channel, f"Remnant Mythical: summons={total_pulls}, after={after_champion}")
+                return
 
             current_mercy = max(0, getattr(record, kind.mercy_field, 0))
             drop_depth = max(0, current_mercy - after_champion)
@@ -746,14 +799,24 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         owned = max(0, getattr(record, kind.stash_field, 0))
         setattr(record, kind.stash_field, owned + amount)
 
-    def _apply_pull_usage(self, record: ShardRecord, kind: ShardKind, amount: int) -> None:
+    def _apply_pull_usage(self, record: ShardRecord, kind: ShardKind, amount: int) -> tuple[bool, str]:
         owned = max(0, getattr(record, kind.stash_field, 0))
+        if kind.key == "remnant":
+            required = max(0, amount) * 100
+            if owned < required:
+                available = owned // 100
+                return False, f"You only have enough Cursed Remnants for {available:,} summons."
+            setattr(record, kind.stash_field, owned - required)
+            record.remnants_since_mythic = max(0, record.remnants_since_mythic) + amount
+            return True, ""
         new_owned = max(0, owned - amount)
         setattr(record, kind.stash_field, new_owned)
-        current_mercy = max(0, getattr(record, kind.mercy_field, 0))
-        setattr(record, kind.mercy_field, current_mercy + amount)
+        if kind.mercy_field:
+            current_mercy = max(0, getattr(record, kind.mercy_field, 0))
+            setattr(record, kind.mercy_field, current_mercy + amount)
         if kind.key == "primal":
             record.primals_since_mythic = max(0, record.primals_since_mythic) + amount
+        return True, ""
 
     def _apply_legendary_reset(self, record: ShardRecord, kind: ShardKind) -> None:
         current_depth = max(0, getattr(record, kind.mercy_field, 0))
@@ -783,10 +846,10 @@ class ShardTracker(commands.Cog, ShardTrackerController):
     ) -> None:
         if kind.key == "primal":
             record.primals_since_lego = max(0, legendary_mercy)
-            record.primals_since_mythic = max(
-                0, mythical_mercy if mythical_mercy is not None else legendary_mercy
-            )
-        else:
+            record.primals_since_mythic = max(0, mythical_mercy if mythical_mercy is not None else legendary_mercy)
+        elif kind.key == "remnant":
+            record.remnants_since_mythic = max(0, legendary_mercy)
+        elif kind.mercy_field:
             setattr(record, kind.mercy_field, max(0, legendary_mercy))
 
     async def _handle_mercy_set(
@@ -1009,6 +1072,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             shard_labels=labels,
             shard_emojis=self._tab_emojis,
             active_tab=tab,
+            action_capabilities=self._action_capabilities(),
             timeout=None,
         )
         return embed, view
@@ -1674,12 +1738,29 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                     return emoji
         return None
 
+    @staticmethod
+    def _action_capabilities() -> dict[str, tuple[str, ...]]:
+        return {
+            "ancient": ("stash", "pulls", "share", "legendary", "last_pulls"),
+            "void": ("stash", "pulls", "share", "legendary", "last_pulls"),
+            "sacred": ("stash", "pulls", "share", "legendary", "last_pulls"),
+            "primal": ("stash", "pulls", "share", "legendary", "last_pulls"),
+            "mystery": ("stash", "pulls", "share"),
+            "remnant": ("stash", "summons", "share", "mythical", "last_pulls"),
+        }
+
     def _build_display(self, record: ShardRecord, kind: ShardKind) -> ShardDisplay:
         owned = max(0, getattr(record, kind.stash_field, 0))
-        since = max(0, getattr(record, kind.mercy_field, 0))
-        mercy = mercy_state(kind.key, since)
-        timestamp = getattr(record, kind.timestamp_field, "")
-        depth = max(0, getattr(record, kind.depth_field, 0))
+        if not kind.mercy_field or kind.mercy_config is None:
+            mercy = None
+            timestamp = ""
+            depth = 0
+        else:
+            since = max(0, getattr(record, kind.mercy_field, 0))
+            mercy_key = "remnant_mythic" if kind.key == "remnant" else kind.key
+            mercy = mercy_state(mercy_key, since)
+            timestamp = getattr(record, kind.timestamp_field, "")
+            depth = max(0, getattr(record, kind.depth_field, 0))
         return ShardDisplay(
             key=kind.key,
             label=kind.label,
@@ -1687,6 +1768,8 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             mercy=mercy,
             last_timestamp=timestamp,
             last_depth=depth,
+            mercy_label=kind.mercy_label,
+            detail_note=kind.detail_note,
         )
 
     def _build_mythic_display(self, record: ShardRecord) -> MythicDisplay:
@@ -1704,6 +1787,8 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             "void": shared_config.get_shard_emoji_void("void"),
             "sacred": shared_config.get_shard_emoji_sacred("sacred"),
             "primal": shared_config.get_shard_emoji_primal("primal"),
+            "mystery": shared_config.get_shard_emoji_mystery("mystery"),
+            "remnant": shared_config.get_shard_emoji_remnant("remnant"),
         }
 
     def _load_tab_emojis(self) -> dict[str, discord.PartialEmoji | None]:
@@ -1712,6 +1797,8 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             "void": self._parse_partial_emoji(os.getenv("SHARD_EMOJI_VOID", "")),
             "sacred": self._parse_partial_emoji(os.getenv("SHARD_EMOJI_SACRED", "")),
             "primal": self._parse_partial_emoji(os.getenv("SHARD_EMOJI_PRIMAL", "")),
+            "mystery": self._parse_partial_emoji(os.getenv("SHARD_EMOJI_MYSTERY", "")),
+            "remnant": self._parse_partial_emoji(os.getenv("SHARD_EMOJI_REMNANT", "")),
         }
 
     def _parse_partial_emoji(self, value: str | None) -> discord.PartialEmoji | None:
@@ -2047,7 +2134,7 @@ class _LastPullsModal(discord.ui.Modal):
         self.active_tab = active_tab
 
         self.legendary_mercy = discord.ui.TextInput(
-            label="Legendary mercy after last pull",
+            label="Mythical mercy after last summon" if shard_key == "remnant" else "Legendary mercy after last pull",
             min_length=1,
             max_length=6,
             required=True,

--- a/modules/community/shard_tracker/data.py
+++ b/modules/community/shard_tracker/data.py
@@ -39,6 +39,11 @@ EXPECTED_HEADERS: List[str] = [
     "last_primal_lego_depth",
     "last_primal_mythic_depth",
     "last_updated_iso",
+    "mysteries_owned",
+    "remnants_owned",
+    "remnants_since_mythic",
+    "last_remnant_mythic_iso",
+    "last_remnant_mythic_depth",
 ]
 
 SHARD_CLANS_REQUIRED_HEADERS: tuple[str, ...] = (
@@ -114,6 +119,11 @@ class ShardRecord:
     last_primal_lego_depth: int = 0
     last_primal_mythic_depth: int = 0
     last_updated_iso: str = ""
+    mysteries_owned: int = 0
+    remnants_owned: int = 0
+    remnants_since_mythic: int = 0
+    last_remnant_mythic_iso: str = ""
+    last_remnant_mythic_depth: int = 0
 
     def snapshot_name(self, value: str) -> None:
         self.username_snapshot = (value or "").strip()[:64]
@@ -142,6 +152,11 @@ class ShardRecord:
             "last_primal_lego_depth": str(max(self.last_primal_lego_depth, 0)),
             "last_primal_mythic_depth": str(max(self.last_primal_mythic_depth, 0)),
             "last_updated_iso": self.last_updated_iso,
+            "mysteries_owned": str(max(self.mysteries_owned, 0)),
+            "remnants_owned": str(max(self.remnants_owned, 0)),
+            "remnants_since_mythic": str(max(self.remnants_since_mythic, 0)),
+            "last_remnant_mythic_iso": self.last_remnant_mythic_iso,
+            "last_remnant_mythic_depth": str(max(self.last_remnant_mythic_depth, 0)),
         }
         return [str(mapping.get(name, "")) for name in self.header]
 
@@ -237,7 +252,7 @@ class ShardSheetStore:
 
     async def save_record(self, config: ShardTrackerConfig, record: ShardRecord) -> None:
         record.last_updated_iso = _now_iso()
-        range_label = f"A{record.row_number}:V{record.row_number}"
+        range_label = f"A{record.row_number}:AA{record.row_number}"
         row = record.to_row()
         worksheet = await async_core.aget_worksheet(config.sheet_id, config.tab_name)
         async with self._sheet_lock:
@@ -428,6 +443,11 @@ class ShardSheetStore:
             last_primal_lego_depth=self._parse_int(cell("last_primal_lego_depth")),
             last_primal_mythic_depth=self._parse_int(cell("last_primal_mythic_depth")),
             last_updated_iso=cell("last_updated_iso"),
+            mysteries_owned=self._parse_int(cell("mysteries_owned")),
+            remnants_owned=self._parse_int(cell("remnants_owned")),
+            remnants_since_mythic=self._parse_int(cell("remnants_since_mythic")),
+            last_remnant_mythic_iso=cell("last_remnant_mythic_iso"),
+            last_remnant_mythic_depth=self._parse_int(cell("last_remnant_mythic_depth")),
         )
         record.snapshot_name(username)
         return record

--- a/modules/community/shard_tracker/mercy.py
+++ b/modules/community/shard_tracker/mercy.py
@@ -65,6 +65,13 @@ MERCY_CONFIGS: Dict[str, MercyConfig] = {
         threshold=200,
         increment=0.10,
     ),
+    "remnant_mythic": MercyConfig(
+        key="remnant_mythic",
+        label="Remnant Mythical",
+        base_rate=0.025,
+        threshold=24,
+        increment=0.01,
+    ),
 }
 
 

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -19,6 +19,8 @@ TAB_LABELS: Mapping[str, str] = {
     "void": "Void",
     "sacred": "Sacred",
     "primal": "Primal",
+    "mystery": "Mystery",
+    "remnant": "Remnants",
     "last_pulls": "Last Pulls",
 }
 
@@ -31,16 +33,20 @@ class ShardDisplay:
     key: str
     label: str
     owned: int
-    mercy: MercySnapshot
+    mercy: MercySnapshot | None
     last_timestamp: str
     last_depth: int
+    mercy_label: str = "Legendary"
+    detail_note: str = ""
 
 
 @dataclass(frozen=True)
 class MythicDisplay:
-    mercy: MercySnapshot
+    mercy: MercySnapshot | None
     last_timestamp: str
     last_depth: int
+    mercy_label: str = "Legendary"
+    detail_note: str = ""
 
 
 class ShardTrackerView(discord.ui.View):
@@ -54,6 +60,7 @@ class ShardTrackerView(discord.ui.View):
         active_tab: str,
         shard_labels: Mapping[str, str],
         shard_emojis: Mapping[str, discord.PartialEmoji | None],
+        action_capabilities: Mapping[str, Sequence[str]] | None = None,
         mythic_controls: bool = True,
         timeout: float | None = None,
     ) -> None:
@@ -61,8 +68,9 @@ class ShardTrackerView(discord.ui.View):
         self.owner_id = owner_id
         self.active_tab = active_tab
         self._controller = controller
+        self._action_capabilities = dict(action_capabilities or {})
         # Tab buttons
-        for tab in ("overview", "ancient", "void", "sacred", "primal", "last_pulls"):
+        for tab in ("overview", "ancient", "void", "sacred", "primal", "mystery", "remnant", "last_pulls"):
             label: str | None = None
             emoji = None
 
@@ -89,11 +97,16 @@ class ShardTrackerView(discord.ui.View):
         if active_tab == "overview":
             self._add_share_button(active_tab)
         elif active_tab in shard_labels:
-            self._add_primary_buttons()
-            self._add_legendary_button()
-            self._add_last_pulls_button()
+            actions = tuple(self._action_capabilities.get(active_tab, ("stash", "pulls", "share", "legendary", "last_pulls")))
+            self._add_primary_buttons(actions)
+            if "legendary" in actions:
+                self._add_legendary_button()
+            if "mythical" in actions:
+                self._add_mythical_button()
+            if "last_pulls" in actions:
+                self._add_last_pulls_button()
 
-    def _add_primary_buttons(self) -> None:
+    def _add_primary_buttons(self, actions: Sequence[str]) -> None:
         self.add_item(
             _ShardButton(
                 custom_id=f"action:stash:{self.active_tab}",
@@ -104,17 +117,19 @@ class ShardTrackerView(discord.ui.View):
                 controller=self._controller,
             )
         )
-        self.add_item(
-            _ShardButton(
-                custom_id=f"action:pulls:{self.active_tab}",
-                label="- Pulls",
-                emoji=None,
-                style=discord.ButtonStyle.secondary,
-                owner_id=self.owner_id,
-                controller=self._controller,
+        if "pulls" in actions or "summons" in actions:
+            self.add_item(
+                _ShardButton(
+                    custom_id=f"action:pulls:{self.active_tab}",
+                    label="- Summons" if "summons" in actions else "- Pulls",
+                    emoji=None,
+                    style=discord.ButtonStyle.secondary,
+                    owner_id=self.owner_id,
+                    controller=self._controller,
+                )
             )
-        )
-        self._add_share_button(self.active_tab)
+        if "share" in actions:
+            self._add_share_button(self.active_tab)
 
     def _add_share_button(self, tab: str) -> None:
         self.add_item(
@@ -134,6 +149,18 @@ class ShardTrackerView(discord.ui.View):
             _ShardButton(
                 custom_id=f"action:legendary:{self.active_tab}",
                 label=label,
+                emoji=None,
+                style=discord.ButtonStyle.success,
+                owner_id=self.owner_id,
+                controller=self._controller,
+            )
+        )
+
+    def _add_mythical_button(self) -> None:
+        self.add_item(
+            _ShardButton(
+                custom_id=f"action:mythical:{self.active_tab}",
+                label="Got Mythical",
                 emoji=None,
                 style=discord.ButtonStyle.success,
                 owner_id=self.owner_id,
@@ -193,6 +220,8 @@ _TAB_COLORS: Mapping[str, discord.Colour] = {
     "void": discord.Colour(0xA970FF),
     "sacred": discord.Colour.gold(),
     "primal": discord.Colour.dark_red(),
+    "mystery": discord.Colour.light_grey(),
+    "remnant": discord.Colour.purple(),
 }
 
 
@@ -203,6 +232,8 @@ _AUTHOR_NAMES: Mapping[str, str] = {
     "void": "Void Shards",
     "sacred": "Sacred Shards",
     "primal": "Primal Shards",
+    "mystery": "Mystery Shards",
+    "remnant": "Cursed Remnants",
 }
 
 
@@ -270,52 +301,43 @@ def build_overview_embed(
             "and the Legendary/Mythical buttons to log pulls."
         ),
     )
-    embed.set_author(
-        name=author_name or _AUTHOR_NAMES.get("overview"),
-        icon_url=author_icon_url,
-    )
-    primal = next((display for display in displays if display.key == "primal"), None)
-    other_displays = [display for display in displays if display.key != "primal"]
+    embed.set_author(name=author_name or _AUTHOR_NAMES.get("overview"), icon_url=author_icon_url)
 
-    for display in other_displays:
+    for display in displays:
+        if display.mercy is None:
+            line = f"Owned: **{max(display.owned, 0):,}**"
+            embed.add_field(name=display.label, value=line, inline=False)
+            continue
+        if display.key == "primal":
+            mythic_mercy = mythic.mercy
+            lines = [
+                f"Owned: **{max(display.owned, 0):,}**",
+                "Legendary",
+                f"Mercy: {display.mercy.pulls_since} / {display.mercy.threshold} | Chance: {format_percent(display.mercy.chance)}",
+            ]
+            if display.last_timestamp:
+                lines.append(f"Last Legendary: {human_time(display.last_timestamp)}")
+            lines += [
+                "Mythical",
+                f"Mercy: {mythic_mercy.pulls_since} / {mythic_mercy.threshold} | Chance: {format_percent(mythic_mercy.chance)}",
+            ]
+            if mythic.last_timestamp:
+                lines.append(f"Last Mythical: {human_time(mythic.last_timestamp)}")
+            lines.append("Details:")
+            embed.add_field(name=display.label, value="\n".join(lines), inline=False)
+            continue
         line = (
             f"Owned: **{max(display.owned, 0):,}** | "
             f"Mercy: {display.mercy.pulls_since} / {display.mercy.threshold} | "
             f"Chance: {format_percent(display.mercy.chance)}"
         )
+        last_label = display.mercy_label
         if display.last_timestamp:
-            line += f"\nLast Legendary: {human_time(display.last_timestamp)}"
+            line += f"\nLast {last_label}: {human_time(display.last_timestamp)}"
         embed.add_field(name=display.label, value=line, inline=False)
-
-    if primal:
-        mythic_mercy = mythic.mercy
-        primal_lines = [
-            f"Owned: **{max(primal.owned, 0):,}**",
-            "Legendary",
-            (
-                f"Mercy: {primal.mercy.pulls_since} / {primal.mercy.threshold} | "
-                f"Chance: {format_percent(primal.mercy.chance)}"
-            ),
-        ]
-        if primal.last_timestamp:
-            primal_lines.append(f"Last Legendary: {human_time(primal.last_timestamp)}")
-        primal_lines.extend(
-            [
-                "Mythical",
-                (
-                    f"Mercy: {mythic_mercy.pulls_since} / {mythic_mercy.threshold} | "
-                    f"Chance: {format_percent(mythic_mercy.chance)}"
-                ),
-            ]
-        )
-        if mythic.last_timestamp:
-            primal_lines.append(f"Last Mythical: {human_time(mythic.last_timestamp)}")
-        primal_lines.append("Details:")
-        embed.add_field(name="Primal", value="\n".join(primal_lines), inline=False)
 
     _apply_footer(embed)
     return embed
-
 
 def build_detail_embed(
     *,
@@ -334,13 +356,15 @@ def build_detail_embed(
         icon_url=author_icon_url,
     )
     embed.description = _detail_block(display)
-    embed.add_field(
-        name="Progress",
-        value=_progress_bar(display.mercy),
-        inline=False,
-    )
+    if display.mercy is not None:
+        embed.add_field(
+            name="Progress",
+            value=_progress_bar(display.mercy),
+            inline=False,
+        )
     if mythic:
-        embed.add_field(name="Primal Mythical", value=_mythic_block(mythic), inline=False)
+        name = "Remnant Mythical" if display.key == "remnant" else "Primal Mythical"
+        embed.add_field(name=name, value=_mythic_block(mythic), inline=False)
     _apply_footer(embed)
     return embed
 
@@ -350,7 +374,7 @@ def build_last_pulls_embed(
     member: discord.abc.User,
     displays: Sequence[ShardDisplay],
     mythic: MythicDisplay,
-    base_rates: Mapping[str, str],
+    base_rates: Mapping[str, str] = None,
     author_name: str | None = None,
     author_icon_url: str | None = None,
     color: discord.Colour | None = None,
@@ -364,9 +388,11 @@ def build_last_pulls_embed(
     )
     last_lines = []
     for display in displays:
+        if display.mercy is None:
+            continue
         stamp = human_time(display.last_timestamp) if display.last_timestamp else "Never"
         depth = f" ({display.last_depth} at pull)" if display.last_depth > 0 else ""
-        last_lines.append(f"{display.label} Legendary: {stamp}{depth}")
+        last_lines.append(f"{display.label} {display.mercy_label}: {stamp}{depth}")
     mythic_stamp = human_time(mythic.last_timestamp) if mythic.last_timestamp else "Never"
     mythic_depth = f" ({mythic.last_depth} at pull)" if mythic.last_depth > 0 else ""
     last_lines.append(f"Primal Mythical: {mythic_stamp}{mythic_depth}")
@@ -378,10 +404,11 @@ def build_last_pulls_embed(
         "Sacred Legendary: after 12 pulls, +2% per shard",
         "Primal Legendary: after 75 pulls, +1% per shard",
         "Primal Mythical: after 200 pulls, +10% per shard",
+        "Remnant Mythical: after 24 summons, +1% per summon",
         "",
         "**Base chances:**",
     ]
-    for label, rate in base_rates.items():
+    for label, rate in (base_rates or {}).items():
         info_lines.append(f"{label:<18} {rate}")
     embed.add_field(name="Mercy Info", value="\n".join(info_lines), inline=False)
     _apply_footer(embed)
@@ -389,27 +416,26 @@ def build_last_pulls_embed(
 
 
 def _detail_block(display: ShardDisplay) -> str:
+    parts = [f"Stash: **{max(display.owned, 0):,}**"]
+    if display.detail_note:
+        parts.append(display.detail_note)
+    if display.mercy is None:
+        return "\n".join(parts)
     mercy = display.mercy
     maxed = mercy.pulls_since >= mercy.threshold
-    parts = [
-        f"Stash: **{max(display.owned, 0):,}**",
-    ]
     if display.key == "primal":
-        parts.append("")
-        parts.append("**Primal Legendary**")
-    parts.extend(
-        [
-            f"Legendary Mercy: {mercy.pulls_since} / {mercy.threshold}" + (" (Maxed)" if maxed else ""),
-            f"Legendary Chance: {format_percent(mercy.chance)}",
-        ]
-    )
+        parts += ["", "**Primal Legendary**"]
+    label = display.mercy_label
+    parts += [
+        f"{label} Mercy: {mercy.pulls_since} / {mercy.threshold}" + (" (Maxed)" if maxed else ""),
+        f"{label} Chance: {format_percent(mercy.chance)}",
+    ]
     if display.last_timestamp:
-        last_line = f"Last Legendary: {human_time(display.last_timestamp)}"
-        if display.key != "primal" and display.last_depth:
+        last_line = f"Last {label}: {human_time(display.last_timestamp)}"
+        if display.last_depth:
             last_line += f" ({display.last_depth} depth)"
         parts.append(last_line)
     return "\n".join(parts)
-
 
 def _mythic_block(display: MythicDisplay) -> str:
     mercy = display.mercy

--- a/shared/config.py
+++ b/shared/config.py
@@ -73,6 +73,8 @@ __all__ = [
     "get_shard_emoji_void",
     "get_shard_emoji_sacred",
     "get_shard_emoji_primal",
+    "get_shard_emoji_mystery",
+    "get_shard_emoji_remnant",
     "get_public_base_url",
     "get_render_external_url",
     "get_emoji_max_bytes",
@@ -1080,6 +1082,14 @@ def get_shard_emoji_sacred(default: str = "sacred") -> str:
 
 def get_shard_emoji_primal(default: str = "primal") -> str:
     return _clean_emoji_value("SHARD_EMOJI_PRIMAL", default)
+
+
+def get_shard_emoji_mystery(default: str = "mystery") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_MYSTERY", default)
+
+
+def get_shard_emoji_remnant(default: str = "remnant") -> str:
+    return _clean_emoji_value("SHARD_EMOJI_REMNANT", default)
 
 
 def get_public_base_url() -> str | None:

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -8,7 +8,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.shard_tracker import setup as shard_setup
-from modules.community.shard_tracker.cog import ShardTracker
+from modules.community.shard_tracker.cog import SHARD_KINDS, ShardTracker
 from modules.community.shard_tracker.data import ShardTrackerConfig
 
 
@@ -19,6 +19,8 @@ def test_resolve_kind_aliases():
     assert tracker._resolve_kind_key("Anc") == "ancient"
     assert tracker._resolve_kind("primals").key == "primal"
     assert tracker._resolve_kind("unknown") is None
+    assert tracker._resolve_kind_key("mysteries") == "mystery"
+    assert tracker._resolve_kind_key("cursed_remnants") == "remnant"
 
 
 def test_resolve_thread_rejects_wrong_channel(fake_discord_env):
@@ -328,7 +330,7 @@ def test_share_embed_uses_overview_payload():
 
     assert embed.title == "Shard Snapshot — Tester"
     assert embed.description == "Shared to `alpha`."
-    assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal"]
+    assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal", "Mystery", "Remnants"]
 
 
 def test_share_button_action_routes_overview_without_active_tab_payload():
@@ -376,6 +378,115 @@ def test_detail_share_button_action_preserves_overview_share_behavior():
         clan = _share_clan()
         embed = tracker._build_share_embed(interaction.user, record, clan)
         assert embed.title == "Shard Snapshot — Tester"
-        assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal"]
+        assert [field.name for field in embed.fields] == ["Ancient", "Void", "Sacred", "Primal", "Mystery", "Remnants"]
 
     asyncio.run(runner())
+
+
+def test_mystery_and_remnant_button_layouts_are_capability_aware():
+    from modules.community.shard_tracker.views import ShardTrackerView
+
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    labels = {kind.key: kind.label for kind in SHARD_KINDS.values()}
+
+    mystery = ShardTrackerView(
+        owner_id=42,
+        controller=tracker,
+        active_tab="mystery",
+        shard_labels=labels,
+        shard_emojis={},
+        action_capabilities=tracker._action_capabilities(),
+        timeout=None,
+    )
+    mystery_action_labels = _button_labels(mystery)[8:]
+    assert mystery_action_labels == ["+ Stash", "- Pulls", "Share to Clan"]
+
+    remnant = ShardTrackerView(
+        owner_id=42,
+        controller=tracker,
+        active_tab="remnant",
+        shard_labels=labels,
+        shard_emojis={},
+        action_capabilities=tracker._action_capabilities(),
+        timeout=None,
+    )
+    remnant_action_labels = _button_labels(remnant)[8:]
+    assert remnant_action_labels == [
+        "+ Stash",
+        "- Summons",
+        "Share to Clan",
+        "Got Mythical",
+        "Last Pulls / Mercy",
+    ]
+
+
+def test_mystery_and_remnant_rendering_shapes():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+    record.mysteries_owned = 12
+    record.remnants_owned = 450
+    record.remnants_since_mythic = 25
+    record.last_remnant_mythic_iso = "2024-01-01T00:00:00+00:00"
+    user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+    overview, _ = tracker._build_panel(user, record, None, "overview")
+    fields = {field.name: field.value for field in overview.fields}
+    assert "Mystery" in fields
+    assert fields["Mystery"] == "Owned: **12**"
+    assert "Remnants" in fields
+    assert "Owned: **450**" in fields["Remnants"]
+    assert "Mercy: 25 / 24" in fields["Remnants"]
+    assert "Chance: 3.50%" in fields["Remnants"]
+    assert "Last Mythical: 2024-01-01 00:00 UTC" in fields["Remnants"]
+
+    mystery, _ = tracker._build_panel(user, record, None, "mystery")
+    assert "Stash: **12**" in (mystery.description or "")
+    assert not mystery.fields
+
+    remnant, _ = tracker._build_panel(user, record, None, "remnant")
+    assert "Each summon costs 100 Cursed Remnants." in (remnant.description or "")
+    assert "Mythical Mercy: 25 / 24" in (remnant.description or "")
+    assert "Mythical Chance: 3.50%" in (remnant.description or "")
+    assert "Last Mythical: 2024-01-01 00:00 UTC" in (remnant.description or "")
+    assert remnant.fields and remnant.fields[0].name == "Progress"
+    assert all("Legendary" not in (field.name + field.value) for field in remnant.fields)
+
+
+def test_mystery_and_remnant_state_mutations():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+
+    tracker._apply_stash_increase(record, SHARD_KINDS["mystery"], 10)
+    assert record.mysteries_owned == 10
+    ok, message = tracker._apply_pull_usage(record, SHARD_KINDS["mystery"], 99)
+    assert ok and message == ""
+    assert record.mysteries_owned == 0
+    assert record.ancients_since_lego == 0
+    assert record.last_ancient_lego_iso == ""
+
+    tracker._apply_stash_increase(record, SHARD_KINDS["remnant"], 250)
+    ok, message = tracker._apply_pull_usage(record, SHARD_KINDS["remnant"], 3)
+    assert not ok
+    assert "2 summons" in message
+    assert record.remnants_owned == 250
+    assert record.remnants_since_mythic == 0
+
+    ok, message = tracker._apply_pull_usage(record, SHARD_KINDS["remnant"], 2)
+    assert ok and message == ""
+    assert record.remnants_owned == 50
+    assert record.remnants_since_mythic == 2
+
+
+def test_last_pulls_embed_includes_remnant_mythical_once():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+    record.remnants_since_mythic = 25
+    record.last_remnant_mythic_iso = "2024-01-01T00:00:00+00:00"
+    record.last_remnant_mythic_depth = 25
+    user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+    embed, _ = tracker._build_panel(user, record, None, "last_pulls")
+    last_pulls = next(field.value for field in embed.fields if field.name == "Last Pulls")
+
+    assert last_pulls.count("Remnants Mythical:") == 1
+    assert "Mystery" not in last_pulls

--- a/tests/community/shard_tracker/test_data.py
+++ b/tests/community/shard_tracker/test_data.py
@@ -100,7 +100,17 @@ def test_load_record_existing_row(monkeypatch):
             "2024-01-03T00:00:00+00:00",
             "2024-01-04T00:00:00+00:00",
             "2024-01-05T00:00:00+00:00",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
             "2024-01-06T00:00:00+00:00",
+            "22",
+            "2300",
+            "24",
+            "2024-01-07T00:00:00+00:00",
+            "25",
         ]
 
         async def fake_values(sheet_id, tab_name, **kwargs):
@@ -113,6 +123,11 @@ def test_load_record_existing_row(monkeypatch):
         assert record.row_number == 2
         assert record.voids_owned == 6
         assert record.sacreds_since_lego == 12
+        assert record.mysteries_owned == 22
+        assert record.remnants_owned == 2300
+        assert record.remnants_since_mythic == 24
+        assert record.last_remnant_mythic_iso == "2024-01-07T00:00:00+00:00"
+        assert record.last_remnant_mythic_depth == 25
         assert record.username_snapshot.startswith("New Name")
 
     asyncio.run(runner())
@@ -154,6 +169,11 @@ def test_load_record_appends_when_missing(monkeypatch):
         assert record.row_number == 2
         assert worksheet.append_payloads, "append_row should be invoked for new records"
         assert worksheet.append_payloads[0][0] == "99999"
+        assert record.mysteries_owned == 0
+        assert record.remnants_owned == 0
+        assert record.remnants_since_mythic == 0
+        assert record.last_remnant_mythic_iso == ""
+        assert record.last_remnant_mythic_depth == 0
 
     asyncio.run(runner())
 
@@ -173,5 +193,52 @@ def test_load_record_invalid_header(monkeypatch):
 
         with pytest.raises(shard_data.ShardTrackerSheetError):
             await store.load_record(1, "Name")
+
+    asyncio.run(runner())
+
+
+def test_expected_headers_include_mystery_and_remnant_columns():
+    assert shard_data.EXPECTED_HEADERS[-5:] == [
+        "mysteries_owned",
+        "remnants_owned",
+        "remnants_since_mythic",
+        "last_remnant_mythic_iso",
+        "last_remnant_mythic_depth",
+    ]
+
+
+def test_save_record_writes_through_aa(monkeypatch):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        config = shard_data.ShardTrackerConfig(sheet_id="sheet-1", tab_name="ShardTracker", channel_id=123)
+        record = shard_data.ShardRecord(
+            header=list(shard_data.EXPECTED_HEADERS),
+            discord_id=1,
+            username_snapshot="Tester",
+            row_number=7,
+        )
+
+        class DummyWorksheet:
+            def __init__(self) -> None:
+                self.calls = []
+
+            async def update(self, range_label, rows, value_input_option="RAW"):
+                self.calls.append((range_label, rows, value_input_option))
+
+        worksheet = DummyWorksheet()
+
+        async def fake_worksheet(sheet_id, tab_name, **kwargs):
+            return worksheet
+
+        async def fake_backoff(func, *args, **kwargs):
+            return await func(*args, **kwargs)
+
+        monkeypatch.setattr(shard_data.async_core, "aget_worksheet", fake_worksheet)
+        monkeypatch.setattr(shard_data.async_core, "acall_with_backoff", fake_backoff)
+
+        await store.save_record(config, record)
+
+        assert worksheet.calls[0][0] == "A7:AA7"
+        assert len(worksheet.calls[0][1][0]) == len(shard_data.EXPECTED_HEADERS)
 
     asyncio.run(runner())

--- a/tests/community/shard_tracker/test_mercy.py
+++ b/tests/community/shard_tracker/test_mercy.py
@@ -31,3 +31,14 @@ def test_mercy_caps_at_hundred_percent():
 def test_format_percent_precision():
     assert format_percent(0.0123) == "1.23%"
     assert format_percent(0.25) == "25.0%"
+
+
+def test_remnant_mythic_mercy_examples():
+    assert mercy_state("remnant_mythic", 0).chance == 0.025
+    assert mercy_state("remnant_mythic", 24).chance == 0.025
+    assert mercy_state("remnant_mythic", 25).chance == 0.035
+    assert mercy_state("remnant_mythic", 26).chance == 0.045
+
+
+def test_remnant_mythic_caps_at_hundred_percent():
+    assert mercy_state("remnant_mythic", 200).chance == 1.0


### PR DESCRIPTION
### Motivation
- Extend the shard tracker to support two new resource types: count-only Mystery Shards and Cursed Remnants with Mythical-only mercy and summon semantics.
- Reflect the new columns and UI affordances so users can track remnant summons that consume currency and use a separate mythical pity curve.

### Description
- Added new sheet headers and `ShardRecord` fields for `mysteries_owned`, `remnants_owned`, `remnants_since_mythic`, `last_remnant_mythic_iso`, and `last_remnant_mythic_depth` and expanded the single-row write range from `A{row}:V{row}` to `A{row}:AA{row}`.
- Introduced a `remnant_mythic` `MercyConfig` and updated `mercy_state` usage to support remnant mythical pity and added base rate to `_BASE_RATES` and docs.
- Extended `SHARD_KINDS` with `mystery` and `remnant` kinds, updated action capability mapping, button/view layouts, and UI rendering so Mystery tabs are count-only and Remnant tabs display mythical mercy and a summon flow that costs `100` Cursed Remnants each.
- Implemented remnant-specific logic in `cog.py`: cost/validation in `_apply_pull_usage`, remnant-specific mythical reset handling, manual mercy setters, emoji/tab loading, and display construction with `mercy_label` and `detail_note`.
- Added config helpers `get_shard_emoji_mystery` and `get_shard_emoji_remnant` in `shared.config` and adjusted emoji/tag loading.
- Updated documentation `docs/ops/modules/ShardTracker.md` to describe new columns, behaviors, and schema requirements.

### Testing
- Updated and added unit tests covering header/schema handling and save range (`test_data.py`), view/button layouts and rendering (`test_cog.py`), and remnant mythical math (`test_mercy.py`), all run as part of the test suite and reported passing.
- Specific tests exercised: `test_expected_headers_include_mystery_and_remnant_columns`, `test_save_record_writes_through_aa`, UI tests for Mystery/Remnant action layouts and rendering (`test_mystery_and_remnant_*`), and `test_remnant_mythic_mercy_examples`, which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b077bafa483239710b8448383e3bd)