### PR TITLE
Polish shard tracker tabs, Remnant labeling, colors, and help text

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -202,14 +202,44 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         function_group="milestones",
         section="community",
         access_tier="user",
-        usage="!shards [type]",
+        usage="!shards | !shards <type> | !shards set <type> <count>",
     )
     @commands.group(
         name="shards",
         invoke_without_command=True,
         help=(
-            "Shard & Mercy tracker with overview and detail tabs. Only runs in the Shards & Mercy "
-            "channel; creates your personal thread when needed."
+            "Open your personal shard tracker panel. It shows your shard counts, mercy counters, "
+            "last tracked Legendary/Mythical pulls, and lets you update everything with buttons.\n\n"
+            "Works in the configured Shards & Mercy channel and your personal shard tracker thread.\n\n"
+            "Usage:\n"
+            "```text\n"
+            "!shards\n"
+            "!shards <type>\n"
+            "!shards set <type> <count>\n"
+            "```\n"
+            "Shard/resource types:\n"
+            "```text\n"
+            "mystery\n"
+            "ancient\n"
+            "void\n"
+            "primal\n"
+            "sacred\n"
+            "remnant\n"
+            "```\n"
+            "Examples: `!shards`, `!shards ancient`, `!shards remnant`, "
+            "`!shards set mystery 1375`, `!shards set remnant 350`.\n\n"
+            "Buttons: `+ Stash` adds shards or Cursed Remnants to your owned count. "
+            "`- Pulls` subtracts normal shard pulls and updates mercy where that shard has mercy; "
+            "for Mystery it only subtracts owned count because Mystery has no mercy. "
+            "`- Summons` is Remnants only: each summon costs 100 Cursed Remnants, logs Remnant Summons, "
+            "and is rejected if you do not have enough Cursed Remnants. "
+            "`Got Legendary` records a Legendary pull and resets that Legendary mercy. "
+            "`Got Legendary/Mythical` is Primal only. `Got Mythical` is Remnants only and resets "
+            "Remnant Mythical mercy. `Last Pulls / Mercy` shows and lets you edit tracked mercy counters; "
+            "Mystery does not appear there because it has no mercy. `Share to Clan` posts the overview snapshot.\n\n"
+            "Notes: Mystery Shards track owned count only. Cursed Remnants track raw Cursed Remnant count "
+            "and Mythical mercy. One Remnant Summon costs 100 Cursed Remnants. "
+            "`!shards set <type> <count>` sets the owned count only."
         ),
     )
     async def shards(self, ctx: commands.Context, *, shard_type: str | None = None) -> None:
@@ -1824,6 +1854,8 @@ class ShardTracker(commands.Cog, ShardTrackerController):
     def _author_meta(self, tab: str, username: str) -> tuple[str, str]:
         if tab in SHARD_KINDS:
             label = SHARD_KINDS[tab].label
+            if tab == "remnant":
+                return (f"Cursed Remnants | {username}", tab)
             return (f"{label} Shards | {username}", tab)
         if tab == "last_pulls":
             return (f"Last Pulls & Mercy Info — C1C | {username}", "overview")

--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -20,7 +20,7 @@ TAB_LABELS: Mapping[str, str] = {
     "sacred": "Sacred",
     "primal": "Primal",
     "mystery": "Mystery",
-    "remnant": "Remnants",
+    "remnant": "Remnant",
     "last_pulls": "Last Pulls",
 }
 
@@ -70,7 +70,7 @@ class ShardTrackerView(discord.ui.View):
         self._controller = controller
         self._action_capabilities = dict(action_capabilities or {})
         # Tab buttons
-        for tab in ("overview", "ancient", "void", "sacred", "primal", "mystery", "remnant", "last_pulls"):
+        for tab in ("overview", "mystery", "ancient", "void", "primal", "sacred", "remnant", "last_pulls"):
             label: str | None = None
             emoji = None
 
@@ -220,8 +220,8 @@ _TAB_COLORS: Mapping[str, discord.Colour] = {
     "void": discord.Colour(0xA970FF),
     "sacred": discord.Colour.gold(),
     "primal": discord.Colour.dark_red(),
-    "mystery": discord.Colour.light_grey(),
-    "remnant": discord.Colour.purple(),
+    "mystery": discord.Colour.green(),
+    "remnant": discord.Colour.red(),
 }
 
 

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -383,6 +383,33 @@ def test_detail_share_button_action_preserves_overview_share_behavior():
     asyncio.run(runner())
 
 
+def test_shard_tab_order_matches_required_sequence():
+    from modules.community.shard_tracker.views import ShardTrackerView
+
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    labels = {kind.key: kind.label for kind in SHARD_KINDS.values()}
+    view = ShardTrackerView(
+        owner_id=42,
+        controller=tracker,
+        active_tab="overview",
+        shard_labels=labels,
+        shard_emojis={},
+        action_capabilities=tracker._action_capabilities(),
+        timeout=None,
+    )
+
+    assert _button_labels(view)[:8] == [
+        "Overview",
+        "Mystery",
+        "Ancient",
+        "Void",
+        "Primal",
+        "Sacred",
+        "Remnant",
+        "Last Pulls",
+    ]
+
+
 def test_mystery_and_remnant_button_layouts_are_capability_aware():
     from modules.community.shard_tracker.views import ShardTrackerView
 
@@ -440,10 +467,15 @@ def test_mystery_and_remnant_rendering_shapes():
     assert "Last Mythical: 2024-01-01 00:00 UTC" in fields["Remnants"]
 
     mystery, _ = tracker._build_panel(user, record, None, "mystery")
+    assert mystery.colour == discord.Colour.green()
+    assert mystery.author.name == "Mystery Shards | Tester"
     assert "Stash: **12**" in (mystery.description or "")
     assert not mystery.fields
 
     remnant, _ = tracker._build_panel(user, record, None, "remnant")
+    assert remnant.colour == discord.Colour.red()
+    assert remnant.author.name == "Cursed Remnants | Tester"
+    assert "Shards" not in remnant.author.name
     assert "Each summon costs 100 Cursed Remnants." in (remnant.description or "")
     assert "Mythical Mercy: 25 / 24" in (remnant.description or "")
     assert "Mythical Chance: 3.50%" in (remnant.description or "")
@@ -490,3 +522,16 @@ def test_last_pulls_embed_includes_remnant_mythical_once():
 
     assert last_pulls.count("Remnants Mythical:") == 1
     assert "Mystery" not in last_pulls
+
+
+def test_shards_help_text_covers_user_facing_actions():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    help_text = tracker.shards.help or ""
+
+    assert "Mystery" in help_text or "mystery" in help_text
+    assert "Remnant" in help_text or "remnant" in help_text
+    assert "+ Stash" in help_text
+    assert "- Pulls" in help_text
+    assert "- Summons" in help_text
+    assert "Share to Clan" in help_text
+    assert "!shards set <type> <count>" in help_text


### PR DESCRIPTION
### Motivation
- Fix several UI polish bugs in the shard tracker so the panels match product expectations (wrong tab order and incorrect embed colours).
- Correct user-facing Remnant labeling which incorrectly read `Remnants Shards` and is misleading.
- Improve the `!shards` help so users can discover shard/resource types, button actions, and Remnant/Mystery-specific behavior.

### Description
- Reordered the hardcoded tab/button order in `modules/community/shard_tracker/views.py` to: `overview`, `mystery`, `ancient`, `void`, `primal`, `sacred`, `remnant`, `last_pulls` and changed the Remnant label to singular `Remnant`.
- Updated `_TAB_COLORS` in `modules/community/shard_tracker/views.py` so `mystery` uses a green Discord colour and `remnant` uses a red Discord colour.
- Special-cased Remnant author/title in `modules/community/shard_tracker/cog.py` so detail pages read `Cursed Remnants | <user>` while preserving existing `Mystery Shards | <user>` behavior.
- Expanded the `!shards` command help text in `modules/community/shard_tracker/cog.py` to include usage examples, the full list of shard/resource types, button explanations, Mystery and Remnant-specific notes (including the 100-Remnant summon cost), and the `!shards set <type> <count>` semantics.
- Added/updated tests in `tests/community/shard_tracker/test_cog.py` to assert the exact tab/button order, Mystery/Remnant colours and labels, and that the `!shards` help contains the user-facing guidance.

### Testing
- Ran `python -m pytest tests/community/shard_tracker -q` and the shard-tracker test suite passed.
- Ran `python -m compileall modules/community/shard_tracker` and compilation succeeded without syntax errors.
- Ran `git diff --check` as part of validation and it produced no whitespace/check failures.
- Ran `python -m pytest packages/c1c-coreops/tests/test_help_renderer.py -q` which failed on a pre-existing unrelated help coverage issue (`ops env channels` missing a `brief`); this failure is orthogonal to the shard tracker changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b92964de88323b263feea9a640846)