### PR TITLE
Fix shard overview code-block spacing

### DIFF
--- a/modules/community/shard_tracker/views.py
+++ b/modules/community/shard_tracker/views.py
@@ -315,14 +315,12 @@ def build_overview_embed(
             mythic_mercy = mythic.mercy
             lines = [
                 f"Owned: {max(display.owned, 0):,}",
-                "",
                 "Legendary",
                 f"Mercy: {display.mercy.pulls_since} / {display.mercy.threshold} | Chance: {format_percent(display.mercy.chance)}",
             ]
             if display.last_timestamp:
                 lines.append(f"Last Legendary: {human_time(display.last_timestamp)}")
             lines += [
-                "",
                 "Mythical",
                 f"Mercy: {mythic_mercy.pulls_since} / {mythic_mercy.threshold} | Chance: {format_percent(mythic_mercy.chance)}",
             ]

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -526,6 +526,38 @@ def test_mystery_and_remnant_rendering_shapes():
     assert all("Legendary" not in (field.name + field.value) for field in remnant.fields)
 
 
+def test_overview_code_blocks_keep_single_label_spacing_and_primal_sections_tight():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+    record.ancients_owned = 1127
+    record.ancients_since_lego = 36
+    record.primals_owned = 5
+    record.primals_since_lego = 16
+    record.primals_since_mythic = 21
+    record.last_primal_mythic_iso = "2026-06-05T11:05:00+00:00"
+    user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+    overview, _ = tracker._build_panel(user, record, None, "overview")
+    fields = {field.name: field.value for field in overview.fields}
+
+    assert overview.footer.text == FOOTER_TEXT
+    assert FOOTER_TEXT not in (overview.description or "")
+    assert all("Owned:  " not in field.value for field in overview.fields)
+    assert all("Mercy:  " not in field.value for field in overview.fields)
+    assert "Owned: 1,127" in fields["Ancient"]
+    assert "Mercy: 36 / 200 | Chance: 0.50%" in fields["Ancient"]
+    assert fields["Primal"] == (
+        "```text\n"
+        "Owned: 5\n"
+        "Legendary\n"
+        "Mercy: 16 / 75 | Chance: 1.00%\n"
+        "Mythical\n"
+        "Mercy: 21 / 200 | Chance: 0.50%\n"
+        "Last Mythical: 2026-06-05 11:05 UTC\n"
+        "```"
+    )
+
+
 def test_mystery_and_remnant_state_mutations():
     tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
     record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]


### PR DESCRIPTION
### Motivation
- Remove unintended extra spaces and blank lines in shard overview code blocks so labels like `Owned:` and `Mercy:` render with single spacing and Primal sections render tightly. 
- Ensure the help text is set in the actual embed footer via `embed.set_footer()` rather than appended into the embed body. 
- Keep all existing behavior intact (no changes to schema, storage, mercy calculations, shard order, buttons, icons, or help content).

### Description
- Removed blank spacer entries from the Primal overview `lines` array in `modules/community/shard_tracker/views.py` so the Primal block emits contiguous lines for `Owned`, `Legendary`/`Mercy`, and `Mythical`/`Mercy` without extra blank lines. 
- Left footer handling as `_apply_footer(embed)` which calls `embed.set_footer(text=FOOTER_TEXT)` to ensure the help text appears in the embed footer. 
- Added a regression test `test_overview_code_blocks_keep_single_label_spacing_and_primal_sections_tight()` in `tests/community/shard_tracker/test_cog.py` to assert there is no double spacing after labels, the Primal overview block has no blank lines, and the footer text is placed in the embed footer.

### Testing
- Ran `python -m pytest tests/community/shard_tracker -q` and the test suite completed successfully. 
- Ran `python -m compileall modules/community/shard_tracker` and compilation succeeded. 
- Ran `git diff --check` and no whitespace or diff-check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bee89f6f88323ba8838a297395a9c)