### PR TITLE
Add sheet-driven share copy/voice support and clean share embed output

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -7,9 +7,10 @@ import io
 from datetime import datetime, time, timedelta, timezone
 import logging
 import os
+import random
 import re
 from dataclasses import dataclass
-from typing import Dict, Iterable, Literal, Optional
+from typing import Dict, Literal
 
 import discord
 from discord import PartialEmoji
@@ -26,11 +27,13 @@ from shared.logfmt import user_label
 from .data import (
     ShardClanRow,
     ShardRecord,
+    ShardShareConfig,
+    ShardShareCopyRow,
     ShardSheetStore,
     ShardTrackerConfigError,
     ShardTrackerSheetError,
 )
-from .mercy import MERCY_CONFIGS, MercyConfig, MercySnapshot, mercy_state
+from .mercy import MERCY_CONFIGS, MercyConfig, mercy_state
 from .threads import ShardThreadRouter
 from .views import (
     MythicDisplay,
@@ -41,6 +44,7 @@ from .views import (
     build_detail_embed,
     build_last_pulls_embed,
     build_overview_embed,
+    human_time,
 )
 from modules.common import runtime
 
@@ -346,7 +350,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
 
         async with self._user_lock(ctx_author.id):
             try:
-                config = await self.store.get_config()
+                await self.store.get_config()
                 record = await self.store.load_record(
                     ctx_author.id, ctx_author.display_name or ctx_author.name
                 )
@@ -1192,7 +1196,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
                 )
                 return
 
-            embed = self._build_share_embed(interaction.user, record, selected)
+            embed = await self._build_share_embed(interaction.user, record, selected)
             try:
                 await destination.send(embed=embed)
             except discord.NotFound:
@@ -1465,7 +1469,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             return None, _SKIP_DESTINATION_NOT_FOUND
         return None, _SKIP_MISSING_DESTINATION
 
-    def _build_share_embed(
+    async def _build_share_embed(
         self,
         member: discord.abc.User,
         record: ShardRecord,
@@ -1473,15 +1477,174 @@ class ShardTracker(commands.Cog, ShardTrackerController):
     ) -> discord.Embed:
         displays = [self._build_display(record, kind) for kind in SHARD_KINDS.values()]
         mythic = self._build_mythic_display(record)
-        embed = build_overview_embed(
-            member=member,
-            displays=displays,
-            mythic=mythic,
-            shard_emojis=self._section_emojis(),
-        )
-        embed.title = f"Shard Snapshot — {member.display_name}"
-        embed.description = f"Shared to `{clan.clan_key}`."
+        share_config = await self._load_share_config()
+        voice = await self._resolve_share_voice(clan, share_config)
+        copy_rows = await self._load_share_copy_rows() if share_config is not None and voice else []
+        random_enabled = share_config.random_copy_enabled if share_config is not None else False
+        placeholders = self._share_base_placeholders(member, clan)
+        lines: list[str] = []
+        intro = self._select_share_copy(copy_rows, voice, "intro", "always", placeholders, random_enabled)
+        if intro:
+            lines.extend([intro, ""])
+        by_key = {display.key: display for display in displays}
+        section_emojis = self._section_emojis()
+        for key in ("mystery", "ancient", "void", "sacred", "primal"):
+            display = by_key[key]
+            section_placeholders = {**placeholders, **self._share_shard_placeholders(display, mythic)}
+            heading = self._share_section_heading(display, section_emojis)
+            lines.append(f"### {heading}")
+            lines.append(f"Owned: {display.owned:,}")
+            if key == "primal":
+                lines.extend([
+                    "",
+                    f"Legendary Mercy: {display.mercy.pulls_since if display.mercy else 0} / {display.mercy.threshold if display.mercy else 0}",
+                    f"Mythical Mercy: {mythic.mercy.pulls_since} / {mythic.mercy.threshold}",
+                    f"Last Mythical: {section_placeholders['last_mythical']}",
+                ])
+            elif display.mercy is not None:
+                lines.extend([
+                    f"Mercy: {display.mercy.pulls_since} / {display.mercy.threshold}",
+                    f"Last Legendary: {section_placeholders['last_legendary']}",
+                ])
+            condition = self._share_comment_condition(display, mythic, share_config)
+            comment = self._select_share_comment(copy_rows, voice, condition, section_placeholders, random_enabled)
+            if comment:
+                lines.extend(["", comment])
+            lines.append("")
+        final = self._select_share_copy(copy_rows, voice, "final_line", "always", placeholders, random_enabled)
+        if final:
+            lines.append(final)
+        embed = discord.Embed(title=f"Shard Stash Report — {member.display_name}", description="\n".join(lines).strip())
+        from .views import FOOTER_TEXT
+        embed.set_footer(text=FOOTER_TEXT)
         return embed
+
+
+    async def _resolve_share_voice(self, clan: ShardClanRow, share_config: ShardShareConfig | None) -> str:
+        default_voice = share_config.default_voice if share_config is not None else ""
+        try:
+            rows = await self.store.get_share_voice_target_rows()
+        except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+            log.error("shard share voice config unavailable; skipping configured voice", extra={"error": str(exc), "clan_key": clan.clan_key})
+            return default_voice
+        target = str(clan.clan_key or "").strip().lower()
+        fallback = ""
+        for row in rows:
+            if not row.enabled or not row.voice:
+                continue
+            if row.target_type == "fallback":
+                fallback = fallback or row.voice
+                continue
+            if row.target_type in {"clan_tag", "clan_key", "target"} and row.target_key.strip().lower() == target:
+                return row.voice
+        return fallback or default_voice
+
+    async def _load_share_config(self) -> ShardShareConfig | None:
+        try:
+            return await self.store.get_share_config()
+        except ShardTrackerConfigError as exc:
+            log.error("shard share config unavailable; skipping flavor copy: %s", exc, extra={"error": str(exc)})
+            return None
+
+    async def _load_share_copy_rows(self) -> list[ShardShareCopyRow]:
+        try:
+            return await self.store.get_share_copy_rows()
+        except (ShardTrackerConfigError, ShardTrackerSheetError) as exc:
+            log.error("shard share copy config unavailable; skipping flavor copy", extra={"error": str(exc)})
+            return []
+
+    def _select_share_copy(self, rows: list[ShardShareCopyRow], voice: str, text_type: str, condition: str, placeholders: dict[str, str], random_enabled: bool) -> str:
+        candidates = []
+        for row in rows:
+            if not row.enabled or row.voice != voice or row.text_type != text_type or row.condition != condition or row.weight <= 0:
+                continue
+            rendered = self._render_share_copy(row, placeholders)
+            if rendered is not None:
+                candidates.append((row, rendered))
+        if not candidates:
+            log.info("shard share copy row not found", extra={"voice": voice, "text_type": text_type, "condition": condition})
+            return ""
+        if not random_enabled:
+            return candidates[0][1]
+        return random.choices([text for _, text in candidates], weights=[row.weight for row, _ in candidates], k=1)[0]
+
+    def _select_share_comment(
+        self,
+        rows: list[ShardShareCopyRow],
+        voice: str,
+        condition: str | None,
+        placeholders: dict[str, str],
+        random_enabled: bool,
+    ) -> str:
+        if not condition:
+            return ""
+        comment = self._select_share_copy(
+            rows, voice, "shard_comment", condition, placeholders, random_enabled
+        )
+        if comment or condition == "always":
+            return comment
+        return self._select_share_copy(
+            rows, voice, "shard_comment", "always", placeholders, random_enabled
+        )
+
+    def _render_share_copy(self, row: ShardShareCopyRow, placeholders: dict[str, str]) -> str | None:
+        names = set(re.findall(r"\{([A-Za-z0-9_]+)\}", row.text))
+        missing = sorted(name for name in names if name not in placeholders)
+        if missing:
+            log.warning("shard share copy row has unavailable placeholders", extra={"voice": row.voice, "text_type": row.text_type, "condition": row.condition, "row_number": row.row_number, "missing": missing})
+            return None
+        return row.text.format(**placeholders)
+
+    def _share_base_placeholders(self, member: discord.abc.User, clan: ShardClanRow) -> dict[str, str]:
+        display_name = str(getattr(member, "display_name", None) or getattr(member, "name", ""))
+        return {"display_name": display_name, "target": clan.clan_key, "target_name": clan.clan_key, "clan_tag": clan.clan_key}
+
+    def _share_shard_placeholders(self, display: ShardDisplay, mythic: MythicDisplay) -> dict[str, str]:
+        mercy = display.mercy
+        last_legendary = human_time(display.last_timestamp) if display.last_timestamp else "Never"
+        last_mythical = human_time(mythic.last_timestamp) if mythic.last_timestamp else "Never"
+        return {
+            "shard_type": display.label,
+            "owned": f"{display.owned:,}",
+            "mercy_current": str(mercy.pulls_since if mercy else 0),
+            "mercy_max": str(mercy.threshold if mercy else 0),
+            "last_legendary": last_legendary,
+            "last_mythical": last_mythical,
+            "legendary_mercy_current": str(mercy.pulls_since if mercy else 0),
+            "legendary_mercy_max": str(mercy.threshold if mercy else 0),
+            "mythical_mercy_current": str(mythic.mercy.pulls_since),
+            "mythical_mercy_max": str(mythic.mercy.threshold),
+        }
+
+    def _share_comment_condition(
+        self, display: ShardDisplay, mythic: MythicDisplay, share_config: ShardShareConfig | None
+    ) -> str | None:
+        if share_config is None:
+            return None
+        owned = max(display.owned, 0)
+        if owned == 0:
+            return "stash_zero"
+        high_percent = share_config.mercy_high_percent / 100
+        if display.key == "primal":
+            mercies = [m for m in (display.mercy, mythic.mercy) if m]
+        else:
+            mercies = [display.mercy] if display.mercy else []
+        if any((m.pulls_since / max(m.threshold, 1)) >= high_percent for m in mercies):
+            return "mercy_high"
+        if owned >= share_config.stash_flex_threshold:
+            return "stash_flex"
+        if owned < share_config.stash_low_threshold:
+            return "stash_low"
+        if any(m.pulls_since > 0 for m in mercies):
+            return "mercy_started"
+        return "always"
+
+    def _share_section_heading(self, display: ShardDisplay, shard_emojis: dict[str, object]) -> str:
+        emoji = str((shard_emojis or {}).get(display.key) or "").strip()
+        if emoji:
+            return f"{emoji} {display.label}"
+        log.warning("shard share icon missing", extra={"shard_type": display.key})
+        return display.label
 
     def _build_clan_reminder_embed(
         self,

--- a/modules/community/shard_tracker/data.py
+++ b/modules/community/shard_tracker/data.py
@@ -67,6 +67,21 @@ SHARD_REMINDER_REQUIRED_HEADERS: tuple[str, ...] = (
     "reminder_type",
     "sent_at_utc",
 )
+SHARD_SHARE_COPY_REQUIRED_HEADERS: tuple[str, ...] = (
+    "voice",
+    "text_type",
+    "condition",
+    "enabled",
+    "weight",
+    "text",
+)
+SHARD_SHARE_VOICE_TARGET_REQUIRED_HEADERS: tuple[str, ...] = (
+    "target_key",
+    "target_type",
+    "voice",
+    "enabled",
+    "notes",
+)
 
 
 @dataclass(slots=True)
@@ -74,6 +89,36 @@ class ShardTrackerConfig:
     sheet_id: str
     tab_name: str
     channel_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShardShareConfig:
+    default_voice: str
+    random_copy_enabled: bool
+    stash_low_threshold: int
+    stash_flex_threshold: int
+    mercy_high_percent: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShardShareCopyRow:
+    voice: str
+    text_type: str
+    condition: str
+    enabled: bool
+    weight: int
+    text: str
+    row_number: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShardShareVoiceTargetRow:
+    target_key: str
+    target_type: str
+    voice: str
+    enabled: bool
+    notes: str
+    row_number: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -269,6 +314,85 @@ class ShardSheetStore:
 
     async def get_clans(self) -> list[ShardClanRow]:
         return await self._load_shard_clans()
+
+    async def get_share_config(self) -> ShardShareConfig:
+        default_voice = _required_config_text("shard_share_default_voice")
+        random_copy_enabled = _required_config_bool("shard_share_random_copy_enabled")
+        stash_low_threshold = _required_config_int("shard_share_stash_low_threshold")
+        stash_flex_threshold = _required_config_int("shard_share_stash_flex_threshold")
+        mercy_high_percent = _required_config_int("shard_share_mercy_high_percent")
+        for key, value in (
+            ("shard_share_stash_low_threshold", stash_low_threshold),
+            ("shard_share_stash_flex_threshold", stash_flex_threshold),
+        ):
+            if value <= 0:
+                raise ShardTrackerConfigError(f"Shard share Config key invalid positive integer: {key}")
+        if mercy_high_percent < 1 or mercy_high_percent > 100:
+            raise ShardTrackerConfigError(
+                "Shard share Config key invalid percent range: shard_share_mercy_high_percent"
+            )
+        return ShardShareConfig(
+            default_voice=default_voice.lower(),
+            random_copy_enabled=random_copy_enabled,
+            stash_low_threshold=stash_low_threshold,
+            stash_flex_threshold=stash_flex_threshold,
+            mercy_high_percent=mercy_high_percent,
+        )
+
+    async def get_share_copy_rows(self) -> list[ShardShareCopyRow]:
+        config = await self.get_config()
+        tab_name = _config_tab_name("shard_share_copy_tab")
+        matrix = await async_core.afetch_values(config.sheet_id, tab_name)
+        if not matrix:
+            raise ShardTrackerSheetError(f"Shard share copy sheet is empty (tab={tab_name})")
+        header = [self._normalize(cell) for cell in matrix[0]]
+        missing = [col for col in SHARD_SHARE_COPY_REQUIRED_HEADERS if col not in header]
+        if missing:
+            raise ShardTrackerSheetError(f"Shard share copy sheet missing required headers (tab={tab_name}, missing={missing})")
+        index = {name: header.index(name) for name in SHARD_SHARE_COPY_REQUIRED_HEADERS}
+        rows: list[ShardShareCopyRow] = []
+        for row_number, row in enumerate(matrix[1:], start=2):
+            weight_raw = self._cell(row, index["weight"])
+            try:
+                weight = int(weight_raw)
+            except (TypeError, ValueError):
+                log.warning("Shard share copy row invalid weight", extra={"tab": tab_name, "row_number": row_number, "weight": weight_raw})
+                weight = 0
+            rows.append(
+                ShardShareCopyRow(
+                    voice=self._cell(row, index["voice"]).lower(),
+                    text_type=self._cell(row, index["text_type"]).lower(),
+                    condition=self._cell(row, index["condition"]).lower(),
+                    enabled=_parse_bool(self._cell(row, index["enabled"])),
+                    weight=weight,
+                    text=self._cell(row, index["text"]),
+                    row_number=row_number,
+                )
+            )
+        return rows
+
+    async def get_share_voice_target_rows(self) -> list[ShardShareVoiceTargetRow]:
+        config = await self.get_config()
+        tab_name = _config_tab_name("shard_share_voice_targets_tab")
+        matrix = await async_core.afetch_values(config.sheet_id, tab_name)
+        if not matrix:
+            raise ShardTrackerSheetError(f"Shard share voice targets sheet is empty (tab={tab_name})")
+        header = [self._normalize(cell) for cell in matrix[0]]
+        missing = [col for col in SHARD_SHARE_VOICE_TARGET_REQUIRED_HEADERS if col not in header]
+        if missing:
+            raise ShardTrackerSheetError(f"Shard share voice targets sheet missing required headers (tab={tab_name}, missing={missing})")
+        index = {name: header.index(name) for name in SHARD_SHARE_VOICE_TARGET_REQUIRED_HEADERS}
+        rows: list[ShardShareVoiceTargetRow] = []
+        for row_number, row in enumerate(matrix[1:], start=2):
+            rows.append(ShardShareVoiceTargetRow(
+                target_key=self._cell(row, index["target_key"]),
+                target_type=self._cell(row, index["target_type"]).lower(),
+                voice=self._cell(row, index["voice"]).lower(),
+                enabled=_parse_bool(self._cell(row, index["enabled"])),
+                notes=self._cell(row, index["notes"]),
+                row_number=row_number,
+            ))
+        return rows
 
     async def get_enabled_clan(self, clan_key: str) -> ShardClanRow | None:
         key = str(clan_key or "").strip().lower()
@@ -505,6 +629,31 @@ def _config_tab_name(key: str) -> str:
         return text
     raise ShardTrackerConfigError(f"{key} missing in milestones Config tab")
 
+
+
+def _required_config_text(key: str) -> str:
+    value = _config_value(key, "")
+    text = str(value or "").strip()
+    if not text:
+        raise ShardTrackerConfigError(f"Shard share Config key missing: {key}")
+    return text
+
+
+def _required_config_int(key: str) -> int:
+    text = _required_config_text(key)
+    try:
+        return int(text)
+    except (TypeError, ValueError) as exc:
+        raise ShardTrackerConfigError(f"Shard share Config key invalid integer: {key}") from exc
+
+
+def _required_config_bool(key: str) -> bool:
+    text = _required_config_text(key).lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ShardTrackerConfigError(f"Shard share Config key invalid boolean: {key}")
 
 def _parse_channel_id(value: object) -> int:
     if value is None:

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 from modules.community.shard_tracker import setup as shard_setup
 from modules.community.shard_tracker.cog import SHARD_KINDS, ShardTracker
-from modules.community.shard_tracker.data import ShardTrackerConfig
+from modules.community.shard_tracker.data import ShardShareConfig, ShardShareCopyRow, ShardShareVoiceTargetRow, ShardTrackerConfig, ShardTrackerConfigError
 from modules.community.shard_tracker.views import FOOTER_TEXT
 
 
@@ -224,6 +224,30 @@ class _ShareInteraction:
         self.followup = _ShareFollowup()
 
 
+def _copy_rows(voice="standard"):
+    return [
+        ShardShareCopyRow(voice=voice, text_type="intro", condition="always", enabled=True, weight=1, text="Intro {display_name} {clan_tag}", row_number=2),
+        ShardShareCopyRow(voice=voice, text_type="shard_comment", condition="stash_zero", enabled=True, weight=1, text="No {shard_type}.", row_number=3),
+        ShardShareCopyRow(voice=voice, text_type="shard_comment", condition="always", enabled=True, weight=1, text="Some {shard_type}.", row_number=4),
+        ShardShareCopyRow(voice=voice, text_type="final_line", condition="always", enabled=True, weight=1, text="Final {target}.", row_number=5),
+    ]
+
+def _voice_rows():
+    return [ShardShareVoiceTargetRow(target_key="default", target_type="fallback", voice="standard", enabled=True, notes="", row_number=2)]
+
+
+def _share_config(**overrides):
+    values = dict(
+        default_voice="standard",
+        random_copy_enabled=True,
+        stash_low_threshold=5,
+        stash_flex_threshold=100,
+        mercy_high_percent=85,
+    )
+    values.update(overrides)
+    return ShardShareConfig(**values)
+
+
 def test_share_summary_sends_to_resolved_destination():
     async def runner():
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
@@ -323,7 +347,10 @@ def test_section_headings_use_configured_icon_sources():
 
     overview, _ = tracker._build_panel(user, record, None, "overview")
     last_pulls, _ = tracker._build_panel(user, record, None, "last_pulls")
-    shared = tracker._build_share_embed(user, record, clan)
+    tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+    tracker.store.get_share_config = AsyncMock(return_value=_share_config())
+    tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
+    shared = asyncio.run(tracker._build_share_embed(user, record, clan))
 
     assert overview.fields[0].name == "<:mystery:123456789012345678> Mystery"
     assert overview.fields[1].name == "<:ancient:223456789012345678> Ancient"
@@ -338,8 +365,8 @@ def test_section_headings_use_configured_icon_sources():
         "sacred_icon Sacred",
         "remnant_icon Remnants",
     ]
-    assert shared.fields[0].name == "<:mystery:123456789012345678> Mystery"
-    assert shared.fields[1].name == "<:ancient:223456789012345678> Ancient"
+    assert "### <:mystery:123456789012345678> Mystery" in shared.description
+    assert "### <:ancient:223456789012345678> Ancient" in shared.description
 
 
 def test_detail_button_layout_still_includes_share_to_clan():
@@ -359,17 +386,22 @@ def test_detail_button_layout_still_includes_share_to_clan():
     assert "action:share:ancient" in _button_custom_ids(view)
 
 
-def test_share_embed_uses_overview_payload():
+def test_share_embed_uses_sheet_driven_clean_payload():
     tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+    tracker.store.get_share_config = AsyncMock(return_value=_share_config())
+    tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
     record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
     clan = _share_clan()
     user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
 
-    embed = tracker._build_share_embed(user, record, clan)
+    embed = asyncio.run(tracker._build_share_embed(user, record, clan))
 
-    assert embed.title == "Shard Snapshot — Tester"
-    assert embed.description == "Shared to `alpha`."
-    assert [field.name for field in embed.fields] == ["Mystery", "Ancient", "Void", "Primal", "Sacred", "Remnants"]
+    assert embed.title == "Shard Stash Report — Tester"
+    assert "Intro Tester alpha" in embed.description
+    assert "### Mystery" in embed.description
+    assert "Chance" not in embed.description
+    assert "Final alpha." in embed.description
 
 
 def test_share_button_action_routes_overview_without_active_tab_payload():
@@ -415,9 +447,12 @@ def test_detail_share_button_action_preserves_overview_share_behavior():
 
         record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
         clan = _share_clan()
-        embed = tracker._build_share_embed(interaction.user, record, clan)
-        assert embed.title == "Shard Snapshot — Tester"
-        assert [field.name for field in embed.fields] == ["Mystery", "Ancient", "Void", "Primal", "Sacred", "Remnants"]
+        tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+        tracker.store.get_share_config = AsyncMock(return_value=_share_config())
+        tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
+        embed = await tracker._build_share_embed(interaction.user, record, clan)
+        assert embed.title == "Shard Stash Report — Tester"
+        assert "### Mystery" in embed.description
 
     asyncio.run(runner())
 
@@ -590,3 +625,137 @@ def test_shards_help_text_covers_user_facing_actions():
     assert "Ancient Legendary: 0.5%" in help_text
     assert "Remnant Mythical: 2.5%" in help_text
     assert "100 Cursed Remnants" in help_text
+
+
+def test_share_voice_uses_fallback_and_target_rows_without_hardcoded_c1cm():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    rows = [
+        ShardShareVoiceTargetRow("default", "fallback", "standard", True, "", 2),
+        ShardShareVoiceTargetRow("C1CM", "clan_tag", "pirate", True, "", 3),
+    ]
+    tracker.store.get_share_voice_target_rows = AsyncMock(return_value=rows)
+
+    assert asyncio.run(tracker._resolve_share_voice(_share_clan(clan_key="alpha"), _share_config())) == "standard"
+    assert asyncio.run(tracker._resolve_share_voice(_share_clan(clan_key="C1CM"), _share_config())) == "pirate"
+    source = __import__("pathlib").Path("modules/community/shard_tracker/cog.py").read_text()
+    assert "C1CM" not in source
+
+
+def test_share_copy_weighted_rows_and_random_disabled_first():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    rows = [
+        ShardShareCopyRow("standard", "intro", "always", True, 1, "first", 2),
+        ShardShareCopyRow("standard", "intro", "always", True, 5, "second", 3),
+    ]
+    placeholders = {"display_name": "Tester"}
+
+    assert tracker._select_share_copy(rows, "standard", "intro", "always", placeholders, False) == "first"
+    seen = {tracker._select_share_copy(rows, "standard", "intro", "always", placeholders, True) for _ in range(80)}
+    assert seen == {"first", "second"}
+
+
+def test_share_condition_priority_and_primal_mythical_mercy():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+    ancient = tracker._build_display(record, SHARD_KINDS["ancient"])
+    assert tracker._share_comment_condition(ancient, tracker._build_mythic_display(record), _share_config()) == "stash_zero"
+
+    record.voids_owned = 150
+    record.voids_since_lego = 190
+    void = tracker._build_display(record, SHARD_KINDS["void"])
+    assert tracker._share_comment_condition(void, tracker._build_mythic_display(record), _share_config()) == "mercy_high"
+
+    record.primals_owned = 10
+    record.primals_since_lego = 0
+    record.primals_since_mythic = 190
+    primal = tracker._build_display(record, SHARD_KINDS["primal"])
+    assert tracker._share_comment_condition(primal, tracker._build_mythic_display(record), _share_config()) == "mercy_high"
+
+
+def test_share_copy_unresolved_placeholder_skips(caplog):
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    row = ShardShareCopyRow("standard", "intro", "always", True, 1, "Bad {missing}", 2)
+    with caplog.at_level(logging.WARNING, logger="c1c.shards.cog"):
+        text = tracker._select_share_copy([row], "standard", "intro", "always", {}, False)
+    assert text == ""
+    assert "unavailable placeholders" in caplog.text
+
+
+def test_share_missing_required_config_logs_and_skips_flavor(caplog):
+    async def runner():
+        tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+        tracker.store.get_share_config = AsyncMock(side_effect=ShardTrackerConfigError("Shard share Config key missing: shard_share_default_voice"))
+        tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+        tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
+        record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+        user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+        with caplog.at_level(logging.ERROR, logger="c1c.shards.cog"):
+            embed = await tracker._build_share_embed(user, record, _share_clan())
+
+        assert "Shard share Config key missing: shard_share_default_voice" in caplog.text
+        assert "Intro" not in embed.description
+        assert "Final" not in embed.description
+        assert "### Mystery" in embed.description
+
+    asyncio.run(runner())
+
+
+def test_share_invalid_threshold_logs_and_skips_conditional_flavor(caplog):
+    async def runner():
+        tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+        tracker.store.get_share_config = AsyncMock(side_effect=ShardTrackerConfigError("Shard share Config key invalid integer: shard_share_mercy_high_percent"))
+        tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+        tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
+        record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+        record.voids_since_lego = 190
+        user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+        with caplog.at_level(logging.ERROR, logger="c1c.shards.cog"):
+            embed = await tracker._build_share_embed(user, record, _share_clan())
+
+        assert "shard_share_mercy_high_percent" in caplog.text
+        assert "Some Void" not in embed.description
+        assert "No Void" not in embed.description
+        assert "### Void" in embed.description
+
+    asyncio.run(runner())
+
+
+def test_share_comment_falls_back_to_always_only_when_stronger_missing():
+    tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+    placeholders = {"shard_type": "Void"}
+    rows = [
+        ShardShareCopyRow("standard", "shard_comment", "always", True, 1, "Always {shard_type}", 2),
+    ]
+    assert tracker._select_share_comment(rows, "standard", "mercy_high", placeholders, False) == "Always Void"
+
+    rows.append(ShardShareCopyRow("standard", "shard_comment", "mercy_high", True, 1, "High {shard_type}", 3))
+    assert tracker._select_share_comment(rows, "standard", "mercy_high", placeholders, False) == "High Void"
+
+
+def test_share_invalid_percent_range_skips_flavor_but_keeps_clean_stats(caplog):
+    async def runner():
+        tracker = ShardTracker(commands.Bot(command_prefix="!", intents=discord.Intents.none()))
+        tracker.store.get_share_config = AsyncMock(
+            side_effect=ShardTrackerConfigError(
+                "Shard share Config key invalid percent range: shard_share_mercy_high_percent"
+            )
+        )
+        tracker.store.get_share_voice_target_rows = AsyncMock(return_value=_voice_rows())
+        tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
+        record = tracker.store._new_record([], 42, "Tester")  # type: ignore[arg-type]
+        record.voids_owned = 10
+        user = type("User", (), {"id": 42, "display_name": "Tester", "name": "Tester"})()
+
+        with caplog.at_level(logging.ERROR, logger="c1c.shards.cog"):
+            embed = await tracker._build_share_embed(user, record, _share_clan())
+
+        assert "invalid percent range: shard_share_mercy_high_percent" in caplog.text
+        assert "Intro" not in embed.description
+        assert "Final" not in embed.description
+        assert "Some Void" not in embed.description
+        assert "### Void" in embed.description
+        assert "Chance" not in embed.description
+
+    asyncio.run(runner())

--- a/tests/community/shard_tracker/test_data.py
+++ b/tests/community/shard_tracker/test_data.py
@@ -242,3 +242,134 @@ def test_save_record_writes_through_aa(monkeypatch):
         assert len(worksheet.calls[0][1][0]) == len(shard_data.EXPECTED_HEADERS)
 
     asyncio.run(runner())
+
+
+def test_share_config_uses_lowercase_sheet_keys(monkeypatch):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        monkeypatch.setattr(
+            shard_data,
+            "runtime_config",
+            _RuntimeConfigStub(
+                {
+                    "shard_share_default_voice": "standard",
+                    "shard_share_random_copy_enabled": "TRUE",
+                    "shard_share_stash_low_threshold": "5",
+                    "shard_share_stash_flex_threshold": "100",
+                    "shard_share_mercy_high_percent": "85",
+                }
+            ),
+        )
+
+        config = await store.get_share_config()
+
+        assert config.default_voice == "standard"
+        assert config.random_copy_enabled is True
+        assert config.stash_low_threshold == 5
+        assert config.stash_flex_threshold == 100
+        assert config.mercy_high_percent == 85
+
+    asyncio.run(runner())
+
+
+def test_share_copy_and_voice_tabs_use_lowercase_config_keys(monkeypatch):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        store.get_config = AsyncMock(return_value=shard_data.ShardTrackerConfig("sheet-1", "main", 123))
+        monkeypatch.setattr(
+            shard_data,
+            "runtime_config",
+            _RuntimeConfigStub(
+                {
+                    "shard_share_copy_tab": "ShardShareCopy",
+                    "shard_share_voice_targets_tab": "ShardShareVoiceTargets",
+                }
+            ),
+        )
+        calls = []
+
+        async def fake_fetch(sheet_id, tab_name):
+            calls.append((sheet_id, tab_name))
+            if tab_name == "ShardShareCopy":
+                return [list(shard_data.SHARD_SHARE_COPY_REQUIRED_HEADERS)]
+            return [list(shard_data.SHARD_SHARE_VOICE_TARGET_REQUIRED_HEADERS)]
+
+        monkeypatch.setattr(shard_data.async_core, "afetch_values", fake_fetch)
+
+        await store.get_share_copy_rows()
+        await store.get_share_voice_target_rows()
+
+        assert calls == [("sheet-1", "ShardShareCopy"), ("sheet-1", "ShardShareVoiceTargets")]
+
+    asyncio.run(runner())
+
+
+def test_share_config_missing_required_key_raises(monkeypatch):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        monkeypatch.setattr(
+            shard_data,
+            "runtime_config",
+            _RuntimeConfigStub(
+                {
+                    "shard_share_random_copy_enabled": "TRUE",
+                    "shard_share_stash_low_threshold": "5",
+                    "shard_share_stash_flex_threshold": "100",
+                    "shard_share_mercy_high_percent": "85",
+                }
+            ),
+        )
+
+        with pytest.raises(shard_data.ShardTrackerConfigError, match="shard_share_default_voice"):
+            await store.get_share_config()
+
+    asyncio.run(runner())
+
+
+@pytest.mark.parametrize("percent", [1, 85, 100])
+def test_share_config_accepts_valid_mercy_high_percent_range(monkeypatch, percent):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        monkeypatch.setattr(
+            shard_data,
+            "runtime_config",
+            _RuntimeConfigStub(
+                {
+                    "shard_share_default_voice": "standard",
+                    "shard_share_random_copy_enabled": "TRUE",
+                    "shard_share_stash_low_threshold": "5",
+                    "shard_share_stash_flex_threshold": "100",
+                    "shard_share_mercy_high_percent": str(percent),
+                }
+            ),
+        )
+
+        config = await store.get_share_config()
+
+        assert config.mercy_high_percent == percent
+
+    asyncio.run(runner())
+
+
+@pytest.mark.parametrize("percent", [0, 101])
+def test_share_config_rejects_invalid_mercy_high_percent_range(monkeypatch, percent):
+    async def runner():
+        store = shard_data.ShardSheetStore()
+        monkeypatch.setattr(
+            shard_data,
+            "runtime_config",
+            _RuntimeConfigStub(
+                {
+                    "shard_share_default_voice": "standard",
+                    "shard_share_random_copy_enabled": "TRUE",
+                    "shard_share_stash_low_threshold": "5",
+                    "shard_share_stash_flex_threshold": "100",
+                    "shard_share_mercy_high_percent": str(percent),
+                }
+            ),
+        )
+
+        with pytest.raises(shard_data.ShardTrackerConfigError, match="invalid percent range: shard_share_mercy_high_percent"):
+            await store.get_share_config()
+
+    asyncio.run(runner())


### PR DESCRIPTION
### Motivation

- Enable configurable, sheet-driven share text and voice selection for shard summary sharing instead of hardcoded payloads.
- Provide conditional and weighted flavor text with placeholder rendering and optional randomness to make shared reports more expressive and configurable.
- Fail gracefully to keep the condensed, clean numeric shard report when share flavor config or rows are missing or invalid.

### Description

- Added new data models `ShardShareConfig`, `ShardShareCopyRow`, and `ShardShareVoiceTargetRow` and required sheet header constants for share copy and voice targets in `data.py`.
- Implemented store accessors `get_share_config`, `get_share_copy_rows`, and `get_share_voice_target_rows` and helper functions `_required_config_text`, `_required_config_int`, and `_required_config_bool` for runtime config parsing and validation in `data.py`.
- Reworked share embed generation in `cog.py`: `_build_share_embed` is now `async` and builds a sheet-driven, markdown-styled embed body using selectable intro/section/comment/final copy, weighting, optional random selection, and placeholder substitution; added `_resolve_share_voice`, `_load_share_config`, `_load_share_copy_rows`, `_select_share_copy`, `_select_share_comment`, `_render_share_copy`, and several placeholder/heading helper methods.
- Added fallback and logging behavior so missing/invalid share config or copy rows are logged and result in the simpler numeric shard report instead of failing.
- Updated imports and small call-site adjustments to await the new async embed builder and to include `random` and `human_time` where needed.
- Updated and expanded unit tests in `tests/community/shard_tracker/test_cog.py` and `tests/community/shard_tracker/test_data.py` to cover voice resolution, weighted/random selection, placeholder handling, config validation, and graceful degradation.

### Testing

- Ran unit tests for the shard tracker module via the existing test suite (`pytest` for `tests/community/shard_tracker`), including new and modified tests for share copy, voice targets, config parsing, and `_build_share_embed`; all tests passed.
- Exercised error paths by simulating `ShardTrackerConfigError` and `ShardTrackerSheetError` from store methods to confirm logged errors and fallback to clean numeric report; assertions in tests succeeded.
- Verifies deterministic behavior when randomness is disabled and probabilistic selection when enabled using repeated sampling assertions in tests; these assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c066b9080832388088e77d1f1f51c)