### PR TITLE
Housekeeping: add cleanup admin command and scheduler notifications; improve reset_reminders load error handling and alerts

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1205,6 +1205,7 @@ class Runtime:
         from cogs import app_admin
         from cogs import housekeeping_mirralith
         from cogs import housekeeping_c1c_ad
+        from modules.housekeeping import cleanup as housekeeping_cleanup_commands
         from modules.onboarding import ops_check as onboarding_ops_check
         from modules.onboarding import reaction_fallback as onboarding_reaction_fallback
         from modules.onboarding import watcher_welcome as onboarding_welcome
@@ -1243,6 +1244,9 @@ class Runtime:
 
         await housekeeping_c1c_ad.setup(self.bot)
         log.info("modules: c1c_ad command registered")
+
+        await housekeeping_cleanup_commands.setup(self.bot)
+        log.info("modules: housekeeping cleanup command registered")
 
         async def _load_feature_module(
             module_path: str, feature_keys: Sequence[str]
@@ -1584,6 +1588,14 @@ class Runtime:
         )
 
         async def cleanup_runner() -> None:
+            tick_message = "cleanup watcher tick: startup_validation=false writeback=true"
+            cleanup_logger.info(tick_message)
+            try:
+                await send_log_message(f"🧹 {tick_message}")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                cleanup_logger.exception("cleanup watcher tick notice failed; cleanup still running")
             try:
                 await housekeeping_cleanup.run_cleanup(
                     self.bot, cleanup_logger, startup_validation=False, writeback=True
@@ -1594,6 +1606,12 @@ class Runtime:
                 cleanup_logger.exception(
                     "cleanup watcher run failed; scheduled cleanup will retry on next tick"
                 )
+                try:
+                    await send_log_message("🧹 cleanup watcher failed; see app logs")
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    cleanup_logger.exception("cleanup watcher failure notice failed")
 
         async def startup_validation_runner() -> None:
             try:

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -4,6 +4,7 @@ import datetime as dt
 import logging
 import math
 import asyncio
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -27,6 +28,8 @@ log = logging.getLogger("c1c.community.reset_reminders.scheduler")
 _RESET_REMINDER_TAB_KEY = "RESET_REMINDER_TAB"
 _FEATURE_TOGGLE_KEY = "reset_reminders"
 _INVALID_ROW_ALERT_DEDUPER = EventDeduper(window_s=900.0, max_keys=128)
+_LOAD_FAILURE_ALERT_COOLDOWN_SEC = 1800.0
+_load_failure_state: dict[str, Any] = {"key": None, "last_alert": 0.0, "failures": 0}
 _PROCESS_LOCK = asyncio.Lock()
 _REQUIRED_COLUMNS: tuple[str, ...] = (
     "reset_id",
@@ -136,12 +139,36 @@ def _resolve_header_map(header: list[Any]) -> dict[str, int]:
 
 
 async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord]]:
-    tab_name = _tab_name()
-    matrix = await afetch_values(_sheet_id(), tab_name)
-    if not matrix:
-        return tab_name, {}, []
+    stage = "config_load"
+    started = time.monotonic()
+    tab_name = "unknown"
+    try:
+        tab_name = _tab_name()
+        sheet_id = _sheet_id()
+        stage = "sheet_fetch"
+        matrix = await afetch_values(sheet_id, tab_name)
+        if not matrix:
+            return tab_name, {}, []
 
-    header_map = _resolve_header_map(matrix[0])
+        stage = "parse_rows"
+        header_map = _resolve_header_map(matrix[0])
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        setattr(exc, "reset_reminder_stage", stage)
+        setattr(exc, "reset_reminder_tab", tab_name)
+        setattr(exc, "reset_reminder_elapsed", elapsed)
+        log.exception(
+            "reset reminder load failed",
+            extra={
+                "scheduler": "reset_reminders",
+                "config_key": _RESET_REMINDER_TAB_KEY,
+                "tab": tab_name,
+                "operation": stage,
+                "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
+                "elapsed_s": round(elapsed, 3),
+            },
+        )
+        raise
     records: list[_ResetReminderRecord] = []
     invalid_rows: list[dict[str, Any]] = []
 
@@ -270,6 +297,52 @@ async def _send_ops_log(message: str) -> None:
         await rt.send_log_message(message)
     except Exception:
         log.warning("failed to send reset reminder ops alert", exc_info=True)
+
+
+def _load_failure_key(exc: Exception) -> str:
+    stage = getattr(exc, "reset_reminder_stage", "unknown")
+    tab = getattr(exc, "reset_reminder_tab", "unknown")
+    return f"{type(exc).__name__}:{stage}:{tab}"
+
+
+async def _record_load_failure(exc: Exception) -> None:
+    state = _load_failure_state
+    key = _load_failure_key(exc)
+    now = time.monotonic()
+    previous_key = state.get("key")
+    state["key"] = key
+    state["failures"] = (int(state.get("failures") or 0) + 1) if previous_key == key else 1
+
+    stage = getattr(exc, "reset_reminder_stage", "unknown")
+    tab = getattr(exc, "reset_reminder_tab", "unknown")
+    elapsed = getattr(exc, "reset_reminder_elapsed", None)
+    log.exception(
+        "failed to load reset reminders; scheduler tick skipped",
+        extra={
+            "scheduler": "reset_reminders",
+            "config_key": _RESET_REMINDER_TAB_KEY,
+            "tab": tab,
+            "operation": stage,
+            "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
+            "elapsed_s": round(float(elapsed), 3) if isinstance(elapsed, (int, float)) else None,
+            "failure_count": state["failures"],
+        },
+    )
+
+    last_alert = float(state.get("last_alert") or 0.0)
+    if previous_key != key or now - last_alert >= _LOAD_FAILURE_ALERT_COOLDOWN_SEC:
+        state["last_alert"] = now
+        await _send_ops_log(
+            "⚠️ Reset reminders failed to load; scheduler tick skipped. "
+            f"See app logs. error={type(exc).__name__}"
+        )
+
+
+async def _record_load_success() -> None:
+    failures = int(_load_failure_state.get("failures") or 0)
+    if failures > 0:
+        await _send_ops_log(f"✅ Reset reminders loaded again after {failures} failed tick(s).")
+    _load_failure_state.update({"key": None, "last_alert": 0.0, "failures": 0})
 
 
 async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) -> discord.abc.Messageable | None:
@@ -407,12 +480,9 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
         try:
             tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
         except Exception as exc:
-            log.exception("failed to load reset reminders; scheduler tick skipped")
-            await _send_ops_log(
-                "⚠️ Reset reminders failed to load; scheduler tick skipped "
-                f"• error={type(exc).__name__}: {str(exc)[:180]}"
-            )
+            await _record_load_failure(exc)
             return
+        await _record_load_success()
 
         if not records:
             return
@@ -582,4 +652,5 @@ __all__ = [
     "process_reset_reminders",
     "register_persistent_reset_views",
     "schedule_reset_reminder_jobs",
+    "_load_failure_state",
 ]

--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -9,6 +9,9 @@ from typing import Any, Iterable, Mapping, Sequence
 import discord
 from discord.ext import commands
 
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+
 from modules.common import feature_flags
 from modules.common import runtime as runtime_helpers
 from shared.sheets import async_core
@@ -434,7 +437,55 @@ async def run_cleanup(
     await runtime_helpers.send_log_message(f"🧹 {summary}")
 
 
+class CleanupCog(commands.Cog):
+    """Admin commands for housekeeping cleanup."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="housekeeping", access_tier="admin")
+    @commands.group(name="cleanup", invoke_without_command=True, help="Housekeeping cleanup admin commands.")
+    @commands.guild_only()
+    @admin_only()
+    async def cleanup(self, ctx: commands.Context) -> None:
+        await ctx.reply("Usage: `!cleanup run`", mention_author=False)
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="housekeeping", access_tier="admin")
+    @cleanup.command(name="run", help="Run housekeeping cleanup immediately.")
+    @commands.guild_only()
+    @admin_only()
+    async def cleanup_run(self, ctx: commands.Context) -> None:
+        actor_id = getattr(getattr(ctx, "author", None), "id", None)
+        channel_id = getattr(getattr(ctx, "channel", None), "id", None)
+        log.info("cleanup manual run requested: actor=%s channel=%s", actor_id, channel_id)
+        try:
+            await runtime_helpers.send_log_message(
+                f"🧹 cleanup manual run requested: actor={actor_id} channel={channel_id}"
+            )
+        except Exception:
+            log.warning("cleanup manual run notice failed", exc_info=True)
+
+        await ctx.reply("Cleanup run started.", mention_author=False)
+        try:
+            await run_cleanup(ctx.bot, log, startup_validation=False, writeback=True)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("cleanup manual run failed")
+            try:
+                await runtime_helpers.send_log_message("🧹 cleanup manual run failed; see app logs")
+            except Exception:
+                log.warning("cleanup manual failure notice failed", exc_info=True)
+            await ctx.reply("Cleanup run failed; see logs.", mention_author=False)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CleanupCog(bot))
+
+
 __all__ = [
     "BOT_WRITABLE_HEADERS", "CleanupConfig", "REQUIRED_CONFIG_KEYS", "REQUIRED_HEADERS",
-    "build_header_map", "resolve_cleanup_config", "rows_from_values", "run_cleanup", "_matches_mode", "_row_update",
+    "CleanupCog", "build_header_map", "resolve_cleanup_config", "rows_from_values", "run_cleanup", "setup", "_matches_mode", "_row_update",
 ]

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -469,3 +469,54 @@ def test_empty_thread_id_posts_to_channel_id(monkeypatch) -> None:
 
     assert len(channel.sent) == 1
     assert updates[-1]["reset_time"] == reference
+
+
+def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(monkeypatch) -> None:
+    now = dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc)
+    sent_logs = []
+    outcomes = [TimeoutError(), TimeoutError(), ("ResetTab", {}, [])]
+
+    async def _load(*, active_only: bool):
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            setattr(outcome, "reset_reminder_stage", "sheet_fetch")
+            setattr(outcome, "reset_reminder_tab", "ResetTab")
+            setattr(outcome, "reset_reminder_elapsed", 30.0)
+            raise outcome
+        return outcome
+
+    async def _send(message: str):
+        sent_logs.append(message)
+
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
+    monkeypatch.setattr(scheduler, "_send_ops_log", _send)
+    monkeypatch.setattr(scheduler, "_load_failure_state", {"key": None, "last_alert": 0.0, "failures": 0})
+    monkeypatch.setattr(scheduler, "time", SimpleNamespace(monotonic=lambda: 100.0))
+
+    bot = _DummyBot(_DummyChannel())
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+    asyncio.run(scheduler.process_reset_reminders(bot, now=now))
+
+    assert sent_logs == [
+        "⚠️ Reset reminders failed to load; scheduler tick skipped. See app logs. error=TimeoutError",
+        "✅ Reset reminders loaded again after 2 failed tick(s).",
+    ]
+
+
+def test_reset_reminder_scheduler_runner_continues_after_timeout(monkeypatch) -> None:
+    runtime = SimpleNamespace(bot=_DummyBot(_DummyChannel()), scheduler=_FakeScheduler())
+    calls = {"count": 0}
+
+    async def _process(_bot):
+        calls["count"] += 1
+
+    monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
+    monkeypatch.setattr(scheduler, "process_reset_reminders", _process)
+
+    scheduler.schedule_reset_reminder_jobs(runtime)
+    asyncio.run(runtime.scheduler.jobs[0]._runner())
+    asyncio.run(runtime.scheduler.jobs[0]._runner())
+
+    assert calls["count"] == 2

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -1,4 +1,6 @@
 import asyncio
+import pytest
+from discord.ext import commands
 from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 
@@ -486,6 +488,96 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(monkeypa
     registration_notice = rt.scheduler.spawned[1]["coro"]
     asyncio.run(registration_notice)
     assert sent_logs == [
+        "🧹 cleanup watcher tick: startup_validation=false writeback=true",
         "🧹 cleanup watcher scheduled: every=6h dry_run=true "
-        "tab=CleanupRows next_run=2026-06-26T12:00:00Z"
+        "tab=CleanupRows next_run=2026-06-26T12:00:00Z",
     ]
+
+
+def test_cleanup_manual_command_is_admin_only():
+    admin_checks = [
+        check for check in cleanup.CleanupCog.cleanup_run.checks
+        if getattr(check, "__module__", "") == "c1c_coreops.rbac"
+        and getattr(check, "__qualname__", "").startswith("admin_only")
+    ]
+    assert admin_checks, "!cleanup run must use the shared admin_only gate"
+
+    replies = []
+
+    class Ctx:
+        guild = object()
+        author = object()
+        command = cleanup.CleanupCog.cleanup_run
+
+        async def reply(self, message, *, mention_author=False):
+            replies.append((message, mention_author))
+
+    with pytest.raises(commands.CheckFailure):
+        asyncio.run(admin_checks[0](Ctx()))
+    assert replies == [("Admins only.", False)]
+
+
+def test_cleanup_manual_command_calls_real_cleanup(monkeypatch, caplog):
+    calls = []
+    replies = []
+    sent_logs = []
+
+    async def fake_run_cleanup(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    async def fake_send_log(message):
+        sent_logs.append(message)
+
+    class Ctx:
+        bot = object()
+        author = SimpleNamespace(id=1234)
+        channel = SimpleNamespace(id=5678)
+
+        async def reply(self, message, *, mention_author=False):
+            replies.append((message, mention_author))
+
+    monkeypatch.setattr(cleanup, "run_cleanup", fake_run_cleanup)
+    monkeypatch.setattr(cleanup.runtime_helpers, "send_log_message", fake_send_log)
+    caplog.set_level("INFO", logger="c1c.housekeeping.cleanup")
+
+    cog = cleanup.CleanupCog(object())
+    asyncio.run(cog.cleanup_run.callback(cog, Ctx()))
+
+    assert replies == [("Cleanup run started.", False)]
+    assert sent_logs == ["🧹 cleanup manual run requested: actor=1234 channel=5678"]
+    assert "cleanup manual run requested: actor=1234 channel=5678" in caplog.text
+    assert calls[0][0] == (Ctx.bot, cleanup.log)
+    assert calls[0][1] == {"startup_validation": False, "writeback": True}
+
+
+def test_cleanup_manual_command_handles_failure(monkeypatch, caplog):
+    replies = []
+    sent_logs = []
+
+    async def fake_run_cleanup(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    async def fake_send_log(message):
+        sent_logs.append(message)
+
+    class Ctx:
+        bot = object()
+        author = SimpleNamespace(id=1234)
+        channel = SimpleNamespace(id=5678)
+
+        async def reply(self, message, *, mention_author=False):
+            replies.append((message, mention_author))
+
+    monkeypatch.setattr(cleanup, "run_cleanup", fake_run_cleanup)
+    monkeypatch.setattr(cleanup.runtime_helpers, "send_log_message", fake_send_log)
+    caplog.set_level("ERROR", logger="c1c.housekeeping.cleanup")
+
+    cog = cleanup.CleanupCog(object())
+    asyncio.run(cog.cleanup_run.callback(cog, Ctx()))
+
+    assert replies == [("Cleanup run started.", False), ("Cleanup run failed; see logs.", False)]
+    assert sent_logs == [
+        "🧹 cleanup manual run requested: actor=1234 channel=5678",
+        "🧹 cleanup manual run failed; see app logs",
+    ]
+    assert "cleanup manual run failed" in caplog.text


### PR DESCRIPTION
### Motivation

- Surface and control the housekeeping cleanup process via a protected admin command and provide visible scheduler tick notices for operational awareness.
- Make reset reminders scheduler more robust by improving error telemetry, rate-limiting ops alerts for repeated load failures, and emitting recovery notifications when loads succeed again.

### Description

- Add a `CleanupCog` with an admin-only `!cleanup` command and `!cleanup run` subcommand and register it via a new `setup` function in `modules/housekeeping/cleanup.py` and export it in `__all__`.
- Emit a tick notice when the cleanup scheduler runner begins (`cleanup watcher tick: startup_validation=false writeback=true`) and attempt to send the same notice to ops via `send_log_message`; add failure notice on exceptions during scheduled runs.
- In `modules/community/reset_reminders/scheduler.py` add structured exception metadata when loading sheet rows, introduce `_load_failure_state`, `_load_failure_key`, `_record_load_failure`, and `_record_load_success` helpers, and implement a cooldown (`_LOAD_FAILURE_ALERT_COOLDOWN_SEC`) so ops alerts on repeated identical failures are rate-limited and a recovery message is sent once loading succeeds again.
- Improve logging for load failures by including `stage`, `tab`, `elapsed_s`, and `timeout_type` context and re-raise to preserve original control flow; export `_load_failure_state` for test visibility.
- Wire the housekeeping cleanup command into runtime by importing and calling its `setup` in `Runtime.load_extensions` and log registration messages.

### Testing

- Ran unit tests covering the reset reminders scheduler: `tests/community/test_reset_reminder_scheduler.py::test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers` and `tests/community/test_reset_reminder_scheduler.py::test_reset_reminder_scheduler_runner_continues_after_timeout`, which passed.
- Ran housekeeping tests in `tests/modules/housekeeping/test_cleanup.py` including scheduler registration, admin gate checks, manual run success, and manual run failure handling, which passed under `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe325a40c83239002b5b2280bdb60)