### PR TITLE
Fix housekeeping cleanup deletion and surface actionable summary errors

### DIFF
--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -59,6 +59,7 @@ ALLOWED_CLEANUP_MODES = {
     "commands_only",
     "bot_messages_and_commands",
 }
+_CLEANUP_RUN_LOCK = asyncio.Lock()
 
 
 @dataclass(frozen=True)
@@ -107,6 +108,38 @@ def _short_error(exc: BaseException, *, limit: int = 180) -> str:
     if len(text) > limit:
         text = text[: max(0, limit - 1)].rstrip() + "…"
     return text
+
+
+def _format_summary_error(summary: CleanupRunSummary, *, limit: int = 180) -> str:
+    first_error = " ".join((summary.first_error or "").split())
+    if not first_error:
+        return ""
+    stage_marker = " stage="
+    if stage_marker in first_error:
+        first_error, stage = first_error.split(stage_marker, 1)
+        stage = stage.split()[0].strip()
+        first_error = f"{first_error.strip()} at {stage}" if stage else first_error.strip()
+    if len(first_error) > limit:
+        first_error = first_error[: max(0, limit - 1)].rstrip() + "…"
+    return first_error
+
+
+def _manual_finished_message(summary: CleanupRunSummary) -> str:
+    has_errors = summary.errors > 0 or bool(summary.first_error)
+    prefix = "Cleanup run finished with errors: " if has_errors else "Cleanup run finished: "
+    message = (
+        prefix +
+        f"deleted={summary.deleted} candidates={summary.candidates} "
+        f"skipped={summary.skipped} errors={summary.errors}"
+    )
+    if has_errors:
+        message += f" status={summary.status}"
+        first_error = _format_summary_error(summary)
+        if first_error:
+            message += f" first_error={first_error}"
+    if summary.summary_notice_failed:
+        message += "; Discord summary notice failed. See app logs."
+    return message
 
 
 def _utc_now() -> datetime:
@@ -282,7 +315,13 @@ async def _delete_messages(messages: Sequence[discord.Message], logger: logging.
     deleted = errors = 0
     for message in messages:
         try:
-            await message.delete(reason="housekeeping cleanup")
+            try:
+                await message.delete(reason="housekeeping cleanup")
+            except TypeError as exc:
+                error_text = str(exc)
+                if "reason" not in error_text or "unexpected" not in error_text:
+                    raise
+                await message.delete()
         except discord.NotFound:
             continue
         except discord.Forbidden:
@@ -290,6 +329,14 @@ async def _delete_messages(messages: Sequence[discord.Message], logger: logging.
             return CleanupResult("missing_permissions", deleted, len(messages), 0, errors)
         except discord.HTTPException as exc:
             logger.warning("cleanup delete failed: target_id=%s error=%s", getattr(getattr(message, "channel", None), "id", None), exc)
+            errors += 1
+        except Exception as exc:
+            logger.warning(
+                "cleanup delete failed unexpectedly: target_id=%s error_type=%s error=%s",
+                getattr(getattr(message, "channel", None), "id", None),
+                exc.__class__.__name__,
+                _short_error(exc),
+            )
             errors += 1
         else:
             deleted += 1
@@ -357,10 +404,29 @@ def _row_update(row: CleanupRow, header_map: Mapping[str, int], updates: Mapping
 async def _flush_updates(worksheet: Any, updates: Mapping[str, str]) -> None:
     if not updates:
         return
-    await asyncio.to_thread(worksheet.batch_update, [{"range": cell, "values": [[value]]} for cell, value in updates.items()])
+    await async_core.acall_with_backoff(
+        worksheet.batch_update,
+        [{"range": cell, "values": [[value]]} for cell, value in updates.items()],
+    )
 
 
 async def run_cleanup(
+    bot: commands.Bot,
+    logger: logging.Logger | None = None,
+    *,
+    startup_validation: bool = False,
+    writeback: bool = True,
+) -> CleanupRunSummary:
+    logger = logger or log
+    if startup_validation and _CLEANUP_RUN_LOCK.locked():
+        summary = CleanupRunSummary(writeback=writeback, dry_run=True, status="startup_validation_skipped", first_error="cleanup run already in progress stage=startup_validation")
+        logger.info("cleanup startup validation skipped; another cleanup run is already in progress")
+        return summary
+    async with _CLEANUP_RUN_LOCK:
+        return await _run_cleanup_locked(bot, logger, startup_validation=startup_validation, writeback=writeback)
+
+
+async def _run_cleanup_locked(
     bot: commands.Bot,
     logger: logging.Logger | None = None,
     *,
@@ -386,7 +452,7 @@ async def run_cleanup(
             worksheet = await async_core.aget_worksheet(recruitment.get_recruitment_sheet_id(), config.tab_name)
             stage = "read_values"
             context["stage"] = stage
-            values = await asyncio.to_thread(worksheet.get_all_values)
+            values = await async_core.acall_with_backoff(worksheet.get_all_values)
             if not values:
                 raise ValueError("cleanup tab is empty")
             stage = "build_headers"
@@ -398,7 +464,7 @@ async def run_cleanup(
         except Exception as exc:
             summary.status = "sheet_unavailable_or_invalid"
             summary.errors += 1
-            summary.first_error = f"{exc.__class__.__name__}: {_short_error(exc)}"
+            summary.first_error = f"{exc.__class__.__name__}: {_short_error(exc)} stage={context.get('stage')}"
             logger.warning(
                 "cleanup sheet unavailable or invalid: error_type=%s error=%s stage=%s",
                 exc.__class__.__name__,
@@ -488,7 +554,7 @@ async def run_cleanup(
         except Exception as exc:
             summary.errors += 1
             if not summary.first_error:
-                summary.first_error = f"{exc.__class__.__name__}: {_short_error(exc)}"
+                summary.first_error = f"{exc.__class__.__name__}: {_short_error(exc)} stage={stage}"
             logger.warning(
                 "cleanup sheet writeback failed: error_type=%s error=%s stage=%s",
                 exc.__class__.__name__, _short_error(exc), stage,
@@ -497,6 +563,11 @@ async def run_cleanup(
         trigger = "startup_validation" if startup_validation else "scheduled_or_manual"
         writeback_label = str(writeback).lower()
         summary_text = f"cleanup run complete: trigger={trigger} checked_rows={summary.checked_rows} dry_run={str(effective_dry_run).lower()} writeback={writeback_label} deleted={summary.deleted} candidates={summary.candidates} skipped={summary.skipped} errors={summary.errors}"
+        if summary.errors > 0 or summary.first_error:
+            summary_text += f" status={summary.status}"
+            first_error = _format_summary_error(summary)
+            if first_error:
+                summary_text += f" first_error={first_error}"
         logger.info(summary_text)
         try:
             stage = "send_summary_log"
@@ -595,13 +666,11 @@ class CleanupCog(commands.Cog):
             await ctx.reply(f"Cleanup run failed: {error_type}. See logs.", mention_author=False)
             return
 
-        finished = (
-            "Cleanup run finished: "
-            f"deleted={summary.deleted} candidates={summary.candidates} "
-            f"skipped={summary.skipped} errors={summary.errors}"
-        )
-        if summary.summary_notice_failed:
-            finished += "; Discord summary notice failed. See app logs."
+        finished = _manual_finished_message(summary)
+        try:
+            await runtime_helpers.send_log_message(f"🧹 {finished}")
+        except Exception:
+            log.warning("cleanup manual completion notice failed", exc_info=True)
         await ctx.reply(finished, mention_author=False)
 
 

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -96,6 +96,26 @@ class Msg:
         self.deleted = True
 
 
+class PartialMsgNoReason(Msg):
+    async def delete(self):
+        self.deleted = True
+
+
+class MsgWithReason(Msg):
+    def __init__(self, content, *, author_id=10, pinned=False, hours_old=10):
+        super().__init__(content, author_id=author_id, pinned=pinned, hours_old=hours_old)
+        self.delete_reasons = []
+
+    async def delete(self, reason=None):
+        self.delete_reasons.append(reason)
+        self.deleted = True
+
+
+class MsgUnexpectedTypeError(Msg):
+    async def delete(self, reason=None):
+        raise TypeError("network adapter exploded")
+
+
 class HistoryTarget:
     id = 123
     name = "target-name"
@@ -190,6 +210,40 @@ def test_cleanup_modes_and_min_age_respected(monkeypatch):
     assert updates["J2"] == "2"
     assert updates["K2"] == "3"
     assert updates["L2"] == "deleted"
+
+
+def test_delete_messages_retries_partial_message_without_reason():
+    msg = PartialMsgNoReason("bot", author_id=99)
+
+    result = asyncio.run(cleanup._delete_messages([msg], cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 1
+    assert result.errors == 0
+    assert msg.deleted is True
+
+
+def test_delete_messages_still_passes_reason_when_supported():
+    msg = MsgWithReason("bot", author_id=99)
+
+    result = asyncio.run(cleanup._delete_messages([msg], cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 1
+    assert msg.delete_reasons == ["housekeeping cleanup"]
+
+
+def test_delete_messages_counts_unexpected_type_error_and_continues(caplog):
+    bad = MsgUnexpectedTypeError("bad", author_id=99)
+    good = Msg("good", author_id=99)
+
+    result = asyncio.run(cleanup._delete_messages([bad, good], cleanup.log))
+
+    assert result.status == "partial_delete_failed"
+    assert result.deleted == 1
+    assert result.errors == 1
+    assert good.deleted is True
+    assert "cleanup delete failed unexpectedly" in caplog.text
 
 
 def test_all_non_pinned_skips_pinned(monkeypatch):
@@ -547,10 +601,53 @@ def test_cleanup_manual_command_calls_real_cleanup(monkeypatch, caplog):
         ("Cleanup run started.", False),
         ("Cleanup run finished: deleted=0 candidates=0 skipped=0 errors=0", False),
     ]
-    assert sent_logs == ["🧹 cleanup manual run requested: actor=1234 channel=5678"]
+    assert sent_logs == [
+        "🧹 cleanup manual run requested: actor=1234 channel=5678",
+        "🧹 Cleanup run finished: deleted=0 candidates=0 skipped=0 errors=0",
+    ]
     assert "cleanup manual run requested: actor=1234 channel=5678" in caplog.text
     assert calls[0][0] == (Ctx.bot, cleanup.log)
     assert calls[0][1] == {"startup_validation": False, "writeback": True}
+
+
+def test_cleanup_manual_command_surfaces_summary_errors(monkeypatch):
+    replies = []
+    sent_logs = []
+    summary = cleanup.CleanupRunSummary(
+        deleted=0,
+        candidates=0,
+        skipped=0,
+        errors=1,
+        status="sheet_unavailable_or_invalid",
+        first_error="APIError: quota exceeded stage=read_values",
+    )
+
+    async def fake_run_cleanup(*_args, **_kwargs):
+        return summary
+
+    async def fake_send_log(message):
+        sent_logs.append(message)
+
+    class Ctx:
+        bot = object()
+        author = SimpleNamespace(id=1234)
+        channel = SimpleNamespace(id=5678)
+
+        async def reply(self, message, *, mention_author=False):
+            replies.append((message, mention_author))
+
+    monkeypatch.setattr(cleanup, "run_cleanup", fake_run_cleanup)
+    monkeypatch.setattr(cleanup.runtime_helpers, "send_log_message", fake_send_log)
+
+    cog = cleanup.CleanupCog(object())
+    asyncio.run(cog.cleanup_run.callback(cog, Ctx()))
+
+    expected = (
+        "Cleanup run finished with errors: deleted=0 candidates=0 skipped=0 errors=1 "
+        "status=sheet_unavailable_or_invalid first_error=APIError: quota exceeded at read_values"
+    )
+    assert replies[-1] == (expected, False)
+    assert sent_logs[-1] == f"🧹 {expected}"
 
 
 def test_cleanup_manual_command_handles_failure(monkeypatch, caplog):
@@ -619,6 +716,35 @@ def test_run_cleanup_summary_notice_failure_does_not_fail_cleanup(monkeypatch, c
     assert summary.summary_notice_failed is True
     assert "cleanup summary notice failed; cleanup completed" in caplog.text
     assert target.messages[0].deleted is True
+
+
+def test_run_cleanup_read_values_api_error_sets_actionable_first_error(monkeypatch):
+    class APIError(Exception):
+        pass
+
+    class FailingWorksheet:
+        def get_all_values(self):
+            raise APIError("quota exceeded")
+
+    cfg = cleanup.CleanupConfig(True, "CleanupRows", 6, True)
+
+    async def fake_sheet(*_):
+        return FailingWorksheet()
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(cleanup, "resolve_cleanup_config", lambda logger=None: cfg)
+    monkeypatch.setattr(cleanup.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(cleanup.async_core, "aget_worksheet", fake_sheet)
+    monkeypatch.setattr(cleanup.async_core, "acall_with_backoff", fake_acall)
+
+    summary = asyncio.run(cleanup.run_cleanup(Bot(Thread([]))))
+
+    assert summary.status == "sheet_unavailable_or_invalid"
+    assert summary.errors == 1
+    assert summary.first_error == "APIError: quota exceeded stage=read_values"
+    assert cleanup._format_summary_error(summary) == "APIError: quota exceeded at read_values"
 
 
 def test_run_cleanup_unexpected_failure_logs_stage_and_context(monkeypatch, caplog):


### PR DESCRIPTION
### Motivation
- PartialMessage.delete in production raised `TypeError` when passed `reason=...`, aborting cleanup runs and preventing sheet writeback.
- Manual `!cleanup run` replies were unhelpful when sheet/Sheets API failures occurred (e.g. APIError 429), leaving admins without an actionable first error or stage.
- Cleanup startup/reads can compete with other startup sheet loads and cause quota pressure; make reads/writes use shared async backoff and avoid duplicate startup validation runs.
- Preserve existing safety constraints: do not change sheet schema, cleanup matching rules, pinned-message protection, or make startup writebacks/deletes on deploy.

### Description
- Update ` _delete_messages` to `try await message.delete(reason="housekeeping cleanup")` and on a `TypeError` retry `await message.delete()` so `discord.PartialMessage` implementations that don't accept `reason` are handled safely, while keeping `NotFound`, `Forbidden`, and `HTTPException` behavior and counting unexpected per-message failures without crashing the run.
- Add defensive logging for unexpected delete errors and classify per-message failures into `delete_failed` / `partial_delete_failed` results so a single TypeError does not abort the whole cleanup.
- Add `_format_summary_error` and `_manual_finished_message` helpers and change the manual command reply so when `summary.errors > 0` or `summary.first_error` is set the reply and ops-log message include `status` and a capped `first_error` (approx 180 chars) in the form `first_error=... at <stage>`.
- Preserve stage context in `CleanupRunSummary.first_error` by appending `stage=<stage>` where sheet/read/write failures occur, and convert that into the admin-facing `at <stage>` text in summaries.
- Use the shared Sheets async backoff helpers for reads/writes by switching to `async_core.acall_with_backoff` for `worksheet.get_all_values` and `worksheet.batch_update` to reduce transient quota failures.
- Add `_CLEANUP_RUN_LOCK` so startup validation will skip if another cleanup run is active (returns a short `startup_validation_skipped` summary) to reduce competing startup reads.
- Add and update unit tests covering PartialMessage-style deletes, reason-preserving deletes, unexpected delete errors, manual summary formatting with `first_error`, and actionable `read_values` API errors.

### Testing
- Ran `pytest tests/modules/housekeeping/test_cleanup.py tests/housekeeping/test_cleanup_config.py` with all tests passing (37 passed, 0 failed).
- Ran `python -m ruff check modules/housekeeping/cleanup.py tests/modules/housekeeping/test_cleanup.py` with no findings.
- Verified new tests exercise: `_delete_messages` PartialMessage retry, reason passed when supported, unexpected TypeError counted and logged, manual `!cleanup run` surfaces `status` + capped `first_error`, and `read_values` API error sets `first_error` with `stage=read_values`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff06e472c832399c3b0342bcca454)