### PR TITLE
Add async-safe Sheets helper and switch cleanup to use it

### DIFF
--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -404,7 +404,7 @@ def _row_update(row: CleanupRow, header_map: Mapping[str, int], updates: Mapping
 async def _flush_updates(worksheet: Any, updates: Mapping[str, str]) -> None:
     if not updates:
         return
-    await async_core.acall_with_backoff(
+    await async_core.a_to_thread_with_backoff(
         worksheet.batch_update,
         [{"range": cell, "values": [[value]]} for cell, value in updates.items()],
     )
@@ -452,7 +452,7 @@ async def _run_cleanup_locked(
             worksheet = await async_core.aget_worksheet(recruitment.get_recruitment_sheet_id(), config.tab_name)
             stage = "read_values"
             context["stage"] = stage
-            values = await async_core.acall_with_backoff(worksheet.get_all_values)
+            values = await async_core.a_to_thread_with_backoff(worksheet.get_all_values)
             if not values:
                 raise ValueError("cleanup tab is empty")
             stage = "build_headers"

--- a/shared/sheets/async_core.py
+++ b/shared/sheets/async_core.py
@@ -75,6 +75,30 @@ async def acall_with_backoff(
     )
 
 
+async def a_to_thread_with_backoff(
+    func: Callable[P, T],
+    *args: P.args,
+    attempts: int | None = None,
+    base_delay: float | None = None,
+    factor: float | None = None,
+    timeout: float | None = None,
+    **kwargs: P.kwargs,
+) -> T:
+    """Run a synchronous Sheets callable off-loop with async retry/backoff."""
+
+    async def _invoke() -> T:
+        if timeout is None:
+            return await _core.async_adapter.arun(func, *args, **kwargs)
+        return await _core.async_adapter.arun(func, *args, timeout=timeout, **kwargs)
+
+    return await _core._retry_with_backoff_async(
+        _invoke,
+        attempts=attempts,
+        base_delay=base_delay,
+        factor=factor,
+    )
+
+
 __all__ = [
     "aopen_by_key",
     "aget_worksheet",
@@ -82,4 +106,5 @@ __all__ = [
     "afetch_values",
     "asheets_read",
     "acall_with_backoff",
+    "a_to_thread_with_backoff",
 ]

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -1,8 +1,10 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
 import pytest
 from discord.ext import commands
-from types import SimpleNamespace
-from datetime import datetime, timedelta, timezone
+import shared.sheets.core as sheets_core
 
 from modules.common import runtime
 from modules.housekeeping import cleanup
@@ -177,6 +179,77 @@ def active_row(**overrides):
     data = {"enabled":"TRUE","target_id":"123","target_type":"","target_name":"","parent_name":"","cleanup_mode":"bot_messages_only","min_age_hours":"1","last_checked_at_utc":"","last_deleted_count":"","last_candidate_count":"","last_skipped_count":"","last_status":"","notes":"admin"}
     data.update(overrides)
     return [data[h] for h in REQUIRED_HEADERS]
+
+
+def test_run_cleanup_uses_async_safe_sheets_helper_for_read_and_write(monkeypatch):
+    ws = Worksheet([REQUIRED_HEADERS, active_row()])
+    target = Thread([Msg("bot", author_id=99)])
+    cfg = cleanup.CleanupConfig(True, "CleanupRows", 6, False)
+    calls = []
+
+    async def fake_sheet(*_):
+        return ws
+
+    async def fake_log(*_):
+        return None
+
+    async def fake_resolve(_bot, _target_id):
+        return target, "thread", None
+
+    async def fake_to_thread_with_backoff(func, *args, **kwargs):
+        calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    async def fail_acall_with_backoff(*_args, **_kwargs):
+        raise AssertionError("cleanup must use a_to_thread_with_backoff")
+
+    monkeypatch.setattr(cleanup, "resolve_cleanup_config", lambda logger=None: cfg)
+    monkeypatch.setattr(cleanup.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(cleanup.async_core, "aget_worksheet", fake_sheet)
+    monkeypatch.setattr(cleanup.async_core, "a_to_thread_with_backoff", fake_to_thread_with_backoff)
+    monkeypatch.setattr(cleanup.async_core, "acall_with_backoff", fail_acall_with_backoff)
+    monkeypatch.setattr(cleanup.runtime_helpers, "send_log_message", fake_log)
+    monkeypatch.setattr(cleanup, "_resolve_any", fake_resolve)
+
+    summary = asyncio.run(cleanup.run_cleanup(Bot(target)))
+
+    assert summary.status == "ok"
+    assert calls == ["get_all_values", "batch_update"]
+    assert update_map(ws)["L2"] == "deleted"
+
+
+def test_run_cleanup_does_not_raise_active_loop_retry_runtime_error(monkeypatch):
+    ws = Worksheet([REQUIRED_HEADERS, active_row()])
+    target = Thread([Msg("bot", author_id=99)])
+    cfg = cleanup.CleanupConfig(True, "CleanupRows", 6, False)
+
+    async def fake_sheet(*_):
+        return ws
+
+    async def fake_log(*_):
+        return None
+
+    async def fake_resolve(_bot, _target_id):
+        return target, "thread", None
+
+    async def fake_arun(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    def fail_sync_retry(*_args, **_kwargs):
+        raise RuntimeError("_retry_with_backoff must not run inside an active event loop; use the async variant")
+
+    monkeypatch.setattr(cleanup, "resolve_cleanup_config", lambda logger=None: cfg)
+    monkeypatch.setattr(cleanup.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
+    monkeypatch.setattr(cleanup.async_core, "aget_worksheet", fake_sheet)
+    monkeypatch.setattr(cleanup.runtime_helpers, "send_log_message", fake_log)
+    monkeypatch.setattr(cleanup, "_resolve_any", fake_resolve)
+    monkeypatch.setattr(sheets_core.async_adapter, "arun", fake_arun)
+    monkeypatch.setattr(sheets_core, "_retry_with_backoff", fail_sync_retry)
+
+    summary = asyncio.run(cleanup.run_cleanup(Bot(target)))
+
+    assert summary.status == "ok"
+    assert update_map(ws)["L2"] == "deleted"
 
 
 def test_blank_target_type_resolved_and_dry_run_deletes_nothing(monkeypatch):
@@ -731,13 +804,13 @@ def test_run_cleanup_read_values_api_error_sets_actionable_first_error(monkeypat
     async def fake_sheet(*_):
         return FailingWorksheet()
 
-    async def fake_acall(func, *args, **kwargs):
+    async def fake_to_thread_with_backoff(func, *args, **kwargs):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(cleanup, "resolve_cleanup_config", lambda logger=None: cfg)
     monkeypatch.setattr(cleanup.recruitment, "get_recruitment_sheet_id", lambda: "sheet")
     monkeypatch.setattr(cleanup.async_core, "aget_worksheet", fake_sheet)
-    monkeypatch.setattr(cleanup.async_core, "acall_with_backoff", fake_acall)
+    monkeypatch.setattr(cleanup.async_core, "a_to_thread_with_backoff", fake_to_thread_with_backoff)
 
     summary = asyncio.run(cleanup.run_cleanup(Bot(Thread([]))))
 

--- a/tests/shared/sheets/test_async_core.py
+++ b/tests/shared/sheets/test_async_core.py
@@ -1,0 +1,77 @@
+import asyncio
+import time
+
+import shared.sheets.async_core as async_core
+import shared.sheets.core as core
+
+
+def test_a_to_thread_with_backoff_does_not_use_sync_retry_inside_event_loop(monkeypatch):
+    sync_retry_calls = []
+
+    def fail_sync_retry(*_args, **_kwargs):
+        sync_retry_calls.append(True)
+        raise AssertionError("sync retry helper must not run inside the event loop")
+
+    async def fake_async_retry(func, *args, **_kwargs):
+        return await func(*args)
+
+    monkeypatch.setattr(core, "_retry_with_backoff", fail_sync_retry)
+    monkeypatch.setattr(core, "_retry_with_backoff_async", fake_async_retry)
+
+    result = asyncio.run(async_core.a_to_thread_with_backoff(lambda: "ok"))
+
+    assert result == "ok"
+    assert sync_retry_calls == []
+
+
+def test_a_to_thread_with_backoff_can_be_awaited_inside_active_event_loop(monkeypatch):
+    async def fake_arun(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(core.async_adapter, "arun", fake_arun)
+
+    async def run_inside_loop():
+        return await async_core.a_to_thread_with_backoff(lambda value: f"{value}-ok", "loop")
+
+    assert asyncio.run(run_inside_loop()) == "loop-ok"
+
+
+def test_a_to_thread_with_backoff_retries_with_async_sleep_not_time_sleep(monkeypatch):
+    calls = []
+    sleeps = []
+
+    class QuotaError(Exception):
+        status_code = 429
+
+    def flaky_call():
+        calls.append("call")
+        if len(calls) == 1:
+            raise QuotaError("429 quota exceeded")
+        return "retried"
+
+    async def fake_arun(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    async def fake_async_sleep(delay):
+        sleeps.append(delay)
+
+    def fail_time_sleep(_delay):
+        raise AssertionError("async Sheets retry must not use time.sleep")
+
+    monkeypatch.setattr(core.async_adapter, "arun", fake_arun)
+    monkeypatch.setattr(core.asyncio, "sleep", fake_async_sleep)
+    monkeypatch.setattr(time, "sleep", fail_time_sleep)
+
+    result = asyncio.run(
+        async_core.a_to_thread_with_backoff(
+            flaky_call,
+            attempts=2,
+            base_delay=0.25,
+            factor=2,
+        )
+    )
+
+    assert result == "retried"
+    assert calls == ["call", "call"]
+    assert len(sleeps) == 1
+    assert 0.1875 <= sleeps[0] <= 0.3125


### PR DESCRIPTION
### Motivation

- Prevent running the synchronous retry helper inside an active event loop by providing an async-friendly wrapper to run blocking Sheets callables off-loop with async backoff. 
- Ensure housekeeping cleanup uses the async-safe helper for reading and writing the recruitment sheet to avoid `RuntimeError` during event-loop activity.

### Description

- Added `a_to_thread_with_backoff` to `shared/sheets/async_core.py` which runs synchronous Sheets callables off-loop via the async adapter and retries using the async retry helper, and exported it in `__all__`.
- Replaced usages of `acall_with_backoff` in `modules/housekeeping/cleanup.py` with `a_to_thread_with_backoff` for `worksheet.get_all_values` and `worksheet.batch_update` to ensure async-safe execution.
- Updated `tests/modules/housekeeping/test_cleanup.py` to assert the new helper is used and to guard against active-loop retry runtime errors, and added `tests/shared/sheets/test_async_core.py` to exercise `a_to_thread_with_backoff` behaviors.

### Testing

- Ran the updated housekeeping tests in `tests/modules/housekeeping/test_cleanup.py` which verify `a_to_thread_with_backoff` is invoked and that cleanup succeeds under active event-loop scenarios (tests passed).
- Ran the new unit tests in `tests/shared/sheets/test_async_core.py` which validate retry behavior, use of the async adapter, and that no sync retry runs inside the event loop (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff486b6d08323a9d9cd8c176d9cce)