### PR TITLE
Add configurable delete pacing to housekeeping cleanup and tests

### DIFF
--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -24,6 +24,9 @@ CONFIG_ENABLED = "HOUSEKEEPING_CLEANUP_ENABLED"
 CONFIG_TAB = "HOUSEKEEPING_CLEANUP_TAB"
 CONFIG_RUN_EVERY_HOURS = "HOUSEKEEPING_CLEANUP_RUN_EVERY_HOURS"
 CONFIG_DRY_RUN = "HOUSEKEEPING_CLEANUP_DRY_RUN"
+CONFIG_DELETE_BATCH_SIZE = "HOUSEKEEPING_CLEANUP_DELETE_BATCH_SIZE"
+CONFIG_DELETE_BATCH_PAUSE_SECONDS = "HOUSEKEEPING_CLEANUP_DELETE_BATCH_PAUSE_SECONDS"
+CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS = "HOUSEKEEPING_CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS"
 CONFIG_BOT_ROLE_IDS = "HOUSEKEEPING_CLEANUP_BOT_ROLE_IDS"
 REQUIRED_CONFIG_KEYS = (CONFIG_TAB, CONFIG_RUN_EVERY_HOURS, CONFIG_DRY_RUN)
 REQUIRED_HEADERS = (
@@ -55,6 +58,9 @@ ALLOWED_TARGET_TYPES = {"thread", "channel"}
 # ``target_type=channel`` means cleanup of the configured target's own
 # message history. Child threads are not discovered or traversed automatically.
 SUPPORTED_TARGET_TYPES = {"thread", "channel"}
+CLEANUP_DELETE_BATCH_SIZE = 25
+CLEANUP_DELETE_BATCH_PAUSE_SECONDS = 2.0
+CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS = 0.15
 ALLOWED_CLEANUP_MODES = {
     "all_non_pinned",
     "bot_messages_only",
@@ -75,6 +81,9 @@ class CleanupConfig:
     run_every_hours: float
     dry_run: bool
     source: str = "Config"
+    delete_batch_size: int = CLEANUP_DELETE_BATCH_SIZE
+    delete_batch_pause_seconds: float = CLEANUP_DELETE_BATCH_PAUSE_SECONDS
+    delete_per_message_pause_seconds: float = CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS
 
 
 @dataclass
@@ -213,6 +222,70 @@ def _parse_nonnegative_hours(value: str | None) -> float | None:
     return parsed if parsed >= 0 else None
 
 
+def _parse_positive_int(value: str | None) -> int | None:
+    try:
+        parsed = int((value or "").strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _resolve_optional_pacing_config(
+    logger: logging.Logger,
+    *,
+    force_refresh: bool,
+) -> tuple[int, float, float]:
+    raw = {
+        CONFIG_DELETE_BATCH_SIZE: recruitment.get_config_value(
+            CONFIG_DELETE_BATCH_SIZE, None, force=force_refresh
+        ),
+        CONFIG_DELETE_BATCH_PAUSE_SECONDS: recruitment.get_config_value(
+            CONFIG_DELETE_BATCH_PAUSE_SECONDS, None, force=force_refresh
+        ),
+        CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS: recruitment.get_config_value(
+            CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS, None, force=force_refresh
+        ),
+    }
+    batch_size = CLEANUP_DELETE_BATCH_SIZE
+    batch_pause = CLEANUP_DELETE_BATCH_PAUSE_SECONDS
+    per_message_pause = CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS
+
+    if raw[CONFIG_DELETE_BATCH_SIZE] is not None and str(raw[CONFIG_DELETE_BATCH_SIZE]).strip():
+        parsed_batch_size = _parse_positive_int(raw[CONFIG_DELETE_BATCH_SIZE])
+        if parsed_batch_size is None:
+            logger.warning(
+                "cleanup pacing config invalid; using default: key=%s value=%r default=%s",
+                CONFIG_DELETE_BATCH_SIZE,
+                raw[CONFIG_DELETE_BATCH_SIZE],
+                CLEANUP_DELETE_BATCH_SIZE,
+            )
+        else:
+            batch_size = parsed_batch_size
+    if raw[CONFIG_DELETE_BATCH_PAUSE_SECONDS] is not None and str(raw[CONFIG_DELETE_BATCH_PAUSE_SECONDS]).strip():
+        parsed_batch_pause = _parse_nonnegative_hours(raw[CONFIG_DELETE_BATCH_PAUSE_SECONDS])
+        if parsed_batch_pause is None:
+            logger.warning(
+                "cleanup pacing config invalid; using default: key=%s value=%r default=%s",
+                CONFIG_DELETE_BATCH_PAUSE_SECONDS,
+                raw[CONFIG_DELETE_BATCH_PAUSE_SECONDS],
+                CLEANUP_DELETE_BATCH_PAUSE_SECONDS,
+            )
+        else:
+            batch_pause = parsed_batch_pause
+    if raw[CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS] is not None and str(raw[CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS]).strip():
+        parsed_per_message_pause = _parse_nonnegative_hours(raw[CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS])
+        if parsed_per_message_pause is None:
+            logger.warning(
+                "cleanup pacing config invalid; using default: key=%s value=%r default=%s",
+                CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS,
+                raw[CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS],
+                CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS,
+            )
+        else:
+            per_message_pause = parsed_per_message_pause
+    return batch_size, batch_pause, per_message_pause
+
+
 def resolve_cleanup_config(
     logger: logging.Logger | None = None,
     *,
@@ -261,18 +334,29 @@ def resolve_cleanup_config(
     if dry_run is None:
         logger.warning("cleanup not scheduled; invalid Config key %s", CONFIG_DRY_RUN)
         return None
+    batch_size, batch_pause, per_message_pause = _resolve_optional_pacing_config(
+        logger, force_refresh=force_refresh
+    )
     config = CleanupConfig(
         True,
         str(raw[CONFIG_TAB]).strip(),
         run_every,
         dry_run,
+        delete_batch_size=batch_size,
+        delete_batch_pause_seconds=batch_pause,
+        delete_per_message_pause_seconds=per_message_pause,
         source=f"{recruitment.get_config_tab_name()}:Config",
     )
     logger.info(
-        "cleanup config resolved: tab=%s run_every_hours=%s dry_run=%s source=%s",
+        "cleanup config resolved: tab=%s run_every_hours=%s dry_run=%s "
+        "delete_batch_size=%s delete_batch_pause_seconds=%s "
+        "delete_per_message_pause_seconds=%s source=%s",
         config.tab_name,
         f"{config.run_every_hours:g}",
         str(config.dry_run).lower(),
+        config.delete_batch_size,
+        config.delete_batch_pause_seconds,
+        config.delete_per_message_pause_seconds,
         config.source,
     )
     return config
@@ -568,10 +652,40 @@ def _format_top_author_sample(author_counts: Mapping[str, _AuthorSourceCounts]) 
 
 
 async def _delete_messages(
-    messages: Sequence[discord.Message], logger: logging.Logger
+    messages: Sequence[discord.Message],
+    logger: logging.Logger,
+    *,
+    batch_size: int | None = None,
+    batch_pause_seconds: float | None = None,
+    per_message_pause_seconds: float | None = None,
 ) -> CleanupResult:
     deleted = errors = 0
-    for message in messages:
+    total_messages = len(messages)
+    batch_size = max(1, batch_size or CLEANUP_DELETE_BATCH_SIZE)
+    batch_pause_seconds = (
+        CLEANUP_DELETE_BATCH_PAUSE_SECONDS
+        if batch_pause_seconds is None
+        else batch_pause_seconds
+    )
+    per_message_pause_seconds = (
+        CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS
+        if per_message_pause_seconds is None
+        else per_message_pause_seconds
+    )
+    target_id = (
+        getattr(getattr(messages[0], "channel", None), "id", None) if messages else None
+    )
+    if total_messages > batch_size:
+        logger.info(
+            "cleanup delete batch run: target_id=%s candidates=%s batch_size=%s "
+            "batch_pause=%s per_message_pause=%s",
+            target_id,
+            total_messages,
+            batch_size,
+            batch_pause_seconds,
+            per_message_pause_seconds,
+        )
+    for index, message in enumerate(messages):
         try:
             try:
                 await message.delete(reason="housekeeping cleanup")
@@ -581,7 +695,7 @@ async def _delete_messages(
                     raise
                 await message.delete()
         except discord.NotFound:
-            continue
+            pass
         except discord.Forbidden:
             errors += 1
             return CleanupResult(
@@ -604,6 +718,22 @@ async def _delete_messages(
             errors += 1
         else:
             deleted += 1
+
+        has_more_messages = index < total_messages - 1
+        if not has_more_messages:
+            continue
+        if (index + 1) % batch_size == 0:
+            await asyncio.sleep(batch_pause_seconds)
+        elif per_message_pause_seconds > 0:
+            await asyncio.sleep(per_message_pause_seconds)
+
+    if total_messages > batch_size:
+        logger.info(
+            "cleanup delete batch complete: target_id=%s deleted=%s errors=%s",
+            target_id,
+            deleted,
+            errors,
+        )
     if errors and deleted:
         return CleanupResult("partial_delete_failed", deleted, len(messages), 0, errors)
     if errors:
@@ -622,6 +752,7 @@ async def _scan_message_history(
     bot: commands.Bot,
     logger: logging.Logger,
     context: dict[str, Any] | None = None,
+    cleanup_config: CleanupConfig | None = None,
 ) -> CleanupResult:
     candidates: list[discord.Message] = []
     skipped = 0
@@ -753,7 +884,17 @@ async def _scan_message_history(
         return CleanupResult("dry_run_ok", 0, len(candidates), skipped, 0)
     if context is not None:
         context["stage"] = "delete_messages"
-    result = await _delete_messages(candidates, logger)
+    result = await _delete_messages(
+        candidates,
+        logger,
+        batch_size=(cleanup_config.delete_batch_size if cleanup_config else None),
+        batch_pause_seconds=(
+            cleanup_config.delete_batch_pause_seconds if cleanup_config else None
+        ),
+        per_message_pause_seconds=(
+            cleanup_config.delete_per_message_pause_seconds if cleanup_config else None
+        ),
+    )
     result.candidates = len(candidates)
     result.skipped = skipped
     return result
@@ -768,6 +909,7 @@ async def _scan_thread(
     bot: commands.Bot,
     logger: logging.Logger,
     context: dict[str, Any] | None = None,
+    cleanup_config: CleanupConfig | None = None,
 ) -> CleanupResult:
     return await _scan_message_history(
         thread,
@@ -777,6 +919,7 @@ async def _scan_thread(
         bot=bot,
         logger=logger,
         context=context,
+        cleanup_config=cleanup_config,
     )
 
 
@@ -789,6 +932,7 @@ async def _scan_channel(
     bot: commands.Bot,
     logger: logging.Logger,
     context: dict[str, Any] | None = None,
+    cleanup_config: CleanupConfig | None = None,
 ) -> CleanupResult:
     """Clean only the configured channel target's own message history.
 
@@ -802,6 +946,7 @@ async def _scan_channel(
         bot=bot,
         logger=logger,
         context=context,
+        cleanup_config=cleanup_config,
     )
 
 
@@ -1051,6 +1196,7 @@ async def _run_cleanup_locked(
                     bot=bot,
                     logger=logger,
                     context=context,
+                    cleanup_config=config,
                 )
             else:
                 result = await _scan_channel(
@@ -1061,6 +1207,7 @@ async def _run_cleanup_locked(
                     bot=bot,
                     logger=logger,
                     context=context,
+                    cleanup_config=config,
                 )
             summary.deleted += result.deleted
             summary.candidates += result.candidates

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -92,6 +92,96 @@ def test_enabled_feature_toggle_reads_config_not_toggle_from_config(monkeypatch)
     )
 
 
+
+
+def test_cleanup_config_missing_optional_pacing_uses_defaults(monkeypatch):
+    values = {
+        cleanup.CONFIG_TAB: "CleanupRows",
+        cleanup.CONFIG_RUN_EVERY_HOURS: "6",
+        cleanup.CONFIG_DRY_RUN: "TRUE",
+    }
+    monkeypatch.setattr(
+        cleanup.feature_flags, "status", lambda key: _toggle_status(enabled=True)
+    )
+    monkeypatch.setattr(
+        cleanup.recruitment,
+        "get_config_value",
+        lambda key, default=None, **_kwargs: values.get(key, default),
+    )
+
+    cfg = cleanup.resolve_cleanup_config()
+
+    assert cfg is not None
+    assert cfg.delete_batch_size == cleanup.CLEANUP_DELETE_BATCH_SIZE
+    assert cfg.delete_batch_pause_seconds == cleanup.CLEANUP_DELETE_BATCH_PAUSE_SECONDS
+    assert (
+        cfg.delete_per_message_pause_seconds
+        == cleanup.CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS
+    )
+
+
+def test_cleanup_config_invalid_optional_pacing_warns_and_uses_defaults(
+    monkeypatch, caplog
+):
+    values = {
+        cleanup.CONFIG_TAB: "CleanupRows",
+        cleanup.CONFIG_RUN_EVERY_HOURS: "6",
+        cleanup.CONFIG_DRY_RUN: "FALSE",
+        cleanup.CONFIG_DELETE_BATCH_SIZE: "0",
+        cleanup.CONFIG_DELETE_BATCH_PAUSE_SECONDS: "nope",
+        cleanup.CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS: "-1",
+    }
+    monkeypatch.setattr(
+        cleanup.feature_flags, "status", lambda key: _toggle_status(enabled=True)
+    )
+    monkeypatch.setattr(
+        cleanup.recruitment,
+        "get_config_value",
+        lambda key, default=None, **_kwargs: values.get(key, default),
+    )
+
+    cfg = cleanup.resolve_cleanup_config()
+
+    assert cfg is not None
+    assert cfg.dry_run is False
+    assert cfg.delete_batch_size == cleanup.CLEANUP_DELETE_BATCH_SIZE
+    assert cfg.delete_batch_pause_seconds == cleanup.CLEANUP_DELETE_BATCH_PAUSE_SECONDS
+    assert (
+        cfg.delete_per_message_pause_seconds
+        == cleanup.CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS
+    )
+    assert caplog.text.count("cleanup pacing config invalid; using default") == 3
+
+
+def test_cleanup_config_valid_optional_pacing_overrides_defaults(monkeypatch, caplog):
+    values = {
+        cleanup.CONFIG_TAB: "CleanupRows",
+        cleanup.CONFIG_RUN_EVERY_HOURS: "6",
+        cleanup.CONFIG_DRY_RUN: "FALSE",
+        cleanup.CONFIG_DELETE_BATCH_SIZE: "10",
+        cleanup.CONFIG_DELETE_BATCH_PAUSE_SECONDS: "1.5",
+        cleanup.CONFIG_DELETE_PER_MESSAGE_PAUSE_SECONDS: "0",
+    }
+    monkeypatch.setattr(
+        cleanup.feature_flags, "status", lambda key: _toggle_status(enabled=True)
+    )
+    monkeypatch.setattr(
+        cleanup.recruitment,
+        "get_config_value",
+        lambda key, default=None, **_kwargs: values.get(key, default),
+    )
+    caplog.set_level("INFO", logger="c1c.housekeeping.cleanup")
+
+    cfg = cleanup.resolve_cleanup_config()
+
+    assert cfg is not None
+    assert cfg.delete_batch_size == 10
+    assert cfg.delete_batch_pause_seconds == 1.5
+    assert cfg.delete_per_message_pause_seconds == 0
+    assert "delete_batch_size=10" in caplog.text
+    assert "delete_batch_pause_seconds=1.5" in caplog.text
+    assert "delete_per_message_pause_seconds=0.0" in caplog.text
+
 def test_enabled_feature_toggle_missing_config_prevents_scheduling(monkeypatch):
     monkeypatch.setattr(
         cleanup.feature_flags, "status", lambda key: _toggle_status(enabled=True)
@@ -161,7 +251,9 @@ class Msg:
     ):
         self.content = content
         self.system_content = system_content if system_content is not None else content
-        self.author = type("Author", (), {"id": author_id, "bot": author_bot, "roles": roles})()
+        self.author = type(
+            "Author", (), {"id": author_id, "bot": author_bot, "roles": roles}
+        )()
         self.pinned = pinned
         self.created_at = datetime.now(timezone.utc) - timedelta(hours=hours_old)
         self.channel = type("Channel", (), {"id": 123})()
@@ -170,6 +262,7 @@ class Msg:
         self.type = message_type
         self.application_id = application_id
         self.automod_rule_id = automod_rule_id
+
     async def delete(self, reason=None):
         self.deleted = True
 
@@ -194,6 +287,24 @@ class MsgWithReason(Msg):
 class MsgUnexpectedTypeError(Msg):
     async def delete(self, reason=None):
         raise TypeError("network adapter exploded")
+
+
+class MsgDeleteRaises(Msg):
+    def __init__(self, content, exc, *, author_id=99):
+        super().__init__(content, author_id=author_id)
+        self.exc = exc
+
+    async def delete(self, reason=None):
+        raise self.exc
+
+
+def _discord_exc(exc_type):
+    response = SimpleNamespace(status=500, reason="test")
+    return exc_type(response, "test error")
+
+
+async def _collecting_sleep(calls, delay):
+    calls.append(delay)
 
 
 class HistoryTarget:
@@ -463,6 +574,112 @@ def test_delete_messages_counts_unexpected_type_error_and_continues(caplog):
     assert "cleanup delete failed unexpectedly" in caplog.text
 
 
+def test_delete_messages_small_set_deletes_without_batch_pause(monkeypatch):
+    messages = [Msg(f"bot {index}", author_id=99) for index in range(3)]
+    sleep_calls = []
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_BATCH_SIZE", 25)
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0)
+    monkeypatch.setattr(
+        cleanup.asyncio, "sleep", lambda delay: _collecting_sleep(sleep_calls, delay)
+    )
+
+    result = asyncio.run(cleanup._delete_messages(messages, cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 3
+    assert [message.deleted for message in messages] == [True, True, True]
+    assert cleanup.CLEANUP_DELETE_BATCH_PAUSE_SECONDS not in sleep_calls
+    assert sleep_calls == []
+
+
+def test_delete_messages_large_set_pauses_between_batches(monkeypatch, caplog):
+    messages = [Msg(f"bot {index}", author_id=99) for index in range(6)]
+    sleep_calls = []
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_BATCH_SIZE", 2)
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_BATCH_PAUSE_SECONDS", 1.25)
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0)
+    monkeypatch.setattr(
+        cleanup.asyncio, "sleep", lambda delay: _collecting_sleep(sleep_calls, delay)
+    )
+    caplog.set_level("INFO", logger="c1c.housekeeping.cleanup")
+
+    result = asyncio.run(cleanup._delete_messages(messages, cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 6
+    assert [message.deleted for message in messages] == [True] * 6
+    assert sleep_calls == [1.25, 1.25]
+    assert "cleanup delete batch run: target_id=123 candidates=6" in caplog.text
+    assert (
+        "cleanup delete batch complete: target_id=123 deleted=6 errors=0" in caplog.text
+    )
+
+
+def test_delete_messages_per_message_pacing(monkeypatch):
+    messages = [Msg(f"bot {index}", author_id=99) for index in range(3)]
+    sleep_calls = []
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_BATCH_SIZE", 25)
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0.4)
+    monkeypatch.setattr(
+        cleanup.asyncio, "sleep", lambda delay: _collecting_sleep(sleep_calls, delay)
+    )
+
+    result = asyncio.run(cleanup._delete_messages(messages, cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 3
+    assert sleep_calls == [0.4, 0.4]
+
+
+def test_delete_messages_not_found_does_not_count_as_error(monkeypatch):
+    messages = [
+        MsgDeleteRaises("gone", _discord_exc(cleanup.discord.NotFound)),
+        Msg("ok"),
+    ]
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0)
+
+    result = asyncio.run(cleanup._delete_messages(messages, cleanup.log))
+
+    assert result.status == "deleted"
+    assert result.deleted == 1
+    assert result.errors == 0
+    assert messages[1].deleted is True
+
+
+def test_delete_messages_forbidden_returns_missing_permissions(monkeypatch):
+    messages = [
+        Msg("ok"),
+        MsgDeleteRaises("forbidden", _discord_exc(cleanup.discord.Forbidden)),
+        Msg("not reached"),
+    ]
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0)
+
+    result = asyncio.run(cleanup._delete_messages(messages, cleanup.log))
+
+    assert result.status == "missing_permissions"
+    assert result.deleted == 1
+    assert result.errors == 1
+    assert messages[2].deleted is False
+
+
+def test_delete_messages_http_exception_counts_errors(monkeypatch, caplog):
+    monkeypatch.setattr(cleanup, "CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS", 0)
+    failed = MsgDeleteRaises("fail", _discord_exc(cleanup.discord.HTTPException))
+    result = asyncio.run(cleanup._delete_messages([failed], cleanup.log))
+
+    assert result.status == "delete_failed"
+    assert result.deleted == 0
+    assert result.errors == 1
+
+    good = Msg("ok")
+    result = asyncio.run(cleanup._delete_messages([failed, good], cleanup.log))
+
+    assert result.status == "partial_delete_failed"
+    assert result.deleted == 1
+    assert result.errors == 1
+    assert "cleanup delete failed: target_id=123" in caplog.text
+
+
 def test_all_non_pinned_skips_pinned(monkeypatch):
     msgs = [Msg("human", author_id=1), Msg("pinned", author_id=1, pinned=True)]
     run_with_sheet(
@@ -685,36 +902,6 @@ def test_automod_system_and_webhook_combined_mode_includes_webhooks(monkeypatch)
     )
 
 
-
-
-def test_automod_system_messages_only_matches_auto_moderation_enum(monkeypatch):
-    monkeypatch.setattr(cleanup.recruitment, "get_config_value", lambda key, default=None, **_kwargs: default)
-    automod_type = getattr(cleanup.discord.MessageType, "auto_moderation_action")
-    assert cleanup._matches_mode(Msg("", author_id=1, message_type=automod_type), "automod_system_messages_only", Bot()) is True
-
-
-def test_automod_system_messages_only_uses_conservative_fallbacks(monkeypatch):
-    monkeypatch.setattr(cleanup.recruitment, "get_config_value", lambda key, default=None, **_kwargs: default)
-    generic_system_type = cleanup.discord.MessageType.pins_add
-    assert cleanup._matches_mode(Msg("", author_id=1, message_type=generic_system_type, automod_rule_id=123), "automod_system_messages_only", Bot()) is True
-    assert cleanup._matches_mode(Msg("AutoMod blocked a message", author_id=1, message_type=generic_system_type), "automod_system_messages_only", Bot()) is True
-
-
-def test_automod_system_messages_only_rejects_non_automod_sources(monkeypatch):
-    monkeypatch.setattr(cleanup.recruitment, "get_config_value", lambda key, default=None, **_kwargs: default)
-    automod_type = getattr(cleanup.discord.MessageType, "auto_moderation_action")
-    generic_system_type = cleanup.discord.MessageType.pins_add
-    assert cleanup._matches_mode(Msg("human", author_id=1), "automod_system_messages_only", Bot()) is False
-    assert cleanup._matches_mode(Msg("bot", author_id=42, author_bot=True), "automod_system_messages_only", Bot()) is False
-    assert cleanup._matches_mode(Msg("", author_id=1, webhook_id=555), "automod_system_messages_only", Bot()) is False
-    assert cleanup._matches_mode(Msg("", author_id=1, message_type=generic_system_type), "automod_system_messages_only", Bot()) is False
-    assert cleanup._matches_mode(Msg("", author_id=1, pinned=True, message_type=automod_type), "automod_system_messages_only", Bot()) is False
-
-
-def test_automod_system_and_webhook_combined_mode_includes_webhooks(monkeypatch):
-    monkeypatch.setattr(cleanup.recruitment, "get_config_value", lambda key, default=None, **_kwargs: default)
-    assert cleanup._matches_mode(Msg("", author_id=1, webhook_id=555), "automod_system_and_webhook_messages_only", Bot()) is True
-
 def test_commands_only_uses_project_prefix_fallback_not_hardcoded(monkeypatch):
     bot = Bot()
     bot.command_prefix = None
@@ -831,10 +1018,14 @@ def test_zero_match_diagnostics_counts_webhooks_empty_content_and_bounded_author
     assert sample.startswith("1:2:false:2")
 
 
-
-
-def test_zero_match_diagnostics_counts_system_automod_and_message_types(monkeypatch, caplog):
-    monkeypatch.setattr(cleanup.recruitment, "get_config_value", lambda key, default=None, **_kwargs: default)
+def test_zero_match_diagnostics_counts_system_automod_and_message_types(
+    monkeypatch, caplog
+):
+    monkeypatch.setattr(
+        cleanup.recruitment,
+        "get_config_value",
+        lambda key, default=None, **_kwargs: default,
+    )
     automod_type = getattr(cleanup.discord.MessageType, "auto_moderation_action")
     messages = [
         Msg("", author_id=1, message_type=automod_type, pinned=True),
@@ -856,12 +1047,17 @@ def test_zero_match_diagnostics_counts_system_automod_and_message_types(monkeypa
     )
 
     assert result.candidates == 0
-    record = next(record for record in caplog.records if record.message.startswith("cleanup row scan complete"))
+    record = next(
+        record
+        for record in caplog.records
+        if record.message.startswith("cleanup row scan complete")
+    )
     assert "system_message_count=2" in record.message
     assert "automod_system_seen=1" in record.message
     assert "message_type_counts=" in record.message
     assert "auto_moderation_action:1" in record.message
     assert "pins_add:1" in record.message
+
 
 def test_zero_match_diagnostics_counts_prefix_and_role_matches(monkeypatch, caplog):
     role = type("Role", (), {"id": 12345})()


### PR DESCRIPTION
### Motivation
- Provide configurable pacing for message deletions during housekeeping to avoid rate-limit bursts and allow operator tuning via recruitment config keys.
- Surface invalid optional pacing settings as warnings and fall back to safe defaults to prevent misconfiguration from breaking cleanup runs.

### Description
- Added three new config keys `HOUSEKEEPING_CLEANUP_DELETE_BATCH_SIZE`, `HOUSEKEEPING_CLEANUP_DELETE_BATCH_PAUSE_SECONDS`, and `HOUSEKEEPING_CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS` and default constants `CLEANUP_DELETE_BATCH_SIZE`, `CLEANUP_DELETE_BATCH_PAUSE_SECONDS`, and `CLEANUP_DELETE_PER_MESSAGE_PAUSE_SECONDS`.
- Extended `CleanupConfig` with `delete_batch_size`, `delete_batch_pause_seconds`, and `delete_per_message_pause_seconds` and implemented `_resolve_optional_pacing_config` and `_parse_positive_int` to read and validate the optional pacing settings from recruitment config with warnings on invalid values.
- Updated `resolve_cleanup_config` to include the resolved pacing values and log them, and threaded `cleanup_config` through `_scan_*` helpers into `_delete_messages` which now accepts `batch_size`, `batch_pause_seconds`, and `per_message_pause_seconds` and implements batch and per-message sleeps with logging and proper handling of `NotFound`, `Forbidden`, and HTTP errors.
- Adjusted tests and added a suite of unit tests in `tests/modules/housekeeping/test_cleanup.py` to validate config parsing, default/fallback behavior, logging, and deletion pacing and error semantics.

### Testing
- Ran unit tests in `tests/modules/housekeeping/test_cleanup.py` including new tests `test_cleanup_config_missing_optional_pacing_uses_defaults`, `test_cleanup_config_invalid_optional_pacing_warns_and_uses_defaults`, `test_cleanup_config_valid_optional_pacing_overrides_defaults`, `test_delete_messages_small_set_deletes_without_batch_pause`, `test_delete_messages_large_set_pauses_between_batches`, `test_delete_messages_per_message_pacing`, `test_delete_messages_not_found_does_not_count_as_error`, `test_delete_messages_forbidden_returns_missing_permissions`, and `test_delete_messages_http_exception_counts_errors` and they all passed.
- Existing cleanup unit tests were also executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402cd405ac83238554524e8e4da718)