### PR TITLE
keepalive: remove previous bot keepalive message if it's the latest before posting new one

### DIFF
--- a/modules/housekeeping/keepalive.py
+++ b/modules/housekeeping/keepalive.py
@@ -367,23 +367,73 @@ async def _get_bot_member(
     return member, 0
 
 
-async def _last_activity_at(
+async def _latest_message(
     thread: discord.Thread, logger: logging.Logger
-) -> tuple[datetime | None, int]:
+) -> tuple[Any | None, datetime | None, int]:
     try:
         async for message in thread.history(limit=1):
-            return _normalize_timestamp(message.created_at), 0
+            return message, _normalize_timestamp(message.created_at), 0
     except discord.Forbidden:
         logger.warning("thread keepalive history forbidden: thread_id=%s", thread.id)
-        return None, 1
+        return None, None, 1
     except discord.HTTPException as exc:
         logger.warning(
             "thread keepalive history failed: thread_id=%s error=%s", thread.id, exc
         )
-        return None, 1
+        return None, None, 1
     if getattr(thread, "created_at", None):
-        return _normalize_timestamp(thread.created_at), 0
-    return None, 0
+        return None, _normalize_timestamp(thread.created_at), 0
+    return None, None, 0
+
+
+def _is_bot_keepalive_message(
+    message_obj: Any | None, *, bot: commands.Bot, keepalive_text: str
+) -> bool:
+    if message_obj is None or bot.user is None:
+        return False
+    author = getattr(message_obj, "author", None)
+    if getattr(author, "id", None) != getattr(bot.user, "id", None):
+        return False
+    return (getattr(message_obj, "content", "") or "").strip() == keepalive_text.strip()
+
+
+async def _delete_previous_keepalive_if_latest(
+    thread: discord.Thread,
+    latest_message: Any | None,
+    *,
+    bot: commands.Bot,
+    keepalive_text: str,
+    logger: logging.Logger,
+) -> int:
+    if not _is_bot_keepalive_message(
+        latest_message, bot=bot, keepalive_text=keepalive_text
+    ):
+        return 0
+    try:
+        await latest_message.delete()
+    except discord.Forbidden:
+        logger.warning(
+            "thread keepalive previous message delete forbidden: thread_id=%s message_id=%s",
+            thread.id,
+            getattr(latest_message, "id", None),
+        )
+        return 1
+    except discord.HTTPException as exc:
+        logger.warning(
+            "thread keepalive previous message delete failed: thread_id=%s message_id=%s error=%s",
+            thread.id,
+            getattr(latest_message, "id", None),
+            exc,
+        )
+        return 1
+    return 0
+
+
+async def _last_activity_at(
+    thread: discord.Thread, logger: logging.Logger
+) -> tuple[datetime | None, int]:
+    _message, last_activity, errors = await _latest_message(thread, logger)
+    return last_activity, errors
 
 
 async def _ensure_unarchived(
@@ -431,7 +481,7 @@ async def _process_thread(
     ):
         return "missing_permissions", False, "", errors + 1
 
-    last_activity, history_errors = await _last_activity_at(thread, logger)
+    _message, last_activity, history_errors = await _latest_message(thread, logger)
     errors += history_errors
     if last_activity is None:
         return "fetch_failed", False, "", errors
@@ -448,6 +498,14 @@ async def _process_thread(
             _format_utc(last_activity),
             errors + 1,
         )
+
+    latest_message, _latest_activity, latest_errors = await _latest_message(
+        thread, logger
+    )
+    errors += latest_errors
+    errors += await _delete_previous_keepalive_if_latest(
+        thread, latest_message, bot=bot, keepalive_text=message, logger=logger
+    )
 
     try:
         await thread.send(message)
@@ -722,6 +780,7 @@ __all__ = [
     "build_header_map",
     "newest_last_seen",
     "parent_keepalive_message_for_thread",
+    "_delete_previous_keepalive_if_latest",
     "resolve_keepalive_config",
     "rows_from_values",
     "run_keepalive",

--- a/tests/modules/housekeeping/test_keepalive.py
+++ b/tests/modules/housekeeping/test_keepalive.py
@@ -520,3 +520,195 @@ def test_parent_not_stale_preserves_explicit_child_keepalive_sent_at(monkeypatch
     assert sent_messages == [(200, "child msg")]
     assert updates["H3"] == prior_sent_at
     assert updates["I3"] == "ok_not_stale"
+
+class _KeepalivePerms:
+    read_message_history = True
+    send_messages = True
+    manage_threads = True
+
+
+class _KeepaliveAuthor:
+    def __init__(self, author_id):
+        self.id = author_id
+
+
+class _KeepaliveMessage:
+    def __init__(self, *, content, author_id, created_at, message_id=10):
+        self.content = content
+        self.author = _KeepaliveAuthor(author_id)
+        self.created_at = created_at
+        self.id = message_id
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class _KeepaliveGuild:
+    def __init__(self, member):
+        self._member = member
+
+    def get_member(self, _user_id):
+        return self._member
+
+
+class _KeepaliveThread:
+    def __init__(self, latest_message):
+        self.id = 1234
+        self.archived = False
+        self.guild = _KeepaliveGuild(_KeepaliveAuthor(42))
+        if isinstance(latest_message, list):
+            self._latest_messages = latest_message
+        else:
+            self._latest_messages = [latest_message]
+        self.sent = []
+
+    def permissions_for(self, _member):
+        return _KeepalivePerms()
+
+    async def history(self, *, limit):
+        assert limit == 1
+        latest_message = (
+            self._latest_messages.pop(0)
+            if len(self._latest_messages) > 1
+            else self._latest_messages[0]
+        )
+        if latest_message is not None:
+            yield latest_message
+
+    async def send(self, message):
+        self.sent.append(message)
+
+
+class _KeepaliveBot:
+    user = _KeepaliveAuthor(42)
+
+
+def _old_timestamp():
+    from datetime import datetime, timedelta, timezone
+
+    return datetime.now(timezone.utc) - timedelta(days=30)
+
+
+def test_process_thread_deletes_previous_keepalive_when_latest():
+    import asyncio
+    import logging
+    from datetime import timedelta
+
+    latest = _KeepaliveMessage(
+        content="🔹 KeepAlive, preventing archive",
+        author_id=42,
+        created_at=_old_timestamp(),
+    )
+    thread = _KeepaliveThread(latest)
+
+    status, did_post, _last_seen, errors = asyncio.run(
+        keepalive._process_thread(
+            thread,
+            stale_after_delta=timedelta(hours=1),
+            message="🔹 KeepAlive, preventing archive",
+            bot=_KeepaliveBot(),
+            logger=logging.getLogger("test.keepalive"),
+        )
+    )
+
+    assert status == "posted"
+    assert did_post is True
+    assert errors == 0
+    assert latest.deleted is True
+    assert thread.sent == ["🔹 KeepAlive, preventing archive"]
+
+
+def test_process_thread_keeps_previous_keepalive_when_user_message_is_latest():
+    import asyncio
+    import logging
+    from datetime import timedelta
+
+    latest = _KeepaliveMessage(
+        content="user follow-up",
+        author_id=99,
+        created_at=_old_timestamp(),
+    )
+    thread = _KeepaliveThread(latest)
+
+    status, did_post, _last_seen, errors = asyncio.run(
+        keepalive._process_thread(
+            thread,
+            stale_after_delta=timedelta(hours=1),
+            message="🔹 KeepAlive, preventing archive",
+            bot=_KeepaliveBot(),
+            logger=logging.getLogger("test.keepalive"),
+        )
+    )
+
+    assert status == "posted"
+    assert did_post is True
+    assert errors == 0
+    assert latest.deleted is False
+    assert thread.sent == ["🔹 KeepAlive, preventing archive"]
+
+
+def test_process_thread_never_deletes_non_keepalive_bot_message():
+    import asyncio
+    import logging
+    from datetime import timedelta
+
+    latest = _KeepaliveMessage(
+        content="regular bot update",
+        author_id=42,
+        created_at=_old_timestamp(),
+    )
+    thread = _KeepaliveThread(latest)
+
+    status, did_post, _last_seen, errors = asyncio.run(
+        keepalive._process_thread(
+            thread,
+            stale_after_delta=timedelta(hours=1),
+            message="🔹 KeepAlive, preventing archive",
+            bot=_KeepaliveBot(),
+            logger=logging.getLogger("test.keepalive"),
+        )
+    )
+
+    assert status == "posted"
+    assert did_post is True
+    assert errors == 0
+    assert latest.deleted is False
+    assert thread.sent == ["🔹 KeepAlive, preventing archive"]
+
+
+def test_process_thread_refetches_latest_before_deleting_keepalive():
+    import asyncio
+    import logging
+    from datetime import timedelta
+
+    old_keepalive = _KeepaliveMessage(
+        content="🔹 KeepAlive, preventing archive",
+        author_id=42,
+        created_at=_old_timestamp(),
+        message_id=10,
+    )
+    newer_user_message = _KeepaliveMessage(
+        content="user arrived after stale check",
+        author_id=99,
+        created_at=_old_timestamp(),
+        message_id=11,
+    )
+    thread = _KeepaliveThread([old_keepalive, newer_user_message])
+
+    status, did_post, _last_seen, errors = asyncio.run(
+        keepalive._process_thread(
+            thread,
+            stale_after_delta=timedelta(hours=1),
+            message="🔹 KeepAlive, preventing archive",
+            bot=_KeepaliveBot(),
+            logger=logging.getLogger("test.keepalive"),
+        )
+    )
+
+    assert status == "posted"
+    assert did_post is True
+    assert errors == 0
+    assert old_keepalive.deleted is False
+    assert newer_user_message.deleted is False
+    assert thread.sent == ["🔹 KeepAlive, preventing archive"]


### PR DESCRIPTION
### Motivation
- Prevent duplicate bot keepalive messages by removing the bot's previous keepalive when it is the most recent message in a thread.
- Improve accuracy of last-activity detection by separating retrieval of the latest message object from the last-activity timestamp.
- Add test coverage for deletion behavior around keepalive messages.

### Description
- Introduced `async def _latest_message(thread, logger)` which returns the latest message object, its normalized timestamp, and an error count, and kept `async def _last_activity_at` as a timestamp-only wrapper returning `(datetime|None, int)`.
- Added `_is_bot_keepalive_message(message_obj, *, bot, keepalive_text)` helper to recognize bot keepalive messages by author and content equality.
- Added `async def _delete_previous_keepalive_if_latest(thread, latest_message, *, bot, keepalive_text, logger)` to delete the previous keepalive when it is the latest message and surface permission/HTTP errors as error counts.
- Updated `_process_thread` to refetch the latest message before deleting a prior keepalive, incorporate deletion errors into the overall error count, and then send the new keepalive message.
- Exported `_delete_previous_keepalive_if_latest` in `__all__` and adjusted related function signatures and call sites to use the new helpers.
- Added unit tests in `tests/modules/housekeeping/test_keepalive.py` covering deletion of previous keepalive messages, preserving user messages, preserving non-keepalive bot messages, and refetch behavior to avoid deleting when a newer message arrived.

### Testing
- Ran the keepalive unit tests in `tests/modules/housekeeping/test_keepalive.py` with `pytest`, and the new and existing keepalive tests passed.
- Verified the added tests exercise deletion logic for bot keepalive messages, user messages, non-keepalive bot messages, and re-fetch scenarios, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40c948ceb083238a4553ec87264e9f)