### PR TITLE
Filter zero-row details, make OpenSpotsPager lazy-refreshing and persistently registered

### DIFF
--- a/modules/recruitment/reporting/daily_recruiter_update.py
+++ b/modules/recruitment/reporting/daily_recruiter_update.py
@@ -30,7 +30,13 @@ log = logging.getLogger("c1c.recruitment.reporting.daily")
 
 UTC = timezone.utc
 
+DETAILS_FILTER_FOOTER = (
+    "Clans with 0 openings, 0 inactives, and 0 reserved seats are hidden here."
+)
+
 _BOT_REFERENCE: Optional[discord.Client] = None
+_PERSISTENT_VIEW_REGISTERED = False
+_PERSISTENT_VIEW_ATTR = "_c1c_open_spots_pager_registered"
 
 
 def feature_enabled() -> bool:
@@ -323,7 +329,7 @@ def _extract_report_sections(
         formatted = [
             line
             for row in entries
-            if (line := _format_line(headers, row, always=True))
+            if (line := _format_line(headers, row, always=False))
         ]
         if formatted:
             detail_blocks.append((label, formatted))
@@ -388,6 +394,8 @@ def _build_details_embed(sections: ReportSections) -> discord.Embed:
             value="\n".join(formatted),
         )
 
+    embed.set_footer(text=DETAILS_FILTER_FOOTER)
+
     for field in getattr(embed, "fields", []):
         try:
             field.inline = False
@@ -397,8 +405,13 @@ def _build_details_embed(sections: ReportSections) -> discord.Embed:
     return embed
 
 
+async def _load_report_sections() -> ReportSections:
+    rows, headers = await _fetch_report_rows()
+    return _extract_report_sections(rows, headers)
+
+
 class OpenSpotsPager(discord.ui.View):
-    def __init__(self, sections: ReportSections) -> None:
+    def __init__(self, sections: ReportSections | None = None) -> None:
         super().__init__(timeout=None)
         self.sections = sections
         self.current_page = "summary"
@@ -411,20 +424,27 @@ class OpenSpotsPager(discord.ui.View):
         self.summary_button.disabled = page == "summary"
         self.details_button.disabled = page == "details"
 
+    async def _resolve_sections(self) -> ReportSections:
+        try:
+            sections = await _load_report_sections()
+        except Exception:
+            if self.sections is None:
+                raise
+            log.debug("failed to refresh recruiter report sections for pager", exc_info=True)
+            return self.sections
+        self.sections = sections
+        return sections
+
     async def set_summary(self, interaction: discord.Interaction) -> None:
-        if self.current_page == "summary":
-            await interaction.response.defer()
-            return
+        sections = await self._resolve_sections()
         self._set_page_state("summary")
-        embed = _build_summary_embed(self.sections)
+        embed = _build_summary_embed(sections)
         await interaction.response.edit_message(embeds=[embed], view=self)
 
     async def set_details(self, interaction: discord.Interaction) -> None:
-        if self.current_page == "details":
-            await interaction.response.defer()
-            return
+        sections = await self._resolve_sections()
         self._set_page_state("details")
-        embed = _build_details_embed(self.sections)
+        embed = _build_details_embed(sections)
         await interaction.response.edit_message(embeds=[embed], view=self)
 
     @discord.ui.button(
@@ -623,9 +643,24 @@ async def scheduler_daily_recruiter_update() -> None:
     await run_full_recruiter_reports(bot, actor="scheduled")
 
 
+def register_persistent_views(bot: discord.Client) -> None:
+    global _PERSISTENT_VIEW_REGISTERED
+    if _PERSISTENT_VIEW_REGISTERED or getattr(bot, _PERSISTENT_VIEW_ATTR, False):
+        return
+    try:
+        bot.add_view(OpenSpotsPager())
+    except ValueError as exc:
+        if "already" not in str(exc).lower() and "duplicate" not in str(exc).lower():
+            raise
+        log.debug("open spots persistent view was already registered", exc_info=True)
+    setattr(bot, _PERSISTENT_VIEW_ATTR, True)
+    _PERSISTENT_VIEW_REGISTERED = True
+
+
 async def ensure_scheduler_started(bot: discord.Client) -> None:
     global _BOT_REFERENCE
     _BOT_REFERENCE = bot
+    register_persistent_views(bot)
 
     if not feature_enabled():
         if scheduler_daily_recruiter_update.is_running():
@@ -664,6 +699,7 @@ __all__ = [
     "feature_enabled",
     "log_manual_result",
     "OpenSpotsPager",
+    "register_persistent_views",
     "post_daily_recruiter_update",
     "run_full_recruiter_reports",
     "scheduler_daily_recruiter_update",

--- a/tests/recruitment/test_daily_recruiter_update.py
+++ b/tests/recruitment/test_daily_recruiter_update.py
@@ -66,8 +66,10 @@ def test_build_embeds_from_rows_filters_and_groups():
     assert elite_end_game.name == "Elite End Game"
     assert elite_end_game.inline is False
     assert "🔹 **Clan Alpha:** open 5 | inactives 0 | reserved 1" in elite_end_game.value
-    assert "🔹 **Elders:** open 0 | inactives 0 | reserved 0" in elite_end_game.value
-    assert "🔹 **Cambions:** open 0 | inactives 0 | reserved 0" in elite_end_game.value
+    assert "🔹 **Elders:** open 0 | inactives 0 | reserved 0" not in elite_end_game.value
+    assert "🔹 **Cambions:** open 0 | inactives 0 | reserved 0" not in elite_end_game.value
+    assert details_embed.footer.text == dru.DETAILS_FILTER_FOOTER
+    assert summary_embed.footer.text != dru.DETAILS_FILTER_FOOTER
 
     mid_game = details_embed.fields[1]
     assert mid_game.name == "Mid Game"
@@ -75,7 +77,7 @@ def test_build_embeds_from_rows_filters_and_groups():
     assert "🔹 **Clan Delta:** open 2 | inactives 2 | reserved 0" in mid_game.value
 
 
-def test_bracket_details_include_zero_rows_and_preserve_sheet_order():
+def test_bracket_details_hide_zero_rows_and_empty_brackets():
     rows = [
         [
             "H1_Headline",
@@ -99,18 +101,11 @@ def test_bracket_details_include_zero_rows_and_preserve_sheet_order():
     sections = dru._extract_report_sections(rows, headers)
     details_embed = dru._build_details_embed(sections)
 
-    assert [field.name for field in details_embed.fields] == [
-        "First Sheet Bracket",
-        "Second Sheet Bracket",
-    ]
+    assert [field.name for field in details_embed.fields] == ["First Sheet Bracket"]
     first_value = details_embed.fields[0].value
-    assert "🔹 **Island Arena:** open 0 | inactives 0 | reserved 0" in first_value
+    assert "🔹 **Island Arena:** open 0 | inactives 0 | reserved 0" not in first_value
     assert "🔹 **Active Clan:** open 4 | inactives 1 | reserved 2" in first_value
-    assert first_value.index("Island Arena") < first_value.index("Active Clan")
-    second_value = details_embed.fields[1].value
-    assert "🔹 **Vindicators:** open 0 | inactives 0 | reserved 0" in second_value
-    assert "🔹 **Warlords:** open 0 | inactives 0 | reserved 0" in second_value
-    assert "🔹 **Eff-It:** open 0 | inactives 0 | reserved 0" in second_value
+    assert "Second Sheet Bracket" not in [field.name for field in details_embed.fields]
 
 
 def test_live_headers_drive_sections_brackets_and_clan_names_without_grouping():
@@ -137,14 +132,49 @@ def test_live_headers_drive_sections_brackets_and_clan_names_without_grouping():
     assert len(details_embed.fields) == 1
     assert details_embed.fields[0].name == "Configured H2 Bracket"
     value = details_embed.fields[0].value
-    assert "🔹 **Key Clan Zero:** open 0 | inactives 0 | reserved 0" in value
+    assert "🔹 **Key Clan Zero:** open 0 | inactives 0 | reserved 0" not in value
     assert "🔹 **Key Clan Active:** open 2 | inactives 1 | reserved 3" in value
 
 
-def test_open_spots_pager_switches_pages():
+def test_bracket_details_keep_each_mixed_non_zero_case():
+    rows = [
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["Bracket Details", "", "", "", "", ""],
+        ["", "Mixed Bracket", "", "", "", ""],
+        ["", "", "Only Inactives", "0", "3", "0"],
+        ["", "", "Only Reserved", "0", "0", "2"],
+        ["", "", "Only Open", "1", "0", "0"],
+        ["", "", "All Zero", "0", "0", "0"],
+    ]
+    headers = dru._headers_map(rows[0])
+
+    sections = dru._extract_report_sections(rows, headers)
+    details_embed = dru._build_details_embed(sections)
+
+    assert len(details_embed.fields) == 1
+    value = details_embed.fields[0].value
+    assert "🔹 **Only Inactives:** open 0 | inactives 3 | reserved 0" in value
+    assert "🔹 **Only Reserved:** open 0 | inactives 0 | reserved 2" in value
+    assert "🔹 **Only Open:** open 1 | inactives 0 | reserved 0" in value
+    assert "🔹 **All Zero:** open 0 | inactives 0 | reserved 0" not in value
+
+
+def test_open_spots_pager_switches_pages(monkeypatch):
     rows = _sample_rows()
     headers = dru._headers_map(rows[0])
     sections = dru._extract_report_sections(rows, headers)
+
+    async def fake_load_sections():
+        return sections
+
+    monkeypatch.setattr(dru, "_load_report_sections", fake_load_sections)
 
     async def runner():
         pager = dru.OpenSpotsPager(sections)
@@ -176,6 +206,56 @@ def test_open_spots_pager_switches_pages():
 
     args, kwargs = interaction_summary.response.edit_message.await_args
     assert kwargs["embeds"][0].title == "Summary Open Spots"
+
+
+def test_open_spots_pager_is_persistent_and_registered_once(monkeypatch):
+    add_view_calls = []
+
+    class DummyBot:
+        def add_view(self, view):
+            add_view_calls.append(view)
+
+    monkeypatch.setattr(dru, "_PERSISTENT_VIEW_REGISTERED", False)
+    bot = DummyBot()
+    dru.register_persistent_views(bot)
+    dru.register_persistent_views(bot)
+
+    assert len(add_view_calls) == 1
+    view = add_view_calls[0]
+    assert isinstance(view, dru.OpenSpotsPager)
+    assert view.timeout is None
+    custom_ids = {item.custom_id for item in view.children}
+    assert custom_ids == {"open_spots_summary", "open_spots_details"}
+
+
+def test_open_spots_pager_registration_skips_bot_marked_registered(monkeypatch):
+    add_view_calls = []
+
+    class DummyBot:
+        _c1c_open_spots_pager_registered = True
+
+        def add_view(self, view):
+            add_view_calls.append(view)
+
+    monkeypatch.setattr(dru, "_PERSISTENT_VIEW_REGISTERED", False)
+    dru.register_persistent_views(DummyBot())
+
+    assert add_view_calls == []
+
+
+def test_open_spots_pager_registration_tolerates_duplicate_value_error(monkeypatch):
+    class DummyBot:
+        def __init__(self):
+            self.marked = False
+
+        def add_view(self, view):
+            raise ValueError("duplicate custom_id open_spots_summary already registered")
+
+    monkeypatch.setattr(dru, "_PERSISTENT_VIEW_REGISTERED", False)
+    bot = DummyBot()
+    dru.register_persistent_views(bot)
+
+    assert getattr(bot, "_c1c_open_spots_pager_registered") is True
 
 
 def test_post_daily_recruiter_update_sends_pager(monkeypatch):


### PR DESCRIPTION
### Motivation

- Remove noise from the bracket details by hiding clan rows that are all zeros and clarify that behavior in the UI footer. 
- Allow the `OpenSpotsPager` to refresh its data on demand (lazy load) so the pager always shows current report sections. 
- Register the pager as a persistent view exactly once per bot to ensure buttons survive restarts and avoid duplicate registration errors. 

### Description

- Change details extraction to skip zero-only rows by using `always=False` when formatting detail lines in `_extract_report_sections`. 
- Add `DETAILS_FILTER_FOOTER` and set it on the details embed to explain the filtering. 
- Add an async helper `async def _load_report_sections()` to fetch rows and build `ReportSections`. 
- Make `OpenSpotsPager` accept an optional initial `sections`, add `_resolve_sections()` to lazily refresh via `_load_report_sections()`, and use refreshed sections when switching pages. 
- Introduce `register_persistent_views(bot)` with deduplication via module-level `_PERSISTENT_VIEW_REGISTERED` and a bot attribute `_c1c_open_spots_pager_registered`, and call it from `ensure_scheduler_started`. 
- Export `register_persistent_views` in `__all__` and add `_PERSISTENT_VIEW_ATTR` constant. 

### Testing

- Updated and added unit tests in `tests/recruitment/test_daily_recruiter_update.py` to assert zero-row filtering, footer text, pager lazy-loading behavior, and persistent-registration behaviors. 
- Ran the updated test file (`pytest tests/recruitment/test_daily_recruiter_update.py`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40d1dd90488323a45ae7872e9a6dcc)