### PR TITLE
Add durable league approval prompts and resilient reset reminder loading

### DIFF
--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -5,13 +5,13 @@ import datetime as dt
 import io
 import logging
 import os
-from typing import TYPE_CHECKING, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 import discord
 from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
-from c1c_coreops.rbac import admin_only
+from c1c_coreops.rbac import admin_only, is_admin_member
 from modules.community.leagues.config import (
     LeagueBundle,
     LeagueSpec,
@@ -19,6 +19,7 @@ from modules.community.leagues.config import (
     load_league_bundles,
 )
 from shared.logfmt import channel_label, user_label
+from shared.sheets.async_core import acall_with_backoff, afetch_records, afetch_values, aget_worksheet
 from shared.sheets.export_utils import export_pdf_as_png, get_tab_gid
 
 if TYPE_CHECKING:
@@ -27,14 +28,32 @@ if TYPE_CHECKING:
 log = logging.getLogger("c1c.community.leagues")
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+_APPROVAL_CONFIG_KEY = "league_approval_state_tab"
+_APPROVAL_HEADERS = (
+    "season_key",
+    "week_key",
+    "prompt_message_id",
+    "prompt_channel_id",
+    "status",
+    "required_reactions",
+    "approved_by_user_ids",
+    "posted_at_utc",
+    "created_at_utc",
+    "updated_at_utc",
+    "last_error",
+)
+_APPROVAL_ACTIVE_STATUSES = {"pending"}
+_APPROVAL_EMOJIS = {"👍", "👍🏻", "👍🏽", "👍🏿", "👍🏾"}
 
 
 class LeaguesCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._last_wednesday_message_id: int | None = None
+        # Approval prompt state is durable in the configured LeagueApprovalState tab.
+        # These in-memory fields only de-dupe concurrent handling within this process.
         self._handled_messages: set[int] = set()
         self._job_lock = asyncio.Lock()
+        self._approval_lock = asyncio.Lock()
 
         sheet_id = os.getenv("LEAGUES_SHEET_ID", "").strip()
         if not sheet_id:
@@ -62,6 +81,23 @@ class LeaguesCog(commands.Cog):
             except (TypeError, ValueError):
                 continue
         return admin_ids
+
+    async def _is_valid_approval_admin(self, payload: discord.RawReactionActionEvent) -> bool:
+        admin_ids = self._admin_ids()
+        if payload.user_id in admin_ids:
+            return True
+
+        member = getattr(payload, "member", None)
+        if member is None and payload.guild_id is not None:
+            guild = self.bot.get_guild(payload.guild_id)
+            if guild is not None:
+                member = guild.get_member(payload.user_id)
+                if member is None:
+                    try:
+                        member = await guild.fetch_member(payload.user_id)
+                    except Exception:
+                        member = None
+        return bool(member is not None and is_admin_member(member))
 
     @staticmethod
     def _is_image_attachment(attachment: discord.Attachment) -> bool:
@@ -141,23 +177,256 @@ class LeaguesCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
-        if not self._last_wednesday_message_id:
+        if str(payload.emoji) not in _APPROVAL_EMOJIS:
+            log.debug("league approval reaction ignored", extra={"reason": "wrong_emoji", "message_id": payload.message_id})
             return
-        if payload.message_id != self._last_wednesday_message_id:
-            return
+        log.info(
+            "league approval reaction candidate seen",
+            extra={
+                "guild_id": payload.guild_id,
+                "channel_id": payload.channel_id,
+                "message_id": payload.message_id,
+                "user_id": payload.user_id,
+            },
+        )
         if payload.user_id == getattr(self.bot.user, "id", None):
+            log.debug("league approval reaction ignored", extra={"reason": "bot_user", "message_id": payload.message_id})
             return
-        if str(payload.emoji) not in {"👍", "👍🏻", "👍🏽", "👍🏿", "👍🏾"}:
-            return
-        admin_ids = self._admin_ids()
-        if not admin_ids or payload.user_id not in admin_ids:
-            return
-        if payload.message_id in self._handled_messages:
+        if not await self._is_valid_approval_admin(payload):
+            log.info(
+                "league approval reaction ignored",
+                extra={"reason": "user_not_allowed", "message_id": payload.message_id, "user_id": payload.user_id},
+            )
             return
 
-        self._handled_messages.add(payload.message_id)
+        async with self._approval_lock:
+            row = await self._find_approval_row(payload.channel_id, payload.message_id, include_terminal=True)
+            if row is None:
+                log.info(
+                    "league approval reaction ignored",
+                    extra={"reason": "no_active_approval_row", "channel_id": payload.channel_id, "message_id": payload.message_id},
+                )
+                return
+            status = row["values"].get("status", "").lower()
+            if status != "pending":
+                log.info(
+                    "league approval reaction ignored",
+                    extra={"reason": "approval_not_pending", "status": status, "message_id": payload.message_id},
+                )
+                return
+
+            approvers = self._parse_approvers(row["values"].get("approved_by_user_ids", ""))
+            if payload.user_id in approvers:
+                log.info("league approval reaction ignored", extra={"reason": "user_already_approved", "message_id": payload.message_id})
+                return
+            approvers.add(payload.user_id)
+            await self._update_approval_row(
+                row,
+                {
+                    "approved_by_user_ids": ",".join(str(user_id) for user_id in sorted(approvers)),
+                    "updated_at_utc": self._utc_iso(),
+                    "last_error": "",
+                },
+            )
+            required = self._parse_positive_int(row["values"].get("required_reactions"), default=1)
+            if len(approvers) < required:
+                log.info(
+                    "league approval threshold not reached yet",
+                    extra={"message_id": payload.message_id, "approvals": len(approvers), "required_reactions": required},
+                )
+                return
+            if payload.message_id in self._handled_messages:
+                log.info("league approval reaction ignored", extra={"reason": "approval_already_posted", "message_id": payload.message_id})
+                return
+            self._handled_messages.add(payload.message_id)
+            await self._update_approval_row(row, {"status": "posting", "updated_at_utc": self._utc_iso(), "last_error": ""})
+
         channel = await self._resolve_channel(payload.channel_id)
-        await self.run_leagues_job(trigger="reaction", status_channel=channel)
+        log.info(
+            "league approval threshold reached; posting starts",
+            extra={
+                "source": "reaction_approval",
+                "season_key": row["values"].get("season_key"),
+                "week_key": row["values"].get("week_key"),
+                "prompt_message_id": payload.message_id,
+                "prompt_channel_id": payload.channel_id,
+            },
+        )
+        try:
+            ok = await self.run_leagues_job(trigger="reaction_approval", status_channel=channel)
+        except Exception as exc:
+            ok = False
+            error = f"{type(exc).__name__}: {exc}"
+            log.exception("league approval posting failed")
+        else:
+            error = "" if ok else "posting job returned failure"
+
+        async with self._approval_lock:
+            fresh = await self._find_approval_row(payload.channel_id, payload.message_id, include_terminal=True)
+            if fresh is not None:
+                posted_at = self._utc_iso() if ok else ""
+                await self._update_approval_row(
+                    fresh,
+                    {
+                        "status": "posted" if ok else "failed",
+                        "posted_at_utc": posted_at,
+                        "updated_at_utc": self._utc_iso(),
+                        "last_error": error[:500],
+                    },
+                )
+        log.info(
+            "league approval posting finished",
+            extra={"success": ok, "posted_at_utc": posted_at if ok else "", "last_error": error},
+        )
+
+    @staticmethod
+    def _column_label(index: int) -> str:
+        value = index + 1
+        label = ""
+        while value > 0:
+            value, remainder = divmod(value - 1, 26)
+            label = chr(65 + remainder) + label
+        return label or "A"
+
+    @staticmethod
+    def _utc_iso() -> str:
+        return dt.datetime.now(dt.timezone.utc).isoformat()
+
+    @staticmethod
+    def _parse_approvers(raw: object) -> set[int]:
+        approvers: set[int] = set()
+        for part in str(raw or "").replace(";", ",").split(","):
+            token = part.strip()
+            if token.isdigit():
+                approvers.add(int(token))
+        return approvers
+
+    @staticmethod
+    def _parse_positive_int(raw: object, *, default: int) -> int:
+        try:
+            value = int(str(raw or "").strip())
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else default
+
+    @staticmethod
+    def _approval_keys(now: dt.datetime | None = None) -> tuple[str, str]:
+        current = now or dt.datetime.now(dt.timezone.utc)
+        iso = current.isocalendar()
+        return str(iso.year), f"{iso.week:02d}"
+
+    def _config_tab_name(self) -> str:
+        return os.getenv("LEAGUES_CONFIG_TAB", "Config").strip() or "Config"
+
+    async def _approval_state_tab(self, sheet_id: str) -> str | None:
+        try:
+            rows = await afetch_records(sheet_id, self._config_tab_name())
+        except Exception:
+            log.exception("league approval config load failed", extra={"config_key": _APPROVAL_CONFIG_KEY})
+            return None
+        for row in rows or []:
+            key = ""
+            value = ""
+            for column, cell in row.items():
+                normalized = str(column or "").strip().lower()
+                if normalized in {"spec_key", "key", "name"}:
+                    key = str(cell or "").strip()
+                if normalized in {"sheet_name", "sheet", "tab", "value", "val"}:
+                    value = str(cell or "").strip()
+            if key == _APPROVAL_CONFIG_KEY and value:
+                return value
+        log.error("league approval state tab config missing", extra={"config_key": _APPROVAL_CONFIG_KEY})
+        return None
+
+    async def _approval_sheet(self) -> tuple[str, Any, dict[str, int], list[list[Any]]] | None:
+        sheet_id = os.getenv("LEAGUES_SHEET_ID", "").strip()
+        if not sheet_id:
+            log.error("league approval unavailable; LEAGUES_SHEET_ID missing")
+            return None
+        tab_name = await self._approval_state_tab(sheet_id)
+        if not tab_name:
+            return None
+        try:
+            matrix = await afetch_values(sheet_id, tab_name)
+        except Exception:
+            log.exception("league approval state load failed", extra={"tab": tab_name})
+            return None
+        if not matrix:
+            log.error("league approval state header missing", extra={"tab": tab_name})
+            return None
+        header = [str(cell or "").strip() for cell in matrix[0]]
+        header_map = {name: idx for idx, name in enumerate(header) if name}
+        missing = [name for name in _APPROVAL_HEADERS if name not in header_map]
+        if missing:
+            log.error("league approval state missing required headers", extra={"tab": tab_name, "missing": missing})
+            return None
+        try:
+            worksheet = await aget_worksheet(sheet_id, tab_name)
+        except Exception:
+            log.exception("league approval worksheet fetch failed", extra={"tab": tab_name})
+            return None
+        return tab_name, worksheet, header_map, matrix
+
+    async def _find_approval_row(self, channel_id: int, message_id: int, *, include_terminal: bool = False) -> dict[str, Any] | None:
+        loaded = await self._approval_sheet()
+        if loaded is None:
+            return None
+        tab_name, worksheet, header_map, matrix = loaded
+        for row_number, row in enumerate(matrix[1:], start=2):
+            values = {name: (str(row[idx]).strip() if idx < len(row) else "") for name, idx in header_map.items()}
+            if values.get("prompt_channel_id") != str(channel_id) or values.get("prompt_message_id") != str(message_id):
+                continue
+            status = values.get("status", "").lower()
+            if include_terminal or status in _APPROVAL_ACTIVE_STATUSES:
+                return {"tab": tab_name, "worksheet": worksheet, "header_map": header_map, "row_number": row_number, "values": values}
+        return None
+
+    async def _update_approval_row(self, row: dict[str, Any], updates: Mapping[str, object]) -> None:
+        worksheet = row["worksheet"]
+        header_map: dict[str, int] = row["header_map"]
+        row_number = int(row["row_number"])
+        for key, value in updates.items():
+            if key not in header_map:
+                continue
+            column = self._column_label(header_map[key])
+            await acall_with_backoff(worksheet.update, f"{column}{row_number}", [[str(value)]], value_input_option="RAW")
+
+    async def _upsert_approval_prompt_state(self, message: discord.Message) -> None:
+        loaded = await self._approval_sheet()
+        if loaded is None:
+            return
+        _tab_name, worksheet, header_map, matrix = loaded
+        season_key, week_key = self._approval_keys()
+        now = self._utc_iso()
+        target_row = None
+        for row_number, row in enumerate(matrix[1:], start=2):
+            values = {name: (str(row[idx]).strip() if idx < len(row) else "") for name, idx in header_map.items()}
+            if values.get("season_key") == season_key and values.get("week_key") == week_key:
+                target_row = row_number
+                created_at = values.get("created_at_utc") or now
+                break
+        else:
+            created_at = now
+        values = {
+            "season_key": season_key,
+            "week_key": week_key,
+            "prompt_message_id": str(message.id),
+            "prompt_channel_id": str(getattr(message.channel, "id", "")),
+            "status": "pending",
+            "required_reactions": "1",
+            "approved_by_user_ids": "",
+            "posted_at_utc": "",
+            "created_at_utc": created_at,
+            "updated_at_utc": now,
+            "last_error": "",
+        }
+        ordered = [values[name] for name in _APPROVAL_HEADERS]
+        if target_row is None:
+            await acall_with_backoff(worksheet.append_row, ordered, value_input_option="RAW")
+        else:
+            end_col = self._column_label(len(_APPROVAL_HEADERS) - 1)
+            await acall_with_backoff(worksheet.update, f"A{target_row}:{end_col}{target_row}", [ordered], value_input_option="RAW")
+        log.info("league approval prompt state stored", extra={"message_id": message.id, "season_key": season_key, "week_key": week_key})
 
     # === Commands ===
     @tier("admin")
@@ -212,8 +481,8 @@ class LeaguesCog(commands.Cog):
             await message.add_reaction("👍")
         except Exception:
             pass
-        self._last_wednesday_message_id = message.id
         self._handled_messages.discard(message.id)
+        await self._upsert_approval_prompt_state(message)
 
     # === Core job ===
     async def run_leagues_job(
@@ -221,16 +490,16 @@ class LeaguesCog(commands.Cog):
         *,
         trigger: str,
         status_channel: discord.abc.Messageable | None,
-    ) -> None:
+    ) -> bool:
         async with self._job_lock:
-            await self._run_leagues_job(trigger=trigger, status_channel=status_channel)
+            return await self._run_leagues_job(trigger=trigger, status_channel=status_channel)
 
     async def _run_leagues_job(
         self,
         *,
         trigger: str,
         status_channel: discord.abc.Messageable | None,
-    ) -> None:
+    ) -> bool:
         sheet_id = os.getenv("LEAGUES_SHEET_ID", "").strip()
         if not sheet_id:
             await self._post_status(
@@ -238,7 +507,7 @@ class LeaguesCog(commands.Cog):
                 f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: LEAGUES_SHEET_ID is missing.",
                 trigger=trigger,
             )
-            return
+            return False
 
         channel_ids = {
             "legendary": self._parse_int_env("LEAGUES_LEGENDARY_THREAD_ID"),
@@ -268,7 +537,7 @@ class LeaguesCog(commands.Cog):
                 f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: {reason}.",
                 trigger=trigger,
             )
-            return
+            return False
 
         try:
             bundles = load_league_bundles(sheet_id, config_tab="Config")
@@ -278,7 +547,7 @@ class LeaguesCog(commands.Cog):
                 f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: {exc}.",
                 trigger=trigger,
             )
-            return
+            return False
         except Exception as exc:
             log.exception("leagues config load failed")
             await self._post_status(
@@ -286,7 +555,7 @@ class LeaguesCog(commands.Cog):
                 f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: config load error: {exc}.",
                 trigger=trigger,
             )
-            return
+            return False
 
         validation_error = self._validate_bundles(bundles)
         if validation_error:
@@ -295,7 +564,7 @@ class LeaguesCog(commands.Cog):
                 f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: {validation_error}.",
                 trigger=trigger,
             )
-            return
+            return False
 
         loop = asyncio.get_running_loop()
         posted_messages: list[discord.Message] = []
@@ -312,7 +581,7 @@ class LeaguesCog(commands.Cog):
                     f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: {header_file}.",
                     trigger=trigger,
                 )
-                return
+                return False
 
             title = self._league_title(bundle, now)
             try:
@@ -325,7 +594,7 @@ class LeaguesCog(commands.Cog):
                     f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: sending {bundle.display_name} header failed ({exc}).",
                     trigger=trigger,
                 )
-                return
+                return False
 
             posted_messages.append(header_msg)
             jump_links[bundle.slug] = header_msg.jump_url
@@ -338,7 +607,7 @@ class LeaguesCog(commands.Cog):
                     f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: {board_files}.",
                     trigger=trigger,
                 )
-                return
+                return False
 
             for board_file in board_files:
                 try:
@@ -351,7 +620,7 @@ class LeaguesCog(commands.Cog):
                         f"❌ C1C Leagues job failed\nTrigger: {trigger}\nReason: sending {bundle.display_name} board failed ({exc}).",
                         trigger=trigger,
                     )
-                    return
+                    return False
                 posted_messages.append(message)
 
         announcement_text = self._build_announcement(bundles, jump_links)
@@ -369,14 +638,14 @@ class LeaguesCog(commands.Cog):
                 content=self._league_role_mention(),
                 embed=announcement_embed,
             )
-        except Exception as exc:
+        except Exception:
             log.exception("leagues announcement failed")
             await self._post_status(
                 status_channel,
                 "⚠️ C1C Leagues boards posted, but announcement failed – check ANNOUNCEMENT_CHANNEL_ID and permissions.",
                 trigger=trigger,
             )
-            return
+            return False
         else:
             try:
                 rr: ReactionRolesCog | None = self.bot.get_cog("ReactionRolesCog")  # type: ignore[name-defined]
@@ -410,6 +679,7 @@ class LeaguesCog(commands.Cog):
             ),
             trigger=trigger,
         )
+        return True
 
     @staticmethod
     async def _cleanup_posts(messages: list[discord.Message]) -> None:

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -29,7 +29,11 @@ _RESET_REMINDER_TAB_KEY = "RESET_REMINDER_TAB"
 _FEATURE_TOGGLE_KEY = "reset_reminders"
 _INVALID_ROW_ALERT_DEDUPER = EventDeduper(window_s=900.0, max_keys=128)
 _LOAD_FAILURE_ALERT_COOLDOWN_SEC = 1800.0
-_load_failure_state: dict[str, Any] = {"key": None, "last_alert": 0.0, "failures": 0}
+_LOAD_FAILURE_ALERT_THRESHOLD = 3
+_LOAD_RETRY_ATTEMPTS = 2
+_LOAD_RETRY_BACKOFF_SEC = 0.5
+_load_failure_state: dict[str, Any] = {"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False}
+_last_successful_load: dict[str, Any] = {"tab_name": None, "header_map": None, "records": None}
 _PROCESS_LOCK = asyncio.Lock()
 _REQUIRED_COLUMNS: tuple[str, ...] = (
     "reset_id",
@@ -146,6 +150,7 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
         tab_name = _tab_name()
         sheet_id = _sheet_id()
         stage = "sheet_fetch"
+        log.info("reset reminder sheet load started", extra={"tab": tab_name, "active_only": active_only})
         matrix = await afetch_values(sheet_id, tab_name)
         if not matrix:
             return tab_name, {}, []
@@ -224,6 +229,7 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
             "valid_active_rows": valid_active_count,
             "invalid_rows": len(invalid_rows),
             "invalid_row_details": invalid_rows,
+            "load_duration_ms": round((time.monotonic() - started) * 1000, 1),
         },
     )
     if active_only and invalid_rows:
@@ -386,19 +392,33 @@ async def _record_load_failure(exc: Exception) -> None:
     )
 
     last_alert = float(state.get("last_alert") or 0.0)
-    if previous_key != key or now - last_alert >= _LOAD_FAILURE_ALERT_COOLDOWN_SEC:
+    should_send = int(state["failures"]) >= _LOAD_FAILURE_ALERT_THRESHOLD and (
+        not bool(state.get("alert_sent")) or previous_key != key or now - last_alert >= _LOAD_FAILURE_ALERT_COOLDOWN_SEC
+    )
+    if should_send:
         state["last_alert"] = now
+        state["alert_sent"] = True
+        log.warning("reset reminder Discord warning sent", extra={"consecutive_failures": state["failures"]})
         await _send_ops_log(
-            "⚠️ Reset reminders failed to load; scheduler tick skipped. "
-            f"See app logs. error={type(exc).__name__}"
+            "⚠️ Reset reminders failed to load after repeated ticks; scheduler tick skipped. "
+            f"See app logs. error={type(exc).__name__} consecutive_failures={state['failures']}"
+        )
+    else:
+        log.info(
+            "reset reminder Discord warning suppressed",
+            extra={"consecutive_failures": state["failures"], "threshold": _LOAD_FAILURE_ALERT_THRESHOLD},
         )
 
 
 async def _record_load_success() -> None:
     failures = int(_load_failure_state.get("failures") or 0)
-    if failures > 0:
+    alert_sent = bool(_load_failure_state.get("alert_sent"))
+    if failures > 0 and alert_sent:
+        log.info("reset reminder recovery message sent", extra={"consecutive_failures": failures})
         await _send_ops_log(f"✅ Reset reminders loaded again after {failures} failed tick(s).")
-    _load_failure_state.update({"key": None, "last_alert": 0.0, "failures": 0})
+    elif failures > 0:
+        log.info("reset reminder recovery message suppressed", extra={"consecutive_failures": failures})
+    _load_failure_state.update({"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False})
 
 
 async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) -> discord.abc.Messageable | None:
@@ -514,6 +534,59 @@ async def _update_row_after_send(
     )
 
 
+async def _load_reset_reminder_records_resilient(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord], bool]:
+    last_exc: Exception | None = None
+    for attempt in range(1, _LOAD_RETRY_ATTEMPTS + 1):
+        started = time.monotonic()
+        try:
+            tab_name, header_map, records = await _load_reset_reminder_records(active_only=active_only)
+        except TimeoutError as exc:
+            last_exc = exc
+            log.warning(
+                "reset reminder sheet load timed out; retrying",
+                extra={
+                    "attempt": attempt,
+                    "max_attempts": _LOAD_RETRY_ATTEMPTS,
+                    "exception_type": type(exc).__name__,
+                    "load_duration_ms": round((time.monotonic() - started) * 1000, 1),
+                },
+            )
+            if attempt < _LOAD_RETRY_ATTEMPTS:
+                await asyncio.sleep(_LOAD_RETRY_BACKOFF_SEC * attempt)
+                continue
+            break
+        except Exception:
+            raise
+        _last_successful_load.update({"tab_name": tab_name, "header_map": header_map, "records": records})
+        log.info(
+            "reset reminder sheet load succeeded",
+            extra={"attempt": attempt, "load_duration_ms": round((time.monotonic() - started) * 1000, 1)},
+        )
+        return tab_name, header_map, records, False
+
+    cached_tab = _last_successful_load.get("tab_name")
+    cached_header = _last_successful_load.get("header_map")
+    cached_records = _last_successful_load.get("records")
+    if (
+        cached_tab
+        and isinstance(cached_header, dict)
+        and all(column in cached_header for column in _REQUIRED_COLUMNS)
+        and isinstance(cached_records, list)
+    ):
+        log.warning(
+            "reset reminder sheet load failed after retries; using cached rows",
+            extra={
+                "exception_type": type(last_exc).__name__ if last_exc else "unknown",
+                "cached_rows": len(cached_records),
+                "used_cached_rows": True,
+            },
+        )
+        return str(cached_tab), cached_header, cached_records, True
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("reset reminder sheet load failed")
+
+
 async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None = None) -> None:
     if not _is_feature_enabled():
         log.debug("reset reminders disabled via feature toggle; skipping scheduler tick")
@@ -533,12 +606,23 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
 
         now_utc = _utc_now(now)
 
+        used_cached_rows = False
         try:
-            tab_name, header_map, records = await _load_reset_reminder_records(active_only=True)
+            tab_name, header_map, records, used_cached_rows = await _load_reset_reminder_records_resilient(active_only=True)
         except Exception as exc:
             await _record_load_failure(exc)
             return
-        await _record_load_success()
+        if used_cached_rows:
+            synthetic = TimeoutError("reset reminder sheet load failed; cached rows used")
+            setattr(synthetic, "reset_reminder_stage", "sheet_fetch")
+            setattr(synthetic, "reset_reminder_tab", tab_name)
+            await _record_load_failure(synthetic)
+            log.info(
+                "reset reminder scheduler continuing with cached rows",
+                extra={"cached_rows": len(records), "consecutive_failed_ticks": _load_failure_state.get("failures")},
+            )
+        else:
+            await _record_load_success()
 
         if not records:
             return
@@ -709,4 +793,5 @@ __all__ = [
     "register_persistent_reset_views",
     "schedule_reset_reminder_jobs",
     "_load_failure_state",
+    "_last_successful_load",
 ]

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -39,3 +39,118 @@ def test_league_role_mention_prefers_role_id(monkeypatch) -> None:
     cog = LeaguesCog(SimpleNamespace())
     monkeypatch.setenv("C1C_LEAGUE_ROLE_ID", "12345")
     assert cog._league_role_mention() == "<@&12345>"
+
+
+def _approval_row(status: str = "pending"):
+    values = {
+        "season_key": "2026",
+        "week_key": "26",
+        "prompt_message_id": "1234",
+        "prompt_channel_id": "5678",
+        "status": status,
+        "required_reactions": "1",
+        "approved_by_user_ids": "",
+        "posted_at_utc": "",
+        "created_at_utc": "2026-06-24T00:00:00+00:00",
+        "updated_at_utc": "2026-06-24T00:00:00+00:00",
+        "last_error": "",
+    }
+    return {"values": values, "row_number": 2, "header_map": {key: index for index, key in enumerate(values)}}
+
+
+class _LeagueApprovalBot:
+    user = SimpleNamespace(id=9999)
+
+    def get_guild(self, _guild_id):
+        return None
+
+    def get_channel(self, _channel_id):
+        return None
+
+
+class _LeagueApprovalPayload:
+    guild_id = 42
+    channel_id = 5678
+    message_id = 1234
+    user_id = 1111
+    emoji = "👍"
+    member = SimpleNamespace(id=1111)
+
+
+async def _run_approval(monkeypatch, *, is_admin: bool, job_result: bool = True, job_error: Exception | None = None):
+    cog = LeaguesCog(_LeagueApprovalBot())
+    row = _approval_row()
+    updates = []
+    calls = {"job": 0}
+
+    monkeypatch.delenv("LEAGUE_ADMIN_IDS", raising=False)
+    monkeypatch.setattr("modules.community.leagues.cog.is_admin_member", lambda member: is_admin)
+
+    async def _find(channel_id, message_id, *, include_terminal=False):
+        assert channel_id == 5678
+        assert message_id == 1234
+        return row
+
+    async def _update(target, changes):
+        updates.append(dict(changes))
+        target["values"].update({key: str(value) for key, value in changes.items()})
+
+    async def _run_job(*, trigger, status_channel):
+        calls["job"] += 1
+        assert trigger == "reaction_approval"
+        assert row["values"]["status"] == "posting"
+        if job_error is not None:
+            raise job_error
+        return job_result
+
+    monkeypatch.setattr(cog, "_find_approval_row", _find)
+    monkeypatch.setattr(cog, "_update_approval_row", _update)
+    monkeypatch.setattr(cog, "run_leagues_job", _run_job)
+
+    await cog.on_raw_reaction_add(_LeagueApprovalPayload())
+    return row, updates, calls
+
+
+def test_league_approval_allows_project_admin_without_league_admin_ids(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(_run_approval(monkeypatch, is_admin=True))
+
+    assert calls["job"] == 1
+    assert row["values"]["approved_by_user_ids"] == "1111"
+    assert any(update.get("status") == "posting" for update in updates)
+    assert row["values"]["status"] == "posted"
+
+
+def test_league_approval_rejects_non_admin_when_not_in_league_admin_ids(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(_run_approval(monkeypatch, is_admin=False))
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "pending"
+
+
+def test_league_approval_marks_posting_before_job_and_posted_on_success(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(_run_approval(monkeypatch, is_admin=True, job_result=True))
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "posted"]
+    assert row["values"]["posted_at_utc"]
+
+
+def test_league_approval_marks_failed_and_last_error_on_post_failure(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(monkeypatch, is_admin=True, job_error=RuntimeError("boom"))
+    )
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "failed"]
+    assert "RuntimeError: boom" in row["values"]["last_error"]

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -513,10 +513,9 @@ def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(monkey
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
 
-    assert sent_logs == [
-        "⚠️ Reset reminders failed to load; scheduler tick skipped. See app logs. error=TimeoutError",
-        "✅ Reset reminders loaded again after 2 failed tick(s).",
-    ]
+    # A short transient outage is retried and no longer sends noisy Discord
+    # failure/recovery alerts unless the warning threshold is reached.
+    assert sent_logs == []
 
 
 def test_reset_reminder_scheduler_runner_continues_after_timeout(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Introduce a durable, sheet-backed approval workflow so league posting can be gated by multiple project admins instead of a single in-memory message id. 
- Make reset reminder scheduler more resilient to transient sheet load failures by retrying, backing off, and using cached rows to avoid noisy ops alerts for short outages. 

### Description
- Add a sheet-backed league approval flow in `LeaguesCog` including approval constants, helpers for column labeling and ISO timestamps, and sheet helpers (`_approval_state_tab`, `_approval_sheet`, `_find_approval_row`, `_update_approval_row`, `_upsert_approval_prompt_state`) using `shared.sheets.async_core` calls. 
- Replace the previous single-message check with reaction-driven approval handling in `on_raw_reaction_add`, including admin membership checks (`_is_valid_approval_admin`), approver parsing, threshold handling, posting state transitions (`pending` → `posting` → `posted`/`failed`), and durable updates to the approval sheet. 
- Wire Wednesday reminders to persist the approval prompt to the sheet (`_upsert_approval_prompt_state`) and add concurrency guards via `_approval_lock` and in-memory `_handled_messages`. 
- Change `run_leagues_job` and `_run_leagues_job` to return `bool` success values and flow-control returns on error paths, and improve status/error logging when announcing and cleaning up posts. 
- Improve reset reminders sheet loading with retry/backoff and caching by introducing `_load_reset_reminder_records_resilient`, `_LOAD_RETRY_*` constants, `_last_successful_load` cache, alert threshold and suppression logic (`_LOAD_FAILURE_ALERT_THRESHOLD`), and logging of load durations and recovery behavior. 
- Export `_last_successful_load` from the reset reminders scheduler module and adjust the load/failure bookkeeping structure to track whether an ops alert was sent. 
- Update unit tests to cover the new league approval behavior and modified reset reminder alerting semantics (`tests/community/test_leagues_rendering.py` and `tests/community/test_reset_reminder_scheduler.py`). 

### Testing
- Ran the updated unit tests in `tests/community` including `test_leagues_rendering.py` approval scenarios and `test_reset_reminder_scheduler.py` load/retry behavior under `pytest`, and they passed. 
- Exercised approval reaction paths in tests to validate admin gating, state transitions (`posting`/`posted`/`failed`), and persisted sheet updates. 
- Exercised reset reminder load retry and cached-row fallback in tests to validate suppressed short-outage alerts and recovery notifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a416f0240e883239ac507cc32b202c2)