### PR TITLE
Register sheet-backed feature refresh buckets, add labels, audit, and tests

### DIFF
--- a/docs/audits/refresh_all_bucket_audit.md
+++ b/docs/audits/refresh_all_bucket_audit.md
@@ -1,0 +1,94 @@
+# Refresh-all sheet bucket audit
+
+Date: 2026-06-29
+
+## Registry location
+
+`!refresh all` reads `shared.cache.telemetry.list_buckets()`, which reflects buckets registered in the shared cache service. Sheet-backed default registration is coordinated by `shared.sheets.runtime.register_default_cache_buckets()`.
+
+## Buckets that existed before this PR
+
+- `clans` — recruitment clan roster cache.
+- `templates` — welcome template cache.
+- `clan_tags` — onboarding clan tag cache.
+- `onboarding_questions` — onboarding question cache.
+- `leagues` — league Config cache.
+- `fusion` — Fusion row cache.
+- `fusion_events` — Fusion event row cache.
+- `reaction_roles` — reaction role cache.
+
+## Added bucket Config sources
+
+| Bucket | Config key | Config source | Evidence |
+|---|---|---|---|
+| `clan_ad_messages` | `clan_ad_messages_tab` | Recruitment Config | `modules.recruitment.clan_ads.CONFIG_KEYS` |
+| `clan_ad_rules` | `clan_ad_rules_tab` | Recruitment Config | `modules.recruitment.clan_ads.CONFIG_KEYS` |
+| `reservations` | `reservations_tab` | Recruitment Config | `shared.sheets.recruitment.get_reservations_tab_name()` |
+| `recruitment_reports` | `reports_tab` | Recruitment Config | `shared.sheets.recruitment.get_reports_tab_name()` |
+| `c1c_ad` | `C1C_AD_TAB` | Recruitment Config | `modules.housekeeping.c1c_ad.CONFIG_KEYS` |
+| `c1c_ad_text` | `C1C_AD_TEXT_TAB` | Recruitment Config | `modules.housekeeping.c1c_ad.CONFIG_KEYS` |
+| `cleanup_rules` | `HOUSEKEEPING_CLEANUP_TAB` | Recruitment Config | `modules.housekeeping.cleanup.CONFIG_TAB` |
+| `keepalive_targets` | `HOUSEKEEPING_KEEPALIVE_TAB` | Recruitment Config | `modules.housekeeping.keepalive.CONFIG_TAB` |
+| `whoweare_role_map` | `rolemap_tab` | Recruitment Config | `shared.sheets.recruitment.get_role_map_tab_name()` |
+| `reset_reminders` | `RESET_REMINDER_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.reset_reminders.scheduler._RESET_REMINDER_TAB_KEY` |
+| `shard_mercy` | `SHARD_MERCY_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data.ShardSheetStore.get_config()` |
+| `shard_clans` | `SHARD_CLANS_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("SHARD_CLANS_TAB")` |
+| `shard_reminders` | `SHARD_REMINDER_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("SHARD_REMINDER_TAB")` |
+| `shard_share_copy` | `shard_share_copy_tab` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("shard_share_copy_tab")` |
+| `shard_voice_targets` | `shard_share_voice_targets_tab` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("shard_share_voice_targets_tab")` |
+
+## Candidate audit results
+
+| Candidate | Status | Reason |
+|---|---|---|
+| Clans | Already covered by existing bucket | `shared.sheets.recruitment.register_cache_buckets()` registers `clans`. |
+| Clan Tags | Already covered by existing bucket | `shared.sheets.onboarding.register_cache_buckets()` registers `clan_tags`. |
+| Welcome/Templates | Already covered by existing bucket | `shared.sheets.recruitment.register_cache_buckets()` registers `templates`. |
+| Onboarding Questions | Already covered by existing bucket | `shared.sheets.onboarding_questions.register_cache_buckets()` registers `onboarding_questions`. |
+| Reaction Roles | Already covered by existing bucket | `shared.sheets.reaction_roles.register_cache_buckets()` registers `reaction_roles`. |
+| Leagues | Already covered by existing bucket | `shared.sheets.config_service.register_cache_buckets()` registers `leagues`. League-specific tabs are resolved from that Config cache. |
+| Fusion rows | Already covered by existing bucket | `shared.sheets.fusion.register_cache_buckets()` registers `fusion`. |
+| Fusion events | Already covered by existing bucket | `shared.sheets.fusion.register_cache_buckets()` registers `fusion_events`. |
+| ClanAdMessages | Missing and added in this PR | Uses existing `clan_ad_messages_tab` from Recruitment Config. |
+| ClanAdRules | Missing and added in this PR | Uses existing `clan_ad_rules_tab` from Recruitment Config. |
+| Reservations | Missing and added in this PR | Uses existing `reservations_tab` from Recruitment Config. |
+| Recruitment reports | Missing and added in this PR | Uses existing `reports_tab` from Recruitment Config. |
+| C1C ad image tab | Missing and added in this PR | Uses existing `C1C_AD_TAB` from Recruitment Config. |
+| C1C ad text tab | Missing and added in this PR | Uses existing `C1C_AD_TEXT_TAB` from Recruitment Config. |
+| Cleanup rules | Missing and added in this PR | Uses existing `HOUSEKEEPING_CLEANUP_TAB` from Recruitment Config. |
+| Keepalive targets | Missing and added in this PR | Uses existing `HOUSEKEEPING_KEEPALIVE_TAB` from Recruitment Config. |
+| WhoWeAre role map | Missing and added in this PR | Uses existing `rolemap_tab` from Recruitment Config. |
+| Reset reminders | Missing and added in this PR | Uses existing `RESET_REMINDER_TAB` from Milestones Config merged into runtime/shared config. |
+| Shard mercy | Missing and added in this PR | Uses existing `SHARD_MERCY_TAB` from Milestones Config merged into runtime/shared config. |
+| Shard clans | Missing and added in this PR | Uses existing `SHARD_CLANS_TAB` from Milestones Config merged into runtime/shared config. |
+| Shard reminders | Missing and added in this PR | Uses existing `SHARD_REMINDER_TAB` from Milestones Config merged into runtime/shared config. |
+| Shard share copy | Missing and added in this PR | Uses existing `shard_share_copy_tab`/normalized `SHARD_SHARE_COPY_TAB` from runtime/shared config. |
+| Shard voice targets | Missing and added in this PR | Uses existing `shard_share_voice_targets_tab`/normalized `SHARD_SHARE_VOICE_TARGETS_TAB` from runtime/shared config. |
+| Fusion user progress | Intentionally not refreshable because not cache-backed | `FUSION_USER_EVENT_PROGRESS_TAB` is a mutable progress/writeback ledger, not a shared cache bucket. |
+| Fusion reminder/dedupe/state tabs | Intentionally not refreshable because not cache-backed | Reminder/settings/state tabs are runtime dedupe and writeback paths, not safe as generic read-only manual warmers. |
+| Mirralith overview tabs | Intentionally not refreshable because not cache-backed | `MIRRALITH_TAB`/`CLUSTER_STRUCTURE_TAB` drive image export ranges; the module does export work, not cache-service tab warming. |
+| Placement / target select tabs | Not sheet-backed | The current module is a stub and only logs during setup; no commands or sheet tab reads exist. |
+| Server map / permissions tabs | Intentionally not refreshable because not cache-backed | These are diagnostic/state paths and not registered cache-service feature buckets. |
+| Onboarding sessions/watchers | Intentionally not refreshable because not cache-backed | Session/ticket tabs are runtime state/writeback paths; question data is already covered by `onboarding_questions`. |
+
+## Expected `!refresh all` output after this PR
+
+The exact table status depends on live Config and Sheets access. The bucket list should include the existing buckets plus the added readable labels below, with each row reporting `ok`, `fail`, retry/TTL/count details when available, and visible errors for missing Config keys or bad tab names:
+
+- C1C Ad
+- C1C Ad Text
+- Clan Ad Messages
+- Clan Ad Rules
+- Cleanup Rules
+- Keepalive Targets
+- Recruitment Reports
+- Reservations
+- Reset Reminders
+- Shard Clans
+- Shard Mercy
+- Shard Reminders
+- Shard Share Copy
+- Shard Voice Targets
+- WhoWeAre Role Map
+
+Duplicate bucket registration is prevented by checking `cache.get_bucket(name)` before registering, and tests assert that `list_buckets()` contains no duplicate names.

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -59,7 +59,6 @@ from c1c_coreops.help import (
     build_help_overview_embeds,
 )
 from c1c_coreops.helpers import help_metadata, tier
-from shared.theme import colors
 from shared.redaction import sanitize_embed, sanitize_log, sanitize_text
 from shared.obs.events import (
     format_refresh_message,
@@ -490,7 +489,28 @@ class _EnvRenderMeta:
     timestamp: dt.datetime
 
 
+_BUCKET_LABELS: Dict[str, str] = {
+    "c1c_ad": "C1C Ad",
+    "c1c_ad_text": "C1C Ad Text",
+    "clan_ad_messages": "Clan Ad Messages",
+    "clan_ad_rules": "Clan Ad Rules",
+    "cleanup_rules": "Cleanup Rules",
+    "keepalive_targets": "Keepalive Targets",
+    "recruitment_reports": "Recruitment Reports",
+    "reset_reminders": "Reset Reminders",
+    "shard_clans": "Shard Clans",
+    "shard_mercy": "Shard Mercy",
+    "shard_reminders": "Shard Reminders",
+    "shard_share_copy": "Shard Share Copy",
+    "shard_voice_targets": "Shard Voice Targets",
+    "whoweare_role_map": "WhoWeAre Role Map",
+}
+
+
 def _format_bucket_label(name: str) -> str:
+    mapped = _BUCKET_LABELS.get(name.strip().lower())
+    if mapped:
+        return mapped
     cleaned = name.replace("_", " ").strip()
     if not cleaned:
         return name

--- a/shared/sheets/feature_refresh.py
+++ b/shared/sheets/feature_refresh.py
@@ -1,0 +1,91 @@
+"""Cache bucket registrations for sheet-backed feature tabs not otherwise cached."""
+
+from __future__ import annotations
+
+import os
+from typing import Awaitable, Callable
+
+from shared.config import get_milestones_sheet_id
+from shared.sheets import async_core
+from shared.sheets import recruitment
+from shared.sheets.cache_service import cache
+
+_CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))
+
+Loader = Callable[[], Awaitable[list[list[str]]]]
+
+
+def _missing_config_key(key: str) -> RuntimeError:
+    return RuntimeError(f"missing Config key {key}")
+
+
+def _recruitment_config_tab_loader(config_key: str) -> Loader:
+    async def _load() -> list[list[str]]:
+        tab_name = recruitment.get_config_value(config_key, None, force=True)
+        if not tab_name:
+            raise _missing_config_key(config_key)
+        try:
+            return await async_core.afetch_values(
+                recruitment.get_recruitment_sheet_id(), tab_name
+            )
+        except Exception as exc:
+            raise RuntimeError(f"could not read configured tab {tab_name}") from exc
+
+    return _load
+
+
+def _milestones_config_tab_loader(config_key: str) -> Loader:
+    async def _load() -> list[list[str]]:
+        from shared.config import cfg as runtime_config
+
+        getter = getattr(runtime_config, "get", None)
+        tab_name = ""
+        if callable(getter):
+            tab_name = str(getter(config_key, "") or "").strip()
+        else:
+            tab_name = str(getattr(runtime_config, config_key, "") or "").strip()
+        if not tab_name:
+            raise _missing_config_key(config_key)
+        sheet_id = (get_milestones_sheet_id() or "").strip()
+        if not sheet_id:
+            raise RuntimeError("MILESTONES_SHEET_ID missing")
+        try:
+            return await async_core.afetch_values(sheet_id, tab_name)
+        except Exception as exc:
+            raise RuntimeError(f"could not read configured tab {tab_name}") from exc
+
+    return _load
+
+
+def _register(name: str, loader: Loader) -> None:
+    if cache.get_bucket(name) is None:
+        cache.register(name, _CACHE_TTL, loader)
+
+
+def register_cache_buckets() -> None:
+    """Register manually refreshable buckets for sheet-backed feature data."""
+
+    recruitment_buckets: tuple[tuple[str, str], ...] = (
+        ("clan_ad_messages", "clan_ad_messages_tab"),
+        ("clan_ad_rules", "clan_ad_rules_tab"),
+        ("reservations", "reservations_tab"),
+        ("recruitment_reports", "reports_tab"),
+        ("c1c_ad", "C1C_AD_TAB"),
+        ("c1c_ad_text", "C1C_AD_TEXT_TAB"),
+        ("cleanup_rules", "HOUSEKEEPING_CLEANUP_TAB"),
+        ("keepalive_targets", "HOUSEKEEPING_KEEPALIVE_TAB"),
+        ("whoweare_role_map", "rolemap_tab"),
+    )
+    for bucket, key in recruitment_buckets:
+        _register(bucket, _recruitment_config_tab_loader(key))
+
+    milestones_buckets: tuple[tuple[str, str], ...] = (
+        ("reset_reminders", "RESET_REMINDER_TAB"),
+        ("shard_mercy", "SHARD_MERCY_TAB"),
+        ("shard_clans", "SHARD_CLANS_TAB"),
+        ("shard_reminders", "SHARD_REMINDER_TAB"),
+        ("shard_share_copy", "shard_share_copy_tab"),
+        ("shard_voice_targets", "shard_share_voice_targets_tab"),
+    )
+    for bucket, key in milestones_buckets:
+        _register(bucket, _milestones_config_tab_loader(key))

--- a/shared/sheets/runtime.py
+++ b/shared/sheets/runtime.py
@@ -14,6 +14,7 @@ def register_default_cache_buckets() -> None:
     import shared.sheets.fusion as fusion
     import shared.sheets.recruitment as recruitment
     import shared.sheets.reaction_roles as reaction_roles
+    import shared.sheets.feature_refresh as feature_refresh
 
     onboarding.register_cache_buckets()
     onboarding_questions.register_cache_buckets()
@@ -21,3 +22,4 @@ def register_default_cache_buckets() -> None:
     fusion.register_cache_buckets()
     recruitment.register_cache_buckets()
     reaction_roles.register_cache_buckets()
+    feature_refresh.register_cache_buckets()

--- a/tests/shared/sheets/test_feature_refresh.py
+++ b/tests/shared/sheets/test_feature_refresh.py
@@ -1,0 +1,191 @@
+import asyncio
+
+from shared.cache import telemetry
+from shared.sheets import cache_service, feature_refresh, runtime
+
+
+EXPECTED_NEW_BUCKETS = {
+    "clan_ad_messages",
+    "clan_ad_rules",
+    "reservations",
+    "recruitment_reports",
+    "c1c_ad",
+    "c1c_ad_text",
+    "cleanup_rules",
+    "keepalive_targets",
+    "whoweare_role_map",
+    "reset_reminders",
+    "shard_mercy",
+    "shard_clans",
+    "shard_reminders",
+    "shard_share_copy",
+    "shard_voice_targets",
+}
+
+
+def _clear_buckets() -> None:
+    cache_service.cache._buckets.clear()
+
+
+def test_feature_refresh_buckets_register_without_duplicates() -> None:
+    _clear_buckets()
+
+    feature_refresh.register_cache_buckets()
+    feature_refresh.register_cache_buckets()
+
+    names = telemetry.list_buckets()
+    for name in EXPECTED_NEW_BUCKETS:
+        assert name in names
+    assert len(names) == len(set(names))
+
+
+def test_default_registration_includes_existing_and_new_buckets(monkeypatch) -> None:
+    _clear_buckets()
+    monkeypatch.setattr("shared.sheets.onboarding.register_cache_buckets", lambda: None)
+    monkeypatch.setattr(
+        "shared.sheets.onboarding_questions.register_cache_buckets", lambda: None
+    )
+    monkeypatch.setattr(
+        "shared.sheets.config_service.register_cache_buckets", lambda: None
+    )
+    monkeypatch.setattr("shared.sheets.fusion.register_cache_buckets", lambda: None)
+    monkeypatch.setattr(
+        "shared.sheets.reaction_roles.register_cache_buckets", lambda: None
+    )
+
+    runtime.register_default_cache_buckets()
+
+    names = telemetry.list_buckets()
+    assert "clans" in names
+    assert "templates" in names
+    assert "clan_ad_messages" in names
+    assert "clan_ad_rules" in names
+    assert "shard_mercy" in names
+    assert len(names) == len(set(names))
+
+
+def test_clan_ad_buckets_use_config_pointers(monkeypatch) -> None:
+    _clear_buckets()
+    requested_keys = []
+    fetched_tabs = []
+
+    def fake_config_value(key, default=None, *, force=False):
+        requested_keys.append((key, force))
+        return {
+            "clan_ad_messages_tab": "AdMessages",
+            "clan_ad_rules_tab": "AdRules",
+        }.get(key, default)
+
+    async def fake_fetch(sheet_id, tab_name):
+        fetched_tabs.append((sheet_id, tab_name))
+        return [["header"], ["row"]]
+
+    monkeypatch.setattr("shared.sheets.recruitment.get_config_value", fake_config_value)
+    monkeypatch.setattr(
+        "shared.sheets.recruitment.get_recruitment_sheet_id", lambda: "sheet123"
+    )
+    monkeypatch.setattr("shared.sheets.async_core.afetch_values", fake_fetch)
+    feature_refresh.register_cache_buckets()
+
+    asyncio.run(cache_service.cache.refresh_now("clan_ad_messages", actor="test"))
+    asyncio.run(cache_service.cache.refresh_now("clan_ad_rules", actor="test"))
+
+    assert ("clan_ad_messages_tab", True) in requested_keys
+    assert ("clan_ad_rules_tab", True) in requested_keys
+    assert ("sheet123", "AdMessages") in fetched_tabs
+    assert ("sheet123", "AdRules") in fetched_tabs
+
+
+def test_missing_config_pointer_is_readable_failure(monkeypatch) -> None:
+    _clear_buckets()
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(cache_service.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        "shared.sheets.recruitment.get_config_value",
+        lambda key, default=None, *, force=False: default,
+    )
+    feature_refresh.register_cache_buckets()
+
+    result = asyncio.run(telemetry.refresh_now("clan_ad_rules", actor="test"))
+
+    assert not result.ok
+    assert "missing Config key clan_ad_rules_tab" in (result.error or "")
+
+
+def test_bad_tab_name_is_readable_failure(monkeypatch) -> None:
+    _clear_buckets()
+
+    async def no_sleep(_seconds):
+        return None
+
+    async def bad_fetch(sheet_id, tab_name):
+        raise RuntimeError("not found")
+
+    monkeypatch.setattr(cache_service.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        "shared.sheets.recruitment.get_config_value",
+        lambda key, default=None, *, force=False: "BogusTab",
+    )
+    monkeypatch.setattr(
+        "shared.sheets.recruitment.get_recruitment_sheet_id", lambda: "sheet123"
+    )
+    monkeypatch.setattr("shared.sheets.async_core.afetch_values", bad_fetch)
+    feature_refresh.register_cache_buckets()
+
+    result = asyncio.run(telemetry.refresh_now("clan_ad_messages", actor="test"))
+
+    assert not result.ok
+    assert "could not read configured tab BogusTab" in (result.error or "")
+
+
+def test_new_bucket_labels_are_readable() -> None:
+    from c1c_coreops.cog import _format_bucket_label
+
+    assert _format_bucket_label("clan_ad_messages") == "Clan Ad Messages"
+    assert _format_bucket_label("clan_ad_rules") == "Clan Ad Rules"
+    assert _format_bucket_label("c1c_ad") == "C1C Ad"
+    assert _format_bucket_label("whoweare_role_map") == "WhoWeAre Role Map"
+
+
+def test_added_config_keys_are_declared_in_expected_sources() -> None:
+    from modules.community import reset_reminders
+    from modules.community.shard_tracker import data as shard_data
+    from modules.housekeeping import c1c_ad, cleanup, keepalive
+    from modules.recruitment import clan_ads
+    from shared.sheets import recruitment
+
+    assert "clan_ad_messages_tab" in clan_ads.CONFIG_KEYS
+    assert "clan_ad_rules_tab" in clan_ads.CONFIG_KEYS
+    assert recruitment.get_reservations_tab_name.__name__ == "get_reservations_tab_name"
+    assert recruitment.get_reports_tab_name.__name__ == "get_reports_tab_name"
+    assert recruitment.get_role_map_tab_name.__name__ == "get_role_map_tab_name"
+    assert "C1C_AD_TAB" in c1c_ad.CONFIG_KEYS
+    assert "C1C_AD_TEXT_TAB" in c1c_ad.CONFIG_KEYS
+    assert cleanup.CONFIG_TAB == "HOUSEKEEPING_CLEANUP_TAB"
+    assert keepalive.CONFIG_TAB == "HOUSEKEEPING_KEEPALIVE_TAB"
+    assert reset_reminders.scheduler._RESET_REMINDER_TAB_KEY == "RESET_REMINDER_TAB"
+
+    shard_config_keys = {
+        "shard_mercy_tab",
+        "SHARD_CLANS_TAB",
+        "SHARD_REMINDER_TAB",
+        "shard_share_copy_tab",
+        "shard_share_voice_targets_tab",
+    }
+    import inspect
+
+    shard_source = "\n".join(
+        inspect.getsource(obj)
+        for obj in (
+            shard_data.ShardSheetStore.get_config,
+            shard_data.ShardSheetStore._load_shard_clans,
+            shard_data.ShardSheetStore.get_sent_weekly_reminder_keys,
+            shard_data.ShardSheetStore.get_share_copy_rows,
+            shard_data.ShardSheetStore.get_share_voice_target_rows,
+        )
+    )
+    for key in shard_config_keys:
+        assert key in shard_source


### PR DESCRIPTION
### Motivation

- Ensure sheet-backed feature tabs can be manually warmed by `!refresh all` by registering them as cache-service buckets.
- Provide human-friendly bucket labels for display in CoreOps refresh output.
- Document the new buckets and their sources for auditability.

### Description

- Add `shared/sheets/feature_refresh.py` which registers readable cache buckets for recruitment and milestones-driven sheet tabs and provides loaders (`_recruitment_config_tab_loader` and `_milestones_config_tab_loader`).
- Update `shared/sheets/runtime.py` to call `feature_refresh.register_cache_buckets()` during Sheets setup so these buckets are included in default registration.
- Add a `_BUCKET_LABELS` mapping and update `_format_bucket_label` in `packages/c1c-coreops/src/c1c_coreops/cog.py` to render friendly names for the new buckets.
- Add an audit document `docs/audits/refresh_all_bucket_audit.md` listing added buckets, their config keys/sources, and rationale for intentionally excluded tabs.
- Add comprehensive tests in `tests/shared/sheets/test_feature_refresh.py` covering registration without duplicates, default registration integration, loader behavior for config pointers, failure modes, label formatting, and declared config keys.

### Testing

- Ran the new feature refresh test module with `pytest tests/shared/sheets/test_feature_refresh.py`, and all tests passed.
- The tests exercised registration idempotence and actual refresh flows using monkeypatches and assertions against `shared.cache.telemetry` and `shared.sheets.cache_service` behaviors, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4240eb9d548323810fdc0d81ec624a)