### PR TITLE
Remove shard_reminders from refresh-all buckets

### DIFF
--- a/docs/audits/refresh_all_bucket_audit.md
+++ b/docs/audits/refresh_all_bucket_audit.md
@@ -33,7 +33,6 @@ Date: 2026-06-29
 | `reset_reminders` | `RESET_REMINDER_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.reset_reminders.scheduler._RESET_REMINDER_TAB_KEY` |
 | `shard_mercy` | `SHARD_MERCY_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data.ShardSheetStore.get_config()` |
 | `shard_clans` | `SHARD_CLANS_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("SHARD_CLANS_TAB")` |
-| `shard_reminders` | `SHARD_REMINDER_TAB` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("SHARD_REMINDER_TAB")` |
 | `shard_share_copy` | `shard_share_copy_tab` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("shard_share_copy_tab")` |
 | `shard_voice_targets` | `shard_share_voice_targets_tab` | Runtime/shared config merged from Milestones Config | `modules.community.shard_tracker.data._config_tab_name("shard_share_voice_targets_tab")` |
 
@@ -61,7 +60,7 @@ Date: 2026-06-29
 | Reset reminders | Missing and added in this PR | Uses existing `RESET_REMINDER_TAB` from Milestones Config merged into runtime/shared config. |
 | Shard mercy | Missing and added in this PR | Uses existing `SHARD_MERCY_TAB` from Milestones Config merged into runtime/shared config. |
 | Shard clans | Missing and added in this PR | Uses existing `SHARD_CLANS_TAB` from Milestones Config merged into runtime/shared config. |
-| Shard reminders | Missing and added in this PR | Uses existing `SHARD_REMINDER_TAB` from Milestones Config merged into runtime/shared config. |
+| Shard reminders | Intentionally not refreshable because not cache-backed | `SHARD_REMINDER_TAB` is the shard tracker weekly reminder dedupe/writeback ledger read by `get_sent_weekly_reminder_keys()` and written by `mark_weekly_reminder_sent()`, not a shared cache bucket. |
 | Shard share copy | Missing and added in this PR | Uses existing `shard_share_copy_tab`/normalized `SHARD_SHARE_COPY_TAB` from runtime/shared config. |
 | Shard voice targets | Missing and added in this PR | Uses existing `shard_share_voice_targets_tab`/normalized `SHARD_SHARE_VOICE_TARGETS_TAB` from runtime/shared config. |
 | Fusion user progress | Intentionally not refreshable because not cache-backed | `FUSION_USER_EVENT_PROGRESS_TAB` is a mutable progress/writeback ledger, not a shared cache bucket. |
@@ -86,7 +85,6 @@ The exact table status depends on live Config and Sheets access. The bucket list
 - Reset Reminders
 - Shard Clans
 - Shard Mercy
-- Shard Reminders
 - Shard Share Copy
 - Shard Voice Targets
 - WhoWeAre Role Map

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -500,7 +500,6 @@ _BUCKET_LABELS: Dict[str, str] = {
     "reset_reminders": "Reset Reminders",
     "shard_clans": "Shard Clans",
     "shard_mercy": "Shard Mercy",
-    "shard_reminders": "Shard Reminders",
     "shard_share_copy": "Shard Share Copy",
     "shard_voice_targets": "Shard Voice Targets",
     "whoweare_role_map": "WhoWeAre Role Map",

--- a/shared/sheets/feature_refresh.py
+++ b/shared/sheets/feature_refresh.py
@@ -83,7 +83,6 @@ def register_cache_buckets() -> None:
         ("reset_reminders", "RESET_REMINDER_TAB"),
         ("shard_mercy", "SHARD_MERCY_TAB"),
         ("shard_clans", "SHARD_CLANS_TAB"),
-        ("shard_reminders", "SHARD_REMINDER_TAB"),
         ("shard_share_copy", "shard_share_copy_tab"),
         ("shard_voice_targets", "shard_share_voice_targets_tab"),
     )

--- a/tests/shared/sheets/test_feature_refresh.py
+++ b/tests/shared/sheets/test_feature_refresh.py
@@ -17,7 +17,6 @@ EXPECTED_NEW_BUCKETS = {
     "reset_reminders",
     "shard_mercy",
     "shard_clans",
-    "shard_reminders",
     "shard_share_copy",
     "shard_voice_targets",
 }


### PR DESCRIPTION
### Motivation
- `!refresh all` attempted to warm a `shard_reminders` bucket and reported `missing Config key SHARD_REMINDER_TAB`, revealing that the shard reminder worksheet was registered as a cache bucket by mistake. 
- The shard reminder sheet is a mutable weekly reminder dedupe/writeback ledger and is read/written directly by the shard tracker, so it should not be treated as a shared cache bucket.

### Description
- Removed `shard_reminders` from `shared/sheets/feature_refresh.register_cache_buckets()` so it is no longer included in `!refresh all` warmers. 
- Removed the corresponding display label from CoreOps `_BUCKET_LABELS` in `packages/c1c-coreops/src/c1c_coreops/cog.py` and adjusted the feature-refresh test expectation in `tests/shared/sheets/test_feature_refresh.py`. 
- Updated the refresh-all audit doc `docs/audits/refresh_all_bucket_audit.md` to document that `SHARD_REMINDER_TAB` is shard tracker storage and is intentionally not refreshable. 
- Confirmed the real config key is `SHARD_REMINDER_TAB`, the expected headers are `clan_key`, `window_key`, `reminder_type`, and `sent_at_utc`, and the sheet is read/written by `modules.community.shard_tracker` via `ShardSheetStore.get_sent_weekly_reminder_keys()` and `ShardSheetStore.mark_weekly_reminder_sent()`.

### Testing
- Ran `pytest tests/shared/sheets/test_feature_refresh.py tests/community/shard_tracker/test_reminders.py` and all tests passed (`12 passed`, with warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425e842df883238e2b0f76de904e25)