### PR TITLE
cluster_role_map: filter missing/empty roles, track missing/empty counts, and filter stale member cache

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -523,6 +523,7 @@ class AppAdmin(commands.Cog):
             "📘 **Cluster role map** — "
             f"cmd=whoweare • guild={guild_name} • categories={render.category_count} "
             f"• roles={render.role_count} • unassigned_roles={render.unassigned_roles} "
+            f"• missing_roles={render.missing_roles} • empty_roles={render.empty_roles} "
             f"• category_messages={len(jump_entries)} • target_channel={target_label}"
         )
 

--- a/modules/ops/cluster_role_map.py
+++ b/modules/ops/cluster_role_map.py
@@ -58,6 +58,8 @@ class RoleMapRender:
     category_count: int
     role_count: int
     unassigned_roles: int
+    missing_roles: int = 0
+    empty_roles: int = 0
 
 
 @dataclass(slots=True)
@@ -178,13 +180,40 @@ def _category_emoji(name: str) -> str:
     return CATEGORY_EMOJIS.get(normalized, "•")
 
 
+def _member_currently_has_role(member: object, role_id: int) -> bool:
+    """Return whether a role member object currently exposes the resolved role."""
+
+    roles = getattr(member, "roles", None)
+    if roles is None:
+        return False
+    return any(getattr(role, "id", None) == role_id for role in roles)
+
+
+def _role_member_mentions(role: object) -> List[str]:
+    """Build mentions only from the resolved live Discord role membership."""
+
+    role_id = int(getattr(role, "id", 0) or 0)
+    mentions: List[str] = []
+    seen: set[str] = set()
+    for member in getattr(role, "members", []) or []:
+        if not _member_currently_has_role(member, role_id):
+            continue
+        mention = str(getattr(member, "mention", "") or "").strip()
+        if not mention or mention in seen:
+            continue
+        seen.add(mention)
+        mentions.append(mention)
+    return mentions
+
+
 def build_role_map_render(guild: discord.Guild | object, entries: Sequence[RoleMapRow]) -> RoleMapRender:
     """Compose the Discord message for the supplied WhoWeAre rows."""
 
     order, grouped = _category_order(entries)
     category_display: Dict[str, str] = {}
     role_count = 0
-    unassigned_roles = 0
+    missing_roles = 0
+    empty_roles = 0
     categories: List[RoleMapCategoryRender] = []
 
     get_role = getattr(guild, "get_role", None)
@@ -197,26 +226,41 @@ def build_role_map_render(guild: discord.Guild | object, entries: Sequence[RoleM
                 category_display[category] = row.category_display or row.category
             role_count += 1
             role = get_role(row.role_id) if callable(get_role) else None
-            display_name = _normalize_text(row.sheet_role_name)
-            if role is not None:
-                members = list(getattr(role, "members", []) or [])
-                if not display_name:
-                    display_name = _normalize_text(getattr(role, "name", ""))
-            if not display_name:
-                display_name = _normalize_text(getattr(role, "name", "")) if role is not None else ""
+            role_ref = f"role_id={row.role_id}"
+            if row.sheet_role_name:
+                role_ref = f"{role_ref} sheet_role_name={row.sheet_role_name!r}"
+            if role is None:
+                missing_roles += 1
+                log.warning(
+                    "cluster_role_map: hiding category role because configured role was not found",
+                    extra={
+                        "category_key": row.category,
+                        "category_name": row.category_display or row.category,
+                        "role_reference": role_ref,
+                        "hidden_reason": "role_not_found",
+                    },
+                )
+                continue
+
+            mentions = _role_member_mentions(role)
+            if not mentions:
+                empty_roles += 1
+                log.info(
+                    "cluster_role_map: hiding category role because no current members are assigned",
+                    extra={
+                        "category_key": row.category,
+                        "category_name": row.category_display or row.category,
+                        "role_reference": role_ref,
+                        "hidden_reason": "no_current_members",
+                    },
+                )
+                continue
+
+            display_name = _normalize_text(getattr(role, "name", ""))
             if not display_name:
                 display_name = f"role {row.role_id}"
             description = row.role_description or DEFAULT_DESCRIPTION
             usage = row.role_usage
-            mentions: List[str] = []
-            if members:
-                mentions = [
-                    str(getattr(member, "mention", getattr(member, "name", "")))
-                    for member in members
-                    if str(getattr(member, "mention", getattr(member, "name", "")))
-                ]
-            if not mentions:
-                unassigned_roles += 1
             role_rows.append(
                 RoleEntryRender(
                     role_id=row.role_id,
@@ -236,7 +280,9 @@ def build_role_map_render(guild: discord.Guild | object, entries: Sequence[RoleM
         categories=categories,
         category_count=len(categories),
         role_count=role_count,
-        unassigned_roles=unassigned_roles,
+        unassigned_roles=missing_roles + empty_roles,
+        missing_roles=missing_roles,
+        empty_roles=empty_roles,
     )
 
 

--- a/tests/cogs/test_app_admin.py
+++ b/tests/cogs/test_app_admin.py
@@ -385,7 +385,8 @@ def test_whoweare_command_posts_multi_message_map(monkeypatch):
         assert category_message.content.rstrip().endswith(cluster_role_map.INVISIBLE_MARKER)
         assert log_messages[-1] == (
             "📘 **Cluster role map** — cmd=whoweare • guild=Guild • categories=1 "
-            "• roles=1 • unassigned_roles=0 • category_messages=1 • target_channel=#Guild:321"
+            "• roles=1 • unassigned_roles=0 • missing_roles=0 • empty_roles=0 "
+            "• category_messages=1 • target_channel=<#321>"
         )
 
     asyncio.run(_run())
@@ -494,7 +495,8 @@ def test_whoweare_command_handles_empty_categories(monkeypatch):
         assert len(channel.sent_messages) == 1
         assert "No categories are currently available" in channel.sent_messages[0].content
         ctx.reply.assert_awaited_once_with("Cluster role map updated.", mention_author=False)
-        assert log_messages[-1].endswith("category_messages=0 • target_channel=#Guild:222")
+        assert log_messages[-1].endswith("category_messages=0 • target_channel=<#222>")
+        assert "missing_roles=0 • empty_roles=0" in log_messages[-1]
 
     asyncio.run(_run())
 
@@ -695,7 +697,7 @@ def test_whoweare_command_falls_back_for_foreign_channel(monkeypatch):
 
         assert channel.sent_messages == []
         assert len(foreign.sent_messages) == 2
-        assert "channel_fallback=#Elsewhere:777" in log_messages[0]
+        assert "channel_fallback=<#777>" in log_messages[0]
         ctx.reply.assert_awaited_once_with(
             "Cluster role map refreshed in <#777>.", mention_author=False
         )

--- a/tests/modules/ops/test_cluster_role_map.py
+++ b/tests/modules/ops/test_cluster_role_map.py
@@ -4,8 +4,10 @@ from modules.ops import cluster_role_map
 
 
 class DummyMember:
-    def __init__(self, mention: str):
+    def __init__(self, mention: str, roles: list[object] | None = None):
         self.mention = mention
+        if roles is not None:
+            self.roles = roles
 
 
 class DummyRole:
@@ -47,7 +49,7 @@ def test_build_role_map_render_renders_categories_and_members():
             category="ClusterLeadership",
             category_display="Cluster Leadership",
             role_id=1,
-            sheet_role_name="Lead", 
+            sheet_role_name="Lead",
             role_description="Runs it",
             role_usage="",
         ),
@@ -55,7 +57,7 @@ def test_build_role_map_render_renders_categories_and_members():
             category="ClusterSupport",
             category_display="",
             role_id=2,
-            sheet_role_name="Support", 
+            sheet_role_name="Support",
             role_description="",
             role_usage="",
         ),
@@ -63,35 +65,37 @@ def test_build_role_map_render_renders_categories_and_members():
             category="ClusterSupport",
             category_display="",
             role_id=99,
-            sheet_role_name="Backup", 
+            sheet_role_name="Backup",
             role_description="Keeps receipts",
             role_usage="",
         ),
     ]
+    leader_role = DummyRole(1, "Leader", [])
+    leader_role.members = [DummyMember("<@1>", roles=[leader_role])]
     guild = DummyGuild(
         "TestGuild",
         [
-            DummyRole(1, "Leader", [DummyMember("<@1>")]),
+            leader_role,
             DummyRole(2, "Shield", []),
         ],
     )
 
     render = cluster_role_map.build_role_map_render(guild, entries)
 
-    assert render.category_count == 2
+    assert render.category_count == 1
     assert render.role_count == 3
     assert render.unassigned_roles == 2
-    assert len(render.categories) == 2
+    assert render.missing_roles == 1
+    assert render.empty_roles == 1
+    assert len(render.categories) == 1
     leadership = render.categories[0]
-    support = render.categories[1]
-    assert leadership.name == "ClusterLeadership"
-    assert leadership.roles[0].display_name == "Lead"
+    assert leadership.name == "Cluster Leadership"
+    assert leadership.roles[0].display_name == "Leader"
     assert leadership.roles[0].members == ["<@1>"]
-    assert support.roles[0].description == "no description set"
     embeds = cluster_role_map.build_category_embeds(leadership)
     assert len(embeds) == 1
-    assert embeds[0].title == "🔥 ClusterLeadership"
-    assert "**Lead**" in embeds[0].description
+    assert embeds[0].title == "🔥 Cluster Leadership"
+    assert "**Leader**" in embeds[0].description
     assert "Runs it" in embeds[0].description
     assert "<@1>" in embeds[0].description
 
@@ -120,3 +124,73 @@ def test_build_category_embeds_renders_usage_instruction():
     embeds = cluster_role_map.build_category_embeds(category)
     category_body = embeds[0].description
     assert "↳ Use <@&42> for" not in category_body
+
+
+def test_build_role_map_render_hides_missing_role_without_members(caplog):
+    entries = [
+        cluster_role_map.RoleMapRow(
+            category="ClusterLeadership",
+            category_display="Cluster Leadership",
+            role_id=404,
+            sheet_role_name="@unknown-role",
+            role_description="Stale sheet row",
+            role_usage="stale pings",
+        )
+    ]
+    guild = DummyGuild("TestGuild", [])
+
+    render = cluster_role_map.build_role_map_render(guild, entries)
+
+    assert render.categories == []
+    assert render.category_count == 0
+    assert render.role_count == 1
+    assert render.missing_roles == 1
+    assert render.unassigned_roles == 1
+    assert "configured role was not found" in caplog.text
+
+
+def test_build_role_map_render_does_not_list_member_when_roles_unavailable():
+    role = DummyRole(12, "Live Role", [DummyMember("<@unverified>")])
+    entries = [
+        cluster_role_map.RoleMapRow(
+            category="ClusterSupport",
+            category_display="Cluster Support",
+            role_id=12,
+            sheet_role_name="Live Role",
+            role_description="Helps",
+            role_usage="support",
+        )
+    ]
+    guild = DummyGuild("TestGuild", [role])
+
+    render = cluster_role_map.build_role_map_render(guild, entries)
+
+    assert render.categories == []
+    assert render.empty_roles == 1
+    assert render.unassigned_roles == 1
+
+
+def test_build_role_map_render_filters_stale_role_member_cache():
+    role = DummyRole(10, "Live Role", [])
+    other_role = DummyRole(11, "Other Role", [])
+    role.members = [
+        DummyMember("<@current>", roles=[role]),
+        DummyMember("<@stale>", roles=[other_role]),
+    ]
+    entries = [
+        cluster_role_map.RoleMapRow(
+            category="ClusterSupport",
+            category_display="Cluster Support",
+            role_id=10,
+            sheet_role_name="Stale Name",
+            role_description="Helps",
+            role_usage="support",
+        )
+    ]
+    guild = DummyGuild("TestGuild", [role, other_role])
+
+    render = cluster_role_map.build_role_map_render(guild, entries)
+
+    assert render.category_count == 1
+    assert render.categories[0].roles[0].display_name == "Live Role"
+    assert render.categories[0].roles[0].members == ["<@current>"]


### PR DESCRIPTION
### Motivation

- Avoid showing roles in the WhoWeAre output that are not present on the guild or that have no current members, and make those conditions visible in logs and metrics.

### Description

- Add `missing_roles` and `empty_roles` counters to `RoleMapRender` and compute them in `build_role_map_render` while skipping roles that are not found or have no current members. 
- Introduce `_member_currently_has_role` and `_role_member_mentions` helpers to filter role members by live membership and de-duplicate mentions. 
- Log warnings/info when rows are hidden for `role_not_found` or `no_current_members`, and update the app admin logging line to include `missing_roles` and `empty_roles`. 
- Update behavior to choose role display names from the live role when available and to treat `unassigned_roles` as the sum of missing and empty roles, plus adjust related tests and expected channel mention formatting.

### Testing

- Updated and ran unit tests in `tests/modules/ops/test_cluster_role_map.py` and `tests/cogs/test_app_admin.py` which exercise `build_role_map_render`, `build_category_embeds`, and the `whoweare` command behavior. 
- Added tests covering hiding missing roles, filtering stale member cache, and empty-role handling; all tests passed when run with `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42b5cd66708323840b1679be1c3c2b)