### PR TITLE
Add async config resolvers and resilient scheduler registration for housekeeping jobs

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import inspect
 import logging
 import math
 import os
@@ -1581,9 +1582,22 @@ class Runtime:
             )
             return
 
-        cleanup_config = await housekeeping_cleanup.resolve_cleanup_config_async(
-            cleanup_logger
-        )
+        try:
+            cleanup_config = await housekeeping_cleanup.resolve_cleanup_config_async(
+                cleanup_logger
+            )
+        except Exception as exc:
+            if sheets_core._is_rate_limited_error(exc):
+                cleanup_logger.warning(
+                    "cleanup scheduler config resolve hit Google Sheets quota/backoff; "
+                    "skipping cleanup registration for this ready cycle without failing startup: %s",
+                    exc,
+                )
+                return
+            cleanup_logger.exception(
+                "cleanup scheduler config resolve failed; skipping cleanup registration without failing startup"
+            )
+            return
         if cleanup_config is None or not cleanup_config.enabled:
             return
 
@@ -1625,8 +1639,19 @@ class Runtime:
 
         async def startup_validation_runner() -> None:
             try:
+                run_cleanup_kwargs: dict[str, Any] = {
+                    "startup_validation": True,
+                    "writeback": False,
+                }
+                try:
+                    if "resolved_config" in inspect.signature(
+                        housekeeping_cleanup.run_cleanup
+                    ).parameters:
+                        run_cleanup_kwargs["resolved_config"] = cleanup_config
+                except (TypeError, ValueError):
+                    run_cleanup_kwargs["resolved_config"] = cleanup_config
                 await housekeeping_cleanup.run_cleanup(
-                    self.bot, cleanup_logger, startup_validation=True, writeback=False
+                    self.bot, cleanup_logger, **run_cleanup_kwargs
                 )
             except asyncio.CancelledError:
                 raise
@@ -1690,6 +1715,7 @@ class Runtime:
         from modules.recruitment import clan_ads as recruitment_clan_ads
         from modules.common import feature_flags
         from shared.sheets import recruitment as recruitment_sheets
+        from shared.sheets import core as sheets_core
         from modules.ops import server_map as server_map_module
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
@@ -1754,7 +1780,7 @@ class Runtime:
             log.info("Mirralith overview job disabled; MIRRALITH_POST_CRON is not set.")
 
         try:
-            c1c_refresh_days_raw = recruitment_sheets.get_config_value(
+            c1c_refresh_days_raw = await recruitment_sheets.get_config_value_async(
                 "C1C_AD_REFRESH_DAYS", None
             )
             c1c_refresh_days = (
@@ -1819,9 +1845,22 @@ class Runtime:
 
         if toggles.housekeeping_enabled:
             keepalive_logger = logging.getLogger("c1c.housekeeping.keepalive")
-            keepalive_config = housekeeping_keepalive.resolve_keepalive_config(
-                keepalive_logger
-            )
+            try:
+                keepalive_config = await housekeeping_keepalive.resolve_keepalive_config_async(
+                    keepalive_logger
+                )
+            except Exception as exc:
+                keepalive_config = None
+                if sheets_core._is_rate_limited_error(exc):
+                    keepalive_logger.warning(
+                        "thread keepalive config resolve hit Google Sheets quota/backoff; "
+                        "skipping keepalive registration for this ready cycle without failing startup: %s",
+                        exc,
+                    )
+                else:
+                    keepalive_logger.exception(
+                        "thread keepalive config resolve failed; skipping keepalive registration without failing startup"
+                    )
             if keepalive_config and keepalive_config.enabled:
                 keepalive_job = self.scheduler.every(
                     hours=float(keepalive_config.run_every_hours),

--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -1192,6 +1192,7 @@ async def run_cleanup(
     *,
     startup_validation: bool = False,
     writeback: bool = True,
+    resolved_config: CleanupConfig | None = None,
 ) -> CleanupRunSummary:
     logger = logger or log
     if startup_validation and _CLEANUP_RUN_LOCK.locked():
@@ -1207,7 +1208,11 @@ async def run_cleanup(
         return summary
     async with _CLEANUP_RUN_LOCK:
         return await _run_cleanup_locked(
-            bot, logger, startup_validation=startup_validation, writeback=writeback
+            bot,
+            logger,
+            startup_validation=startup_validation,
+            writeback=writeback,
+            resolved_config=resolved_config,
         )
 
 
@@ -1217,6 +1222,7 @@ async def _run_cleanup_locked(
     *,
     startup_validation: bool = False,
     writeback: bool = True,
+    resolved_config: CleanupConfig | None = None,
 ) -> CleanupRunSummary:
     logger = logger or log
     stage = "resolve_config"
@@ -1228,7 +1234,7 @@ async def _run_cleanup_locked(
     }
     summary = CleanupRunSummary(writeback=writeback)
     try:
-        config = await resolve_cleanup_config_async(logger)
+        config = resolved_config or await resolve_cleanup_config_async(logger)
         if config is None or not config.enabled:
             summary.status = "disabled"
             return summary

--- a/modules/housekeeping/keepalive.py
+++ b/modules/housekeeping/keepalive.py
@@ -519,6 +519,72 @@ async def _process_thread(
     return "posted", True, _format_utc(last_activity), errors
 
 
+async def resolve_keepalive_config_async(
+    logger: logging.Logger | None = None,
+) -> KeepaliveConfig | None:
+    """Async variant of resolve_keepalive_config for startup/runtime code."""
+
+    logger = logger or log
+    toggle = feature_flags.status(CONFIG_ENABLED)
+    if toggle.get("invalid"):
+        logger.warning(
+            "thread keepalive not scheduled; required Feature Toggle %s has invalid value %r in %s",
+            CONFIG_ENABLED,
+            toggle.get("invalid_value"),
+            toggle.get("source_tab") or "Feature Toggles",
+        )
+        return None
+    if not toggle.get("present"):
+        logger.warning(
+            "thread keepalive not scheduled; required Feature Toggle %s is missing from %s",
+            CONFIG_ENABLED,
+            toggle.get("source_tab") or "Feature Toggles",
+        )
+        return None
+    if not toggle.get("enabled"):
+        logger.info(
+            "thread keepalive disabled by Feature Toggle %s=FALSE",
+            CONFIG_ENABLED,
+        )
+        return None
+
+    raw = {
+        key: await recruitment.get_config_value_async(key, None)
+        for key in REQUIRED_CONFIG_KEYS
+    }
+    missing = [
+        key for key, value in raw.items() if value is None or not str(value).strip()
+    ]
+    if missing:
+        logger.warning(
+            "thread keepalive config missing required Config key(s): %s",
+            ", ".join(missing),
+        )
+        return None
+
+    stale_after_hours = _parse_positive_hours(raw[CONFIG_STALE_AFTER_HOURS])
+    run_every_hours = _parse_positive_hours(raw[CONFIG_RUN_EVERY_HOURS])
+    if stale_after_hours is None:
+        logger.warning(
+            "thread keepalive config invalid: %s must be a positive number",
+            CONFIG_STALE_AFTER_HOURS,
+        )
+        return None
+    if run_every_hours is None:
+        logger.warning(
+            "thread keepalive config invalid: %s must be a positive number",
+            CONFIG_RUN_EVERY_HOURS,
+        )
+        return None
+
+    return KeepaliveConfig(
+        True,
+        str(raw[CONFIG_TAB]).strip(),
+        str(raw[CONFIG_DEFAULT_MESSAGE]).strip(),
+        stale_after_hours,
+        run_every_hours,
+    )
+
 def _cell_name(row: int, col_zero: int) -> str:
     col = col_zero + 1
     letters = ""
@@ -554,7 +620,7 @@ async def run_keepalive(
     bot: commands.Bot, logger: logging.Logger | None = None
 ) -> None:
     logger = logger or log
-    config = resolve_keepalive_config(logger)
+    config = await resolve_keepalive_config_async(logger)
     if config is None or not config.enabled:
         return
 
@@ -782,6 +848,7 @@ __all__ = [
     "parent_keepalive_message_for_thread",
     "_delete_previous_keepalive_if_latest",
     "resolve_keepalive_config",
+    "resolve_keepalive_config_async",
     "rows_from_values",
     "run_keepalive",
     "select_keepalive_message",

--- a/modules/recruitment/clan_ads.py
+++ b/modules/recruitment/clan_ads.py
@@ -212,7 +212,10 @@ async def build_clan_card(
 async def load_config(
     reporter: RunReporter | None = None, *, force: bool = False
 ) -> Config | None:
-    vals = {k: recruitment.get_config_value(k, None, force=force) for k in CONFIG_KEYS}
+    vals = {
+        k: await recruitment.get_config_value_async(k, None, force=force)
+        for k in CONFIG_KEYS
+    }
     missing = [
         config_key for config_key in REQUIRED_CONFIG_KEYS if not vals.get(config_key)
     ]

--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import random
+import time
 from functools import lru_cache
 from typing import Any, Awaitable, Callable, Dict, Tuple, TypeVar
 
@@ -149,17 +150,19 @@ def _next_backoff_delay(delay: float, *, multiplier: float, jitter_ratio: float 
 
 
 def _sleep_with_new_loop(delay: float) -> None:
-    """Sleep for ``delay`` seconds without relying on ``time.sleep``."""
+    """Sleep for ``delay`` seconds only when no event loop is active."""
 
     if delay <= 0:
         return
 
     try:
-        asyncio.run(asyncio.sleep(delay))
-    except RuntimeError as exc:  # pragma: no cover - unexpected event loop reuse
-        raise RuntimeError(
-            "_retry_with_backoff must not run inside an active event loop; use the async variant"
-        ) from exc
+        asyncio.get_running_loop()
+    except RuntimeError:
+        time.sleep(delay)
+        return
+    raise RuntimeError(
+        "_retry_with_backoff must not run inside an active event loop; use the async variant"
+    )
 
 
 def _resolve_sheet_id(sheet_id: str | None) -> str:

--- a/tests/modules/housekeeping/test_keepalive.py
+++ b/tests/modules/housekeeping/test_keepalive.py
@@ -103,6 +103,42 @@ def test_invalid_feature_toggle_logs_invalid_and_does_not_resolve(monkeypatch, c
     assert "sometimes" in caplog.text
 
 
+def test_resolve_keepalive_config_async_never_calls_sync_resolver(monkeypatch):
+    import asyncio
+
+    values = {
+        keepalive.CONFIG_TAB: "ConfiguredBySheet",
+        keepalive.CONFIG_DEFAULT_MESSAGE: "bump",
+        keepalive.CONFIG_STALE_AFTER_HOURS: "144",
+        keepalive.CONFIG_RUN_EVERY_HOURS: "6",
+    }
+
+    monkeypatch.setattr(
+        keepalive.feature_flags, "status", lambda key: _toggle_status(enabled=True)
+    )
+    monkeypatch.setattr(
+        keepalive,
+        "resolve_keepalive_config",
+        lambda _logger=None: (_ for _ in ()).throw(
+            AssertionError("async resolver must not call sync resolver")
+        ),
+    )
+
+    async def fake_get_config_value_async(key, default=None):
+        return values.get(key, default)
+
+    monkeypatch.setattr(
+        keepalive.recruitment, "get_config_value_async", fake_get_config_value_async
+    )
+
+    config = asyncio.run(keepalive.resolve_keepalive_config_async())
+
+    assert config is not None
+    assert config.tab_name == "ConfiguredBySheet"
+    assert config.default_message == "bump"
+    assert config.stale_after_hours == 144
+    assert config.run_every_hours == 6
+
 def test_resolve_keepalive_config_reads_enabled_from_feature_toggle_only(monkeypatch):
     requested_toggles = []
     config_keys = []
@@ -245,8 +281,11 @@ def _run_keepalive_with_sheet(
     async def fake_send_log_message(_summary):
         return None
 
+    async def fake_resolve_config(_logger=None):
+        return config
+
     monkeypatch.setattr(
-        keepalive, "resolve_keepalive_config", lambda _logger=None: config
+        keepalive, "resolve_keepalive_config_async", fake_resolve_config
     )
     monkeypatch.setattr(
         keepalive.recruitment, "get_recruitment_sheet_id", lambda: "sheet"


### PR DESCRIPTION
### Motivation

- Make housekeeping startup scheduler registration resilient to Google Sheets rate limits and backoff errors so startup doesn't fail on transient quota issues.
- Add async configuration resolution paths so scheduled jobs (`keepalive`, `cleanup`, `clan_ads`) can be registered/started without blocking the event loop and so runtime code uses async sheet reads.
- Allow `run_cleanup` to accept a pre-resolved config to avoid duplicate sheet reads when the runtime resolves config once for scheduling.

### Description

- Introduced `resolve_keepalive_config_async` in `modules/housekeeping/keepalive.py` and switched `run_keepalive` to use the async resolver (`await resolve_keepalive_config_async`).
- Updated `modules/housekeeping/cleanup.py` to accept an optional `resolved_config` parameter in `run_cleanup` and `_run_cleanup_locked`, and to use the provided config when present.
- In `modules/common/runtime.py` wrapped calls to resolve cleanup and keepalive configs in `try/except` and skip registration on Google Sheets quota/backoff by detecting rate-limited errors via `sheets_core._is_rate_limited_error`, logging warnings instead of failing startup; also added an `inspect`-based feature to pass `resolved_config` into `housekeeping_cleanup.run_cleanup` when the signature accepts it.
- Switched some config fetches to async variants: `recruitment.get_config_value_async` used in `modules/recruitment/clan_ads.py` and `resolve_keepalive_config_async` uses `recruitment.get_config_value_async`.
- Adjusted shared sheets helper `_sleep_with_new_loop` in `shared/sheets/core.py` to only call `time.sleep` when no running event loop is present and raise when called inside an active loop to enforce correct sync/async usage.
- Updated test `tests/modules/housekeeping/test_keepalive.py` to add `test_resolve_keepalive_config_async_never_calls_sync_resolver` and to exercise the new async resolver path.

### Testing

- Ran unit tests for the updated keepalive tests using `pytest tests/modules/housekeeping/test_keepalive.py`, and the updated test `test_resolve_keepalive_config_async_never_calls_sync_resolver` passed (test suite succeeded for that file).
- Verified existing `keepalive` unit tests that exercise both sync and async resolution paths were executed and succeeded during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42bca1c0e48323baafb6aebb770e09)