### PR TITLE
Harden ready scheduler registration against Google Sheets quota/backoff

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -25,6 +25,7 @@ from discord.ext import commands
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from shared import watchdog as watchdog_loop
+from shared.sheets import core as sheets_core
 from modules.common.logs import channel_label, log as human_log
 from shared import config as shared_config
 from shared.config import (
@@ -1703,6 +1704,48 @@ class Runtime:
             )
         )
 
+    def _log_optional_scheduler_quota_skip(
+        self,
+        *,
+        logger: logging.Logger,
+        scheduler_name: str,
+        config_source: str,
+        exc: Exception,
+    ) -> None:
+        logger.warning(
+            "%s scheduler config resolve hit Google Sheets quota/backoff; "
+            "skipping %s registration for this ready cycle without failing startup "
+            "(config_source=%s exception_type=%s): %s",
+            scheduler_name,
+            scheduler_name,
+            config_source,
+            type(exc).__name__,
+            exc,
+        )
+
+    def _register_optional_scheduler(
+        self,
+        scheduler_name: str,
+        config_source: str,
+        callback: Callable[[], Any],
+        *,
+        logger: logging.Logger | None = None,
+    ) -> bool:
+        target_logger = logger or log
+        try:
+            callback()
+            return True
+        except Exception as exc:
+            if sheets_core._is_rate_limited_error(exc):
+                self._log_optional_scheduler_quota_skip(
+                    logger=target_logger,
+                    scheduler_name=scheduler_name,
+                    config_source=config_source,
+                    exc=exc,
+                )
+                return False
+            raise
+
     async def _register_ready_schedulers_inner(self) -> None:
         from shared.sheets.cache_scheduler import (
             ensure_cache_registration,
@@ -1715,7 +1758,6 @@ class Runtime:
         from modules.recruitment import clan_ads as recruitment_clan_ads
         from modules.common import feature_flags
         from shared.sheets import recruitment as recruitment_sheets
-        from shared.sheets import core as sheets_core
         from modules.ops import server_map as server_map_module
         from modules.community.leagues import schedule_leagues_jobs
         from modules.community.fusion.scheduler import schedule_fusion_jobs
@@ -1786,9 +1828,17 @@ class Runtime:
             c1c_refresh_days = (
                 int(c1c_refresh_days_raw) if c1c_refresh_days_raw else None
             )
-        except Exception:
+        except Exception as exc:
             c1c_refresh_days = None
-            log.exception("C1C ad refresh interval lookup failed; skipping schedule")
+            if sheets_core._is_rate_limited_error(exc):
+                self._log_optional_scheduler_quota_skip(
+                    logger=log,
+                    scheduler_name="c1c_ad",
+                    config_source="Config:C1C_AD_REFRESH_DAYS",
+                    exc=exc,
+                )
+            else:
+                log.exception("C1C ad refresh interval lookup failed; skipping schedule")
 
         if c1c_refresh_days and c1c_refresh_days > 0:
             c1c_ad_job = self.scheduler.every(
@@ -1814,10 +1864,36 @@ class Runtime:
         else:
             log.info("C1C ad job disabled; C1C_AD_REFRESH_DAYS is not configured.")
 
-        if not feature_flags.is_enabled("clan_ads"):
+        try:
+            clan_ads_enabled = feature_flags.is_enabled("clan_ads")
+        except Exception as exc:
+            if sheets_core._is_rate_limited_error(exc):
+                self._log_optional_scheduler_quota_skip(
+                    logger=log,
+                    scheduler_name="clan_ads",
+                    config_source="Feature Toggle:clan_ads",
+                    exc=exc,
+                )
+                clan_ads_enabled = False
+            else:
+                raise
+
+        if not clan_ads_enabled:
             log.info("Clan ads job disabled via feature toggle.")
         else:
-            clan_ads_config = await recruitment_clan_ads.load_config(force=True)
+            try:
+                clan_ads_config = await recruitment_clan_ads.load_config(force=True)
+            except Exception as exc:
+                if sheets_core._is_rate_limited_error(exc):
+                    self._log_optional_scheduler_quota_skip(
+                        logger=log,
+                        scheduler_name="clan_ads",
+                        config_source="Config:clan ads scheduler",
+                        exc=exc,
+                    )
+                    clan_ads_config = None
+                else:
+                    raise
             if clan_ads_config and clan_ads_config.interval_hours > 0:
                 clan_ads_job = self.scheduler.every(
                     hours=clan_ads_config.interval_hours,
@@ -1890,11 +1966,36 @@ class Runtime:
         else:
             log.info("housekeeping keepalive disabled via feature toggle")
 
-        server_map_module.schedule_server_map_job(self)
-        schedule_leagues_jobs(self)
-        schedule_fusion_jobs(self)
-        schedule_shard_jobs(self)
-        schedule_reset_reminder_jobs(self)
+        self._register_optional_scheduler(
+            "server_map",
+            "Feature Toggle:SERVER_MAP / shared config",
+            lambda: server_map_module.schedule_server_map_job(self),
+            logger=logging.getLogger("c1c.server_map"),
+        )
+        self._register_optional_scheduler(
+            "leagues",
+            "environment scheduler config",
+            lambda: schedule_leagues_jobs(self),
+            logger=logging.getLogger("c1c.community.leagues.scheduler"),
+        )
+        self._register_optional_scheduler(
+            "fusion",
+            "runtime scheduler config",
+            lambda: schedule_fusion_jobs(self),
+            logger=logging.getLogger("c1c.community.fusion.scheduler"),
+        )
+        self._register_optional_scheduler(
+            "shard_weekly_reminders",
+            "runtime scheduler config",
+            lambda: schedule_shard_jobs(self),
+            logger=logging.getLogger("c1c.shards.scheduler"),
+        )
+        self._register_optional_scheduler(
+            "reset_reminders",
+            "Feature Toggle:reset_reminders",
+            lambda: schedule_reset_reminder_jobs(self),
+            logger=logging.getLogger("c1c.community.reset_reminders.scheduler"),
+        )
 
     async def close(self) -> None:
         await self.shutdown_webserver()

--- a/tests/common/test_runtime_scheduler_quota.py
+++ b/tests/common/test_runtime_scheduler_quota.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+from modules.common import runtime as runtime_module
+
+
+class _Bot:
+    def is_closed(self):
+        return False
+
+    def is_ready(self):
+        return True
+
+    def get_cog(self, _name):
+        return None
+
+
+class _QuotaError(Exception):
+    pass
+
+
+def test_clan_ads_config_quota_skips_registration_without_startup_failure(
+    monkeypatch, caplog
+):
+    from shared.sheets import cache_scheduler
+    from shared.sheets import recruitment as recruitment_sheets
+    from modules.common import feature_flags
+    from modules.recruitment import clan_ads
+    from modules.ops import server_map
+    from modules.community.leagues import scheduler as leagues_scheduler
+    from modules.community.fusion import scheduler as fusion_scheduler
+    from modules.community.shard_tracker import scheduler as shard_scheduler
+    from modules.community.reset_reminders import scheduler as reset_scheduler
+
+    runtime = runtime_module.Runtime(_Bot())
+    caplog.set_level(logging.WARNING)
+
+    monkeypatch.setattr(
+        runtime_module.shared_config,
+        "features",
+        SimpleNamespace(housekeeping_enabled=False, mirralith_overview_enabled=False),
+    )
+    monkeypatch.setattr(cache_scheduler, "ensure_cache_registration", lambda: None)
+
+    def fake_register_refresh_job(owner, *, bucket, interval, cadence_label):
+        job = owner.scheduler.every(hours=1, tag=bucket, name=f"{bucket}_refresh")
+        return SimpleNamespace(bucket=bucket, cadence_label=cadence_label), job
+
+    monkeypatch.setattr(
+        cache_scheduler, "register_refresh_job", fake_register_refresh_job
+    )
+    monkeypatch.setenv("MIRRALITH_POST_CRON", "")
+
+    async def fake_config_value(key, default=None):
+        assert key == "C1C_AD_REFRESH_DAYS"
+        return default
+
+    monkeypatch.setattr(recruitment_sheets, "get_config_value_async", fake_config_value)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda key: key == "clan_ads")
+
+    async def fail_load_config(*, force=False):
+        raise _QuotaError("Google Sheets 429 RESOURCE_EXHAUSTED")
+
+    monkeypatch.setattr(clan_ads, "load_config", fail_load_config)
+    monkeypatch.setattr(server_map, "schedule_server_map_job", lambda _runtime: None)
+    monkeypatch.setattr(
+        leagues_scheduler, "schedule_leagues_jobs", lambda _runtime: None
+    )
+    monkeypatch.setattr(fusion_scheduler, "schedule_fusion_jobs", lambda _runtime: None)
+    monkeypatch.setattr(shard_scheduler, "schedule_shard_jobs", lambda _runtime: None)
+    monkeypatch.setattr(
+        reset_scheduler, "schedule_reset_reminder_jobs", lambda _runtime: None
+    )
+
+    asyncio.run(runtime._register_ready_schedulers_inner())
+
+    assert all(
+        getattr(job, "name", None) != "clan_ads" for job in runtime.scheduler.jobs
+    )
+    assert (
+        "clan_ads scheduler config resolve hit Google Sheets quota/backoff"
+        in caplog.text
+    )
+    assert "exception_type=_QuotaError" in caplog.text
+    assert "without failing startup" in caplog.text
+
+
+def test_optional_scheduler_quota_skip_returns_false_and_logs(caplog):
+    runtime = runtime_module.Runtime(_Bot())
+    caplog.set_level(logging.WARNING)
+
+    registered = runtime._register_optional_scheduler(
+        "reset_reminders",
+        "Feature Toggle:reset_reminders",
+        lambda: (_ for _ in ()).throw(_QuotaError("429 RESOURCE_EXHAUSTED")),
+    )
+
+    assert registered is False
+    assert (
+        "reset_reminders scheduler config resolve hit Google Sheets quota/backoff"
+        in caplog.text
+    )
+    assert "config_source=Feature Toggle:reset_reminders" in caplog.text
+    assert "exception_type=_QuotaError" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent Google Sheets 429/quota/backoff errors during ready-phase scheduler registration from aborting startup by making optional scheduler config reads recoverable.

### Description
- Added `_log_optional_scheduler_quota_skip` and `_register_optional_scheduler` helpers in `modules/common/runtime.py` to detect Sheets rate-limit errors and log scheduler name, config source, exception type, and that startup will continue.
- Made the `modules/common/runtime.py` registration flow resilient by catching Sheets quota/backoff failures for C1C ad config lookup, Clan Ads feature/config lookup, and the later optional scheduler registration calls (server_map, leagues, fusion, shard reminders, reset reminders) so failures skip only the affected job for this ready cycle.
- Imported `sheets_core` into the runtime module and preserved existing behavior for non-rate-limited failures by re-raising them. 
- Added `tests/common/test_runtime_scheduler_quota.py` covering clan ads quota handling and the generic optional scheduler quota-skip logging.

### Testing
- Ran the targeted unit test file with `PYTHONDONTWRITEBYTECODE=1 pytest -q tests/common/test_runtime_scheduler_quota.py` and it passed. 
- Verified syntax/compilation with `PYTHONDONTWRITEBYTECODE=1 python -m py_compile modules/common/runtime.py tests/common/test_runtime_scheduler_quota.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c423cb50832396bf50337e7c4d20)