### PR TITLE
Fix recruitment clan header diagnostics

### DIFF
--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -67,6 +67,16 @@ def _column_aliases(*aliases: str) -> tuple[str, ...]:
     return tuple(aliases)
 
 
+CLAN_DIAGNOSTIC_REQUIRED_KEYS: tuple[str, ...] = (
+    "clan_tag",
+    "open_spots",
+    "inactives",
+    "reserved",
+    "reservation_count",
+    "reservation_summary",
+)
+
+
 HEADER_MAP: Dict[str, tuple[str, ...]] = {
     "clan_name": _column_aliases(
         "clan name",
@@ -132,6 +142,8 @@ HEADER_MAP: Dict[str, tuple[str, ...]] = {
     ),
     "reserved": _column_aliases(
         "reserved",
+        "reservation_count",
+        "reserved_spots",
         "reserved slots",
         "reserved spot",
         "reserved count",
@@ -139,12 +151,14 @@ HEADER_MAP: Dict[str, tuple[str, ...]] = {
         "manual reserved",
     ),
     "reservation_count": _column_aliases(
+        "reservation_count",
         "reservation count",
         "reservations count",
         "reserved count",
         "active reservations",
     ),
     "reservation_summary": _column_aliases(
+        "reservation_summary",
         "reservation summary",
         "reservations summary",
         "reserved summary",
@@ -160,7 +174,7 @@ HEADER_MAP: Dict[str, tuple[str, ...]] = {
 
 def _normalize_header(cell: Any) -> str:
     text = "" if cell is None else str(cell).strip().lower()
-    return " ".join(text.split())
+    return " ".join(text.replace("_", " ").split())
 
 
 def _find_header_row_with_index(
@@ -235,7 +249,9 @@ def _log_clan_header_diagnostics(
     raw_values = _diagnostic_header_values(header_row)
     normalized_values = _normalize_header_values(raw_values)
     header_map_columns = _header_map_columns(header_map)
-    missing_required_keys = [key for key in HEADER_MAP if key not in header_map]
+    missing_required_keys = [
+        key for key in CLAN_DIAGNOSTIC_REQUIRED_KEYS if key not in header_map
+    ]
 
     log.info(
         "recruitment clan header diagnostics: sheet_id=%s tab=%r "

--- a/tests/recruitment/test_header_diagnostics.py
+++ b/tests/recruitment/test_header_diagnostics.py
@@ -59,3 +59,44 @@ def test_process_clan_sheet_logs_header_diagnostics(caplog):
     assert diagnostic.header_map_columns["manual_open_spots_seen"] == "AJ"
     assert diagnostic.header_map_columns["manual_open_spots"] == "AK"
     assert "reservation_count" in diagnostic.missing_required_keys
+
+
+def test_process_clan_sheet_maps_underscore_reservation_headers_without_missing_diagnostics(caplog):
+    header = [""] * 37
+    header[31] = "open_spots"
+    header[32] = "inactives"
+    header[33] = "reservation_count"
+    header[34] = "reservation_summary"
+    header[35] = "manual_open_spots_seen"
+    header[36] = "clan_tag"
+    rows = [
+        ["title"],
+        [""],
+        header,
+        [""] * 37,
+    ]
+
+    with caplog.at_level(logging.INFO, logger=recruitment.log.name):
+        recruitment._process_clan_sheet(
+            rows,
+            now=456.0,
+            tab="ConfiguredClansTab",
+            sheet_id="1234567890abcdef",
+        )
+
+    diagnostic = next(
+        record
+        for record in caplog.records
+        if "recruitment clan header diagnostics" in record.message
+    )
+    assert diagnostic.header_map_columns["open_spots"] == "AF"
+    assert diagnostic.header_map_columns["inactives"] == "AG"
+    assert diagnostic.header_map_columns["reserved"] == "AH"
+    assert diagnostic.header_map_columns["reservation_count"] == "AH"
+    assert diagnostic.header_map_columns["reservation_summary"] == "AI"
+    assert diagnostic.header_map_columns["clan_tag"] == "AK"
+    assert "open_spots" not in diagnostic.missing_required_keys
+    assert "reserved" not in diagnostic.missing_required_keys
+    assert "reservation_count" not in diagnostic.missing_required_keys
+    assert "reservation_summary" not in diagnostic.missing_required_keys
+    assert "roster" not in diagnostic.missing_required_keys


### PR DESCRIPTION
### Motivation
- Diagnostics were reporting keys like `open_spots`, `reservation_count`, and `reservation_summary` as missing even when visible headers (e.g., `open_spots`, `reservation_count`, `reservation_summary`) existed in the clan sheet row 4. 
- The header lookup must remain dynamic (no hard-coded column letters) and preserve existing `clan_tag`/`inactives` mappings while removing legacy/incorrect required diagnostics. 
- Tests need a regression that covers the AF:AK row-4 header layout seen in production so diagnostics are trustworthy.

### Description
- Add `CLAN_DIAGNOSTIC_REQUIRED_KEYS` and use it to limit the keys reported by `_log_clan_header_diagnostics` so legacy `roster` is not flagged as required. 
- Normalize underscore-delimited visible headers by updating `_normalize_header` to treat `_` as a space so `open_spots`, `reservation_count`, and `reservation_summary` resolve via the existing dynamic lookup. 
- Add `reservation_count` and `reserved_spots` as visible header aliases for the internal `reserved` key and add underscored forms to `reservation_count`/`reservation_summary` aliases in `HEADER_MAP`. 
- Add a regression test `test_process_clan_sheet_maps_underscore_reservation_headers_without_missing_diagnostics` in `tests/recruitment/test_header_diagnostics.py` that asserts AF:AK headers map correctly and are not reported missing.

### Testing
- Ran `pytest tests/recruitment/test_header_diagnostics.py -q` and the new test passed. 
- Ran the recruitment test suite with `pytest tests/recruitment -q` and all tests passed. 
- The change is covered by the added regression test which verifies the AF:AK row-4 header layout is mapped and not falsely reported as missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d4d7b39c832397498cd404e36cba)