### PR TITLE
Clan Ads: render posts as embeds (embed_title/description/footer)

### DIFF
--- a/cogs/recruitment_clan_ads.py
+++ b/cogs/recruitment_clan_ads.py
@@ -39,7 +39,18 @@ class ClanAdsCog(commands.Cog):
                 "Clan ads post failed. Please check the bot logs for details."
             )
             return
-        await ctx.send(result.get("message") or "Clan ads command completed.")
+        delete_after = None
+        config = getattr(result, "get", lambda *_: None)("config")
+        target_channel_id = getattr(config, "channel_id", None)
+        if (
+            target_channel_id is not None
+            and getattr(getattr(ctx, "channel", None), "id", None) == target_channel_id
+        ):
+            delete_after = 20
+        await ctx.send(
+            result.get("message") or "Clan ads command completed.",
+            delete_after=delete_after,
+        )
 
     # This listener intentionally handles clan ad buttons by stable custom_id prefix
     # instead of relying on in-memory View state, so existing ad buttons keep working
@@ -51,16 +62,16 @@ class ClanAdsCog(commands.Cog):
         if not custom_id or not str(custom_id).startswith("clan_ads:view_card:"):
             return
         tag = str(custom_id).rsplit(":", 1)[-1]
-        embed, files, _state = await clan_ads.build_clan_card(
+        embeds, files, _state = await clan_ads.build_clan_card(
             self.bot, tag, interaction.guild
         )
-        if embed is None:
+        if not embeds:
             await interaction.response.send_message(
                 f"Unknown clan tag `{tag}`.", ephemeral=True
             )
             return
         await interaction.response.send_message(
-            embed=embed, files=files, ephemeral=True
+            embeds=embeds, files=files, ephemeral=True
         )
 
 

--- a/cogs/recruitment_clan_profile.py
+++ b/cogs/recruitment_clan_profile.py
@@ -136,6 +136,21 @@ class ClanProfileCog(commands.Cog):
             state,
         )
 
+    async def build_profile_pages(
+        self, tag: str, *, guild: discord.Guild | None
+    ) -> tuple[list[discord.Embed], List[discord.File], _FlipState | None]:
+        """Build both clan card pages for non-reaction consumers such as Clan Ads."""
+        profile_embed, attachments, state = await self.build_profile_payload(
+            tag, guild=guild
+        )
+        if profile_embed is None or state is None:
+            return [], attachments, state
+        return (
+            [profile_embed, self._build_entry_embed(state, guild)],
+            attachments,
+            state,
+        )
+
     @commands.Cog.listener("on_raw_reaction_add")
     async def _on_raw_reaction_add(
         self, payload: discord.RawReactionActionEvent

--- a/modules/recruitment/clan_ads.py
+++ b/modules/recruitment/clan_ads.py
@@ -25,13 +25,15 @@ STATUS_NOT_QUALIFIED = "skipped_not_qualified"
 STATUS_MISSING_CLAN_ROW = "skipped_missing_clan_row"
 STATUS_MISSING_RULE = "skipped_missing_rule"
 STATUS_RULE_DISABLED = "skipped_rule_disabled"
-STATUS_MISSING_DEFAULT = "skipped_missing_default_message"
+STATUS_MISSING_DEFAULT = "skipped_missing_embed_template"
 STATUS_ERROR_POST = "error_post_failed"
 
 MESSAGE_HEADERS = {
     "clan_tag": "clan_tag",
     "enabled": "enabled",
-    "message": "message",
+    "embed_title": "embed_title",
+    "embed_description": "embed_description",
+    "embed_footer": "embed_footer",
     "last_ad_message_id": "last_ad_message_id",
     "last_posted_at_utc": "last_posted_at_utc",
     "last_open_spots": "last_open_spots",
@@ -163,7 +165,9 @@ class MessageRow:
     row_number: int
     tag: str
     enabled: bool
-    message: str
+    embed_title: str
+    embed_description: str
+    embed_footer: str
     last_message_id: str
 
 
@@ -203,10 +207,21 @@ async def build_clan_card(
     bot: discord.Client, clan_tag: str, guild: discord.Guild | None
 ):
     cog = bot.get_cog("ClanProfileCog") if hasattr(bot, "get_cog") else None
-    if cog is None or not hasattr(cog, "build_profile_payload"):
+    if cog is None:
         log.error("Clan Ads could not find loaded ClanProfileCog for card rendering")
         return None, [], None
-    return await cog.build_profile_payload(tag_norm(clan_tag), guild=guild)
+    if hasattr(cog, "build_profile_pages"):
+        embeds, files, state = await cog.build_profile_pages(
+            tag_norm(clan_tag), guild=guild
+        )
+        return embeds, files, state
+    if hasattr(cog, "build_profile_payload"):
+        embed, files, state = await cog.build_profile_payload(
+            tag_norm(clan_tag), guild=guild
+        )
+        return ([embed] if embed is not None else []), files, state
+    log.error("Clan Ads loaded ClanProfileCog has no supported card renderer")
+    return None, [], None
 
 
 async def load_config(
@@ -346,7 +361,9 @@ async def load_messages(
             row_number=row_number,
             tag=tag_norm(raw_tag),
             enabled=is_true(cell(row, header_map["enabled"])),
-            message=cell(row, header_map["message"]),
+            embed_title=cell(row, header_map["embed_title"]),
+            embed_description=cell(row, header_map["embed_description"]),
+            embed_footer=cell(row, header_map["embed_footer"]),
             last_message_id=cell(row, header_map["last_ad_message_id"]),
         )
         if raw_tag.lower() == "default":
@@ -461,25 +478,27 @@ async def decide(
             STATUS_DISABLED,
             f"{clan.tag} was not posted because clan ads are disabled for that clan.",
         )
-    if not row.message and (default is None or not default.message):
+    missing_fields = []
+    if not (row.embed_title or (default and default.embed_title)):
+        missing_fields.append("embed_title")
+    if not (row.embed_description or (default and default.embed_description)):
+        missing_fields.append("embed_description")
+    if missing_fields:
+        detail = "Missing required clan ad embed template field(s): " + ", ".join(
+            missing_fields
+        )
         await write_state(
             config,
             header_map,
             row,
             last_status=STATUS_MISSING_DEFAULT,
-            last_error="Missing default clan ad message",
+            last_error=detail,
         )
         await reporter.warn(
-            f"⚠️ Clan Ads skipped `{clan.tag}`: default row in `{config.messages_tab}` is missing or has an empty message.",
-            dedupe_key="missing_default_message",
+            f"⚠️ Clan Ads skipped `{clan.tag}`: `{config.messages_tab}` is missing required embed template field(s): {', '.join(missing_fields)}.",
+            dedupe_key=f"missing_embed_template:{clan.tag}:{','.join(missing_fields)}",
         )
-        return Decision(
-            clan.tag,
-            clan,
-            row,
-            STATUS_MISSING_DEFAULT,
-            "Missing default clan ad message",
-        )
+        return Decision(clan.tag, clan, row, STATUS_MISSING_DEFAULT, detail)
 
     rule = rules.get(key(clan.bracket))
     if not rule:
@@ -581,10 +600,22 @@ async def post_decision(
             )
 
     try:
-        message = await channel.send(
-            render(row.message or (default.message if default else ""), clan, guild),
-            view=ClanAdButtonView(clan.tag),
+        embed = discord.Embed(
+            title=render(
+                row.embed_title or (default.embed_title if default else ""), clan, guild
+            ),
+            description=render(
+                row.embed_description or (default.embed_description if default else ""),
+                clan,
+                guild,
+            ),
         )
+        footer = render(
+            row.embed_footer or (default.embed_footer if default else ""), clan, guild
+        )
+        if footer:
+            embed.set_footer(text=footer)
+        message = await channel.send(embed=embed, view=ClanAdButtonView(clan.tag))
     except Exception as exc:
         log.exception("failed to post clan ad", extra={"clan_tag": clan.tag})
         await write_state(
@@ -682,6 +713,7 @@ async def run(
             "posted": 0,
             "skipped": 0,
             "message": "Clan Ads channel is invalid or inaccessible.",
+            "config": config,
         }
 
     rules = await load_rules(config, reporter)
@@ -691,6 +723,7 @@ async def run(
             "posted": 0,
             "skipped": 0,
             "message": "Clan Ads sheet setup is incomplete.",
+            "config": config,
         }
     rows, default, header_map = loaded_messages
 
@@ -721,6 +754,7 @@ async def run(
             "posted": 0,
             "skipped": clan_field_failures,
             "message": "Clan ads could not evaluate any clans because required clan data fields are missing. Check the bot logging channel for details.",
+            "config": config,
         }
 
     if clan_tag_filter:
@@ -731,11 +765,25 @@ async def run(
                 "posted": 0,
                 "skipped": 0,
                 "message": f"{wanted} was not posted because the clan was not found.",
+                "config": config,
             }
 
-    templates = [row.message for row in rows.values() if row.message]
-    if default and default.message:
-        templates.append(default.message)
+    templates = [
+        template
+        for row in rows.values()
+        for template in (row.embed_title, row.embed_description, row.embed_footer)
+        if template
+    ]
+    if default:
+        templates.extend(
+            template
+            for template in (
+                default.embed_title,
+                default.embed_description,
+                default.embed_footer,
+            )
+            if template
+        )
     if any("{clan_description}" in template for template in templates):
         if "clan_description" not in recruitment.get_clan_header_map():
             await reporter.warn(
@@ -756,7 +804,12 @@ async def run(
         )
         if scheduled:
             log.info("Clan Ads scheduled run skipped: no qualifying clans")
-        return {"posted": 0, "skipped": len(decisions), "message": fallback}
+        return {
+            "posted": 0,
+            "skipped": len(decisions),
+            "message": fallback,
+            "config": config,
+        }
 
     posted = 0
     for decision in qualified:
@@ -810,6 +863,7 @@ async def run(
             skipped_or_failed,
             "No clan ads were posted. No enabled clans currently meet their bracket posting rules.",
         ),
+        "config": config,
     }
 
 

--- a/tests/recruitment/test_clan_ads_fields.py
+++ b/tests/recruitment/test_clan_ads_fields.py
@@ -103,3 +103,261 @@ def test_clan_ads_run_reports_when_all_clans_fail_required_field_resolution(
         "Check the bot logging channel for details."
     )
     assert result["skipped"] == 1
+
+
+def _message_row(
+    row_number=2, tag="C1CE", enabled=True, title="", desc="", footer="", last_id=""
+):
+    return clan_ads.MessageRow(
+        row_number=row_number,
+        tag=tag,
+        enabled=enabled,
+        embed_title=title,
+        embed_description=desc,
+        embed_footer=footer,
+        last_message_id=last_id,
+    )
+
+
+def _clan():
+    return clan_ads.ClanData(
+        record=None,
+        tag="C1CE",
+        name="Clan One",
+        bracket="Late Game",
+        open_spots=3,
+        description="Desc",
+    )
+
+
+def test_clan_ad_messages_embed_headers_do_not_require_message(monkeypatch):
+    import asyncio
+
+    rows = [
+        [
+            "clan_tag",
+            "enabled",
+            "embed_title",
+            "embed_description",
+            "embed_footer",
+            "last_ad_message_id",
+            "last_posted_at_utc",
+            "last_open_spots",
+            "last_status",
+            "last_error",
+        ],
+        [
+            "default",
+            "TRUE",
+            "Join {clan_name}",
+            "Open: {open_spots}",
+            "Footer {clan_tag}",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
+    ]
+
+    async def fake_fetch_values(*args, **kwargs):
+        return rows
+
+    monkeypatch.setattr(clan_ads.sheets, "fetch_values", fake_fetch_values)
+    monkeypatch.setattr(
+        clan_ads.recruitment, "get_recruitment_sheet_id", lambda: "sheet"
+    )
+    loaded = asyncio.run(
+        clan_ads.load_messages(
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            clan_ads.RunReporter(None),
+        )
+    )
+
+    assert loaded is not None
+    _items, default, header_map = loaded
+    assert "message" not in header_map
+    assert {"embed_title", "embed_description", "embed_footer"} <= set(header_map)
+    assert default.embed_title == "Join {clan_name}"
+
+
+def test_embed_field_fallbacks_are_independent_and_footer_optional():
+    clan = _clan()
+    default = _message_row(
+        tag="DEFAULT",
+        title="Default {clan_name}",
+        desc="Default {open_spots}",
+        footer="Default {clan_tag}",
+    )
+    title_only = _message_row(title="Clan {bracket}")
+    desc_only = _message_row(desc="Clan desc {clan_description}")
+    empty_footer_default = _message_row(
+        tag="DEFAULT", title="Default", desc="Default", footer=""
+    )
+
+    assert (
+        clan_ads.render(title_only.embed_title or default.embed_title, clan, None)
+        == "Clan Late Game"
+    )
+    assert (
+        clan_ads.render(
+            title_only.embed_description or default.embed_description, clan, None
+        )
+        == "Default 3"
+    )
+    assert (
+        clan_ads.render(desc_only.embed_title or default.embed_title, clan, None)
+        == "Default Clan One"
+    )
+    assert (
+        clan_ads.render(
+            desc_only.embed_description or default.embed_description, clan, None
+        )
+        == "Clan desc Desc"
+    )
+    assert (
+        clan_ads.render(
+            desc_only.embed_footer or empty_footer_default.embed_footer, clan, None
+        )
+        == ""
+    )
+
+
+def test_missing_embed_title_or_description_skips_with_clear_status(monkeypatch):
+    import asyncio
+
+    writes = []
+
+    async def fake_write_state(*args, **kwargs):
+        writes.append(kwargs)
+
+    async def fake_warn(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    reporter = clan_ads.RunReporter(None)
+    monkeypatch.setattr(reporter, "warn", fake_warn)
+
+    decision = asyncio.run(
+        clan_ads.decide(
+            _clan(),
+            {"C1CE": _message_row(title="", desc="")},
+            _message_row(tag="DEFAULT", title="", desc=""),
+            {},
+            {"last_status": 8, "last_error": 9},
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            reporter,
+        )
+    )
+
+    assert decision.status == clan_ads.STATUS_MISSING_DEFAULT
+    assert decision.status != clan_ads.STATUS_NOT_QUALIFIED
+    assert "embed_title" in writes[-1]["last_error"]
+    assert "embed_description" in writes[-1]["last_error"]
+
+
+def test_post_decision_posts_embed_deletes_old_and_writes_new_id(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+
+    writes = []
+    deleted = []
+    sent = []
+
+    class Old:
+        async def delete(self):
+            deleted.append(True)
+
+    class Channel:
+        guild = None
+
+        async def fetch_message(self, message_id):
+            assert message_id == 99
+            return Old()
+
+        async def send(self, *args, **kwargs):
+            sent.append((args, kwargs))
+            return SimpleNamespace(id=1234)
+
+    async def fake_write_state(*args, **kwargs):
+        writes.append(kwargs)
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    row = _message_row(
+        title="Join {clan_name}",
+        desc="Open {open_spots}",
+        footer="Tag {clan_tag}",
+        last_id="99",
+    )
+    decision = clan_ads.Decision("C1CE", _clan(), row, "qualified", "qualified")
+
+    ok = asyncio.run(
+        clan_ads.post_decision(
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            {},
+            _message_row(tag="DEFAULT", title="D", desc="D"),
+            decision,
+            None,
+            clan_ads.RunReporter(None),
+        )
+    )
+
+    assert ok is True
+    assert deleted == [True]
+    assert sent[0][0] == ()
+    assert sent[0][1]["embed"].title == "Join Clan One"
+    assert sent[0][1]["embed"].description == "Open 3"
+    assert sent[0][1]["view"].timeout is None
+    assert sent[0][1]["view"].children[0].custom_id == "clan_ads:view_card:C1CE"
+    assert writes[-1]["last_ad_message_id"] == "1234"
+
+
+def test_clan_ads_button_builds_both_profile_pages():
+    import asyncio
+    from types import SimpleNamespace
+    import discord
+
+    class Cog:
+        async def build_profile_pages(self, tag, *, guild):
+            return (
+                [discord.Embed(title="Profile"), discord.Embed(title="Entry")],
+                [],
+                SimpleNamespace(),
+            )
+
+    class Bot:
+        def get_cog(self, name):
+            assert name == "ClanProfileCog"
+            return Cog()
+
+    embeds, files, state = asyncio.run(clan_ads.build_clan_card(Bot(), "c1ce", None))
+    assert [embed.title for embed in embeds] == ["Profile", "Entry"]
+    assert files == []
+    assert state is not None
+
+
+def test_manual_clanads_summary_auto_deletes_only_in_ad_channel(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+    from cogs.recruitment_clan_ads import ClanAdsCog
+
+    sends = []
+
+    class Ctx:
+        channel = SimpleNamespace(id=123)
+
+        async def send(self, content, **kwargs):
+            sends.append((content, kwargs))
+
+    async def fake_run(*args, **kwargs):
+        return {
+            "message": "Posted 1 clan ad(s).",
+            "config": clan_ads.Config("ClanAdMessages", "Rules", 123, "", "", 24, ""),
+        }
+
+    monkeypatch.setattr(clan_ads, "run", fake_run)
+    command = ClanAdsCog.post.callback
+    asyncio.run(command(ClanAdsCog(SimpleNamespace()), Ctx(), "all"))
+
+    assert sends == [("Posted 1 clan ad(s).", {"delete_after": 20})]


### PR DESCRIPTION
### Motivation
- Move Clan Ads from the legacy plain-text `message` column to sheet-driven embed fields so ads render as Discord embeds and look correct in-channel. 
- Apply independent default fallbacks per embed field and preserve existing posting, scheduling, rules, and button behavior without adding new config keys or tabs. 

### Description
- Header handling: `MESSAGE_HEADERS` and `MessageRow` were updated to require `embed_title`, `embed_description`, and `embed_footer` and the loader no longer depends on the legacy `message` header, so `load_messages` and `build_header_map` resolve the new columns only. 
- Embed fallback & validation: `decide()` independently resolves each embed field from the clan row or the `default` row, treats `embed_title` and `embed_description` as required (skipping with `skipped_missing_embed_template` and a clear `last_error` when missing after fallback), and treats `embed_footer` as optional. 
- Posting & placeholders: `post_decision()` now renders a `discord.Embed` (title, description, optional footer) applying existing placeholder replacement to title/description/footer, preserves old-ad deletion behavior and state writes (`last_ad_message_id`, `last_posted_at_utc`, `last_open_spots`, `last_status`, `last_error`), and keeps the non-expiring `View Clan Card` button with the stable `clan_ads:view_card:<clan_tag>` custom_id and restart-safe `on_interaction` listener. 
- UI & command flow: `ClanProfileCog` exposes a new `build_profile_pages()` helper and `build_clan_card()` will return both card pages so the button sends both embeds ephemerally, the normal `!clan` reaction flip remains unchanged, and the manual `!clanads post` feedback message is still sent to the command context but will auto-delete after 20 seconds when issued in the configured ad channel. 

### Testing
- Ran unit tests `pytest tests/recruitment/test_clan_ads_fields.py` and `pytest tests/shared/sheets/test_feature_refresh.py tests/common/test_runtime_scheduler_quota.py`, and all tests passed. 
- Compiled modules with `python -m compileall`, reformatted with `black`, and ran `git diff --check` to surface issues; no runtime/formatting errors were found. 
- Added/updated tests in `tests/recruitment/test_clan_ads_fields.py` covering header handling, independent field fallbacks, optional footer behavior, missing-template skipping and clear `last_error`, placeholder rendering, embed posting (including old-ad deletion and `last_ad_message_id` writes), two-page clan-card responses, and manual summary auto-delete, and these assertions passed under the test run. 
- Performed grep checks to confirm there are no hard-coded clan-sheet positional reads or lingering references to the old `message` header; those checks returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d8e9ab948323864c8dec35185183)