### PR TITLE
Add per-message embed color and static clan-card thumbnail support to Clan Ads

### DIFF
--- a/modules/recruitment/clan_ads.py
+++ b/modules/recruitment/clan_ads.py
@@ -169,6 +169,7 @@ class MessageRow:
     embed_description: str
     embed_footer: str
     last_message_id: str
+    embed_color: str = ""
 
 
 @dataclass
@@ -338,6 +339,9 @@ async def load_messages(
             )
             return None
         header_map = build_header_map(rows[0], MESSAGE_HEADERS)
+        optional_lookup = {key(header): index for index, header in enumerate(rows[0])}
+        if "embed_color" in optional_lookup:
+            header_map["embed_color"] = optional_lookup["embed_color"]
     except MissingHeaderError as exc:
         log.exception("clan ad messages tab missing header")
         await reporter.warn(
@@ -365,6 +369,7 @@ async def load_messages(
             embed_description=cell(row, header_map["embed_description"]),
             embed_footer=cell(row, header_map["embed_footer"]),
             last_message_id=cell(row, header_map["last_ad_message_id"]),
+            embed_color=cell(row, header_map.get("embed_color")),
         )
         if raw_tag.lower() == "default":
             default = message_row
@@ -425,6 +430,52 @@ def clan_data(record: Any) -> ClanData:
         open_spots=int(open_spots),
         description=description,
     )
+
+
+def parse_embed_color(value: Any) -> int | None:
+    """Parse optional ClanAdMessages embed_color values into Discord RGB ints."""
+    raw = norm(value)
+    if not raw:
+        return None
+    if raw.startswith("#"):
+        raw = raw[1:]
+    elif raw.lower().startswith("0x"):
+        raw = raw[2:]
+    if not re.fullmatch(r"[0-9a-fA-F]{6}", raw):
+        return None
+    return int(raw, 16)
+
+
+async def resolve_embed_color(
+    row: MessageRow,
+    default: MessageRow | None,
+    clan_tag: str,
+    reporter: RunReporter,
+) -> int | None:
+    raw_color = row.embed_color or (default.embed_color if default else "")
+    if not raw_color:
+        return None
+    parsed = parse_embed_color(raw_color)
+    if parsed is not None:
+        return parsed
+    await reporter.warn(
+        f"⚠️ Clan Ads warning: invalid embed_color `{raw_color}` for `{clan_tag}`; using default embed color.",
+        dedupe_key=f"invalid_embed_color:{raw_color}",
+    )
+    return None
+
+
+def clan_card_static_thumbnail(embeds: Sequence[discord.Embed]) -> str | None:
+    for embed in embeds:
+        url = str(getattr(getattr(embed, "thumbnail", None), "url", None) or "")
+        if url.startswith(("https://", "http://")):
+            return url
+        if url:
+            log.debug(
+                "Clan Ads skipped non-static clan card thumbnail URL",
+                extra={"thumbnail_url": url},
+            )
+    return None
 
 
 def render(template: str, clan: ClanData, guild: discord.Guild | None) -> str:
@@ -574,6 +625,7 @@ async def send_notification(channel: Any, config: Config, count: int) -> None:
 
 
 async def post_decision(
+    bot: discord.Client,
     channel: Any,
     config: Config,
     header_map: dict[str, int],
@@ -600,6 +652,7 @@ async def post_decision(
             )
 
     try:
+        color = await resolve_embed_color(row, default, clan.tag, reporter)
         embed = discord.Embed(
             title=render(
                 row.embed_title or (default.embed_title if default else ""), clan, guild
@@ -609,12 +662,32 @@ async def post_decision(
                 clan,
                 guild,
             ),
+            color=color,
         )
         footer = render(
             row.embed_footer or (default.embed_footer if default else ""), clan, guild
         )
         if footer:
             embed.set_footer(text=footer)
+        try:
+            card_embeds, _card_files, _state = await build_clan_card(
+                bot, clan.tag, guild
+            )
+        except Exception:
+            log.debug(
+                "Clan Ads could not resolve clan card crest thumbnail",
+                exc_info=True,
+                extra={"clan_tag": clan.tag},
+            )
+            card_embeds = []
+        thumbnail_url = clan_card_static_thumbnail(card_embeds or [])
+        if thumbnail_url:
+            embed.set_thumbnail(url=thumbnail_url)
+        else:
+            log.debug(
+                "Clan Ads could not resolve clan card crest thumbnail",
+                extra={"clan_tag": clan.tag},
+            )
         message = await channel.send(embed=embed, view=ClanAdButtonView(clan.tag))
     except Exception as exc:
         log.exception("failed to post clan ad", extra={"clan_tag": clan.tag})
@@ -814,6 +887,7 @@ async def run(
     posted = 0
     for decision in qualified:
         if await post_decision(
+            bot,
             channel,
             config,
             header_map,

--- a/tests/recruitment/test_clan_ads_fields.py
+++ b/tests/recruitment/test_clan_ads_fields.py
@@ -106,7 +106,14 @@ def test_clan_ads_run_reports_when_all_clans_fail_required_field_resolution(
 
 
 def _message_row(
-    row_number=2, tag="C1CE", enabled=True, title="", desc="", footer="", last_id=""
+    row_number=2,
+    tag="C1CE",
+    enabled=True,
+    title="",
+    desc="",
+    footer="",
+    last_id="",
+    color="",
 ):
     return clan_ads.MessageRow(
         row_number=row_number,
@@ -116,6 +123,7 @@ def _message_row(
         embed_description=desc,
         embed_footer=footer,
         last_message_id=last_id,
+        embed_color=color,
     )
 
 
@@ -145,6 +153,7 @@ def test_clan_ad_messages_embed_headers_do_not_require_message(monkeypatch):
             "last_open_spots",
             "last_status",
             "last_error",
+            "embed_color",
         ],
         [
             "default",
@@ -157,6 +166,7 @@ def test_clan_ad_messages_embed_headers_do_not_require_message(monkeypatch):
             "",
             "",
             "",
+            "#5865F2",
         ],
     ]
 
@@ -177,8 +187,11 @@ def test_clan_ad_messages_embed_headers_do_not_require_message(monkeypatch):
     assert loaded is not None
     _items, default, header_map = loaded
     assert "message" not in header_map
-    assert {"embed_title", "embed_description", "embed_footer"} <= set(header_map)
+    assert {"embed_title", "embed_description", "embed_footer", "embed_color"} <= set(
+        header_map
+    )
     assert default.embed_title == "Join {clan_name}"
+    assert default.embed_color == "#5865F2"
 
 
 def test_embed_field_fallbacks_are_independent_and_footer_optional():
@@ -293,6 +306,7 @@ def test_post_decision_posts_embed_deletes_old_and_writes_new_id(monkeypatch):
 
     ok = asyncio.run(
         clan_ads.post_decision(
+            SimpleNamespace(),
             Channel(),
             clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
             {},
@@ -361,3 +375,204 @@ def test_manual_clanads_summary_auto_deletes_only_in_ad_channel(monkeypatch):
     asyncio.run(command(ClanAdsCog(SimpleNamespace()), Ctx(), "all"))
 
     assert sends == [("Posted 1 clan ad(s).", {"delete_after": 20})]
+
+
+def test_embed_color_parsing_and_fallbacks(monkeypatch):
+    import asyncio
+
+    warnings = []
+    reporter = clan_ads.RunReporter(None)
+
+    async def fake_warn(message, *, dedupe_key=None):
+        warnings.append((message, dedupe_key))
+
+    monkeypatch.setattr(reporter, "warn", fake_warn)
+    default = _message_row(tag="DEFAULT", color="5865F2")
+
+    assert clan_ads.parse_embed_color("#5865F2") == 0x5865F2
+    assert clan_ads.parse_embed_color("5865F2") == 0x5865F2
+    assert clan_ads.parse_embed_color("0x5865F2") == 0x5865F2
+    assert (
+        asyncio.run(
+            clan_ads.resolve_embed_color(
+                _message_row(color="0xABCDEF"), default, "C1CE", reporter
+            )
+        )
+        == 0xABCDEF
+    )
+    assert (
+        asyncio.run(
+            clan_ads.resolve_embed_color(
+                _message_row(color=""), default, "C1CE", reporter
+            )
+        )
+        == 0x5865F2
+    )
+    assert (
+        asyncio.run(
+            clan_ads.resolve_embed_color(
+                _message_row(color=""),
+                _message_row(tag="DEFAULT", color=""),
+                "C1CE",
+                reporter,
+            )
+        )
+        is None
+    )
+    assert (
+        asyncio.run(
+            clan_ads.resolve_embed_color(
+                _message_row(color="not-a-color"), default, "C1CE", reporter
+            )
+        )
+        is None
+    )
+    assert "invalid embed_color `not-a-color`" in warnings[-1][0]
+
+
+def test_post_decision_applies_color_and_static_clan_card_thumbnail(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+    import discord
+
+    sent = []
+
+    class Channel:
+        guild = None
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(id=5678)
+
+    async def fake_write_state(*args, **kwargs):
+        return None
+
+    async def fake_build_clan_card(*args, **kwargs):
+        embed = discord.Embed(title="Profile")
+        embed.set_thumbnail(url="https://example.com/crest.png")
+        return [embed, discord.Embed(title="Entry")], [], SimpleNamespace()
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    decision = clan_ads.Decision(
+        "C1CE",
+        _clan(),
+        _message_row(title="Join", desc="Open", color="#123456"),
+        "qualified",
+        "qualified",
+    )
+
+    ok = asyncio.run(
+        clan_ads.post_decision(
+            SimpleNamespace(),
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            {},
+            _message_row(tag="DEFAULT", title="D", desc="D"),
+            decision,
+            None,
+            clan_ads.RunReporter(None),
+        )
+    )
+
+    assert ok is True
+    embed = sent[0]["embed"]
+    assert embed.color.value == 0x123456
+    assert embed.thumbnail.url == "https://example.com/crest.png"
+    assert sent[0]["view"].timeout is None
+
+
+def test_post_decision_skips_attachment_thumbnail_without_public_files(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+    import discord
+
+    sent = []
+
+    class Channel:
+        guild = None
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(id=3456)
+
+    async def fake_write_state(*args, **kwargs):
+        return None
+
+    async def fake_build_clan_card(*args, **kwargs):
+        embed = discord.Embed(title="Profile")
+        embed.set_thumbnail(url="attachment://c1ce-badge.png")
+        return [embed, discord.Embed(title="Entry")], [object()], SimpleNamespace()
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    decision = clan_ads.Decision(
+        "C1CE",
+        _clan(),
+        _message_row(title="Join", desc="Open"),
+        "qualified",
+        "qualified",
+    )
+
+    ok = asyncio.run(
+        clan_ads.post_decision(
+            SimpleNamespace(),
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            {},
+            _message_row(tag="DEFAULT", title="D", desc="D"),
+            decision,
+            None,
+            clan_ads.RunReporter(None),
+        )
+    )
+
+    assert ok is True
+    assert not sent[0]["embed"].thumbnail.url
+    assert "files" not in sent[0]
+
+
+def test_post_decision_still_posts_without_static_clan_card_thumbnail(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+
+    sent = []
+
+    class Channel:
+        guild = None
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(id=9012)
+
+    async def fake_write_state(*args, **kwargs):
+        return None
+
+    async def fake_build_clan_card(*args, **kwargs):
+        return [], [], None
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    decision = clan_ads.Decision(
+        "C1CE",
+        _clan(),
+        _message_row(title="Join", desc="Open"),
+        "qualified",
+        "qualified",
+    )
+
+    ok = asyncio.run(
+        clan_ads.post_decision(
+            SimpleNamespace(),
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 1, "", "", 24, ""),
+            {},
+            _message_row(tag="DEFAULT", title="D", desc="D"),
+            decision,
+            None,
+            clan_ads.RunReporter(None),
+        )
+    )
+
+    assert ok is True
+    assert not sent[0]["embed"].thumbnail.url


### PR DESCRIPTION
### Motivation
- Allow Clan Ads messages to specify a custom embed color via the `embed_color` message column and fall back to a default when appropriate.
- Use clan profile card crest thumbnails when they are public static URLs while avoiding attachment/internal URLs that are not publicly accessible.
- Surface a warning when an invalid `embed_color` value is provided so operators can correct sheet data.

### Description
- Added `embed_color` field to the `MessageRow` dataclass and updated `load_messages` to read an optional `embed_color` header from the messages sheet.
- Implemented `parse_embed_color` to parse hex color values (`#RRGGBB`, `RRGGBB`, `0xRRGGBB`) into Discord integer RGB and `resolve_embed_color` to choose per-row or default colors with reporter warnings on invalid values.
- Introduced `clan_card_static_thumbnail` to select a clan-card thumbnail only if it is a public `http(s)` URL and updated `post_decision` to accept a `bot` parameter, apply the resolved embed color to `discord.Embed`, and set a valid static clan-card thumbnail when available.
- Updated logging and error handling when the clan card thumbnail cannot be resolved or when non-static thumbnails are skipped.
- Updated tests and helpers in `tests/recruitment/test_clan_ads_fields.py` to cover `embed_color` header handling, parsing and fallback behavior, embed color application, and static vs attachment thumbnail behavior.

### Testing
- Ran the recruitment clan-ads unit tests in `tests/recruitment/test_clan_ads_fields.py`, including new tests `test_embed_color_parsing_and_fallbacks`, `test_post_decision_applies_color_and_static_clan_card_thumbnail`, `test_post_decision_skips_attachment_thumbnail_without_public_files`, and `test_post_decision_still_posts_without_static_clan_card_thumbnail`; all tests passed locally.
- Existing tests that exercise message loading and posting were updated to include the optional `embed_color` column and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42dd20acc483238ef7871aa9ae86e4)