### PR TITLE
Ignore non-ticket welcome threads before sheet lookup

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -68,6 +68,7 @@ _FALLBACK_AUTO_ADD_ATTEMPTS = 4
 _FALLBACK_AUTO_ADD_DELAY_SECONDS = 1.0
 
 _TICKET_CODE_RE = re.compile(r"(W?\d{4})", re.IGNORECASE)
+_WELCOME_TICKET_THREAD_NAME_RE = re.compile(r"^W\d{4}-")
 _PROMO_TICKET_CODE_RE = re.compile(r"([RML]\d{4})", re.IGNORECASE)
 _PROMO_THREAD_NAME_RE = re.compile(
     r"^(?P<prefix>[RML])(?P<digits>\d{4})[-_\s]+(?P<slug>[A-Za-z0-9][A-Za-z0-9._-]*)"
@@ -205,6 +206,13 @@ def _normalize_promo_ticket(ticket: str | None) -> str:
         if normalized[:1] in _PROMO_TYPE_MAP:
             return normalized
     return ""
+
+
+def is_welcome_ticket_thread_name(name: str | None) -> bool:
+    """Return whether ``name`` starts with the canonical welcome ticket prefix."""
+    if not name:
+        return False
+    return bool(_WELCOME_TICKET_THREAD_NAME_RE.match(name.strip()))
 
 
 def parse_welcome_thread_name(name: str | None) -> Optional[ThreadNameParts]:
@@ -3416,6 +3424,17 @@ class WelcomeTicketWatcher(commands.Cog):
         context = self._tickets.get(thread.id)
         if context is not None:
             return context
+
+        if not is_welcome_ticket_thread_name(getattr(thread, "name", None)):
+            log.debug(
+                "ignored_non_welcome_ticket_thread_name",
+                extra={
+                    "flow": "welcome",
+                    "thread_id": getattr(thread, "id", None),
+                    "thread_name": getattr(thread, "name", None),
+                },
+            )
+            return None
 
         row = None
         try:

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -13,6 +13,7 @@ from modules.onboarding.watcher_welcome import (
     _NO_PLACEMENT_TAG,
     _determine_reservation_decision,
     cleanup_reservation_for_ticket_close,
+    is_welcome_ticket_thread_name,
     parse_welcome_thread_name,
     rename_thread_to_reserved,
     _clan_math_column_indices,
@@ -159,6 +160,73 @@ def test_parse_thread_name_closed() -> None:
 
 def test_parse_thread_name_invalid() -> None:
     assert parse_welcome_thread_name("welcome-caillean") is None
+
+
+def test_welcome_ticket_thread_name_guard_requires_canonical_prefix() -> None:
+    assert is_welcome_ticket_thread_name("W0861-something") is True
+    assert is_welcome_ticket_thread_name("W1234-") is True
+    assert is_welcome_ticket_thread_name("[WK§]ᴹʸᵍᵃʳᵈᴼᴳ") is False
+    assert is_welcome_ticket_thread_name("0861-something") is False
+    assert is_welcome_ticket_thread_name("Closed-W0861-something") is False
+
+
+def test_ensure_context_ignores_non_welcome_ticket_thread_before_sheet_lookup(
+    monkeypatch, caplog
+) -> None:
+    watcher = WelcomeTicketWatcher(bot=SimpleNamespace())
+    thread = SimpleNamespace(id=9876, name="[WK§]ᴹʸᵍᵃʳᵈᴼᴳ")
+    sheet_lookups = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        sheet_lookups.append((func, args, kwargs))
+        return None
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="c1c.onboarding.welcome_watcher"):
+        context = asyncio.run(watcher._ensure_context(thread))
+
+    assert context is None
+    assert sheet_lookups == []
+    assert "ignored_non_welcome_ticket_thread_name" in caplog.text
+    assert "close_context_unresolved" not in caplog.text
+    assert "close_context_resolved failed reading welcome row by thread_id" not in caplog.text
+
+
+def test_ensure_context_keeps_lookup_errors_visible_for_valid_ticket_threads(
+    monkeypatch, caplog
+) -> None:
+    watcher = WelcomeTicketWatcher(bot=SimpleNamespace())
+    thread = SimpleNamespace(id=9877, name="W0861-something")
+    sheet_lookups = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        sheet_lookups.append((func, args, kwargs))
+        if func is onboarding_sheets.find_welcome_row_by_thread_id:
+            raise RuntimeError("sheet unavailable")
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.asyncio.to_thread",
+        fake_to_thread,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.onboarding_sessions.get_by_thread_id",
+        lambda _thread_id: None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="c1c.onboarding.welcome_watcher"):
+        context = asyncio.run(watcher._ensure_context(thread))
+
+    assert context is not None
+    assert context.ticket_number == "W0861"
+    assert [call[0] for call in sheet_lookups] == [
+        onboarding_sheets.find_welcome_row_by_thread_id
+    ]
+    assert "close_context_resolved failed reading welcome row by thread_id" in caplog.text
 
 
 def test_decision_reservation_same_clan() -> None:


### PR DESCRIPTION
### Motivation
- Production logs showed the welcome watcher attempting sheet lookups for non-ticket threads (e.g. `[WK§]ᴹʸᵍᵃʳᵈᴼᴳ`) and emitting noisy/error logs when no row was found. 
- The watcher must avoid any sheet `thread_id` lookup unless the thread name matches the canonical welcome ticket pattern (`Wdddd-`).

### Description
- Added a canonical thread-name regex `_WELCOME_TICKET_THREAD_NAME_RE = re.compile(r"^W\d{4}-")` and helper `is_welcome_ticket_thread_name(name)` to centralize the check.  
- Added an early guard in `WelcomeTicketWatcher._ensure_context` to return `None` (with a debug-only `ignored_non_welcome_ticket_thread_name` log) when the thread name does not match the `Wdddd-` prefix, preventing any `find_welcome_row_by_thread_id` lookup.  
- Preserved existing behavior for valid welcome ticket threads so sheet lookup errors still surface (no suppression of real sheet errors).  
- Added regression tests in `tests/onboarding/test_welcome_reservations.py` that assert non-ticket threads are ignored without triggering sheet lookups or unresolved/exception close-context logs, and that valid `Wdddd-` threads still run lookups and propagate lookup errors to logs.

### Testing
- Ran `pytest tests/onboarding/test_welcome_reservations.py -q` and the test suite in that file completed successfully with all tests passing.  
- Tests include `caplog` assertions that verified the debug-only `ignored_non_welcome_ticket_thread_name` message for non-ticket names and the presence of sheet lookup error logs for valid welcome ticket names.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42e65439888323982894cc1698a9b8)