### PR TITLE
Extract clan crest thumbnail helper and use in Clan Ads

### DIFF
--- a/cogs/recruitment_clan_profile.py
+++ b/cogs/recruitment_clan_profile.py
@@ -20,6 +20,14 @@ _FLIP_EMOJI = "\N{ELECTRIC LIGHT BULB}"  # 💡
 
 
 @dataclass
+class ClanCrestThumbnail:
+    """Resolved crest thumbnail URL plus optional Discord attachment file."""
+
+    thumbnail_url: Optional[str] = None
+    file: Optional[discord.File] = None
+
+
+@dataclass
 class _FlipState:
     """State tracked for each toggleable clan profile message."""
 
@@ -232,44 +240,54 @@ class ClanProfileCog(commands.Cog):
         for message_id in payload.message_ids:
             self._flip_index.pop(message_id, None)
 
-    async def _load_crest(
+    async def build_clan_crest_thumbnail(
         self,
-        guild: discord.Guild | None,
         tag: str,
-    ) -> tuple[Optional[bytes], Optional[str], Optional[str]]:
+        *,
+        guild: discord.Guild | None,
+    ) -> ClanCrestThumbnail:
+        """Return the clan crest thumbnail asset used by clan profile cards."""
         if guild is None:
-            return None, None, None
-
-        crest_bytes: Optional[bytes] = None
-        crest_filename: Optional[str] = None
-        crest_static_url: Optional[str] = None
+            return ClanCrestThumbnail()
 
         size, box = emoji_pipeline.tag_badge_defaults()
-        file, _ = await emoji_pipeline.build_tag_thumbnail(
+        file, attachment_url = await emoji_pipeline.build_tag_thumbnail(
             guild,
             tag,
             size=size,
             box=box,
         )
-        if file and file.fp:
+        if file and attachment_url:
+            return ClanCrestThumbnail(thumbnail_url=attachment_url, file=file)
+
+        proxy_url = emoji_pipeline.padded_emoji_url(guild, tag)
+        if proxy_url:
+            return ClanCrestThumbnail(thumbnail_url=proxy_url)
+
+        if not emoji_pipeline.is_strict_proxy_enabled():
+            emoji = emoji_pipeline.emoji_for_tag(guild, tag)
+            if emoji:
+                return ClanCrestThumbnail(thumbnail_url=str(emoji.url))
+
+        return ClanCrestThumbnail()
+
+    async def _load_crest(
+        self,
+        guild: discord.Guild | None,
+        tag: str,
+    ) -> tuple[Optional[bytes], Optional[str], Optional[str]]:
+        asset = await self.build_clan_crest_thumbnail(tag, guild=guild)
+        if asset.file and asset.file.fp:
             try:
-                file.fp.seek(0)
-                crest_bytes = file.fp.read()
-                crest_filename = file.filename or f"{tag.lower() or 'crest'}-badge.png"
+                asset.file.fp.seek(0)
+                crest_bytes = asset.file.fp.read()
+                crest_filename = (
+                    asset.file.filename or f"{tag.lower() or 'crest'}-badge.png"
+                )
+                return crest_bytes, crest_filename, None
             except Exception:
-                crest_bytes = None
-                crest_filename = None
-
-        if crest_bytes is None:
-            proxy_url = emoji_pipeline.padded_emoji_url(guild, tag)
-            if proxy_url:
-                crest_static_url = proxy_url
-            elif not emoji_pipeline.is_strict_proxy_enabled():
-                emoji = emoji_pipeline.emoji_for_tag(guild, tag)
-                if emoji:
-                    crest_static_url = str(emoji.url)
-
-        return crest_bytes, crest_filename, crest_static_url
+                pass
+        return None, None, asset.thumbnail_url
 
     def _crest_embed_url(self, state: _FlipState) -> Optional[str]:
         if state.crest_bytes and state.crest_filename:

--- a/modules/recruitment/clan_ads.py
+++ b/modules/recruitment/clan_ads.py
@@ -183,6 +183,12 @@ class ClanData:
 
 
 @dataclass
+class ClanCrestThumbnail:
+    thumbnail_url: str | None = None
+    file: discord.File | None = None
+
+
+@dataclass
 class Decision:
     tag: str
     clan: ClanData | None
@@ -223,6 +229,23 @@ async def build_clan_card(
         return ([embed] if embed is not None else []), files, state
     log.error("Clan Ads loaded ClanProfileCog has no supported card renderer")
     return None, [], None
+
+
+async def resolve_clan_crest_thumbnail(
+    bot: discord.Client, clan_tag: str, guild: discord.Guild | None
+) -> ClanCrestThumbnail:
+    cog = bot.get_cog("ClanProfileCog") if hasattr(bot, "get_cog") else None
+    if cog is None:
+        log.error("Clan Ads could not find loaded ClanProfileCog for crest rendering")
+        return ClanCrestThumbnail()
+    if not hasattr(cog, "build_clan_crest_thumbnail"):
+        log.error("Clan Ads loaded ClanProfileCog has no crest thumbnail resolver")
+        return ClanCrestThumbnail()
+    asset = await cog.build_clan_crest_thumbnail(tag_norm(clan_tag), guild=guild)
+    return ClanCrestThumbnail(
+        thumbnail_url=getattr(asset, "thumbnail_url", None),
+        file=getattr(asset, "file", None),
+    )
 
 
 async def load_config(
@@ -465,19 +488,6 @@ async def resolve_embed_color(
     return None
 
 
-def clan_card_static_thumbnail(embeds: Sequence[discord.Embed]) -> str | None:
-    for embed in embeds:
-        url = str(getattr(getattr(embed, "thumbnail", None), "url", None) or "")
-        if url.startswith(("https://", "http://")):
-            return url
-        if url:
-            log.debug(
-                "Clan Ads skipped non-static clan card thumbnail URL",
-                extra={"thumbnail_url": url},
-            )
-    return None
-
-
 def render(template: str, clan: ClanData, guild: discord.Guild | None) -> str:
     banner = ""
     emoji = emoji_pipeline.emoji_for_tag(guild, clan.tag) if guild else None
@@ -669,26 +679,28 @@ async def post_decision(
         )
         if footer:
             embed.set_footer(text=footer)
+        crest_file = None
         try:
-            card_embeds, _card_files, _state = await build_clan_card(
-                bot, clan.tag, guild
-            )
+            crest = await resolve_clan_crest_thumbnail(bot, clan.tag, guild)
         except Exception:
             log.debug(
-                "Clan Ads could not resolve clan card crest thumbnail",
+                "Clan Ads could not resolve clan crest thumbnail",
                 exc_info=True,
                 extra={"clan_tag": clan.tag},
             )
-            card_embeds = []
-        thumbnail_url = clan_card_static_thumbnail(card_embeds or [])
-        if thumbnail_url:
-            embed.set_thumbnail(url=thumbnail_url)
+            crest = ClanCrestThumbnail()
+        if crest.thumbnail_url:
+            embed.set_thumbnail(url=crest.thumbnail_url)
+            crest_file = crest.file
         else:
             log.debug(
-                "Clan Ads could not resolve clan card crest thumbnail",
+                "Clan Ads could not resolve clan crest thumbnail",
                 extra={"clan_tag": clan.tag},
             )
-        message = await channel.send(embed=embed, view=ClanAdButtonView(clan.tag))
+        send_kwargs = {"embed": embed, "view": ClanAdButtonView(clan.tag)}
+        if crest_file is not None:
+            send_kwargs["files"] = [crest_file]
+        message = await channel.send(**send_kwargs)
     except Exception as exc:
         log.exception("failed to post clan ad", extra={"clan_tag": clan.tag})
         await write_state(

--- a/tests/recruitment/test_clan_ads_fields.py
+++ b/tests/recruitment/test_clan_ads_fields.py
@@ -430,7 +430,7 @@ def test_embed_color_parsing_and_fallbacks(monkeypatch):
     assert "invalid embed_color `not-a-color`" in warnings[-1][0]
 
 
-def test_post_decision_applies_color_and_static_clan_card_thumbnail(monkeypatch):
+def test_post_decision_applies_color_and_crest_thumbnail(monkeypatch):
     import asyncio
     from types import SimpleNamespace
     import discord
@@ -447,13 +447,15 @@ def test_post_decision_applies_color_and_static_clan_card_thumbnail(monkeypatch)
     async def fake_write_state(*args, **kwargs):
         return None
 
-    async def fake_build_clan_card(*args, **kwargs):
-        embed = discord.Embed(title="Profile")
-        embed.set_thumbnail(url="https://example.com/crest.png")
-        return [embed, discord.Embed(title="Entry")], [], SimpleNamespace()
+    async def fake_resolve_clan_crest_thumbnail(*args, **kwargs):
+        return clan_ads.ClanCrestThumbnail(
+            thumbnail_url="https://example.com/crest.png"
+        )
 
     monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
-    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    monkeypatch.setattr(
+        clan_ads, "resolve_clan_crest_thumbnail", fake_resolve_clan_crest_thumbnail
+    )
     decision = clan_ads.Decision(
         "C1CE",
         _clan(),
@@ -482,7 +484,7 @@ def test_post_decision_applies_color_and_static_clan_card_thumbnail(monkeypatch)
     assert sent[0]["view"].timeout is None
 
 
-def test_post_decision_skips_attachment_thumbnail_without_public_files(monkeypatch):
+def test_post_decision_sends_attachment_crest_file(monkeypatch):
     import asyncio
     from types import SimpleNamespace
     import discord
@@ -499,13 +501,17 @@ def test_post_decision_skips_attachment_thumbnail_without_public_files(monkeypat
     async def fake_write_state(*args, **kwargs):
         return None
 
-    async def fake_build_clan_card(*args, **kwargs):
-        embed = discord.Embed(title="Profile")
-        embed.set_thumbnail(url="attachment://c1ce-badge.png")
-        return [embed, discord.Embed(title="Entry")], [object()], SimpleNamespace()
+    crest_file = object()
+
+    async def fake_resolve_clan_crest_thumbnail(*args, **kwargs):
+        return clan_ads.ClanCrestThumbnail(
+            thumbnail_url="attachment://c1ce-badge.png", file=crest_file
+        )
 
     monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
-    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    monkeypatch.setattr(
+        clan_ads, "resolve_clan_crest_thumbnail", fake_resolve_clan_crest_thumbnail
+    )
     decision = clan_ads.Decision(
         "C1CE",
         _clan(),
@@ -528,8 +534,8 @@ def test_post_decision_skips_attachment_thumbnail_without_public_files(monkeypat
     )
 
     assert ok is True
-    assert not sent[0]["embed"].thumbnail.url
-    assert "files" not in sent[0]
+    assert sent[0]["embed"].thumbnail.url == "attachment://c1ce-badge.png"
+    assert sent[0]["files"] == [crest_file]
 
 
 def test_post_decision_still_posts_without_static_clan_card_thumbnail(monkeypatch):
@@ -548,11 +554,13 @@ def test_post_decision_still_posts_without_static_clan_card_thumbnail(monkeypatc
     async def fake_write_state(*args, **kwargs):
         return None
 
-    async def fake_build_clan_card(*args, **kwargs):
-        return [], [], None
+    async def fake_resolve_clan_crest_thumbnail(*args, **kwargs):
+        return clan_ads.ClanCrestThumbnail()
 
     monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
-    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    monkeypatch.setattr(
+        clan_ads, "resolve_clan_crest_thumbnail", fake_resolve_clan_crest_thumbnail
+    )
     decision = clan_ads.Decision(
         "C1CE",
         _clan(),


### PR DESCRIPTION
### Motivation
- Clan Ads was building the full clan card just to scrape the crest thumbnail, causing duplication and unnecessary attachment handling. 
- Centralize the crest/emoji thumbnail resolution so both `!clan` rendering and Clan Ads use the same logic and mappings. 

### Description
- Add a shared `ClanCrestThumbnail` asset shape and `ClanProfileCog.build_clan_crest_thumbnail()` helper that returns `thumbnail_url` and an optional `discord.File`, reusing existing `emoji_pipeline` proxy/attachment/fallback logic. 
- Preserve `!clan` reaction-flip behavior by having `_load_crest` use the new helper and continue returning attachment bytes for profile card edits. 
- Introduce `resolve_clan_crest_thumbnail()` in `modules/recruitment/clan_ads.py` that queries the `ClanProfileCog` helper and make `post_decision()` set the ad embed thumbnail from the helper and attach the matching file when the URL is `attachment://`. 
- Update tests to exercise static URL, attachment-file, and missing-crest cases and keep the existing `View Clan Card` button flow unchanged. 

### Testing
- Ran code formatting with `black` on the modified files; formatting completed successfully. 
- Executed unit tests with `pytest -q tests/recruitment/test_clan_ads_fields.py`, and all tests passed (`............. [100%]`). 
- Verified the updated Clan Ads tests now assert static crest URLs, `attachment://` attachment delivery, and fallback/no-thumbnail behavior and they succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42e6ffa6108323b936be43eac72ab2)