### PR TITLE
Simplify share embed formatting, use final copy as footer, and adjust section order

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -1485,29 +1485,24 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         lines: list[str] = []
         intro = self._select_share_copy(copy_rows, voice, "intro", "always", placeholders, random_enabled)
         if intro:
-            lines.extend([intro, ""])
+            lines.append(intro)
         by_key = {display.key: display for display in displays}
         section_emojis = self._section_emojis()
-        for key in ("mystery", "ancient", "void", "sacred", "primal"):
+        for key in ("mystery", "ancient", "void", "primal", "sacred"):
             display = by_key[key]
             section_placeholders = {**placeholders, **self._share_shard_placeholders(display, mythic)}
             heading = self._share_section_heading(display, section_emojis)
-            stat_lines = [f"Owned: {display.owned:,}"]
             condition = self._share_comment_condition(display, mythic, share_config)
             comment = self._select_share_comment(copy_rows, voice, condition, section_placeholders, random_enabled)
-            lines.append(f"### **{heading}**")
-            lines.append("```text")
-            lines.extend(stat_lines)
-            lines.append("```")
+            lines.append(f"`{heading}: {display.owned:,}`")
             if comment:
                 lines.append(f"-# {comment}")
-            lines.append("")
         final = self._select_share_copy(copy_rows, voice, "final_line", "always", placeholders, random_enabled)
-        if final:
-            lines.append(final)
         embed = discord.Embed(title=f"Shard Stash Report — {member.display_name}", description="\n".join(lines).strip())
-        from .views import FOOTER_TEXT
-        embed.set_footer(text=FOOTER_TEXT)
+        if final:
+            embed.set_footer(text=final)
+        else:
+            embed.set_footer(text=" ")
         return embed
 
 

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -365,8 +365,8 @@ def test_section_headings_use_configured_icon_sources():
         "sacred_icon Sacred",
         "remnant_icon Remnants",
     ]
-    assert "### **<:mystery:123456789012345678> Mystery**" in shared.description
-    assert "### **<:ancient:223456789012345678> Ancient**" in shared.description
+    assert "`<:mystery:123456789012345678> Mystery: 0`" in shared.description
+    assert "`<:ancient:223456789012345678> Ancient: 0`" in shared.description
 
 
 def test_detail_button_layout_still_includes_share_to_clan():
@@ -399,17 +399,17 @@ def test_share_embed_uses_sheet_driven_clean_payload():
 
     assert embed.title == "Shard Stash Report — Tester"
     assert "Intro Tester alpha" in embed.description
-    assert "### **Mystery**" in embed.description
-    assert "```text\nOwned: 0\n```\n-# No Mystery." in embed.description
-    assert "```\n\n-# No Mystery." not in embed.description
-    assert "Owned: 0\n\n```" not in embed.description
+    assert "Intro Tester alpha\n`Mystery: 0`" in embed.description
+    assert "`Mystery: 0`\n-# No Mystery.\n`Ancient: 0`" in embed.description
+    assert embed.description.index("`Primal: 0`") < embed.description.index("`Sacred: 0`")
+    assert "Owned:" not in embed.description
+    assert "```" not in embed.description
+    assert "\n\n" not in embed.description
     assert "Mercy:" not in embed.description
     assert "Last Legendary:" not in embed.description
-    assert embed.description.index("Intro Tester alpha") < embed.description.index("```text")
-    assert embed.description.rindex("```") < embed.description.index("Final alpha.")
-    assert embed.description.count("```text") == 5
     assert "Chance" not in embed.description
-    assert "Final alpha." in embed.description
+    assert "Final alpha." not in embed.description
+    assert embed.footer.text == "Final alpha."
 
 
 def test_share_button_action_routes_overview_without_active_tab_payload():
@@ -460,7 +460,8 @@ def test_detail_share_button_action_preserves_overview_share_behavior():
         tracker.store.get_share_copy_rows = AsyncMock(return_value=_copy_rows())
         embed = await tracker._build_share_embed(interaction.user, record, clan)
         assert embed.title == "Shard Stash Report — Tester"
-        assert "### **Mystery**" in embed.description
+        assert "`Mystery: 0`" in embed.description
+        assert embed.footer.text == "Final alpha."
 
     asyncio.run(runner())
 
@@ -736,7 +737,8 @@ def test_share_missing_required_config_logs_and_skips_flavor(caplog):
         assert "Shard share Config key missing: shard_share_default_voice" in caplog.text
         assert "Intro" not in embed.description
         assert "Final" not in embed.description
-        assert "### **Mystery**" in embed.description
+        assert "`Mystery: 0`" in embed.description
+        assert embed.footer.text == " "
 
     asyncio.run(runner())
 
@@ -757,7 +759,8 @@ def test_share_invalid_threshold_logs_and_skips_conditional_flavor(caplog):
         assert "shard_share_mercy_high_percent" in caplog.text
         assert "Some Void" not in embed.description
         assert "No Void" not in embed.description
-        assert "### **Void**" in embed.description
+        assert "`Void: 0`" in embed.description
+        assert embed.footer.text == " "
 
     asyncio.run(runner())
 
@@ -795,10 +798,10 @@ def test_share_invalid_percent_range_skips_flavor_but_keeps_clean_stats(caplog):
         assert "Intro" not in embed.description
         assert "Final" not in embed.description
         assert "Some Void" not in embed.description
-        assert "### **Void**" in embed.description
-        assert "```text\nOwned: 10\n```" in embed.description
+        assert "`Void: 10`" in embed.description
         assert "Mercy:" not in embed.description
         assert "Last Legendary:" not in embed.description
         assert "Chance" not in embed.description
+        assert embed.footer.text == " "
 
     asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Make the shard share embed payload cleaner and easier to consume by removing code blocks and multi-line stat sections and by surfacing the final sheet-driven copy in the embed footer.
- Ensure shard section ordering matches the required sequence for display.

### Description
- Replace multi-line heading + code-block owned stats with a single inline stat line formatted as ```<heading>: <owned>``` and keep comment lines as ``-# <comment>`` in the embed description.
- Change the shard section iteration order to ensure ``primal`` appears before ``sacred`` when building the share embed.
- Use the sheet-driven final copy as the embed footer when present and fall back to a blank footer string when absent, removing the hard dependency on a static `FOOTER_TEXT` value.
- Tidy up construction of the intro line by appending instead of extending with an extra blank line to avoid double newlines.

### Testing
- Updated and ran the shard tracker unit tests in ``tests/community/shard_tracker/test_cog.py`` to reflect the new embed formatting and footer behavior, and the tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c0652d0c8323ac03137dc4cf3514)