### PR TITLE
Add Fusion Requirements section to fusion embed

### DIFF
--- a/modules/community/fusion/rendering.py
+++ b/modules/community/fusion/rendering.py
@@ -126,12 +126,17 @@ def _build_fusion_embed(
     else:
         goal_line = f"Goal: Earn {fusion.needed:g} {reward_unit} for {fusion.champion}"
 
-    summary_lines = [
-        f"Type: {_humanize_type(fusion.fusion_type)}",
-        goal_line,
-        f"Target: {fusion.needed:g} {reward_unit} needed / {fusion.available:g} available",
-        f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
-    ]
+    summary_lines = [f"Type: {_humanize_type(fusion.fusion_type)}"]
+    fusion_structure = str(fusion.fusion_structure or "").strip()
+    if fusion_structure:
+        summary_lines.extend(["", "Fusion Requirements", fusion_structure, ""])
+    summary_lines.extend(
+        [
+            goal_line,
+            f"Target: {fusion.needed:g} {reward_unit} needed / {fusion.available:g} available",
+            f"Schedule: {len(events)} events" + (" • includes bonus rewards" if has_bonus else ""),
+        ]
+    )
 
     milestones_lines = [
         f"First start: {_format_day_label(min(event_days))}" if event_days else "First start: TBA",

--- a/tests/community/test_fusion_rendering.py
+++ b/tests/community/test_fusion_rendering.py
@@ -77,6 +77,33 @@ def test_build_fusion_embed_target_and_schedule_field_chunks() -> None:
     ]
 
 
+def test_build_fusion_embed_adds_non_empty_fusion_requirements_between_type_and_goal() -> None:
+    fusion = replace(_fusion(), fusion_structure="• 4 Epics\n• 16 Rares")
+
+    embed = build_fusion_announcement_embed(fusion, [])
+
+    assert embed.description == (
+        "Type: Traditional\n"
+        "\n"
+        "Fusion Requirements\n"
+        "• 4 Epics\n"
+        "• 16 Rares\n"
+        "\n"
+        "Goal: Earn 400 fragments for Mavara\n"
+        "Target: 400 fragments needed / 450 available\n"
+        "Schedule: 0 events"
+    )
+
+
+def test_build_fusion_embed_omits_empty_fusion_requirements() -> None:
+    embed = build_fusion_announcement_embed(_fusion(), [])
+
+    assert "Fusion Requirements" not in (embed.description or "")
+    assert (embed.description or "").splitlines()[:2] == [
+        "Type: Traditional",
+        "Goal: Earn 400 fragments for Mavara",
+    ]
+
 def test_build_fusion_embed_sets_champion_image_when_url_present() -> None:
     fusion = replace(_fusion(), champion_image_url="https://cdn.discordapp.com/champion.png")
 


### PR DESCRIPTION
### Motivation
- Surface per-fusion requirements from the Sheets row in the announcement embed so recipients can see exact fusion composition without changing existing lines or layout.

### Description
- Insert the non-empty `fusion.fusion_structure` value into the embed description between the `Type` line and the existing `Goal` line inside `_build_fusion_embed` in `modules/community/fusion/rendering.py`.
- Preserve original header-resolution and data-loading behavior by reading the existing `fusion_structure` field on the `FusionRow` dataclass and by not introducing any new Config keys, hard-coded column indexes/letters, or tab names.
- Preserve line breaks and bullet formatting from the sheet cell by inserting the raw trimmed string into the description unchanged and only showing the `Fusion Requirements` section when the value is non-empty.
- Add unit tests in `tests/community/test_fusion_rendering.py` to assert the requirements block appears with multiline/bulleted content and is omitted when empty.

### Testing
- Ran `PYTHONDONTWRITEBYTECODE=1 pytest tests/community/test_fusion_rendering.py -q` which passed successfully.  
- Running a broader set including `tests/community/test_fusion_announcement_refresh.py` surfaced an unrelated expectation mismatch in a test that looks for an "Event Status" field versus the implementation's "Schedule Status" naming, which is pre-existing and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44f3eb4e948323b47c2d40461983a0)