### PR TITLE
Fix shard share compact emoji layout

### DIFF
--- a/modules/community/shard_tracker/cog.py
+++ b/modules/community/shard_tracker/cog.py
@@ -1491,10 +1491,10 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         for key in ("mystery", "ancient", "void", "primal", "sacred"):
             display = by_key[key]
             section_placeholders = {**placeholders, **self._share_shard_placeholders(display, mythic)}
-            heading = self._share_section_heading(display, section_emojis)
+            icon = self._share_section_icon(display, section_emojis)
             condition = self._share_comment_condition(display, mythic, share_config)
             comment = self._select_share_comment(copy_rows, voice, condition, section_placeholders, random_enabled)
-            lines.append(f"`{heading}: {display.owned:,}`")
+            lines.append(f"{icon} `{display.label}: {display.owned:,}`".strip())
             if comment:
                 lines.append(f"-# {comment}")
         final = self._select_share_copy(copy_rows, voice, "final_line", "always", placeholders, random_enabled)
@@ -1502,7 +1502,7 @@ class ShardTracker(commands.Cog, ShardTrackerController):
         if final:
             embed.set_footer(text=final)
         else:
-            embed.set_footer(text=" ")
+            embed.set_footer(text="Status: counted like treasure, judged like gossip, guarded like rum.")
         return embed
 
 
@@ -1625,11 +1625,17 @@ class ShardTracker(commands.Cog, ShardTrackerController):
             return "mercy_started"
         return "always"
 
-    def _share_section_heading(self, display: ShardDisplay, shard_emojis: dict[str, object]) -> str:
+    def _share_section_icon(self, display: ShardDisplay, shard_emojis: dict[str, object]) -> str:
         emoji = str((shard_emojis or {}).get(display.key) or "").strip()
         if emoji:
-            return f"{emoji} {display.label}"
+            return emoji
         log.warning("shard share icon missing", extra={"shard_type": display.key})
+        return ""
+
+    def _share_section_heading(self, display: ShardDisplay, shard_emojis: dict[str, object]) -> str:
+        emoji = self._share_section_icon(display, shard_emojis)
+        if emoji:
+            return f"{emoji} {display.label}"
         return display.label
 
     def _build_clan_reminder_embed(

--- a/tests/community/shard_tracker/test_cog.py
+++ b/tests/community/shard_tracker/test_cog.py
@@ -365,8 +365,10 @@ def test_section_headings_use_configured_icon_sources():
         "sacred_icon Sacred",
         "remnant_icon Remnants",
     ]
-    assert "`<:mystery:123456789012345678> Mystery: 0`" in shared.description
-    assert "`<:ancient:223456789012345678> Ancient: 0`" in shared.description
+    assert "<:mystery:123456789012345678> `Mystery: 0`" in shared.description
+    assert "`<:mystery:123456789012345678> Mystery: 0`" not in shared.description
+    assert "<:ancient:223456789012345678> `Ancient: 0`" in shared.description
+    assert "`<:ancient:223456789012345678> Ancient: 0`" not in shared.description
 
 
 def test_detail_button_layout_still_includes_share_to_clan():
@@ -738,7 +740,7 @@ def test_share_missing_required_config_logs_and_skips_flavor(caplog):
         assert "Intro" not in embed.description
         assert "Final" not in embed.description
         assert "`Mystery: 0`" in embed.description
-        assert embed.footer.text == " "
+        assert embed.footer.text == "Status: counted like treasure, judged like gossip, guarded like rum."
 
     asyncio.run(runner())
 
@@ -760,7 +762,7 @@ def test_share_invalid_threshold_logs_and_skips_conditional_flavor(caplog):
         assert "Some Void" not in embed.description
         assert "No Void" not in embed.description
         assert "`Void: 0`" in embed.description
-        assert embed.footer.text == " "
+        assert embed.footer.text == "Status: counted like treasure, judged like gossip, guarded like rum."
 
     asyncio.run(runner())
 
@@ -802,6 +804,6 @@ def test_share_invalid_percent_range_skips_flavor_but_keeps_clean_stats(caplog):
         assert "Mercy:" not in embed.description
         assert "Last Legendary:" not in embed.description
         assert "Chance" not in embed.description
-        assert embed.footer.text == " "
+        assert embed.footer.text == "Status: counted like treasure, judged like gossip, guarded like rum."
 
     asyncio.run(runner())


### PR DESCRIPTION
### Motivation
- Custom Discord emojis were rendered as raw markup because the compact shard lines placed the icon inside inline-code formatting.  
- The share embed must display configured shard icons as real emojis while keeping the shard name/count compact and backticked.  
- Ensure existing sheet-driven intro, shard comments, and final copy behavior remain unchanged while avoiding hard-coded names/icons.

### Description
- Render the icon separately and outside backticks by adding `_share_section_icon` and using `lines.append(f"{icon} `{display.label}: {display.owned:,}`".strip())` in `_build_share_embed` so icons show as emojis.  
- Preserve the original `_share_section_heading` behavior for other callers by refactoring it to call the new `_share_section_icon`.  
- Keep the dynamic comment selection and placeholders (`_share_comment_condition` / `_select_share_comment`) exactly as-is and append comments immediately after the corresponding shard line.  
- Use the configured `final_line` as the embed footer and fall back to the required text `Status: counted like treasure, judged like gossip, guarded like rum.` when no final copy is available, and update tests to reflect these changes.

### Testing
- Ran `pytest tests/community/shard_tracker/test_cog.py -q` and all tests passed.  
- Ran `git diff --check` to ensure no whitespace or diff issues, which reported no problems.  
- Modified and validated assertions in `tests/community/shard_tracker/test_cog.py` to confirm icons are outside inline code and footer fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44f5f26fa0832391b9b4de60c5f872)