### PR TITLE
Add traditional fusion champion-prep tracking and make announcement publish more robust

### DIFF
--- a/modules/community/fusion/announcements.py
+++ b/modules/community/fusion/announcements.py
@@ -205,6 +205,36 @@ async def publish_fusion_announcement(
     if channel is None:
         return None
 
+    resolution = await resolve_stored_announcement(bot, target)
+    if resolution.message is not None:
+        edited = await edit_fusion_announcement(resolution.message, target)
+        log.info(
+            "fusion existing announcement edited during publish",
+            extra={
+                "fusion_id": target.fusion_id,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+        )
+        return edited
+    if (
+        resolution.had_reference
+        and isinstance(resolution.error, (discord.Forbidden, discord.HTTPException))
+        and not isinstance(resolution.error, discord.NotFound)
+    ):
+        raise FusionAnnouncementPermissionError(
+            "Bot cannot fetch stored fusion announcement message"
+        ) from resolution.error
+    if resolution.had_reference and resolution.is_stale:
+        log.warning(
+            "fusion stored announcement missing during publish; creating clearly logged replacement",
+            extra={
+                "fusion_id": target.fusion_id,
+                "announcement_channel_id": target.announcement_channel_id,
+                "announcement_message_id": target.announcement_message_id,
+            },
+        )
+
     events = await fusion_sheets.get_fusion_events(target.fusion_id)
     announcement_embed = build_fusion_announcement_embed(target, events)
     announcement_view = build_fusion_opt_in_view(target)

--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -27,6 +27,9 @@ _FUSION_PROGRESS_SHARE_SUMMARY_CUSTOM_ID = "fusion:progress:share:summary"
 _FUSION_PROGRESS_SHARE_DETAILED_CUSTOM_ID = "fusion:progress:share:detailed"
 _FUSION_PROGRESS_MARK_ALL_CUSTOM_ID = "fusion:progress:mark_all"
 _FUSION_PROGRESS_UPDATE_CUSTOM_ID = "fusion:progress:update"
+_FUSION_TRAD_CHOICE_EVENT_CUSTOM_ID = "fusion:traditional:choice:event"
+_FUSION_TRAD_CHOICE_PREP_CUSTOM_ID = "fusion:traditional:choice:prep"
+_FUSION_TRAD_PREP_UPDATE_CUSTOM_ID = "fusion:traditional:prep:update"
 
 _DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
 _EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done", "done_bonus")
@@ -58,6 +61,85 @@ _STATUS_INDEX_TO_CANONICAL = {
 _EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
 _PROGRESS_EVENT_PAGE_SIZE = 10
 
+
+
+def _is_traditional_fusion(target: fusion_sheets.FusionRow) -> bool:
+    return str(target.fusion_type or "").strip().casefold() == "traditional"
+
+
+def _traditional_rares_acquired(
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str],
+) -> int:
+    total = 0.0
+    for event in events:
+        if str(event.reward_type or "").strip().casefold() not in {"rare", "rares"}:
+            continue
+        if progress_by_event.get(event.event_id) in {"done", "done_bonus"}:
+            total += max(0.0, float(event.reward_amount or 0))
+    return min(max(0, int(total)), max(0, int(target.needed)))
+
+
+def _validate_traditional_prep_counts(
+    *,
+    needed_total: int,
+    rares_acquired: int,
+    rares_level_40: int,
+    rares_ascended: int,
+    epics_fused: int,
+    epics_level_50: int,
+    epics_ascended: int,
+) -> str | None:
+    values = {
+        "Rares level 40": rares_level_40,
+        "Rares fully ascended": rares_ascended,
+        "Epics fused": epics_fused,
+        "Epics level 50": epics_level_50,
+        "Epics fully ascended": epics_ascended,
+    }
+    if any(value < 0 for value in values.values()):
+        return "All champion preparation counts must be non-negative integers."
+    if rares_level_40 > needed_total or rares_ascended > needed_total:
+        return f"Rare prep counts cannot be higher than {needed_total}."
+    if epics_fused > 4 or epics_level_50 > 4 or epics_ascended > 4:
+        return "Epic prep counts cannot be higher than 4."
+    if rares_level_40 > rares_acquired:
+        return "Rares level 40 cannot be higher than Rares acquired from event rewards."
+    if rares_ascended > rares_level_40:
+        return "Rares fully ascended cannot be higher than Rares level 40."
+    if epics_fused > rares_ascended // 4:
+        return "Epics fused cannot be higher than the number allowed by fully ascended Rares."
+    if epics_level_50 > epics_fused:
+        return "Epics level 50 cannot be higher than Epics fused."
+    if epics_ascended > epics_level_50:
+        return "Epics fully ascended cannot be higher than Epics level 50."
+    return None
+
+
+def _build_traditional_prep_embed(
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str],
+    prep: fusion_sheets.FusionTraditionalUserProgressRow,
+) -> discord.Embed:
+    needed_total = max(0, int(target.needed))
+    rares_acquired = _traditional_rares_acquired(target=target, events=events, progress_by_event=progress_by_event)
+    rares_still_needed = max(0, needed_total - rares_acquired)
+    ready = prep.epics_ascended >= 4
+    missing = "Nothing, the target champion is ready to fuse." if ready else f"{4 - prep.epics_ascended} fully ascended Epics"
+    embed = discord.Embed(
+        title=f"Champion Preparation: {target.champion or target.fusion_name}",
+        description="Traditional fusion prep tracker.",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Event Rewards", value=f"Rares acquired: {rares_acquired} / {needed_total}\nRares still needed: {rares_still_needed}", inline=False)
+    embed.add_field(name="Rare Prep", value=f"Rares level 40: {prep.rares_level_40} / {needed_total}\nRares fully ascended: {prep.rares_ascended} / {needed_total}", inline=False)
+    embed.add_field(name="Epic Prep", value=f"Epics fused: {prep.epics_fused} / 4\nEpics level 50: {prep.epics_level_50} / 4\nEpics fully ascended: {prep.epics_ascended} / 4", inline=False)
+    embed.add_field(name="Final Fusion", value=f"Ready to fuse {target.champion or target.fusion_name}: {'Yes' if ready else 'No'}\nMissing: {missing}", inline=False)
+    return embed
 
 def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, status: str | None) -> bool:
     if event is None:
@@ -526,7 +608,7 @@ class FusionProgressShareModeView(discord.ui.View):
         progress_by_event: Mapping[str, str],
         partial_by_event: Mapping[str, float] | None = None,
     ) -> None:
-        super().__init__(timeout=300)
+        super().__init__(timeout=None)
         self.user_id = int(user_id)
         self.target = target
         self.events = list(events)
@@ -782,6 +864,127 @@ class _FusionProgressModal(discord.ui.Modal, title="Log Partial Fragments"):
         await _edit_progress_message(interaction, view=self.panel_view)
 
 
+
+class TraditionalProgressChoiceView(discord.ui.View):
+    def __init__(self, *, user_id: int, target: fusion_sheets.FusionRow, events: Sequence[fusion_sheets.FusionEventRow], progress_by_event: dict[str, str], partial_by_event: dict[str, float]) -> None:
+        super().__init__(timeout=None)
+        self.user_id = int(user_id)
+        self.target = target
+        self.events = list(events)
+        self.progress_by_event = dict(progress_by_event)
+        self.partial_by_event = dict(partial_by_event)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await _send_ephemeral(interaction, "This progress choice belongs to a different user.")
+            return False
+        return True
+
+    @discord.ui.button(label="Event/Tournament Progress", style=discord.ButtonStyle.primary, custom_id=_FUSION_TRAD_CHOICE_EVENT_CUSTOM_ID)
+    async def event_progress(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        view = FusionProgressPanelView(user_id=self.user_id, target=self.target, events=self.events, progress_by_event=self.progress_by_event, partial_by_event=self.partial_by_event)
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+    @discord.ui.button(label="Champion Preparation", style=discord.ButtonStyle.secondary, custom_id=_FUSION_TRAD_CHOICE_PREP_CUSTOM_ID)
+    async def champion_prep(self, interaction: discord.Interaction, _button: discord.ui.Button) -> None:
+        try:
+            prep = await fusion_sheets.get_user_traditional_progress(self.target.fusion_id, str(self.user_id))
+        except Exception as exc:
+            log.exception("fusion traditional prep failed to load", extra={"fusion_id": self.target.fusion_id, "user_id": self.user_id})
+            await fusion_logs.send_ops_alert(component="traditional_prep", summary="load_failed", dedupe_key=f"fusion:traditional_prep:load:{self.target.fusion_id}", error=exc, fields={"fusion_id": self.target.fusion_id})
+            await _send_ephemeral(interaction, "Couldn’t load champion preparation right now. Ask an admin to check the traditional progress tab config.")
+            return
+        view = TraditionalPrepPanelView(user_id=self.user_id, target=self.target, events=self.events, progress_by_event=self.progress_by_event, prep=prep)
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+
+class TraditionalPrepPanelView(discord.ui.View):
+    def __init__(self, *, user_id: int, target: fusion_sheets.FusionRow, events: Sequence[fusion_sheets.FusionEventRow], progress_by_event: Mapping[str, str], prep: fusion_sheets.FusionTraditionalUserProgressRow) -> None:
+        super().__init__(timeout=None)
+        self.user_id = int(user_id)
+        self.target = target
+        self.events = list(events)
+        self.progress_by_event = dict(progress_by_event)
+        self.prep = prep
+        self.add_item(_TraditionalPrepUpdateButton())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await _send_ephemeral(interaction, "This champion preparation panel belongs to a different user.")
+            return False
+        return True
+
+    def build_embed(self) -> discord.Embed:
+        return _build_traditional_prep_embed(target=self.target, events=self.events, progress_by_event=self.progress_by_event, prep=self.prep)
+
+
+class _TraditionalPrepUpdateButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(label="Update Champion Prep", style=discord.ButtonStyle.primary, custom_id=_FUSION_TRAD_PREP_UPDATE_CUSTOM_ID)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not isinstance(self.view, TraditionalPrepPanelView):
+            return
+        await interaction.response.send_modal(_TraditionalPrepModal(view=self.view))
+
+
+class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
+    rares_level_40 = discord.ui.TextInput(label="Rares level 40", required=True, max_length=3)
+    rares_ascended = discord.ui.TextInput(label="Rares fully ascended", required=True, max_length=3)
+    epics_fused = discord.ui.TextInput(label="Epics fused", required=True, max_length=1)
+    epics_level_50 = discord.ui.TextInput(label="Epics level 50", required=True, max_length=1)
+    epics_ascended = discord.ui.TextInput(label="Epics fully ascended", required=True, max_length=1)
+
+    def __init__(self, *, view: TraditionalPrepPanelView) -> None:
+        super().__init__()
+        self.panel_view = view
+        self.rares_level_40.default = str(view.prep.rares_level_40)
+        self.rares_ascended.default = str(view.prep.rares_ascended)
+        self.epics_fused.default = str(view.prep.epics_fused)
+        self.epics_level_50.default = str(view.prep.epics_level_50)
+        self.epics_ascended.default = str(view.prep.epics_ascended)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        try:
+            values = [int(str(item.value).strip()) for item in (self.rares_level_40, self.rares_ascended, self.epics_fused, self.epics_level_50, self.epics_ascended)]
+        except ValueError:
+            await _send_ephemeral(interaction, "Champion preparation counts must be whole numbers.")
+            return
+        needed_total = max(0, int(self.panel_view.target.needed))
+        rares_acquired = _traditional_rares_acquired(target=self.panel_view.target, events=self.panel_view.events, progress_by_event=self.panel_view.progress_by_event)
+        error = _validate_traditional_prep_counts(needed_total=needed_total, rares_acquired=rares_acquired, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4])
+        if error:
+            await _send_ephemeral(interaction, error)
+            return
+        try:
+            prep = await fusion_sheets.upsert_user_traditional_progress(self.panel_view.target.fusion_id, str(self.panel_view.user_id), rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4], updated_at=dt.datetime.now(dt.timezone.utc))
+        except Exception as exc:
+            log.exception("fusion traditional prep save failed", extra={"fusion_id": self.panel_view.target.fusion_id, "user_id": self.panel_view.user_id})
+            await fusion_logs.send_ops_alert(component="traditional_prep", summary="save_failed", dedupe_key=f"fusion:traditional_prep:save:{self.panel_view.target.fusion_id}", error=exc, fields={"fusion_id": self.panel_view.target.fusion_id})
+            await _send_ephemeral(interaction, "Couldn’t save champion preparation right now. Try again in a moment.")
+            return
+        self.panel_view.prep = prep
+        await _edit_traditional_prep_message(interaction, view=self.panel_view)
+
+async def _edit_traditional_prep_message(interaction: discord.Interaction, *, view: "TraditionalPrepPanelView") -> None:
+    context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_TRAD_PREP_UPDATE_CUSTOM_ID)
+    context.update({
+        "fusion_id": view.target.fusion_id,
+        "user_id": view.user_id,
+        "response_done_before_send": interaction.response.is_done(),
+    })
+    log.info("fusion traditional prep panel edit path selected", extra=context)
+    await _safe_defer_progress_interaction(interaction)
+    edit_original = getattr(interaction, "edit_original_response", None)
+    if callable(edit_original):
+        await edit_original(embed=view.build_embed(), view=view)
+        return
+    if not interaction.response.is_done():
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+        return
+    await interaction.followup.send(embed=view.build_embed(), view=view, ephemeral=True)
+
+
 class FusionProgressPanelView(discord.ui.View):
     """Ephemeral progress panel for one user and one fusion."""
 
@@ -794,7 +997,7 @@ class FusionProgressPanelView(discord.ui.View):
         progress_by_event: dict[str, str],
         partial_by_event: dict[str, float] | None = None,
     ) -> None:
-        super().__init__(timeout=900)
+        super().__init__(timeout=None)
         self.user_id = int(user_id)
         self.fusion_id = target.fusion_id
         self.target = target
@@ -1010,6 +1213,26 @@ async def _handle_my_progress(interaction: discord.Interaction) -> None:
             dedupe_key=f"fusion:my_progress:malformed:{target.fusion_id}",
             fields=context,
         )
+
+    if _is_traditional_fusion(target):
+        view = TraditionalProgressChoiceView(
+            user_id=interaction.user.id,
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            partial_by_event=partial_by_event,
+        )
+        embed = discord.Embed(
+            title=f"My Progress: {target.fusion_name}",
+            description="What do you want to track for this traditional fusion?",
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(name="Choices", value="Event/Tournament Progress\nChampion Preparation", inline=False)
+        if interaction.response.is_done():
+            await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        else:
+            await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+        return
 
     view = FusionProgressPanelView(
         user_id=interaction.user.id,

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -28,6 +28,7 @@ _FUSION_EVENTS_BUCKET = "fusion_events"
 _LAST_FUSION_PARSE_ERRORS: dict[str, str] = {}
 _FUSION_REMINDER_TAB_KEY = "FUSION_REMINDER_TAB"
 _FUSION_PROGRESS_TAB_KEY = "FUSION_USER_EVENT_PROGRESS_TAB"
+_FUSION_TRADITIONAL_PROGRESS_TAB_KEY = "FUSION_TRADITIONAL_USER_PROGRESS_TAB"
 _FUSION_REMINDER_SETTINGS_TAB_KEY = "FUSION_REMINDER_SETTINGS_TAB"
 _FUSION_ROLE_CLEANUP_SUMMARY_UNREPORTED = "__fusion_role_cleanup_summary_unreported__"
 _FUSION_ROLE_CLEANUP_SUMMARY_REPORTED = "__fusion_role_cleanup_summary_reported__"
@@ -41,6 +42,16 @@ _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "event_id": ("event_id",),
     "reminder_type": ("reminder_type",),
     "sent_at_utc": ("sent_at_utc",),
+}
+_FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
+    "fusion_id": ("fusion_id",),
+    "user_id": ("user_id",),
+    "rares_level_40": ("rares_level_40",),
+    "rares_ascended": ("rares_ascended",),
+    "epics_fused": ("epics_fused",),
+    "epics_level_50": ("epics_level_50",),
+    "epics_ascended": ("epics_ascended",),
+    "updated_at_utc": ("updated_at_utc", "updated at utc", "updatedat", "updated_at"),
 }
 _FUSION_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "fusion_id": ("fusion_id", "fusion key", "fusionkey"),
@@ -100,6 +111,18 @@ class FusionEventRow:
     embed_title: str = ""
     embed_description: str = ""
     embed_footer: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class FusionTraditionalUserProgressRow:
+    fusion_id: str
+    user_id: str
+    rares_level_40: int = 0
+    rares_ascended: int = 0
+    epics_fused: int = 0
+    epics_level_50: int = 0
+    epics_ascended: int = 0
+    updated_at: dt.datetime | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -395,6 +418,33 @@ def reminder_dedupe_backend_metadata() -> dict[str, str]:
         "tab_name": tab_name,
     }
 
+
+
+def _resolve_traditional_progress_sheet_schema() -> tuple[str, dict[str, str]]:
+    tab_name = _resolve_tab_name(_FUSION_TRADITIONAL_PROGRESS_TAB_KEY)
+    return tab_name, dict(_FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES)
+
+
+def _resolve_traditional_progress_header_indices(*, tab_name: str, header: list[str]) -> dict[str, int]:
+    required_fields = [
+        "fusion_id",
+        "user_id",
+        "rares_level_40",
+        "rares_ascended",
+        "epics_fused",
+        "epics_level_50",
+        "epics_ascended",
+        "updated_at_utc",
+    ]
+    return {
+        field: _resolve_header_index(
+            tab_name=tab_name,
+            header=header,
+            field=field,
+            aliases_by_field=_FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES,
+        )
+        for field in required_fields
+    }
 
 def _resolve_progress_sheet_schema() -> tuple[str, dict[str, str]]:
     tab_name = _resolve_tab_name(_FUSION_PROGRESS_TAB_KEY)
@@ -1561,6 +1611,106 @@ def _progress_save_log_fields(result: FusionProgressSaveResult) -> dict[str, obj
 
 
 
+
+async def get_user_traditional_progress(fusion_id: str, user_id: str) -> FusionTraditionalUserProgressRow:
+    """Return champion-prep progress for one traditional fusion/user tuple."""
+
+    tab_name, _aliases = _resolve_traditional_progress_sheet_schema()
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        raise RuntimeError(
+            "Fusion traditional user progress sheet is empty "
+            f"(tab={tab_name}, key={_FUSION_TRADITIONAL_PROGRESS_TAB_KEY})"
+        )
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = _resolve_traditional_progress_header_indices(tab_name=tab_name, header=header)
+    fusion_idx = index_by_field["fusion_id"]
+    user_idx = index_by_field["user_id"]
+    target_fusion = str(fusion_id or "").strip()
+    target_user = str(user_id or "").strip()
+    for row in matrix[1:]:
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_user = str(row[user_idx] if user_idx < len(row) else "").strip()
+        if row_fusion != target_fusion or row_user != target_user:
+            continue
+        return FusionTraditionalUserProgressRow(
+            fusion_id=target_fusion,
+            user_id=target_user,
+            rares_level_40=max(0, _parse_int(row[index_by_field["rares_level_40"]] if index_by_field["rares_level_40"] < len(row) else "")),
+            rares_ascended=max(0, _parse_int(row[index_by_field["rares_ascended"]] if index_by_field["rares_ascended"] < len(row) else "")),
+            epics_fused=max(0, _parse_int(row[index_by_field["epics_fused"]] if index_by_field["epics_fused"] < len(row) else "")),
+            epics_level_50=max(0, _parse_int(row[index_by_field["epics_level_50"]] if index_by_field["epics_level_50"] < len(row) else "")),
+            epics_ascended=max(0, _parse_int(row[index_by_field["epics_ascended"]] if index_by_field["epics_ascended"] < len(row) else "")),
+            updated_at=_parse_iso_utc_optional(row[index_by_field["updated_at_utc"]] if index_by_field["updated_at_utc"] < len(row) else ""),
+        )
+    return FusionTraditionalUserProgressRow(fusion_id=target_fusion, user_id=target_user)
+
+
+async def upsert_user_traditional_progress(
+    fusion_id: str,
+    user_id: str,
+    *,
+    rares_level_40: int,
+    rares_ascended: int,
+    epics_fused: int,
+    epics_level_50: int,
+    epics_ascended: int,
+    updated_at: dt.datetime,
+) -> FusionTraditionalUserProgressRow:
+    """Create or update champion-prep progress for one traditional fusion/user tuple."""
+
+    tab_name, _aliases = _resolve_traditional_progress_sheet_schema()
+    matrix = await afetch_values(_sheet_id(), tab_name)
+    if not matrix:
+        raise RuntimeError(
+            "Fusion traditional user progress sheet is empty "
+            f"(tab={tab_name}, key={_FUSION_TRADITIONAL_PROGRESS_TAB_KEY})"
+        )
+    header = [str(cell or "").strip().lower() for cell in matrix[0]]
+    index_by_field = _resolve_traditional_progress_header_indices(tab_name=tab_name, header=header)
+    target_fusion = str(fusion_id or "").strip()
+    target_user = str(user_id or "").strip()
+    timestamp = updated_at.astimezone(dt.timezone.utc).isoformat()
+    updates = {
+        "fusion_id": target_fusion,
+        "user_id": target_user,
+        "rares_level_40": str(max(0, int(rares_level_40))),
+        "rares_ascended": str(max(0, int(rares_ascended))),
+        "epics_fused": str(max(0, int(epics_fused))),
+        "epics_level_50": str(max(0, int(epics_level_50))),
+        "epics_ascended": str(max(0, int(epics_ascended))),
+        "updated_at_utc": timestamp,
+    }
+    fusion_idx = index_by_field["fusion_id"]
+    user_idx = index_by_field["user_id"]
+    worksheet = await aget_worksheet(_sheet_id(), tab_name)
+    row_number = None
+    for row_idx, row in enumerate(matrix[1:], start=2):
+        row_fusion = str(row[fusion_idx] if fusion_idx < len(row) else "").strip()
+        row_user = str(row[user_idx] if user_idx < len(row) else "").strip()
+        if row_fusion == target_fusion and row_user == target_user:
+            row_number = row_idx
+            break
+    if row_number is None:
+        row_values = [""] * len(header)
+        for field, value in updates.items():
+            row_values[index_by_field[field]] = value
+        await acall_with_backoff(worksheet.append_row, row_values, value_input_option="RAW")
+    else:
+        for field, value in updates.items():
+            await acall_with_backoff(
+                worksheet.update,
+                f"{_column_label(index_by_field[field])}{row_number}",
+                [[value]],
+                value_input_option="RAW",
+            )
+    return FusionTraditionalUserProgressRow(
+        fusion_id=target_fusion, user_id=target_user,
+        rares_level_40=int(updates["rares_level_40"]), rares_ascended=int(updates["rares_ascended"]),
+        epics_fused=int(updates["epics_fused"]), epics_level_50=int(updates["epics_level_50"]),
+        epics_ascended=int(updates["epics_ascended"]), updated_at=updated_at.astimezone(dt.timezone.utc),
+    )
+
 async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:
     """Return ended fusions that may still need post-end cleanup tasks."""
 
@@ -1745,6 +1895,7 @@ async def transition_fusion_to_ended(fusion_id: str) -> bool:
 __all__ = [
     "FusionEventRow",
     "FusionRow",
+    "FusionTraditionalUserProgressRow",
     "FusionUserEventProgressRow",
     "FusionProgressSaveResult",
     "FusionReminderSettings",
@@ -1762,6 +1913,7 @@ __all__ = [
     "has_role_cleanup_summary",
     "reminder_dedupe_backend_metadata",
     "get_user_event_progress",
+    "get_user_traditional_progress",
     "get_progress_sheet_diagnostics",
     "get_upcoming_events",
     "get_fusion_reminder_settings",
@@ -1770,6 +1922,7 @@ __all__ = [
     "mark_reminder_sent",
     "upsert_role_cleanup_summary",
     "upsert_user_event_progress",
+    "upsert_user_traditional_progress",
     "update_fusion_publication",
     "update_fusion_announcement_refresh_state",
     "transition_fusion_to_ended",

--- a/tests/community/test_fusion_announcement_refresh.py
+++ b/tests/community/test_fusion_announcement_refresh.py
@@ -74,10 +74,8 @@ def test_build_embed_includes_event_status_section() -> None:
         ),
     ]
     embed = build_fusion_announcement_embed(_fusion_row(last_refresh=None, last_hash=""), events, now=now)
-    status_field = next(field for field in embed.fields if field.name == "Event Status")
-    assert "⏳ Event upcoming" in status_field.value
-    assert "🔥 Event live" in status_field.value
-    assert "✅ Event ended" in status_field.value
+    status_field = next(field for field in embed.fields if field.name == "Schedule Status")
+    assert status_field.value == "1 ended • 1 live • 1 upcoming"
 
 
 def test_refresh_skips_when_day_and_status_hash_unchanged(monkeypatch) -> None:

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -8,13 +8,13 @@ from modules.community.fusion import opt_in_view
 from shared.sheets import fusion as fusion_sheets
 
 
-def _fusion_row(*, opt_in_role_id: int | None) -> fusion_sheets.FusionRow:
+def _fusion_row(*, opt_in_role_id: int | None, fusion_type: str = "fragment") -> fusion_sheets.FusionRow:
     return fusion_sheets.FusionRow(
         fusion_id="f-1",
         fusion_name="Mavara",
         champion="Mavara",
         champion_image_url="",
-        fusion_type="traditional",
+        fusion_type=fusion_type,
         fusion_structure="",
         reward_type="fragments",
         needed=400,
@@ -35,10 +35,14 @@ class _Response:
     def __init__(self) -> None:
         self.send_message = AsyncMock()
         self.edit_message = AsyncMock()
+        self.defer = AsyncMock(side_effect=self._defer)
         self._is_done = False
 
     def is_done(self) -> bool:
         return self._is_done
+
+    async def _defer(self, **_kwargs) -> None:
+        self._is_done = True
 
 
 class _Member:
@@ -78,6 +82,7 @@ def _interaction(guild, member):
         client=SimpleNamespace(),
         response=_Response(),
         followup=SimpleNamespace(send=AsyncMock()),
+        edit_original_response=AsyncMock(),
     )
 
 
@@ -88,6 +93,8 @@ def _event_row(
     start_at_utc: dt.datetime | None = None,
     end_at_utc: dt.datetime | None = None,
     sort_order: int = 1,
+    reward_type: str = "fragments",
+    reward_amount: float = 5.0,
 ) -> fusion_sheets.FusionEventRow:
     return fusion_sheets.FusionEventRow(
         fusion_id="f-1",
@@ -97,9 +104,9 @@ def _event_row(
         category="Tournaments",
         start_at_utc=start_at_utc or dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc),
         end_at_utc=end_at_utc or dt.datetime(2026, 4, 9, tzinfo=dt.timezone.utc),
-        reward_amount=5.0,
+        reward_amount=reward_amount,
         bonus=None,
-        reward_type="fragments",
+        reward_type=reward_type,
         points_needed=None,
         is_estimated=False,
         sort_order=sort_order,
@@ -627,5 +634,129 @@ def test_my_progress_next_page_rebuilds_smaller_event_options():
         event_select = next(item for item in view.children if item.custom_id == "fusion:progress:event")
         assert [option.value for option in event_select.options] == ["e10", "e11"]
         assert event_select.placeholder == "Choose event (page 2/2)"
+
+    asyncio.run(_run())
+
+
+def test_traditional_my_progress_opens_choice_view(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        events = [_event_row("e1")]
+        monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777, fusion_type="traditional")))
+        monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=events))
+        monkeypatch.setattr(fusion_sheets, "get_user_event_progress", AsyncMock(return_value={"progress": {"e1": "done"}}))
+
+        await opt_in_view._handle_my_progress(interaction)
+
+        sent_kwargs = interaction.response.send_message.await_args.kwargs
+        assert isinstance(sent_kwargs["view"], opt_in_view.TraditionalProgressChoiceView)
+        assert "Event/Tournament Progress" in sent_kwargs["embed"].fields[0].value
+        assert "Champion Preparation" in sent_kwargs["embed"].fields[0].value
+
+    asyncio.run(_run())
+
+
+def test_traditional_prep_validation_blocks_impossible_counts():
+    message = opt_in_view._validate_traditional_prep_counts(
+        needed_total=16,
+        rares_acquired=8,
+        rares_level_40=8,
+        rares_ascended=4,
+        epics_fused=2,
+        epics_level_50=0,
+        epics_ascended=0,
+    )
+
+    assert message == "Epics fused cannot be higher than the number allowed by fully ascended Rares."
+
+
+
+def test_fusion_my_progress_views_do_not_expire():
+    target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+    events = [_event_row("e1")]
+    progress_by_event = {"e1": "done"}
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id="42")
+
+    choice_view = opt_in_view.TraditionalProgressChoiceView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+        partial_by_event={},
+    )
+    prep_view = opt_in_view.TraditionalPrepPanelView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+        prep=prep,
+    )
+    event_view = opt_in_view.FusionProgressPanelView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+    )
+    share_view = opt_in_view.FusionProgressShareModeView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+        partial_by_event={},
+    )
+
+    assert choice_view.timeout is None
+    assert prep_view.timeout is None
+    assert event_view.timeout is None
+    assert share_view.timeout is None
+
+
+
+def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+        events = [_event_row("e1", reward_type="rare", reward_amount=16)]
+        progress_by_event = {"e1": "done"}
+        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id))
+        panel = opt_in_view.TraditionalPrepPanelView(
+            user_id=member.id,
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            prep=prep,
+        )
+        modal = opt_in_view._TraditionalPrepModal(view=panel)
+        for item, value in (
+            (modal.rares_level_40, "16"),
+            (modal.rares_ascended, "16"),
+            (modal.epics_fused, "4"),
+            (modal.epics_level_50, "4"),
+            (modal.epics_ascended, "4"),
+        ):
+            item._value = value
+
+        saved = fusion_sheets.FusionTraditionalUserProgressRow(
+            fusion_id="f-1",
+            user_id=str(member.id),
+            rares_level_40=16,
+            rares_ascended=16,
+            epics_fused=4,
+            epics_level_50=4,
+            epics_ascended=4,
+        )
+        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
+
+        await modal.on_submit(interaction)
+
+        interaction.response.defer.assert_awaited_once_with(thinking=False)
+        interaction.edit_original_response.assert_awaited_once()
+        interaction.response.edit_message.assert_not_awaited()
+        interaction.followup.send.assert_not_awaited()
+        assert panel.prep.epics_ascended == 4
 
     asyncio.run(_run())

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -476,3 +476,54 @@ def test_upsert_user_event_progress_returns_insert_diagnostics(monkeypatch: pyte
     assert result.operation == "inserted"
     assert result.saved is True
     assert appended[0][4] == "done"
+
+
+def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _afetch_values(_sheet_id: str, tab_name: str):
+        assert tab_name == "fusion_traditional_user_prog"
+        return [
+            ["user_id", "fusion_id", "epics_ascended", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "updated_at_utc"],
+            ["42", "f-1", "3", "12", "8", "2", "2", "2026-07-01T00:00:00+00:00"],
+        ]
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "fusion_traditional_user_prog")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+
+    row = asyncio.run(fusion.get_user_traditional_progress("f-1", "42"))
+
+    assert row.rares_level_40 == 12
+    assert row.rares_ascended == 8
+    assert row.epics_fused == 2
+    assert row.epics_level_50 == 2
+    assert row.epics_ascended == 3
+
+
+def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    worksheet = AsyncMock()
+
+    async def _afetch_values(_sheet_id: str, _tab_name: str):
+        return [
+            ["user_id", "fusion_id", "epics_ascended", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "updated_at_utc"],
+            ["42", "f-1", "1", "4", "4", "1", "1", "old"],
+        ]
+
+    async def _acall_with_backoff(fn, *args, **kwargs):
+        return await fn(*args, **kwargs)
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "fusion_traditional_user_prog")
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+    monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
+    monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
+
+    row = asyncio.run(fusion.upsert_user_traditional_progress(
+        "f-1", "42", rares_level_40=8, rares_ascended=8, epics_fused=2,
+        epics_level_50=2, epics_ascended=2, updated_at=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+    ))
+
+    assert row.epics_ascended == 2
+    updated_cells = [call.args[0] for call in worksheet.update.await_args_list]
+    assert "D2" in updated_cells
+    assert "C2" in updated_cells
+    worksheet.append_row.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Add first-class support for "traditional" fusions where users track champion preparation (rares/epics) separate from event progress.
- Improve robustness of publishing fusion announcements by reusing and editing existing stored messages and surfacing permission/stale conditions.

### Description
- Update `publish_fusion_announcement` to `resolve_stored_announcement` first, edit the existing message when present, log and raise a `FusionAnnouncementPermissionError` for fetch permission failures, and warn when a referenced message is missing/stale before creating a replacement.
- Implement traditional fusion UI flows in `modules/community/fusion/opt_in_view.py` including `_is_traditional_fusion`, `_traditional_rares_acquired`, `_validate_traditional_prep_counts`, `_build_traditional_prep_embed`, `TraditionalProgressChoiceView`, `TraditionalPrepPanelView`, `_TraditionalPrepModal`, and related buttons; change several progress/share views to non-expiring by setting `timeout=None`.
- Add sheet-backed traditional progress support in `shared/sheets/fusion.py` with a new `FusionTraditionalUserProgressRow` dataclass, schema/header resolution helpers, `get_user_traditional_progress` and `upsert_user_traditional_progress` functions, and export them from `__all__`.
- Update and add unit tests and small test fixtures to reflect status label changes and the new traditional flow and sheet APIs.

### Testing
- Ran unit tests touching the modified areas including `tests/community/test_fusion_opt_in_view.py`, `tests/shared/sheets/test_fusion.py`, and `tests/community/test_fusion_announcement_refresh.py`, and the test suite for the updated modules passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a451dbe27308323abf31a4da73fa032)