### PR TITLE
Track rares_owned/target_ready and include champion preparation in fusion progress shares

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -127,16 +127,15 @@ def _build_traditional_prep_embed(
     prep: fusion_sheets.FusionTraditionalUserProgressRow,
 ) -> discord.Embed:
     needed_total = max(0, int(target.needed))
-    rares_acquired = _traditional_rares_acquired(target=target, events=events, progress_by_event=progress_by_event)
-    rares_still_needed = max(0, needed_total - rares_acquired)
-    ready = prep.epics_ascended >= 4
-    missing = "Nothing, the target champion is ready to fuse." if ready else f"{4 - prep.epics_ascended} fully ascended Epics"
+    rares_still_needed = max(0, needed_total - prep.rares_owned)
+    ready = prep.target_ready
+    missing = "Nothing, the target champion is ready to fuse." if ready else f"{max(0, 4 - prep.epics_ascended)} fully ascended Epics"
     embed = discord.Embed(
         title=f"Champion Preparation: {target.champion or target.fusion_name}",
         description="Traditional fusion prep tracker.",
         color=discord.Color.blurple(),
     )
-    embed.add_field(name="Event Rewards", value=f"Rares acquired: {rares_acquired} / {needed_total}\nRares still needed: {rares_still_needed}", inline=False)
+    embed.add_field(name="Rare Progress", value=f"Rares owned: {prep.rares_owned} / {needed_total}\nRares still needed: {rares_still_needed}", inline=False)
     embed.add_field(name="Rare Prep", value=f"Rares level 40: {prep.rares_level_40} / {needed_total}\nRares fully ascended: {prep.rares_ascended} / {needed_total}", inline=False)
     embed.add_field(name="Epic Prep", value=f"Epics fused: {prep.epics_fused} / 4\nEpics level 50: {prep.epics_level_50} / 4\nEpics fully ascended: {prep.epics_ascended} / 4", inline=False)
     embed.add_field(name="Final Fusion", value=f"Ready to fuse {target.champion or target.fusion_name}: {'Yes' if ready else 'No'}\nMissing: {missing}", inline=False)
@@ -621,6 +620,7 @@ class FusionProgressShareModeView(discord.ui.View):
         events: Sequence[fusion_sheets.FusionEventRow],
         progress_by_event: Mapping[str, str],
         partial_by_event: Mapping[str, float] | None = None,
+        traditional_prep: fusion_sheets.FusionTraditionalUserProgressRow | None = None,
     ) -> None:
         super().__init__(timeout=None)
         self.user_id = int(user_id)
@@ -628,6 +628,7 @@ class FusionProgressShareModeView(discord.ui.View):
         self.events = list(events)
         self.progress_by_event = dict(progress_by_event)
         self.partial_by_event = dict(partial_by_event or {})
+        self.traditional_prep = traditional_prep
 
     async def _handle_share(self, interaction: discord.Interaction, *, mode: Literal["summary", "detailed"]) -> None:
         if interaction.user.id != self.user_id:
@@ -642,11 +643,22 @@ class FusionProgressShareModeView(discord.ui.View):
             await _send_ephemeral(interaction, "Couldn’t find the fusion share channel right now.")
             return
 
+        traditional_prep = self.traditional_prep
+        if _is_traditional_fusion(self.target) and traditional_prep is None:
+            try:
+                traditional_prep = await fusion_sheets.get_user_traditional_progress(self.target.fusion_id, str(self.user_id))
+            except Exception as exc:
+                log.exception("fusion traditional prep failed to load for share", extra={"fusion_id": self.target.fusion_id, "user_id": self.user_id})
+                await fusion_logs.send_ops_alert(component="traditional_prep", summary="share_load_failed", dedupe_key=f"fusion:traditional_prep:share:{self.target.fusion_id}", error=exc, fields={"fusion_id": self.target.fusion_id})
+                await _send_ephemeral(interaction, "Couldn’t load champion preparation for sharing right now.")
+                return
+
         share_embed = build_progress_share_embed(
             target=self.target,
             events=self.events,
             progress_by_event=self.progress_by_event,
             partial_by_event=self.partial_by_event,
+            traditional_prep=traditional_prep,
             user_display_name=interaction.user.display_name,
             mode=mode,
         )
@@ -796,7 +808,7 @@ class _FusionProgressShareButton(discord.ui.Button):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         view = self.view
-        if not isinstance(view, FusionProgressPanelView):
+        if not isinstance(view, (FusionProgressPanelView, TraditionalProgressChoiceView)):
             return
         share_view = FusionProgressShareModeView(
             user_id=view.user_id,
@@ -940,6 +952,7 @@ class TraditionalProgressChoiceView(discord.ui.View):
         self.events = list(events)
         self.progress_by_event = dict(progress_by_event)
         self.partial_by_event = dict(partial_by_event)
+        self.add_item(_FusionProgressShareButton())
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.user_id:
@@ -1052,13 +1065,13 @@ class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
             await _send_ephemeral(interaction, "Champion preparation counts must be whole numbers.")
             return
         needed_total = max(0, int(self.panel_view.target.needed))
-        rares_acquired = _traditional_rares_acquired(target=self.panel_view.target, events=self.panel_view.events, progress_by_event=self.panel_view.progress_by_event)
+        rares_acquired = self.panel_view.prep.rares_owned
         error = _validate_traditional_prep_counts(needed_total=needed_total, rares_acquired=rares_acquired, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4])
         if error:
             await _send_ephemeral(interaction, error)
             return
         try:
-            prep = await fusion_sheets.upsert_user_traditional_progress(self.panel_view.target.fusion_id, str(self.panel_view.user_id), rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4], updated_at=dt.datetime.now(dt.timezone.utc))
+            prep = await fusion_sheets.upsert_user_traditional_progress(self.panel_view.target.fusion_id, str(self.panel_view.user_id), rares_owned=self.panel_view.prep.rares_owned, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4], target_ready=self.panel_view.prep.target_ready, updated_at=dt.datetime.now(dt.timezone.utc))
         except Exception as exc:
             log.exception("fusion traditional prep save failed", extra={"fusion_id": self.panel_view.target.fusion_id, "user_id": self.panel_view.user_id})
             await fusion_logs.send_ops_alert(component="traditional_prep", summary="save_failed", dedupe_key=f"fusion:traditional_prep:save:{self.panel_view.target.fusion_id}", error=exc, fields={"fusion_id": self.panel_view.target.fusion_id})
@@ -1173,7 +1186,8 @@ class FusionProgressPanelView(discord.ui.View):
         if self.event_page_count > 1:
             self.add_item(_FusionProgressPageButton(direction="previous", disabled=self.event_page_index <= 0))
             self.add_item(_FusionProgressPageButton(direction="next", disabled=self.event_page_index >= self.event_page_count - 1))
-        self.add_item(_FusionProgressShareButton())
+        if not self.return_to_traditional_choice:
+            self.add_item(_FusionProgressShareButton())
         if self.return_to_traditional_choice:
             self.add_item(_FusionProgressBackButton())
 

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -150,7 +150,8 @@ def _build_summary_block(*, snapshot: ProgressShareSnapshot, overall_progress_li
         f"🟡 In Progress: {snapshot.counts['in_progress']}\n"
         f"⏭️ Skipped: {snapshot.counts['skipped']}\n"
         f"⚠️ Missed: {snapshot.counts['missed']}\n"
-        f"⬜ Not Started: {snapshot.counts['not_started']}"
+        f"⬜ Not Started: {snapshot.counts['not_started']}\n"
+        f"{overall_progress_line}"
     )
 
 
@@ -175,6 +176,7 @@ def build_progress_share_embed(
     events: Sequence[fusion_sheets.FusionEventRow],
     progress_by_event: Mapping[str, str],
     partial_by_event: Mapping[str, float] | None = None,
+    traditional_prep: fusion_sheets.FusionTraditionalUserProgressRow | None = None,
     user_display_name: str,
     mode: ShareMode,
 ) -> discord.Embed:
@@ -191,15 +193,46 @@ def build_progress_share_embed(
     )
     embed.add_field(name="User", value=user_display_name, inline=False)
     embed.add_field(
-        name="Summary",
+        name="Event/Tournament Progress",
         value=_build_summary_block(snapshot=snapshot, overall_progress_line=overall_progress_line),
         inline=False,
     )
-    embed.add_field(
-        name="\u200b",
-        value=_build_strategic_progress_block(target=target, snapshot=snapshot),
-        inline=False,
-    )
+    if traditional_prep is None:
+        embed.add_field(
+            name="\u200b",
+            value=_build_strategic_progress_block(target=target, snapshot=snapshot),
+            inline=False,
+        )
+
+    if traditional_prep is not None:
+        needed_total = max(0, int(target.needed))
+        rares_acquired = max(0, int(traditional_prep.rares_owned))
+        rares_skipped = min(max(0, int(snapshot.skipped_reward_total)), needed_total)
+        rares_to_go = max(0, needed_total - rares_acquired)
+        embed.add_field(
+            name="Rare Progress",
+            value=(
+                f"{needed_total} / {max(0, int(target.available))} needed\n"
+                f"{rares_acquired} acquired\n"
+                f"{rares_skipped} skipped\n"
+                f"{rares_to_go} to go"
+            ),
+            inline=False,
+        )
+        target_ready = traditional_prep.target_ready
+        embed.add_field(
+            name="Champion Preparation",
+            value=(
+                f"Rares owned: {rares_acquired}\n"
+                f"Rares level 40: {traditional_prep.rares_level_40}\n"
+                f"Rares ascended: {traditional_prep.rares_ascended}\n"
+                f"Epics fused: {traditional_prep.epics_fused}\n"
+                f"Epics level 50: {traditional_prep.epics_level_50}\n"
+                f"Epics ascended: {traditional_prep.epics_ascended}\n"
+                f"Target ready: {'Yes' if target_ready else 'No'}"
+            ),
+            inline=False,
+        )
 
     if mode == "detailed":
         sorted_events = sorted(events, key=lambda row: (row.sort_order, row.start_at_utc, row.event_id))

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -46,11 +46,13 @@ _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
 _FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "fusion_id": ("fusion_id",),
     "user_id": ("user_id",),
+    "rares_owned": ("rares_owned",),
     "rares_level_40": ("rares_level_40",),
     "rares_ascended": ("rares_ascended",),
     "epics_fused": ("epics_fused",),
     "epics_level_50": ("epics_level_50",),
     "epics_ascended": ("epics_ascended",),
+    "target_ready": ("target_ready",),
     "updated_at_utc": ("updated_at_utc", "updated at utc", "updatedat", "updated_at"),
 }
 _FUSION_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
@@ -117,11 +119,13 @@ class FusionEventRow:
 class FusionTraditionalUserProgressRow:
     fusion_id: str
     user_id: str
+    rares_owned: int = 0
     rares_level_40: int = 0
     rares_ascended: int = 0
     epics_fused: int = 0
     epics_level_50: int = 0
     epics_ascended: int = 0
+    target_ready: bool = False
     updated_at: dt.datetime | None = None
 
 
@@ -429,11 +433,13 @@ def _resolve_traditional_progress_header_indices(*, tab_name: str, header: list[
     required_fields = [
         "fusion_id",
         "user_id",
+        "rares_owned",
         "rares_level_40",
         "rares_ascended",
         "epics_fused",
         "epics_level_50",
         "epics_ascended",
+        "target_ready",
         "updated_at_utc",
     ]
     return {
@@ -1636,11 +1642,13 @@ async def get_user_traditional_progress(fusion_id: str, user_id: str) -> FusionT
         return FusionTraditionalUserProgressRow(
             fusion_id=target_fusion,
             user_id=target_user,
+            rares_owned=max(0, _parse_int(row[index_by_field["rares_owned"]] if index_by_field["rares_owned"] < len(row) else "")),
             rares_level_40=max(0, _parse_int(row[index_by_field["rares_level_40"]] if index_by_field["rares_level_40"] < len(row) else "")),
             rares_ascended=max(0, _parse_int(row[index_by_field["rares_ascended"]] if index_by_field["rares_ascended"] < len(row) else "")),
             epics_fused=max(0, _parse_int(row[index_by_field["epics_fused"]] if index_by_field["epics_fused"] < len(row) else "")),
             epics_level_50=max(0, _parse_int(row[index_by_field["epics_level_50"]] if index_by_field["epics_level_50"] < len(row) else "")),
             epics_ascended=max(0, _parse_int(row[index_by_field["epics_ascended"]] if index_by_field["epics_ascended"] < len(row) else "")),
+            target_ready=_parse_bool(row[index_by_field["target_ready"]] if index_by_field["target_ready"] < len(row) else ""),
             updated_at=_parse_iso_utc_optional(row[index_by_field["updated_at_utc"]] if index_by_field["updated_at_utc"] < len(row) else ""),
         )
     return FusionTraditionalUserProgressRow(fusion_id=target_fusion, user_id=target_user)
@@ -1650,11 +1658,13 @@ async def upsert_user_traditional_progress(
     fusion_id: str,
     user_id: str,
     *,
+    rares_owned: int,
     rares_level_40: int,
     rares_ascended: int,
     epics_fused: int,
     epics_level_50: int,
     epics_ascended: int,
+    target_ready: bool,
     updated_at: dt.datetime,
 ) -> FusionTraditionalUserProgressRow:
     """Create or update champion-prep progress for one traditional fusion/user tuple."""
@@ -1674,11 +1684,13 @@ async def upsert_user_traditional_progress(
     updates = {
         "fusion_id": target_fusion,
         "user_id": target_user,
+        "rares_owned": str(max(0, int(rares_owned))),
         "rares_level_40": str(max(0, int(rares_level_40))),
         "rares_ascended": str(max(0, int(rares_ascended))),
         "epics_fused": str(max(0, int(epics_fused))),
         "epics_level_50": str(max(0, int(epics_level_50))),
         "epics_ascended": str(max(0, int(epics_ascended))),
+        "target_ready": "TRUE" if bool(target_ready) else "FALSE",
         "updated_at_utc": timestamp,
     }
     fusion_idx = index_by_field["fusion_id"]
@@ -1706,9 +1718,10 @@ async def upsert_user_traditional_progress(
             )
     return FusionTraditionalUserProgressRow(
         fusion_id=target_fusion, user_id=target_user,
+        rares_owned=int(updates["rares_owned"]),
         rares_level_40=int(updates["rares_level_40"]), rares_ascended=int(updates["rares_ascended"]),
         epics_fused=int(updates["epics_fused"]), epics_level_50=int(updates["epics_level_50"]),
-        epics_ascended=int(updates["epics_ascended"]), updated_at=updated_at.astimezone(dt.timezone.utc),
+        epics_ascended=int(updates["epics_ascended"]), target_ready=updates["target_ready"] == "TRUE", updated_at=updated_at.astimezone(dt.timezone.utc),
     )
 
 async def get_ended_fusions(now: dt.datetime | None = None) -> list[FusionRow]:

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -540,7 +540,7 @@ def test_share_mode_summary_posts_to_fusion_announcement_channel(monkeypatch):
         channel.send.assert_awaited_once()
         embed = channel.send.await_args.kwargs["embed"]
         assert embed.title == "Progress Share: Mavara"
-        summary_field = next(field for field in embed.fields if field.name == "Summary")
+        summary_field = next(field for field in embed.fields if field.name == "Event/Tournament Progress")
         assert "✅ Done: 1" in summary_field.value
 
     asyncio.run(_run())
@@ -773,7 +773,7 @@ def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
         target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
         events = [_event_row("e1", reward_type="rare", reward_amount=16)]
         progress_by_event = {"e1": "done"}
-        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id))
+        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id), rares_owned=16)
         panel = opt_in_view.TraditionalPrepPanelView(
             user_id=member.id,
             target=target,
@@ -794,11 +794,13 @@ def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
         saved = fusion_sheets.FusionTraditionalUserProgressRow(
             fusion_id="f-1",
             user_id=str(member.id),
+            rares_owned=16,
             rares_level_40=16,
             rares_ascended=16,
             epics_fused=4,
             epics_level_50=4,
             epics_ascended=4,
+            target_ready=True,
         )
         monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
 
@@ -923,3 +925,44 @@ def test_non_traditional_event_progress_does_not_show_back():
     )
 
     assert all(getattr(child, "label", None) != "Back" for child in view.children)
+
+
+def test_traditional_overview_has_share_and_event_detail_does_not():
+    target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+    events = [_event_row("e1")]
+    overview = opt_in_view.TraditionalProgressChoiceView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event={"e1": "done"},
+        partial_by_event={},
+    )
+    assert _button_by_label(overview, "Share") is not None
+
+    detail = opt_in_view.FusionProgressPanelView(
+        user_id=42,
+        target=target,
+        events=events,
+        progress_by_event={"e1": "done"},
+        partial_by_event={},
+        return_to_traditional_choice=True,
+    )
+    assert all(getattr(child, "label", None) != "Share" for child in detail.children)
+    assert _button_by_label(detail, "Back") is not None
+
+
+def test_traditional_reopened_progress_merges_saved_rows_with_event_defaults():
+    events = [_event_row(f"e{i}", start_at_utc=dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc), end_at_utc=dt.datetime(2026, 8, 2, tzinfo=dt.timezone.utc)) for i in range(1, 17)]
+    raw_progress = {"progress": {"e1": "done", "e2": "done", "e3": "done", "e4": "in_progress", "stale": "done"}}
+
+    progress_by_event = opt_in_view._normalize_saved_progress(raw_progress=raw_progress, events=events)
+    embed = opt_in_view._build_progress_summary_embed(
+        target=_fusion_row(opt_in_role_id=777, fusion_type="traditional"),
+        events=events,
+        progress_by_event=progress_by_event,
+    )
+
+    summary = next(field.value for field in embed.fields if field.name == "Summary")
+    assert "✅ Done: 3" in summary
+    assert "🟡 In Progress: 1" in summary
+    assert "⬜ Not Started: 12" in summary

--- a/tests/community/test_fusion_progress_share.py
+++ b/tests/community/test_fusion_progress_share.py
@@ -35,8 +35,8 @@ def _event_row(event_id: str, event_name: str) -> fusion_sheets.FusionEventRow:
         event_name=event_name,
         event_type="dungeon",
         category="Tournaments",
-        start_at_utc=dt.datetime(2026, 4, 28, tzinfo=dt.timezone.utc),
-        end_at_utc=dt.datetime(2026, 4, 29, tzinfo=dt.timezone.utc),
+        start_at_utc=dt.datetime(2026, 8, 28, tzinfo=dt.timezone.utc),
+        end_at_utc=dt.datetime(2026, 8, 29, tzinfo=dt.timezone.utc),
         reward_amount=5.0,
         bonus=None,
         reward_type="fragments",
@@ -55,7 +55,7 @@ def test_build_progress_share_embed_summary_mode_has_generic_summary_block():
         mode="summary",
     )
 
-    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    summary_field = next(field for field in embed.fields if field.name == "Event/Tournament Progress")
     assert "✅ Done: 1" in summary_field.value
     assert "Progress: 5 / 450 fragments" in summary_field.value
     strategic_field = next(field for field in embed.fields if field.name == "\u200b")
@@ -88,7 +88,46 @@ def test_build_progress_share_embed_uses_dynamic_reward_unit():
         mode="summary",
     )
 
-    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    summary_field = next(field for field in embed.fields if field.name == "Event/Tournament Progress")
     strategic_field = next(field for field in embed.fields if field.name == "\u200b")
     assert "Progress: 25 / 1750 points" in summary_field.value
     assert "**Points Progress**" in strategic_field.value
+
+
+def test_traditional_progress_share_includes_event_and_champion_prep():
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(
+        fusion_id="f-1",
+        user_id="42",
+        rares_owned=7,
+        rares_level_40=3,
+        rares_ascended=2,
+        epics_fused=1,
+        epics_level_50=1,
+        epics_ascended=0,
+        target_ready=True,
+    )
+    events = [_event_row(f"e{i}", f"Event {i}") for i in range(1, 17)]
+    progress = {"e1": "done", "e2": "done", "e3": "done", "e4": "in_progress"}
+
+    embed = progress_share.build_progress_share_embed(
+        target=_fusion_row(),
+        events=events,
+        progress_by_event=progress,
+        traditional_prep=prep,
+        user_display_name="Tester",
+        mode="detailed",
+    )
+
+    event_field = next(field for field in embed.fields if field.name == "Event/Tournament Progress")
+    assert "✅ Done: 3" in event_field.value
+    assert "🟡 In Progress: 1" in event_field.value
+    assert "⬜ Not Started: 12" in event_field.value
+    rare_field = next(field for field in embed.fields if field.name == "Rare Progress")
+    assert "7 acquired" in rare_field.value
+    assert not any(field.name == "\u200b" for field in embed.fields)
+    prep_field = next(field for field in embed.fields if field.name == "Champion Preparation")
+    assert "Rares level 40: 3" in prep_field.value
+    assert "Epics ascended: 0" in prep_field.value
+    assert "Rares owned: 7" in prep_field.value
+    assert "Target ready: Yes" in prep_field.value
+    assert any(field.name == "Event Breakdown" for field in embed.fields)

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -482,8 +482,8 @@ def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.Monk
     async def _afetch_values(_sheet_id: str, tab_name: str):
         assert tab_name == "fusion_traditional_user_prog"
         return [
-            ["user_id", "fusion_id", "epics_ascended", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "updated_at_utc"],
-            ["42", "f-1", "3", "12", "8", "2", "2", "2026-07-01T00:00:00+00:00"],
+            ["user_id", "fusion_id", "epics_ascended", "rares_owned", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "target_ready", "updated_at_utc"],
+            ["42", "f-1", "3", "14", "12", "8", "2", "2", "yes", "2026-07-01T00:00:00+00:00"],
         ]
 
     monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "fusion_traditional_user_prog")
@@ -492,11 +492,13 @@ def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.Monk
 
     row = asyncio.run(fusion.get_user_traditional_progress("f-1", "42"))
 
+    assert row.rares_owned == 14
     assert row.rares_level_40 == 12
     assert row.rares_ascended == 8
     assert row.epics_fused == 2
     assert row.epics_level_50 == 2
     assert row.epics_ascended == 3
+    assert row.target_ready is True
 
 
 def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -504,8 +506,8 @@ def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkey
 
     async def _afetch_values(_sheet_id: str, _tab_name: str):
         return [
-            ["user_id", "fusion_id", "epics_ascended", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "updated_at_utc"],
-            ["42", "f-1", "1", "4", "4", "1", "1", "old"],
+            ["user_id", "fusion_id", "epics_ascended", "rares_owned", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "target_ready", "updated_at_utc"],
+            ["42", "f-1", "1", "4", "4", "4", "1", "1", "FALSE", "old"],
         ]
 
     async def _acall_with_backoff(fn, *args, **kwargs):
@@ -518,12 +520,15 @@ def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkey
     monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
 
     row = asyncio.run(fusion.upsert_user_traditional_progress(
-        "f-1", "42", rares_level_40=8, rares_ascended=8, epics_fused=2,
-        epics_level_50=2, epics_ascended=2, updated_at=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+        "f-1", "42", rares_owned=9, rares_level_40=8, rares_ascended=8, epics_fused=2,
+        epics_level_50=2, epics_ascended=4, target_ready=True, updated_at=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
     ))
 
-    assert row.epics_ascended == 2
+    assert row.rares_owned == 9
+    assert row.epics_ascended == 4
+    assert row.target_ready is True
     updated_cells = [call.args[0] for call in worksheet.update.await_args_list]
-    assert "D2" in updated_cells
+    assert "E2" in updated_cells
     assert "C2" in updated_cells
+    assert "I2" in updated_cells
     worksheet.append_row.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Add explicit tracking of how many Rare champions a user already owns and whether the traditional fusion target is ready to support more accurate prep status and shares.
- Surface champion preparation details in public progress shares so others can see Rare acquisition and Epic preparation alongside event progress.
- Allow sharing from the traditional prep overview and ensure UI states hide the share action when viewing event detail under a traditional flow.

### Description
- Added `rares_owned: int` and `target_ready: bool` to `FusionTraditionalUserProgressRow` and the sheet column aliases and header resolution in `shared/sheets/fusion.py`.
- Parse and persist `rares_owned` and `target_ready` in `get_user_traditional_progress` and `upsert_user_traditional_progress`, and return them from the upsert call.
- Updated UI and embed builders to use the persisted prep row everywhere: `_build_traditional_prep_embed` now reads `prep.rares_owned` and `prep.target_ready`, `FusionProgressShareModeView` will load traditional prep when sharing, and `build_progress_share_embed` accepts `traditional_prep` to render `Rare Progress` and `Champion Preparation` blocks and renames the summary field to `Event/Tournament Progress`.
- Added the `Share` button to the traditional overview (`TraditionalProgressChoiceView`), hid the share action on the per-event detail when returning to the traditional choice, and adjusted related button/flow behavior and validations.
- Updated unit tests to cover the new fields and sharing behavior and to align field names and event dates used in assertions.

### Testing
- Ran `tests/community/test_fusion_opt_in_view.py` which exercises the traditional prep modal, share button visibility, and panel flows, and it passed.
- Ran `tests/community/test_fusion_progress_share.py` which validates the share embed content with and without `traditional_prep`, and it passed.
- Ran `tests/shared/sheets/test_fusion.py` which verifies header resolution and `upsert_user_traditional_progress` behavior for the new sheet columns, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c6d7e8ac8323921ebdde7b1eb884)