### PR TITLE
Leagues: approval workflow, scheduling logs, and approval-state persistence enhancements

### DIFF
--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -43,6 +43,7 @@ _APPROVAL_HEADERS = (
     "last_error",
 )
 _APPROVAL_ACTIVE_STATUSES = {"pending"}
+_APPROVAL_DUPLICATE_PROMPT_STATUSES = {"pending", "posting", "approved", "posted"}
 _APPROVAL_EMOJIS = {"👍", "👍🏻", "👍🏽", "👍🏿", "👍🏾"}
 
 
@@ -253,14 +254,16 @@ class LeaguesCog(commands.Cog):
             },
         )
         try:
+            log.info("league board publish started", extra={"trigger": "reaction_approval", "message_id": payload.message_id})
             ok = await self.run_leagues_job(trigger="reaction_approval", status_channel=channel)
         except Exception as exc:
             ok = False
             error = f"{type(exc).__name__}: {exc}"
-            log.exception("league approval posting failed")
+            log.exception("league board publish failed", extra={"reason": error})
         else:
             error = "" if ok else "posting job returned failure"
 
+        posted_at = ""
         async with self._approval_lock:
             fresh = await self._find_approval_row(payload.channel_id, payload.message_id, include_terminal=True)
             if fresh is not None:
@@ -275,7 +278,7 @@ class LeaguesCog(commands.Cog):
                     },
                 )
         log.info(
-            "league approval posting finished",
+            "league board publish succeeded" if ok else "league board publish failed",
             extra={"success": ok, "posted_at_utc": posted_at if ok else "", "last_error": error},
         )
 
@@ -333,9 +336,10 @@ class LeaguesCog(commands.Cog):
                     key = str(cell or "").strip()
                 if normalized in {"sheet_name", "sheet", "tab", "value", "val"}:
                     value = str(cell or "").strip()
-            if key == _APPROVAL_CONFIG_KEY and value:
+            if key.strip().lower() == _APPROVAL_CONFIG_KEY and value:
+                log.info("league approval state tab config found", extra={"config_key": _APPROVAL_CONFIG_KEY, "sheet": "LEAGUES_SHEET_ID"})
                 return value
-        log.error("league approval state tab config missing", extra={"config_key": _APPROVAL_CONFIG_KEY})
+        log.error("league approval state tab config missing", extra={"config_key": _APPROVAL_CONFIG_KEY, "sheet": "LEAGUES_SHEET_ID", "config_tab": self._config_tab_name()})
         return None
 
     async def _approval_sheet(self) -> tuple[str, Any, dict[str, int], list[list[Any]]] | None:
@@ -378,6 +382,51 @@ class LeaguesCog(commands.Cog):
                 continue
             status = values.get("status", "").lower()
             if include_terminal or status in _APPROVAL_ACTIVE_STATUSES:
+                log.info("league approval state row matched", extra={"channel_id": channel_id, "message_id": message_id, "status": status, "row_number": row_number})
+                return {"tab": tab_name, "worksheet": worksheet, "header_map": header_map, "row_number": row_number, "values": values}
+        log.info("league approval state row not matched", extra={"channel_id": channel_id, "message_id": message_id})
+        return None
+
+
+    @staticmethod
+    def _approval_row_log_extra(row: dict[str, Any], *, reason: str) -> dict[str, object]:
+        values = row.get("values", {})
+        return {
+            "reason": reason,
+            "season_key": values.get("season_key", ""),
+            "week_key": values.get("week_key", ""),
+            "status": values.get("status", ""),
+            "prompt_message_id": values.get("prompt_message_id", ""),
+            "prompt_channel_id": values.get("prompt_channel_id", ""),
+            "last_error": values.get("last_error", ""),
+        }
+
+    async def _approval_prompt_message_exists(self, row: dict[str, Any]) -> bool | None:
+        values = row.get("values", {})
+        try:
+            channel_id = int(str(values.get("prompt_channel_id", "")).strip())
+            message_id = int(str(values.get("prompt_message_id", "")).strip())
+        except (TypeError, ValueError):
+            return None
+        channel = await self._resolve_channel(channel_id)
+        if channel is None or not hasattr(channel, "fetch_message"):
+            return None
+        try:
+            await channel.fetch_message(message_id)  # type: ignore[attr-defined]
+        except discord.NotFound:
+            return False
+        except Exception:
+            return None
+        return True
+
+    async def _find_approval_row_for_week(self, season_key: str, week_key: str) -> dict[str, Any] | None:
+        loaded = await self._approval_sheet()
+        if loaded is None:
+            return None
+        tab_name, worksheet, header_map, matrix = loaded
+        for row_number, row in enumerate(matrix[1:], start=2):
+            values = {name: (str(row[idx]).strip() if idx < len(row) else "") for name, idx in header_map.items()}
+            if values.get("season_key") == season_key and values.get("week_key") == week_key:
                 return {"tab": tab_name, "worksheet": worksheet, "header_map": header_map, "row_number": row_number, "values": values}
         return None
 
@@ -391,22 +440,18 @@ class LeaguesCog(commands.Cog):
             column = self._column_label(header_map[key])
             await acall_with_backoff(worksheet.update, f"{column}{row_number}", [[str(value)]], value_input_option="RAW")
 
-    async def _upsert_approval_prompt_state(self, message: discord.Message) -> None:
-        loaded = await self._approval_sheet()
+    async def _create_approval_prompt_state(
+        self,
+        message: discord.Message,
+        loaded: tuple[str, Any, dict[str, int], list[list[Any]]] | None = None,
+    ) -> None:
+        loaded = loaded or await self._approval_sheet()
         if loaded is None:
-            return
-        _tab_name, worksheet, header_map, matrix = loaded
+            raise RuntimeError("league approval state sheet unavailable")
+        _tab_name, worksheet, header_map, _matrix = loaded
         season_key, week_key = self._approval_keys()
         now = self._utc_iso()
-        target_row = None
-        for row_number, row in enumerate(matrix[1:], start=2):
-            values = {name: (str(row[idx]).strip() if idx < len(row) else "") for name, idx in header_map.items()}
-            if values.get("season_key") == season_key and values.get("week_key") == week_key:
-                target_row = row_number
-                created_at = values.get("created_at_utc") or now
-                break
-        else:
-            created_at = now
+        created_at = now
         values = {
             "season_key": season_key,
             "week_key": week_key,
@@ -421,12 +466,8 @@ class LeaguesCog(commands.Cog):
             "last_error": "",
         }
         ordered = [values[name] for name in _APPROVAL_HEADERS]
-        if target_row is None:
-            await acall_with_backoff(worksheet.append_row, ordered, value_input_option="RAW")
-        else:
-            end_col = self._column_label(len(_APPROVAL_HEADERS) - 1)
-            await acall_with_backoff(worksheet.update, f"A{target_row}:{end_col}{target_row}", [ordered], value_input_option="RAW")
-        log.info("league approval prompt state stored", extra={"message_id": message.id, "season_key": season_key, "week_key": week_key})
+        await acall_with_backoff(worksheet.append_row, ordered, value_input_option="RAW")
+        log.info("league approval state row created", extra={"message_id": message.id, "channel_id": getattr(message.channel, "id", None), "season_key": season_key, "week_key": week_key})
 
     # === Commands ===
     @tier("admin")
@@ -451,9 +492,10 @@ class LeaguesCog(commands.Cog):
 
     # === Reminder helpers ===
     async def send_monday_reminder(self) -> None:
+        log.info("league reminder fired", extra={"weekday": "monday"})
         channel = await self._resolve_channel(self._parse_int_env("LEAGUES_REMINDER_THREAD_ID"))
         if channel is None:
-            log.warning("Leagues reminder thread missing; Monday reminder skipped")
+            log.warning("league reminder skipped", extra={"weekday": "monday", "reason": "reminder_thread_missing"})
             return
         mentions = self._admin_mentions_text()
         lines = [
@@ -463,12 +505,50 @@ class LeaguesCog(commands.Cog):
         if mentions:
             lines.append(mentions)
         await channel.send("\n".join(lines))
+        log.info("league reminder sent", extra={"weekday": "monday", "channel_id": getattr(channel, "id", None)})
 
     async def send_wednesday_reminder(self) -> None:
+        log.info("league approval prompt fired", extra={"weekday": "wednesday"})
+        season_key, week_key = self._approval_keys()
+        loaded = await self._approval_sheet()
+        if loaded is None:
+            log.warning("league approval prompt skipped", extra={"reason": "approval_state_unavailable", "season_key": season_key, "week_key": week_key})
+            return
+        tab_name, worksheet, header_map, matrix = loaded
+        existing = None
+        for row_number, row in enumerate(matrix[1:], start=2):
+            values = {name: (str(row[idx]).strip() if idx < len(row) else "") for name, idx in header_map.items()}
+            if values.get("season_key") == season_key and values.get("week_key") == week_key:
+                existing = {"tab": tab_name, "worksheet": worksheet, "header_map": header_map, "row_number": row_number, "values": values}
+                break
         channel = await self._resolve_channel(self._parse_int_env("LEAGUES_REMINDER_THREAD_ID"))
         if channel is None:
-            log.warning("Leagues reminder thread missing; Wednesday reminder skipped")
+            log.warning("league approval prompt skipped", extra={"reason": "reminder_thread_missing"})
             return
+        if existing is not None:
+            status = existing["values"].get("status", "").strip().lower()
+            if status == "failed" and not existing["values"].get("posted_at_utc", "").strip():
+                log.warning(
+                    "league approval prompt recovery allowed after failed row",
+                    extra=self._approval_row_log_extra(existing, reason="failed_without_posted_at"),
+                )
+            elif status == "pending" and await self._approval_prompt_message_exists(existing) is False:
+                log.warning(
+                    "league approval prompt recovery allowed for stale approval row",
+                    extra=self._approval_row_log_extra(existing, reason="prompt_message_deleted"),
+                )
+            elif status in _APPROVAL_DUPLICATE_PROMPT_STATUSES:
+                log.info(
+                    "league approval prompt skipped",
+                    extra=self._approval_row_log_extra(existing, reason="approval_row_exists"),
+                )
+                return
+            else:
+                log.warning(
+                    "league approval prompt skipped",
+                    extra=self._approval_row_log_extra(existing, reason="manual_cleanup_required"),
+                )
+                return
         mentions = self._admin_mentions_text()
         lines = [
             "🌩 C1C Leagues – Post This Week’s Boards?",
@@ -482,7 +562,8 @@ class LeaguesCog(commands.Cog):
         except Exception:
             pass
         self._handled_messages.discard(message.id)
-        await self._upsert_approval_prompt_state(message)
+        await self._create_approval_prompt_state(message, loaded)
+        log.info("league approval prompt sent", extra={"message_id": message.id, "channel_id": getattr(channel, "id", None), "season_key": season_key, "week_key": week_key})
 
     # === Core job ===
     async def run_leagues_job(
@@ -540,7 +621,7 @@ class LeaguesCog(commands.Cog):
             return False
 
         try:
-            bundles = load_league_bundles(sheet_id, config_tab="Config")
+            bundles = load_league_bundles(sheet_id, config_tab=self._config_tab_name())
         except LeaguesConfigError as exc:
             await self._post_status(
                 status_channel,

--- a/modules/community/leagues/scheduler.py
+++ b/modules/community/leagues/scheduler.py
@@ -39,6 +39,8 @@ def schedule_leagues_jobs(runtime: "Runtime") -> None:
     def _resolve_cog():
         return runtime.bot.get_cog("LeaguesCog")
 
+    log.info("league reminder scheduled", extra={"weekday": "monday", "cron": monday_cron})
+    log.info("league approval prompt scheduled", extra={"weekday": "wednesday", "cron": wednesday_cron})
     monday_job = runtime.scheduler.cron(
         monday_cron, tag="leagues_reminder", name="leagues_reminder_monday"
     )

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -154,3 +154,203 @@ def test_league_approval_marks_failed_and_last_error_on_post_failure(monkeypatch
     assert calls["job"] == 1
     assert statuses == ["posting", "failed"]
     assert "RuntimeError: boom" in row["values"]["last_error"]
+
+
+def test_approval_state_tab_is_loaded_from_leagues_config(monkeypatch):
+    import asyncio
+    from modules.community.leagues import cog as leagues_cog
+
+    seen = {}
+
+    async def _records(sheet_id, tab):
+        seen["sheet_id"] = sheet_id
+        seen["tab"] = tab
+        return [{"spec_key": "league_approval_state_tab", "sheet_name": "LeagueApprovalState"}]
+
+    monkeypatch.setenv("LEAGUES_CONFIG_TAB", "Config")
+    monkeypatch.setattr(leagues_cog, "afetch_records", _records)
+    cog = LeaguesCog(SimpleNamespace())
+
+    assert asyncio.run(cog._approval_state_tab("leagues-sheet")) == "LeagueApprovalState"
+    assert seen == {"sheet_id": "leagues-sheet", "tab": "Config"}
+
+
+def test_create_approval_prompt_state_appends_pending_row(monkeypatch):
+    import asyncio
+
+    appended = []
+    worksheet = SimpleNamespace(append_row=object())
+    header_map = {key: index for index, key in enumerate(
+        [
+            "season_key",
+            "week_key",
+            "prompt_message_id",
+            "prompt_channel_id",
+            "status",
+            "required_reactions",
+            "approved_by_user_ids",
+            "posted_at_utc",
+            "created_at_utc",
+            "updated_at_utc",
+            "last_error",
+        ]
+    )}
+    matrix = [list(header_map)]
+    message = SimpleNamespace(id=2468, channel=SimpleNamespace(id=1357))
+
+    async def _acall(func, *args, **kwargs):
+        appended.append((func, args, kwargs))
+
+    monkeypatch.setattr("modules.community.leagues.cog.acall_with_backoff", _acall)
+    cog = LeaguesCog(SimpleNamespace())
+    monkeypatch.setattr(cog, "_approval_keys", lambda: ("2026", "27"))
+
+    asyncio.run(cog._create_approval_prompt_state(message, ("LeagueApprovalState", worksheet, header_map, matrix)))
+
+    assert len(appended) == 1
+    assert appended[0][0] == worksheet.append_row
+    row = appended[0][1][0]
+    assert row[:6] == ["2026", "27", "2468", "1357", "pending", "1"]
+    assert row[8]
+    assert row[9]
+
+
+def test_wednesday_reminder_skips_existing_week_row(monkeypatch):
+    import asyncio
+
+    sent = {"count": 0}
+    headers = [
+        "season_key",
+        "week_key",
+        "prompt_message_id",
+        "prompt_channel_id",
+        "status",
+        "required_reactions",
+        "approved_by_user_ids",
+        "posted_at_utc",
+        "created_at_utc",
+        "updated_at_utc",
+        "last_error",
+    ]
+    matrix = [headers, ["2026", "27", "123", "456", "pending", "1", "", "", "c", "u", ""]]
+
+    async def _approval_sheet():
+        return ("LeagueApprovalState", SimpleNamespace(), {name: i for i, name in enumerate(headers)}, matrix)
+
+    async def _send(*_args, **_kwargs):
+        sent["count"] += 1
+        return SimpleNamespace(id=999, channel=SimpleNamespace(id=456), add_reaction=lambda *_a, **_k: None)
+
+    async def _resolve(_channel_id):
+        return SimpleNamespace(send=_send)
+
+    cog = LeaguesCog(SimpleNamespace())
+    monkeypatch.setattr(cog, "_approval_keys", lambda: ("2026", "27"))
+    monkeypatch.setattr(cog, "_approval_sheet", _approval_sheet)
+    monkeypatch.setattr(cog, "_resolve_channel", _resolve)
+
+    asyncio.run(cog.send_wednesday_reminder())
+
+    assert sent["count"] == 0
+
+
+def test_wednesday_reminder_allows_recovery_for_failed_unposted_row(monkeypatch):
+    import asyncio
+
+    calls = {"send": 0, "append": 0}
+    headers = [
+        "season_key",
+        "week_key",
+        "prompt_message_id",
+        "prompt_channel_id",
+        "status",
+        "required_reactions",
+        "approved_by_user_ids",
+        "posted_at_utc",
+        "created_at_utc",
+        "updated_at_utc",
+        "last_error",
+    ]
+    matrix = [headers, ["2026", "27", "123", "456", "failed", "1", "111", "", "c", "u", "boom"]]
+    worksheet = SimpleNamespace(append_row=object())
+
+    async def _approval_sheet():
+        return ("LeagueApprovalState", worksheet, {name: i for i, name in enumerate(headers)}, matrix)
+
+    async def _send(*_args, **_kwargs):
+        calls["send"] += 1
+
+        async def _add_reaction(*_a, **_k):
+            return None
+
+        return SimpleNamespace(id=999, channel=SimpleNamespace(id=456), add_reaction=_add_reaction)
+
+    async def _resolve(_channel_id):
+        return SimpleNamespace(id=456, send=_send)
+
+    async def _acall(func, *args, **kwargs):
+        if func == worksheet.append_row:
+            calls["append"] += 1
+
+    cog = LeaguesCog(SimpleNamespace())
+    monkeypatch.setattr(cog, "_approval_keys", lambda: ("2026", "27"))
+    monkeypatch.setattr(cog, "_approval_sheet", _approval_sheet)
+    monkeypatch.setattr(cog, "_resolve_channel", _resolve)
+    monkeypatch.setattr("modules.community.leagues.cog.acall_with_backoff", _acall)
+
+    asyncio.run(cog.send_wednesday_reminder())
+
+    assert calls == {"send": 1, "append": 1}
+
+
+def test_wednesday_reminder_allows_recovery_for_deleted_pending_prompt(monkeypatch):
+    import asyncio
+
+    calls = {"send": 0, "append": 0}
+    headers = [
+        "season_key",
+        "week_key",
+        "prompt_message_id",
+        "prompt_channel_id",
+        "status",
+        "required_reactions",
+        "approved_by_user_ids",
+        "posted_at_utc",
+        "created_at_utc",
+        "updated_at_utc",
+        "last_error",
+    ]
+    matrix = [headers, ["2026", "27", "123", "456", "pending", "1", "", "", "c", "u", ""]]
+    worksheet = SimpleNamespace(append_row=object())
+
+    async def _approval_sheet():
+        return ("LeagueApprovalState", worksheet, {name: i for i, name in enumerate(headers)}, matrix)
+
+    async def _send(*_args, **_kwargs):
+        calls["send"] += 1
+
+        async def _add_reaction(*_a, **_k):
+            return None
+
+        return SimpleNamespace(id=999, channel=SimpleNamespace(id=456), add_reaction=_add_reaction)
+
+    async def _resolve(_channel_id):
+        return SimpleNamespace(id=456, send=_send)
+
+    async def _message_exists(_row):
+        return False
+
+    async def _acall(func, *args, **kwargs):
+        if func == worksheet.append_row:
+            calls["append"] += 1
+
+    cog = LeaguesCog(SimpleNamespace())
+    monkeypatch.setattr(cog, "_approval_keys", lambda: ("2026", "27"))
+    monkeypatch.setattr(cog, "_approval_sheet", _approval_sheet)
+    monkeypatch.setattr(cog, "_resolve_channel", _resolve)
+    monkeypatch.setattr(cog, "_approval_prompt_message_exists", _message_exists)
+    monkeypatch.setattr("modules.community.leagues.cog.acall_with_backoff", _acall)
+
+    asyncio.run(cog.send_wednesday_reminder())
+
+    assert calls == {"send": 1, "append": 1}


### PR DESCRIPTION
### Motivation
- Improve reliability and observability of the Leagues approval/publish workflow and scheduled reminders by adding state checks and richer logging.
- Ensure the approval-state tab is discovered from the Leagues config and make prompt-state persistence and recovery behavior more explicit.
- Make scheduler startup logging visible for the leagues reminder jobs.

### Description
- Added `_APPROVAL_DUPLICATE_PROMPT_STATUSES` to control duplicate prompt handling and switched `load_league_bundles` to use `self._config_tab_name()` when loading bundles.
- Introduced richer logging across the approval flow (`_approval_state_tab`, `_find_approval_row`, run/publish paths, reminders, scheduler) with structured `extra` metadata for diagnostics.
- Added helpers `_approval_row_log_extra`, `_approval_prompt_message_exists`, and `_find_approval_row_for_week` to check prompt message existence and provide structured log context.
- Replaced `_upsert_approval_prompt_state` with `_create_approval_prompt_state` which appends a new pending row (and raises if the sheet is unavailable), and updated Wednesday reminder logic (`send_wednesday_reminder`) to inspect existing week rows and allow safe recovery for failed/unposted or deleted prompts before creating a new prompt.
- Minor housekeeping: set `posted_at` handling in reaction approval flow and small message text/log changes, and added scheduler logs for Monday/Wednesday cron strings.

### Testing
- Ran the leagues rendering unit tests under `tests/community/test_leagues_rendering.py`, including new tests: `test_approval_state_tab_is_loaded_from_leagues_config`, `test_create_approval_prompt_state_appends_pending_row`, `test_wednesday_reminder_skips_existing_week_row`, `test_wednesday_reminder_allows_recovery_for_failed_unposted_row`, and `test_wednesday_reminder_allows_recovery_for_deleted_pending_prompt` and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d411dac8832389991fb8aa88353f)