### PR TITLE
Refresh clan ads before bulk posting

### DIFF
--- a/modules/recruitment/clan_ads.py
+++ b/modules/recruitment/clan_ads.py
@@ -623,6 +623,133 @@ async def decide(
     return Decision(clan.tag, clan, row, "qualified", "qualified", rule)
 
 
+def _message_has_clan_ad_marker(message: Any) -> bool:
+    """Return True when a bot message carries the stable clan-ad button marker."""
+    for row in getattr(message, "components", None) or []:
+        children = getattr(row, "children", None) or []
+        for child in children:
+            custom_id = getattr(child, "custom_id", None)
+            if custom_id and str(custom_id).startswith("clan_ads:view_card:"):
+                return True
+    return False
+
+
+def _message_authored_by_bot(message: Any, bot: discord.Client) -> bool:
+    author = getattr(message, "author", None)
+    bot_user = getattr(bot, "user", None)
+    return bool(
+        getattr(author, "bot", False)
+        and bot_user is not None
+        and getattr(author, "id", None) == getattr(bot_user, "id", None)
+    )
+
+
+async def _delete_message_for_refresh(message: Any, *, context: str) -> bool:
+    try:
+        await message.delete()
+        return True
+    except Exception:
+        log.warning(
+            "failed to delete clan ad during full refresh",
+            exc_info=True,
+            extra={"message_id": getattr(message, "id", None), "context": context},
+        )
+        return False
+
+
+async def full_refresh_existing_ads(
+    bot: discord.Client,
+    channel: Any,
+    config: Config,
+    rows: dict[str, MessageRow],
+    header_map: dict[str, int],
+    reporter: RunReporter,
+    *,
+    source: str,
+) -> tuple[int, int]:
+    """Delete existing safe clan-ad messages and clear deleted message ids."""
+    deleted = 0
+    failures = 0
+    cleared_tags: set[str] = set()
+    seen_message_ids: set[int] = set()
+
+    for row in rows.values():
+        if not row.last_message_id:
+            continue
+        try:
+            message_id = int(row.last_message_id)
+        except ValueError:
+            await write_state(config, header_map, row, last_ad_message_id="")
+            row.last_message_id = ""
+            cleared_tags.add(row.tag)
+            continue
+        try:
+            message = await channel.fetch_message(message_id)
+        except Exception:
+            log.info(
+                "stored clan ad message was not fetchable during full refresh",
+                extra={"clan_tag": row.tag, "message_id": message_id, "source": source},
+            )
+            await write_state(config, header_map, row, last_ad_message_id="")
+            row.last_message_id = ""
+            cleared_tags.add(row.tag)
+            continue
+        seen_message_ids.add(message_id)
+        if _message_authored_by_bot(message, bot) and _message_has_clan_ad_marker(
+            message
+        ):
+            if await _delete_message_for_refresh(
+                message, context=f"stored:{row.tag}:{source}"
+            ):
+                deleted += 1
+                await write_state(config, header_map, row, last_ad_message_id="")
+                row.last_message_id = ""
+                cleared_tags.add(row.tag)
+            else:
+                failures += 1
+                await reporter.warn(
+                    f"⚠️ Clan Ads full refresh could not delete old ad message `{message_id}` for `{row.tag}` in <#{config.channel_id}>.",
+                    dedupe_key=f"refresh_delete_failed:{message_id}",
+                )
+        else:
+            log.warning(
+                "stored clan ad message lacked safe marker; leaving it in place",
+                extra={"clan_tag": row.tag, "message_id": message_id, "source": source},
+            )
+
+    history = getattr(channel, "history", None)
+    if callable(history):
+        async for message in channel.history(limit=200):
+            message_id = getattr(message, "id", None)
+            if message_id in seen_message_ids:
+                continue
+            if not (
+                _message_authored_by_bot(message, bot)
+                and _message_has_clan_ad_marker(message)
+            ):
+                continue
+            if await _delete_message_for_refresh(message, context=f"history:{source}"):
+                deleted += 1
+            else:
+                failures += 1
+                await reporter.warn(
+                    f"⚠️ Clan Ads full refresh could not delete old ad message `{message_id}` in <#{config.channel_id}>.",
+                    dedupe_key=f"refresh_delete_failed:{message_id}",
+                )
+
+    log.info(
+        "Clan Ads full refresh deleted old ads",
+        extra={
+            "source": source,
+            "channel_id": config.channel_id,
+            "deleted": deleted,
+            "delete_failures": failures,
+            "cleared_sheet_rows": len(cleared_tags),
+        },
+    )
+    return deleted, failures
+
+
 async def send_notification(channel: Any, config: Config, count: int) -> None:
     if not config.notification:
         return
@@ -842,6 +969,11 @@ async def run(
             "config": config,
         }
 
+    full_refresh = clan_tag_filter is None
+    refresh_source = "scheduled job" if scheduled else "manual !clanads post all"
+    deleted_old_ads = 0
+    delete_failures = 0
+
     if clan_tag_filter:
         wanted = tag_norm(clan_tag_filter)
         clans = [clan for clan in clans if clan.tag == wanted]
@@ -881,6 +1013,21 @@ async def run(
         for clan in clans
     ]
     qualified = [decision for decision in decisions if decision.status == "qualified"]
+
+    if full_refresh:
+        log.info(
+            "Clan Ads full refresh starting",
+            extra={
+                "source": refresh_source,
+                "channel_id": config.channel_id,
+                "qualified": len(qualified),
+                "skipped_not_qualified": len(decisions) - len(qualified),
+            },
+        )
+        deleted_old_ads, delete_failures = await full_refresh_existing_ads(
+            bot, channel, config, rows, header_map, reporter, source=refresh_source
+        )
+
     if not qualified:
         fallback = (
             decisions[0].reason
@@ -889,11 +1036,25 @@ async def run(
         )
         if scheduled:
             log.info("Clan Ads scheduled run skipped: no qualifying clans")
+        if full_refresh:
+            log.info(
+                "Clan Ads full refresh completed",
+                extra={
+                    "source": refresh_source,
+                    "channel_id": config.channel_id,
+                    "deleted": deleted_old_ads,
+                    "posted": 0,
+                    "skipped_not_qualified": len(decisions),
+                    "delete_failures": delete_failures,
+                },
+            )
         return {
             "posted": 0,
             "skipped": len(decisions),
             "message": fallback,
             "config": config,
+            "deleted": deleted_old_ads,
+            "delete_failures": delete_failures,
         }
 
     posted = 0
@@ -941,6 +1102,19 @@ async def run(
                 break
 
     skipped_or_failed = len(decisions) - posted
+    if full_refresh:
+        log.info(
+            "Clan Ads full refresh completed",
+            extra={
+                "source": refresh_source,
+                "channel_id": config.channel_id,
+                "deleted": deleted_old_ads,
+                "posted": posted,
+                "skipped_not_qualified": len(decisions) - len(qualified),
+                "post_failures": len(qualified) - posted,
+                "delete_failures": delete_failures,
+            },
+        )
     return {
         "posted": posted,
         "skipped": skipped_or_failed,
@@ -950,6 +1124,8 @@ async def run(
             "No clan ads were posted. No enabled clans currently meet their bracket posting rules.",
         ),
         "config": config,
+        "deleted": deleted_old_ads,
+        "delete_failures": delete_failures,
     }
 
 

--- a/tests/recruitment/test_clan_ads_fields.py
+++ b/tests/recruitment/test_clan_ads_fields.py
@@ -584,3 +584,105 @@ def test_post_decision_still_posts_without_static_clan_card_thumbnail(monkeypatc
 
     assert ok is True
     assert not sent[0]["embed"].thumbnail.url
+
+
+def test_full_refresh_deletes_only_bot_clan_ad_markers_and_clears_deleted_ids(
+    monkeypatch,
+):
+    import asyncio
+    from types import SimpleNamespace
+
+    writes = []
+    deleted = []
+
+    class Button:
+        custom_id = "clan_ads:view_card:C1CE"
+
+    class Row:
+        children = [Button()]
+
+    class Message:
+        def __init__(self, message_id, *, bot_author=True, marker=True):
+            self.id = message_id
+            self.author = SimpleNamespace(id=42, bot=bot_author)
+            self.components = [Row()] if marker else []
+
+        async def delete(self):
+            deleted.append(self.id)
+
+    class Channel:
+        async def fetch_message(self, message_id):
+            if message_id == 99:
+                return Message(99)
+            return Message(message_id, marker=False)
+
+        def history(self, limit=200):
+            async def gen():
+                yield Message(99)
+                yield Message(100)
+                yield Message(101, bot_author=False)
+                yield Message(102, marker=False)
+
+            return gen()
+
+    async def fake_write_state(*args, **kwargs):
+        writes.append((args[2].tag, kwargs))
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    rows = {
+        "C1CE": _message_row(tag="C1CE", last_id="99"),
+        "C1CF": _message_row(tag="C1CF", last_id="102"),
+    }
+
+    deleted_count, failures = asyncio.run(
+        clan_ads.full_refresh_existing_ads(
+            SimpleNamespace(user=SimpleNamespace(id=42)),
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 123, "", "", 24, ""),
+            rows,
+            {"last_ad_message_id": 5},
+            clan_ads.RunReporter(None),
+            source="manual !clanads post all",
+        )
+    )
+
+    assert deleted_count == 2
+    assert failures == 0
+    assert deleted == [99, 100]
+    assert writes == [("C1CE", {"last_ad_message_id": ""})]
+    assert rows["C1CE"].last_message_id == ""
+    assert rows["C1CF"].last_message_id == "102"
+
+
+def test_full_refresh_clears_unfetchable_stored_message_id(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+
+    writes = []
+
+    class Channel:
+        async def fetch_message(self, message_id):
+            raise RuntimeError("not found")
+
+    async def fake_write_state(*args, **kwargs):
+        writes.append((args[2].tag, kwargs))
+
+    monkeypatch.setattr(clan_ads, "write_state", fake_write_state)
+    rows = {"C1CE": _message_row(tag="C1CE", last_id="99")}
+
+    deleted_count, failures = asyncio.run(
+        clan_ads.full_refresh_existing_ads(
+            SimpleNamespace(user=SimpleNamespace(id=42)),
+            Channel(),
+            clan_ads.Config("ClanAdMessages", "Rules", 123, "", "", 24, ""),
+            rows,
+            {"last_ad_message_id": 5},
+            clan_ads.RunReporter(None),
+            source="scheduled job",
+        )
+    )
+
+    assert deleted_count == 0
+    assert failures == 0
+    assert writes == [("C1CE", {"last_ad_message_id": ""})]
+    assert rows["C1CE"].last_message_id == ""


### PR DESCRIPTION
### Motivation
- Prevent stale clan recruitment ads remaining in the clan-ads channel by making bulk/scheduled posting fully refresh the channel before reposting.
- Keep single-clan targeted posting behavior unchanged so `!clanads post <clantag>` still replaces only that clan's ad.
- Ensure sheet-backed state does not preserve message IDs for deleted or unfetchable messages to avoid stale references.

### Description
- Added safe full-refresh helper functions: `_message_has_clan_ad_marker`, `_message_authored_by_bot`, and `_delete_message_for_refresh` and a `full_refresh_existing_ads` function that deletes only bot-authored messages carrying the stable `clan_ads:view_card:` button marker and clears stored message IDs when appropriate.
- Updated the `run` flow to perform a full refresh when `clan_tag_filter is None` (manual `!clanads post all` and scheduled runs), logging source, target channel, deleted count, posted count, skipped count, and any delete failures; single-clan flows are unchanged.
- When stored message IDs are unfetchable or deleted during refresh, the code clears those `last_ad_message_id` values in the sheet via the existing `write_state` pattern so sheet state never points to deleted messages.
- Added regression tests that cover safe deletion (only bot + marker), cleanup of unfetchable stored message IDs, and overall full-refresh behavior in `tests/recruitment/test_clan_ads_fields.py`.

### Testing
- Added tests and ran `pytest -q tests/recruitment/test_clan_ads_fields.py`, which passed.
- Ran the recruitment test suite `pytest -q tests/recruitment`, which passed.
- New tests added: full-refresh deletion and unfetchable stored-message cleanup in `tests/recruitment/test_clan_ads_fields.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ebc39c488323a20512ecba3c4222)