### PR TITLE
Add traditional fusion rare progress calculator and update progress UI/embed logic

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -14,6 +14,7 @@ from discord.ext import commands
 from modules.community.fusion import announcements as fusion_announcements
 from modules.community.fusion import logs as fusion_logs
 from modules.community.fusion.progress_share import build_progress_share_embed, build_share_snapshot
+from modules.community.fusion.traditional_progress import calculate_traditional_rare_progress
 from shared.sheets import fusion as fusion_sheets
 
 log = logging.getLogger("c1c.community.fusion.opt_in")
@@ -33,7 +34,7 @@ _FUSION_TRAD_PREP_UPDATE_CUSTOM_ID = "fusion:traditional:prep:update"
 _FUSION_TRAD_BACK_CUSTOM_ID = "fusion:traditional:back"
 
 _DISPLAY_STATUS_ORDER = ("done", "in_progress", "skipped", "missed", "not_started")
-_EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "missed", "skipped", "done", "done_bonus")
+_EVENT_DROPDOWN_STATUS_ORDER = ("not_started", "in_progress", "skipped", "done", "done_bonus")
 _STATUS_LABELS = {
     "not_started": "Not Started",
     "in_progress": "In Progress",
@@ -55,9 +56,9 @@ _ALLOWED_PROGRESS_STATES = frozenset({"not_started", "in_progress", "done", "don
 _STATUS_INDEX_TO_CANONICAL = {
     "0": "not_started",
     "1": "in_progress",
-    "2": "done",
-    "3": "done_bonus",
-    "4": "skipped",
+    "2": "skipped",
+    "3": "done",
+    "4": "done_bonus",
 }
 _EVENT_DROPDOWN_STATUS_RANK = {status: idx for idx, status in enumerate(_EVENT_DROPDOWN_STATUS_ORDER)}
 _PROGRESS_EVENT_PAGE_SIZE = 10
@@ -66,21 +67,6 @@ _PROGRESS_EVENT_PAGE_SIZE = 10
 
 def _is_traditional_fusion(target: fusion_sheets.FusionRow) -> bool:
     return str(target.fusion_type or "").strip().casefold() == "traditional"
-
-
-def _traditional_rares_acquired(
-    *,
-    target: fusion_sheets.FusionRow,
-    events: Sequence[fusion_sheets.FusionEventRow],
-    progress_by_event: Mapping[str, str],
-) -> int:
-    total = 0.0
-    for event in events:
-        if str(event.reward_type or "").strip().casefold() not in {"rare", "rares"}:
-            continue
-        if progress_by_event.get(event.event_id) in {"done", "done_bonus"}:
-            total += max(0.0, float(event.reward_amount or 0))
-    return min(max(0, int(total)), max(0, int(target.needed)))
 
 
 def _validate_traditional_prep_counts(
@@ -124,10 +110,19 @@ def _build_traditional_prep_embed(
     target: fusion_sheets.FusionRow,
     events: Sequence[fusion_sheets.FusionEventRow],
     progress_by_event: Mapping[str, str],
+    partial_by_event: Mapping[str, float] | None = None,
     prep: fusion_sheets.FusionTraditionalUserProgressRow,
 ) -> discord.Embed:
-    needed_total = max(0, int(target.needed))
-    rares_still_needed = max(0, needed_total - prep.rares_owned)
+    snapshot = build_share_snapshot(events=events, progress_by_event=progress_by_event, partial_by_event=partial_by_event)
+    rare_progress = calculate_traditional_rare_progress(
+        target=target,
+        events=events,
+        progress_by_event=progress_by_event,
+        effective_status_by_event=snapshot.display_status_by_event,
+        partial_by_event=partial_by_event,
+    )
+    needed_total = rare_progress.required
+    rares_still_needed = rare_progress.to_go
     ready = prep.target_ready
     missing = "Nothing, the target champion is ready to fuse." if ready else f"{max(0, 4 - prep.epics_ascended)} fully ascended Epics"
     embed = discord.Embed(
@@ -135,7 +130,15 @@ def _build_traditional_prep_embed(
         description="Traditional fusion prep tracker.",
         color=discord.Color.blurple(),
     )
-    embed.add_field(name="Rare Progress", value=f"Rares owned: {prep.rares_owned} / {needed_total}\nRares still needed: {rares_still_needed}", inline=False)
+    embed.add_field(
+        name="Rare Progress",
+        value=(
+            f"Rares acquired: {rare_progress.acquired} / {needed_total}\n"
+            f"Rares still needed: {rares_still_needed}\n"
+            f"Rare sources available: {rare_progress.available_sources}"
+        ),
+        inline=False,
+    )
     embed.add_field(name="Rare Prep", value=f"Rares level 40: {prep.rares_level_40} / {needed_total}\nRares fully ascended: {prep.rares_ascended} / {needed_total}", inline=False)
     embed.add_field(name="Epic Prep", value=f"Epics fused: {prep.epics_fused} / 4\nEpics level 50: {prep.epics_level_50} / 4\nEpics fully ascended: {prep.epics_ascended} / 4", inline=False)
     embed.add_field(name="Final Fusion", value=f"Ready to fuse {target.champion or target.fusion_name}: {'Yes' if ready else 'No'}\nMissing: {missing}", inline=False)
@@ -387,6 +390,17 @@ def _build_progress_summary_embed(
     skipped = snapshot.skipped_reward_total
     still_needed = max(float(target.needed) - acquired, 0.0)
     still_needed_line = "Fusion ready" if still_needed <= 0 else f"{still_needed:g} to go"
+    traditional_rare_progress = (
+        calculate_traditional_rare_progress(
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            effective_status_by_event=snapshot.display_status_by_event,
+            partial_by_event=partial_by_event,
+        )
+        if _is_traditional_fusion(target)
+        else None
+    )
 
     embed = discord.Embed(
         title=f"My Progress: {target.fusion_name}",
@@ -407,11 +421,22 @@ def _build_progress_summary_embed(
     embed.add_field(
         name="\u200b",
         value=(
-            f"**{reward_label} Progress**\n"
-            f"{acquired:g} acquired\n"
-            f"{skipped:g} skipped\n"
-            f"{still_needed_line}\n\n"
-            f"{target.needed:g} / {target.available:g} needed"
+            (
+                f"**Rare Progress**\n"
+                f"{traditional_rare_progress.acquired} acquired\n"
+                f"{traditional_rare_progress.skipped} skipped\n"
+                f"{traditional_rare_progress.to_go} to go\n\n"
+                f"{traditional_rare_progress.acquired} / {traditional_rare_progress.required} required rares"
+                + (f"\n{traditional_rare_progress.available_sources} rare sources available" if traditional_rare_progress.available_sources else "")
+            )
+            if traditional_rare_progress is not None
+            else (
+                f"**{reward_label} Progress**\n"
+                f"{acquired:g} acquired\n"
+                f"{skipped:g} skipped\n"
+                f"{still_needed_line}\n\n"
+                f"{target.needed:g} / {target.available:g} needed"
+            )
         ),
         inline=False,
     )
@@ -516,11 +541,11 @@ class _FusionProgressStatusSelect(discord.ui.Select):
         options = [
             discord.SelectOption(label="Not Started", value="not_started", default=selected_status == "not_started"),
             discord.SelectOption(label="In Progress", value="in_progress", default=selected_status == "in_progress"),
+            discord.SelectOption(label="Skipped", value="skipped", default=selected_status == "skipped"),
             discord.SelectOption(label="Done", value="done", default=selected_status == "done"),
         ]
         if selected_event is not None and _event_has_bonus(selected_event):
             options.append(discord.SelectOption(label="Done + Bonus", value="done_bonus", default=selected_status == "done_bonus"))
-        options.append(discord.SelectOption(label="Skipped", value="skipped", default=selected_status == "skipped"))
         super().__init__(
             placeholder="Set status",
             min_values=1,
@@ -1011,7 +1036,13 @@ class TraditionalPrepPanelView(discord.ui.View):
         return True
 
     def build_embed(self) -> discord.Embed:
-        return _build_traditional_prep_embed(target=self.target, events=self.events, progress_by_event=self.progress_by_event, prep=self.prep)
+        return _build_traditional_prep_embed(
+            target=self.target,
+            events=self.events,
+            progress_by_event=self.progress_by_event,
+            partial_by_event=self.partial_by_event,
+            prep=self.prep,
+        )
 
 
 class _TraditionalPrepBackButton(discord.ui.Button):
@@ -1065,7 +1096,18 @@ class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
             await _send_ephemeral(interaction, "Champion preparation counts must be whole numbers.")
             return
         needed_total = max(0, int(self.panel_view.target.needed))
-        rares_acquired = self.panel_view.prep.rares_owned
+        rare_progress = calculate_traditional_rare_progress(
+            target=self.panel_view.target,
+            events=self.panel_view.events,
+            progress_by_event=self.panel_view.progress_by_event,
+            effective_status_by_event=build_share_snapshot(
+                events=self.panel_view.events,
+                progress_by_event=self.panel_view.progress_by_event,
+                partial_by_event=self.panel_view.partial_by_event,
+            ).display_status_by_event,
+            partial_by_event=self.panel_view.partial_by_event,
+        )
+        rares_acquired = rare_progress.acquired
         error = _validate_traditional_prep_counts(needed_total=needed_total, rares_acquired=rares_acquired, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4])
         if error:
             await _send_ephemeral(interaction, error)

--- a/modules/community/fusion/progress_share.py
+++ b/modules/community/fusion/progress_share.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 import discord
 
+from modules.community.fusion.traditional_progress import calculate_traditional_rare_progress
 from shared.sheets import fusion as fusion_sheets
 
 ShareMode = Literal["summary", "detailed"]
@@ -205,17 +206,24 @@ def build_progress_share_embed(
         )
 
     if traditional_prep is not None:
-        needed_total = max(0, int(target.needed))
-        rares_acquired = max(0, int(traditional_prep.rares_owned))
-        rares_skipped = min(max(0, int(snapshot.skipped_reward_total)), needed_total)
-        rares_to_go = max(0, needed_total - rares_acquired)
+        rare_progress = calculate_traditional_rare_progress(
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            effective_status_by_event=snapshot.display_status_by_event,
+            partial_by_event=partial_by_event,
+        )
+        needed_total = rare_progress.required
+        display_acquired = rare_progress.acquired
+        display_to_go = rare_progress.to_go
         embed.add_field(
             name="Rare Progress",
             value=(
-                f"{needed_total} / {max(0, int(target.available))} needed\n"
-                f"{rares_acquired} acquired\n"
-                f"{rares_skipped} skipped\n"
-                f"{rares_to_go} to go"
+                f"{display_acquired} acquired\n"
+                f"{rare_progress.skipped} skipped\n"
+                f"{display_to_go} to go\n\n"
+                f"{display_acquired} / {needed_total} required rares"
+                + (f"\n{rare_progress.available_sources} rare sources available" if rare_progress.available_sources else "")
             ),
             inline=False,
         )
@@ -223,7 +231,9 @@ def build_progress_share_embed(
         embed.add_field(
             name="Champion Preparation",
             value=(
-                f"Rares owned: {rares_acquired}\n"
+                f"Rares acquired: {rare_progress.acquired} / {needed_total}\n"
+                f"Rares still needed: {rare_progress.to_go}\n"
+                f"Rare sources available: {rare_progress.available_sources}\n"
                 f"Rares level 40: {traditional_prep.rares_level_40}\n"
                 f"Rares ascended: {traditional_prep.rares_ascended}\n"
                 f"Epics fused: {traditional_prep.epics_fused}\n"

--- a/modules/community/fusion/traditional_progress.py
+++ b/modules/community/fusion/traditional_progress.py
@@ -1,0 +1,86 @@
+"""Shared traditional-fusion rare progress calculations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from shared.sheets import fusion as fusion_sheets
+
+_RARE_REWARD_TYPES = {"rare", "rares"}
+
+
+@dataclass(frozen=True, slots=True)
+class TraditionalRareProgress:
+    required: int
+    available_sources: int
+    acquired: int
+    skipped: int
+    missed: int
+    to_go: int
+
+
+def is_rare_reward(event: fusion_sheets.FusionEventRow) -> bool:
+    return str(event.reward_type or "").strip().casefold() in _RARE_REWARD_TYPES
+
+
+def _reward_count(event: fusion_sheets.FusionEventRow, *, include_bonus: bool = False) -> int:
+    amount = max(0.0, float(event.reward_amount or 0))
+    if include_bonus:
+        amount += max(0.0, float(event.bonus or 0))
+    return max(0, int(amount))
+
+
+def calculate_traditional_rare_progress(
+    *,
+    target: fusion_sheets.FusionRow,
+    events: Sequence[fusion_sheets.FusionEventRow],
+    progress_by_event: Mapping[str, str] | None = None,
+    effective_status_by_event: Mapping[str, str] | None = None,
+    partial_by_event: Mapping[str, float] | None = None,
+) -> TraditionalRareProgress:
+    """Calculate required rare progress separately from available rare source count.
+
+    Done and done_bonus rare rewards are acquired. Skipped and missed are tracked
+    separately. In-progress rare rewards only count when an explicit partial amount
+    is recorded.
+    """
+
+    required = max(0, int(target.needed))
+    acquired = 0
+    skipped = 0
+    missed = 0
+    available_sources = max(0, int(target.available))
+    partials = partial_by_event or {}
+    raw_statuses = progress_by_event or {}
+    effective_statuses = effective_status_by_event or raw_statuses
+
+    for event in events:
+        if not is_rare_reward(event):
+            continue
+        status = str(effective_statuses.get(event.event_id, "not_started") or "").strip().casefold()
+        if status == "done_bonus":
+            acquired += _reward_count(event, include_bonus=True)
+        elif status == "done":
+            acquired += _reward_count(event)
+        elif status == "skipped":
+            skipped += _reward_count(event, include_bonus=True)
+        elif status == "missed":
+            missed += _reward_count(event, include_bonus=True)
+        elif status == "in_progress":
+            acquired += max(0, int(float(partials.get(event.event_id, 0) or 0)))
+
+    acquired = min(acquired, required) if required else acquired
+    skipped = min(skipped, required) if required else skipped
+    missed = min(missed, required) if required else missed
+    return TraditionalRareProgress(
+        required=required,
+        available_sources=available_sources,
+        acquired=acquired,
+        skipped=skipped,
+        missed=missed,
+        to_go=max(0, required - acquired),
+    )
+
+
+__all__ = ["TraditionalRareProgress", "calculate_traditional_rare_progress", "is_rare_reward"]

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 from modules.community.fusion import opt_in_view
+from modules.community.fusion.progress_share import build_share_snapshot
+from modules.community.fusion.traditional_progress import calculate_traditional_rare_progress
 from shared.sheets import fusion as fusion_sheets
 
 
@@ -292,9 +294,9 @@ def test_my_progress_load_failure_still_opens_panel(monkeypatch):
 def test_coerce_status_for_save_accepts_canonical_and_index_values():
     assert opt_in_view._coerce_status_for_save("not_started") == "not_started"
     assert opt_in_view._coerce_status_for_save("in_progress") == "in_progress"
-    assert opt_in_view._coerce_status_for_save("2") == "done"
-    assert opt_in_view._coerce_status_for_save("3") == "done_bonus"
-    assert opt_in_view._coerce_status_for_save(4) == "skipped"
+    assert opt_in_view._coerce_status_for_save("2") == "skipped"
+    assert opt_in_view._coerce_status_for_save("3") == "done"
+    assert opt_in_view._coerce_status_for_save(4) == "done_bonus"
     assert opt_in_view._coerce_status_for_save("999") is None
 
 
@@ -485,15 +487,15 @@ def test_status_options_include_done_bonus_only_when_event_has_bonus():
     assert [option.value for option in bonus_select.options] == [
         "not_started",
         "in_progress",
+        "skipped",
         "done",
         "done_bonus",
-        "skipped",
     ]
     assert [option.value for option in plain_select.options] == [
         "not_started",
         "in_progress",
-        "done",
         "skipped",
+        "done",
     ]
 
 
@@ -966,3 +968,208 @@ def test_traditional_reopened_progress_merges_saved_rows_with_event_defaults():
     assert "✅ Done: 3" in summary
     assert "🟡 In Progress: 1" in summary
     assert "⬜ Not Started: 12" in summary
+
+
+def test_traditional_my_progress_uses_required_rare_denominator_not_source_count():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    events = [
+        _event_row(
+            f"rare_{idx}",
+            reward_type="rare",
+            reward_amount=1.0,
+            start_at_utc=dt.datetime(2026, 8, 8, tzinfo=dt.timezone.utc),
+            end_at_utc=dt.datetime(2026, 8, 9, tzinfo=dt.timezone.utc),
+        )
+        for idx in range(1, 18)
+    ]
+    progress = {f"rare_{idx}": "done" for idx in range(1, 5)}
+    progress.update({"rare_5": "in_progress"})
+
+    embed = opt_in_view._build_progress_summary_embed(
+        target=target,
+        events=events,
+        progress_by_event=progress,
+    )
+
+    summary_field = next(field for field in embed.fields if field.name == "Summary")
+    progress_field = next(field for field in embed.fields if field.name == "\u200b")
+    assert "✅ Done: 4" in summary_field.value
+    assert "🟡 In Progress: 1" in summary_field.value
+    assert "⬜ Not Started: 12" in summary_field.value
+    assert "**Rare Progress**" in progress_field.value
+    assert "4 acquired" in progress_field.value
+    assert "0 skipped" in progress_field.value
+    assert "12 to go" in progress_field.value
+    assert "4 / 16 required rares" in progress_field.value
+    assert "17 rare sources available" in progress_field.value
+    assert "16 / 17 needed" not in progress_field.value
+
+
+def test_traditional_prep_embed_separates_manual_inventory_from_event_acquired():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    events = [_event_row(f"rare_{idx}", reward_type="rare", reward_amount=1.0) for idx in range(1, 18)]
+    progress = {f"rare_{idx}": "done" for idx in range(1, 5)}
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(
+        fusion_id="f-1",
+        user_id="42",
+        rares_owned=0,
+        rares_level_40=2,
+        rares_ascended=2,
+        epics_fused=0,
+        epics_level_50=0,
+        epics_ascended=0,
+        target_ready=False,
+    )
+
+    embed = opt_in_view._build_traditional_prep_embed(
+        target=target,
+        events=events,
+        progress_by_event=progress,
+        prep=prep,
+    )
+
+    rare_field = next(field for field in embed.fields if field.name == "Rare Progress")
+    prep_field = next(field for field in embed.fields if field.name == "Rare Prep")
+    assert "Rares acquired: 4 / 16" in rare_field.value
+    assert "Rares still needed: 12" in rare_field.value
+    assert "Rare sources available: 17" in rare_field.value
+    assert "Manual inventory" not in rare_field.value
+    assert "Rares owned" not in rare_field.value
+    assert "Total known rares" not in rare_field.value
+    assert "Known rare count" not in rare_field.value
+    assert "Rares level 40: 2 / 16" in prep_field.value
+    assert "Rares fully ascended: 2 / 16" in prep_field.value
+
+
+
+def test_traditional_rare_progress_counts_effectively_missed_events():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    now = dt.datetime(2026, 7, 4, tzinfo=dt.timezone.utc)
+    events = [
+        _event_row(
+            "rare_missed",
+            reward_type="rare",
+            reward_amount=1.0,
+            start_at_utc=dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc),
+            end_at_utc=dt.datetime(2026, 6, 2, tzinfo=dt.timezone.utc),
+        )
+    ]
+    snapshot = build_share_snapshot(events=events, progress_by_event={}, now=now)
+
+    rare_progress = calculate_traditional_rare_progress(
+        target=target,
+        events=events,
+        progress_by_event={},
+        effective_status_by_event=snapshot.display_status_by_event,
+    )
+
+    assert snapshot.display_status_by_event["rare_missed"] == "missed"
+    assert rare_progress.missed == 1
+    assert rare_progress.acquired == 0
+    assert rare_progress.to_go == 16
+
+
+
+def test_traditional_rare_progress_counts_bonus_done_skipped_and_partials():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    done_bonus = replace(_event_row("done_bonus", reward_type="rare", reward_amount=1.0), bonus=1.0)
+    done = replace(_event_row("done", reward_type="rare", reward_amount=1.0), bonus=1.0)
+    skipped = replace(_event_row("skipped", reward_type="rare", reward_amount=1.0), bonus=1.0)
+    in_progress = _event_row("in_progress", reward_type="rare", reward_amount=1.0)
+
+    rare_progress = calculate_traditional_rare_progress(
+        target=target,
+        events=[done_bonus, done, skipped, in_progress],
+        effective_status_by_event={
+            "done_bonus": "done_bonus",
+            "done": "done",
+            "skipped": "skipped",
+            "in_progress": "in_progress",
+        },
+        partial_by_event={"in_progress": 1.0},
+    )
+
+    assert rare_progress.acquired == 4
+    assert rare_progress.skipped == 2
+    assert rare_progress.to_go == 12
+    assert rare_progress.available_sources == 17
+
+
+def test_traditional_rare_progress_in_progress_without_partial_counts_zero():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    event = _event_row("in_progress", reward_type="rare", reward_amount=1.0)
+
+    rare_progress = calculate_traditional_rare_progress(
+        target=target,
+        events=[event],
+        effective_status_by_event={"in_progress": "in_progress"},
+    )
+
+    assert rare_progress.acquired == 0
+    assert rare_progress.to_go == 16
+
+def test_traditional_prep_validation_uses_event_acquired_rares():
+    assert opt_in_view._validate_traditional_prep_counts(
+        needed_total=16,
+        rares_acquired=max(0, 4),
+        rares_level_40=2,
+        rares_ascended=0,
+        epics_fused=0,
+        epics_level_50=0,
+        epics_ascended=0,
+    ) is None
+    assert opt_in_view._validate_traditional_prep_counts(
+        needed_total=16,
+        rares_acquired=max(0, 0),
+        rares_level_40=2,
+        rares_ascended=0,
+        epics_fused=0,
+        epics_level_50=0,
+        epics_ascended=0,
+    ) == "Rares level 40 cannot be higher than Rares acquired from event rewards."
+
+
+def test_traditional_prep_embed_uses_partial_rare_progress():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
+    event = _event_row("rare_partial", reward_type="rare", reward_amount=1.0)
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(
+        fusion_id="f-1",
+        user_id="42",
+        rares_owned=0,
+        rares_level_40=1,
+        rares_ascended=0,
+        epics_fused=0,
+        epics_level_50=0,
+        epics_ascended=0,
+        target_ready=False,
+    )
+
+    embed = opt_in_view._build_traditional_prep_embed(
+        target=target,
+        events=[event],
+        progress_by_event={"rare_partial": "in_progress"},
+        partial_by_event={"rare_partial": 1.0},
+        prep=prep,
+    )
+
+    rare_field = next(field for field in embed.fields if field.name == "Rare Progress")
+    assert "Rares acquired: 1 / 16" in rare_field.value
+    assert "Rares still needed: 15" in rare_field.value
+
+
+def test_progress_status_index_mapping_matches_dropdown_order_and_excludes_missed():
+    bonus_event = replace(_event_row("rare_bonus"), bonus=1.0)
+    select = opt_in_view._FusionProgressStatusSelect("not_started", selected_event=bonus_event)
+
+    assert [option.value for option in select.options] == [
+        "not_started",
+        "in_progress",
+        "skipped",
+        "done",
+        "done_bonus",
+    ]
+    assert "missed" not in [option.value for option in select.options]
+    assert opt_in_view._coerce_status_for_save("2") == "skipped"
+    assert opt_in_view._coerce_status_for_save("3") == "done"
+    assert opt_in_view._coerce_status_for_save("4") == "done_bonus"
+    assert opt_in_view._coerce_status_for_save("missed") is None

--- a/tests/community/test_fusion_progress_share.py
+++ b/tests/community/test_fusion_progress_share.py
@@ -106,11 +106,12 @@ def test_traditional_progress_share_includes_event_and_champion_prep():
         epics_ascended=0,
         target_ready=True,
     )
-    events = [_event_row(f"e{i}", f"Event {i}") for i in range(1, 17)]
+    target = replace(_fusion_row(), needed=16, available=17, reward_type="rares")
+    events = [replace(_event_row(f"e{i}", f"Event {i}"), reward_type="rare", reward_amount=1.0) for i in range(1, 18)]
     progress = {"e1": "done", "e2": "done", "e3": "done", "e4": "in_progress"}
 
     embed = progress_share.build_progress_share_embed(
-        target=_fusion_row(),
+        target=target,
         events=events,
         progress_by_event=progress,
         traditional_prep=prep,
@@ -121,13 +122,56 @@ def test_traditional_progress_share_includes_event_and_champion_prep():
     event_field = next(field for field in embed.fields if field.name == "Event/Tournament Progress")
     assert "✅ Done: 3" in event_field.value
     assert "🟡 In Progress: 1" in event_field.value
-    assert "⬜ Not Started: 12" in event_field.value
+    assert "⬜ Not Started: 13" in event_field.value
     rare_field = next(field for field in embed.fields if field.name == "Rare Progress")
-    assert "7 acquired" in rare_field.value
+    assert "3 acquired" in rare_field.value
     assert not any(field.name == "\u200b" for field in embed.fields)
     prep_field = next(field for field in embed.fields if field.name == "Champion Preparation")
     assert "Rares level 40: 3" in prep_field.value
     assert "Epics ascended: 0" in prep_field.value
-    assert "Rares owned: 7" in prep_field.value
+    assert "Rares acquired: 3 / 16" in prep_field.value
+    assert "Rare sources available: 17" in prep_field.value
+    assert "Manual inventory" not in prep_field.value
+    assert "Known rare count" not in prep_field.value
     assert "Target ready: Yes" in prep_field.value
     assert any(field.name == "Event Breakdown" for field in embed.fields)
+
+
+def test_traditional_progress_share_uses_event_acquired_required_rare_ratio():
+    target = replace(_fusion_row(), needed=16, available=17, reward_type="rares")
+    events = [replace(_event_row(f"rare_{idx}", f"Rare {idx}"), reward_type="rare", reward_amount=1.0) for idx in range(1, 18)]
+    progress = {f"rare_{idx}": "done" for idx in range(1, 5)}
+    progress["rare_5"] = "in_progress"
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(
+        fusion_id="f-1",
+        user_id="42",
+        rares_owned=0,
+        rares_level_40=2,
+        rares_ascended=2,
+        epics_fused=0,
+        epics_level_50=0,
+        epics_ascended=0,
+        target_ready=False,
+    )
+
+    embed = progress_share.build_progress_share_embed(
+        target=target,
+        events=events,
+        progress_by_event=progress,
+        traditional_prep=prep,
+        user_display_name="Tester",
+        mode="summary",
+    )
+
+    rare_field = next(field for field in embed.fields if field.name == "Rare Progress")
+    prep_field = next(field for field in embed.fields if field.name == "Champion Preparation")
+    assert "4 acquired" in rare_field.value
+    assert "0 skipped" in rare_field.value
+    assert "12 to go" in rare_field.value
+    assert "4 / 16 required rares" in rare_field.value
+    assert "16 / 17 needed" not in rare_field.value
+    assert "Rares acquired: 4 / 16" in prep_field.value
+    assert "Rares still needed: 12" in prep_field.value
+    assert "Rare sources available: 17" in prep_field.value
+    assert "Manual inventory" not in prep_field.value
+    assert "Known rare count" not in prep_field.value


### PR DESCRIPTION
### Motivation
- Introduce a single, shared calculation for traditional-fusion rare progress so displays and validation use the same logic.
- Surface more accurate rare counts (acquired, skipped, missed, to_go) and available source counts in user-facing embeds and prep validation.
- Adjust progress status dropdown ordering to exclude `missed` and match the intended index-to-status mapping.

### Description
- Add `modules/community/fusion/traditional_progress.py` implementing `calculate_traditional_rare_progress`, `TraditionalRareProgress`, and helpers to centralize rare reward counting and partial handling.
- Replace ad-hoc rare counting in `modules/community/fusion/opt_in_view.py` with calls to `calculate_traditional_rare_progress`, and pass `partial_by_event` through the traditional prep views and modals for accurate partial fragment handling.
- Update `modules/community/fusion/progress_share.py` to use the shared rare progress calculator for traditional fusion shares and to show acquired/skipped/to_go and available sources in embeds.
- Remove the old `_traditional_rares_acquired` implementation and update the event status dropdown ordering and `_STATUS_INDEX_TO_CANONICAL` mapping to match the new dropdown order (exclude `missed`).
- Update and add tests in `tests/community/test_fusion_opt_in_view.py` and `tests/community/test_fusion_progress_share.py` to validate new rare progress calculations, partial handling, prep validation, and status option changes.

### Testing
- Ran unit tests in `tests/community/test_fusion_opt_in_view.py` which include new cases for traditional rare counting, partials, and prep validation, and they passed.
- Ran unit tests in `tests/community/test_fusion_progress_share.py` covering traditional share rendering and they passed.
- Overall test suite for modified modules completed successfully with the updated expectations for rare progress and status ordering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48fd7c38b88323be0a102401f4f49e)