### PR TITLE
Fix leadership move request summary context

### DIFF
--- a/modules/recruitment/summary_embed.py
+++ b/modules/recruitment/summary_embed.py
@@ -112,7 +112,7 @@ def _build_leadership_summary(
     author: discord.abc.User | discord.Member | None = None,
     now: datetime | None = None,
 ) -> discord.Embed:
-    title = "C1C – Leadership move request"
+    title = "C1C - Leadership move request"
     description = (
         "Got your request! A coordinator will review the move and follow up here. "
         "Please leave the thread unlocked until we reply."
@@ -145,20 +145,36 @@ def _build_leadership_summary(
         if lines:
             embed.add_field(name=f"**{header}**", value="\n".join(lines), inline=False)
 
-    player_lines: list[str] = []
-    player = _clean("pl_player_name")
+    move_lines: list[str] = []
+    private_request = _clean("pl_private")
+    if private_request:
+        move_lines.append(f"**Private request:** {private_request}")
+
+    player = _clean("pl_discord") or _clean("pl_player_name")
     if player:
-        player_lines.append(f"**Player:** {player}")
+        move_lines.append(f"**Player:** {player}")
+
     reporter = _clean("pl_reporter")
     if reporter:
-        player_lines.append(f"**Reported by:** {reporter}")
-    current_clan = _clean("pl_current_clan")
+        move_lines.append(f"**Reported by:** {reporter}")
+
+    reason = _clean("pl_reason") or _clean("pl_move_reason")
+    if reason:
+        move_lines.append(f"**Reason:** {reason}")
+
+    timing = _clean("pl_time") or _clean("pl_move_urgency") or _clean("pl_move_window")
+    if timing:
+        move_lines.append(f"**Urgency / timing:** {timing}")
+
+    current_clan = _clean("pl_curr_clan") or _clean("pl_current_clan")
     if current_clan:
-        player_lines.append(f"**Current clan:** {current_clan}")
-    target_clan = _clean("pl_target_clan")
+        move_lines.append(f"**Current clan:** {current_clan}")
+
+    target_clan = _clean("pl_new_clan") or _clean("pl_target_clan")
     if target_clan:
-        player_lines.append(f"**Target clan:** {target_clan}")
-    _append_section("Player & reporter", player_lines)
+        move_lines.append(f"**Requested new clan / fit:** {target_clan}")
+
+    _append_section("Move request", move_lines)
 
     performance_lines: list[str] = []
     power = _abbr(answers.get("pl_power")) if "pl_power" in answers else ""
@@ -219,21 +235,9 @@ def _build_leadership_summary(
 
     _append_section("War modes", war_lines)
 
-    rationale_lines: list[str] = []
-    move_reason = _clean("pl_move_reason")
-    if move_reason:
-        rationale_lines.append(f"**Move reason:** {move_reason}")
-    move_urgency = _clean("pl_move_urgency")
-    if move_urgency:
-        rationale_lines.append(f"**Urgency:** {move_urgency}")
-    move_window = _clean("pl_move_window")
-    if move_window:
-        rationale_lines.append(f"**Timing window:** {move_window}")
-    notes = _clean("pl_notes")
-    if notes:
-        rationale_lines.append(f"**Notes:** {notes}")
-
-    _append_section("Move rationale & constraints", rationale_lines)
+    extra_notes = _clean("pl_various") or _clean("pl_notes")
+    if extra_notes:
+        _append_section("Extra notes", [extra_notes])
 
     return embed
 

--- a/tests/recruitment/test_promo_summary_embed.py
+++ b/tests/recruitment/test_promo_summary_embed.py
@@ -110,12 +110,12 @@ def test_build_promo_leadership_summary_full_sections():
 
     embed = build_promo_summary_embed("promo.l", answers, _visibility_map(answers))
 
-    assert embed.title == "C1C – Leadership move request"
+    assert embed.title == "C1C - Leadership move request"
     assert "coordinator will review the move" in (embed.description or "")
 
-    player_section = next(field for field in embed.fields if "Player & reporter" in field.name)
+    player_section = next(field for field in embed.fields if "Move request" in field.name)
     assert "Lead Recruit" in player_section.value
-    assert "Target clan" in player_section.value
+    assert "Requested new clan / fit" in player_section.value
 
     performance_section = next(field for field in embed.fields if "Performance snapshot" in field.name)
     assert "Power & level" in performance_section.value
@@ -128,11 +128,9 @@ def test_build_promo_leadership_summary_full_sections():
     assert "Avg CvC points" in war_section.value
 
     rationale_section = next(
-        field for field in embed.fields if "Move rationale" in field.name
+        field for field in embed.fields if "Extra notes" in field.name
     )
-    assert "Move reason" in rationale_section.value
-    assert "Timing window" in rationale_section.value
-    assert "Notes" in rationale_section.value
+    assert "Ready for transfer" in rationale_section.value
 
 
 def test_build_promo_leadership_summary_handles_missing_optionals():
@@ -161,7 +159,7 @@ def test_build_promo_leadership_summary_handles_missing_optionals():
 
     embed = build_promo_summary_embed("promo.l", answers, _visibility_map(answers))
 
-    player_section = next(field for field in embed.fields if "Player & reporter" in field.name)
+    player_section = next(field for field in embed.fields if "Move request" in field.name)
     assert "Target clan" not in player_section.value
 
     performance_section = next(field for field in embed.fields if "Performance snapshot" in field.name)
@@ -175,6 +173,49 @@ def test_build_promo_leadership_summary_handles_missing_optionals():
     assert "CvC" not in war_section.value
 
     rationale_section = next(
-        (field for field in embed.fields if "Move rationale" in field.name), None
+        (field for field in embed.fields if "Extra notes" in field.name), None
     )
     assert rationale_section is None
+
+
+def test_build_promo_leadership_summary_renders_collected_move_payload():
+    answers = {
+        "pl_private": {"value": "yes", "label": "yes"},
+        "pl_discord": "<@1324831292784775309>",
+        "pl_reason": "progression mismatch",
+        "pl_time": "not urgent",
+        "pl_curr_clan": "C1CD",
+        "pl_new_clan": "relaxed",
+        "pl_CB": {"value": "Easy", "label": "Easy"},
+        "pl_hydra_diff": [{"value": "Normal", "label": "Normal"}],
+        "pl_hydra_clash": "0",
+        "pl_chimera_diff": [{"value": "Easy", "label": "Easy"}],
+        "pl_chimera_clash": "0",
+        "pl_siege": "no",
+        "pl_cvc": "no",
+        "pl_various": "I dunno what else to tell you",
+    }
+
+    embed = build_promo_summary_embed("promo.l", answers, _visibility_map(answers))
+
+    move_section = next(field for field in embed.fields if "Move request" in field.name)
+    assert "Private request:** yes" in move_section.value
+    assert "Player:** <@1324831292784775309>" in move_section.value
+    assert "Reason:** progression mismatch" in move_section.value
+    assert "Urgency / timing:** not urgent" in move_section.value
+    assert "Current clan:** C1CD" in move_section.value
+    assert "Requested new clan / fit:** relaxed" in move_section.value
+
+    performance_section = next(field for field in embed.fields if "Performance snapshot" in field.name)
+    assert "Clan Boss:** Easy" in performance_section.value
+    assert "Hydra:** Normal" in performance_section.value
+    assert "Avg Hydra Clash:** 0" in performance_section.value
+    assert "Chimera:** Easy" in performance_section.value
+    assert "Avg Chimera Clash:** 0" in performance_section.value
+
+    war_section = next(field for field in embed.fields if "War modes" in field.name)
+    assert "Siege participation:** no" in war_section.value
+    assert "CvC:** no" in war_section.value
+
+    notes_section = next(field for field in embed.fields if "Extra notes" in field.name)
+    assert notes_section.value == "I dunno what else to tell you"


### PR DESCRIPTION
### Motivation
- The leadership move request summary omitted collected move-context fields (privacy, player mention, reason, timing, current/target clan and extra notes) while still showing the performance snapshot and war modes.
- The change aims to ensure the posted summary reflects the original collected payload and configured question schema without changing the collection flow or hard-coding sheet positions.

### Description
- Add a compact **Move request** section to the leadership summary rendering that emits `pl_private`, `pl_discord` (fall back to `pl_player_name`), `pl_reporter`, `pl_reason` (falls back to `pl_move_reason`), `pl_time` (falls back to urgency/window fields), `pl_curr_clan` (or `pl_current_clan`), and `pl_new_clan` (or `pl_target_clan`).
- Preserve existing performance snapshot and war-mode logic (CB, hydra/chimera diff + clash, siege, CvC) and continue to support single-select objects, multi-select arrays, numeric abbreviation and plain strings via existing `_stringify`/formatters.
- Add an **Extra notes** section rendered from `pl_various` with a `pl_notes` fallback for backward compatibility.
- Minor title punctuation normalized to `C1C - Leadership move request` and tests updated/added to reflect the new compact layout and payload shapes.

### Testing
- Ran `pytest -q tests/recruitment/test_promo_summary_embed.py` and the suite passed after the change (new test `test_build_promo_leadership_summary_renders_collected_move_payload` added).
- Ran `pytest -q tests/recruitment/test_promo_summary_embed.py tests/recruitment/test_summary_format.py tests/onboarding/test_summary_embed.py` and all tests passed.
- No changes were made to gateway intents, OAuth scopes, permissions, access lists, or sheet IDs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a34b267e483238ca45b82b09a33e8)