### PR TITLE
Refine Promo ticket user_id review reasons and metadata patching logic

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -572,9 +572,9 @@ class PromoTicketWatcher(commands.Cog):
         resolved_user_id = user_id if user_id is not None else context.user_id
         reason = review_reason
         if resolved_user_id is None and not reason:
-            reason = "user_id unresolved from Ticket Tool intro message"
+            reason = "missing_user_id"
             log.warning(
-                "promo metadata user_id unresolved",
+                "promo metadata user_id missing",
                 extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
             )
         try:

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -1161,6 +1161,51 @@ PROMO_METADATA_PRESERVE_FIELDS = {
     "clanname",
     "progression",
 }
+_LEGACY_USER_ID_REVIEW_REASONS = {
+    "user_id_unresolved",
+    "user_id unresolved from ticket tool intro message",
+}
+_USER_ID_REVIEW_REASONS = {
+    "missing_user_id",
+    "invalid_user_id",
+    "discord_user_lookup_failed",
+    *_LEGACY_USER_ID_REVIEW_REASONS,
+}
+
+
+def _promo_user_id_review_reason(
+    *,
+    stored_user_id: str,
+    incoming_review_reason: str,
+    existing_review_reason: str,
+) -> str:
+    """Return the precise user-id review reason for Promo ticket metadata.
+
+    Legacy callers used ``user_id_unresolved`` for several different states.
+    Keep the classification local to metadata patching so dynamic sheet/header
+    behavior stays unchanged while stale rows are repaired on the next write.
+    """
+
+    user_id_text = str(stored_user_id or "").strip()
+    requested_reason = str(incoming_review_reason or "").strip()
+    existing_reason = str(existing_review_reason or "").strip()
+    active_reason = requested_reason or existing_reason
+    normalized_requested = requested_reason.lower()
+    normalized_active = active_reason.lower()
+
+    if not user_id_text:
+        if normalized_active in _LEGACY_USER_ID_REVIEW_REASONS:
+            return "missing_user_id"
+        return active_reason
+    if not _is_discord_id(user_id_text):
+        if not active_reason or normalized_active in _USER_ID_REVIEW_REASONS:
+            return "invalid_user_id"
+        return active_reason
+    if normalized_requested == "discord_user_lookup_failed":
+        return requested_reason
+    if normalized_active in _USER_ID_REVIEW_REASONS:
+        return ""
+    return active_reason
 
 
 def patch_promo_ticket_metadata(
@@ -1254,14 +1299,30 @@ def patch_promo_ticket_metadata(
         "createdat": created.isoformat() if created is not None else "",
         "updatedat": now.isoformat(),
     }
+    effective_user_id = incoming["userid"]
+    user_id_idx = idx.get("userid")
+    if not effective_user_id and user_id_idx is not None and user_id_idx < len(row_values):
+        effective_user_id = str(row_values[user_id_idx] or "").strip()
+    review_idx = idx.get("reviewreason")
+    if review_idx is not None:
+        existing_review = str(row_values[review_idx] or "").strip() if review_idx < len(row_values) else ""
+        incoming["reviewreason"] = _promo_user_id_review_reason(
+            stored_user_id=effective_user_id,
+            incoming_review_reason=incoming["reviewreason"],
+            existing_review_reason=existing_review,
+        )
 
     changed = False
     for field, value in incoming.items():
         if field not in idx or field not in PROMO_METADATA_FIELDS:
             continue
-        if not value:
-            continue
         current = str(row_values[idx[field]] or "").strip()
+        if not value and not (
+            field == "reviewreason"
+            and current
+            and current.lower() in _USER_ID_REVIEW_REASONS
+        ):
+            continue
         if field in PROMO_METADATA_PRESERVE_FIELDS and current:
             continue
         if field in {"threadid", "userid", "threadname", "createdat"} and current:

--- a/tests/onboarding/test_promo_metadata_persistence.py
+++ b/tests/onboarding/test_promo_metadata_persistence.py
@@ -153,14 +153,14 @@ def test_patch_promo_metadata_finalization_preserves_business_and_no_blank_overw
     assert row["progression"] == "TH15"
 
 
-def test_patch_promo_metadata_missing_user_id_sets_review_reason(promo_sheet):
+def test_patch_promo_metadata_missing_user_id_sets_precise_review_reason(promo_sheet):
     result = onboarding_sheets.patch_promo_ticket_metadata(
         ticket="M0371",
         username="No Mention",
         thread_name="M0371-No-Mention",
         thread_id=778,
         status="open",
-        review_reason="user_id unresolved from Ticket Tool intro message",
+        review_reason="user_id_unresolved",
     )
 
     assert result == "inserted"
@@ -168,7 +168,202 @@ def test_patch_promo_metadata_missing_user_id_sets_review_reason(promo_sheet):
     assert row["thread_name"] == "M0371-No-Mention"
     assert row["thread_id"] == "778"
     assert row["user_id"] == ""
-    assert row["review_reason"] == "user_id unresolved from Ticket Tool intro message"
+    assert row["review_reason"] == "missing_user_id"
+
+
+def test_patch_promo_metadata_valid_user_id_gets_no_unresolved_review_reason(promo_sheet):
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0373",
+        username="Has User",
+        thread_name="M0373-Has-User",
+        user_id=384926516792131584,
+        thread_id=780,
+        status="open",
+    )
+
+    assert result == "inserted"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == ""
+
+
+def test_patch_promo_metadata_discord_lookup_failure_uses_lookup_reason(promo_sheet):
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0374",
+        username="Lookup Failed",
+        user_id=384926516792131584,
+        thread_id=781,
+        status="open",
+        review_reason="discord_user_lookup_failed",
+    )
+
+    assert result == "inserted"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == "discord_user_lookup_failed"
+
+
+def test_patch_promo_metadata_malformed_user_id_sets_invalid_reason(promo_sheet):
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0375",
+        username="Bad User",
+        user_id="not-a-snowflake",
+        thread_id=782,
+        status="open",
+    )
+
+    assert result == "inserted"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "not-a-snowflake"
+    assert row["review_reason"] == "invalid_user_id"
+
+
+def test_patch_promo_metadata_clears_stale_user_id_unresolved_for_valid_user_id(promo_sheet):
+    promo_sheet.rows.append([
+        "L0059", "Caillean", "", "", "", "clan lead move request", "", "L0059-Caillean",
+        "384926516792131584", "783", "", "open", "user_id_unresolved", "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="L0059",
+        thread_id=783,
+        status="open",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == ""
+
+
+@pytest.mark.parametrize(
+    "incoming_reason,existing_reason",
+    [
+        ("missing_user_id", ""),
+        ("", "missing_user_id"),
+        ("", "invalid_user_id"),
+        ("", "discord_user_lookup_failed"),
+    ],
+)
+def test_patch_promo_metadata_clears_user_id_reasons_when_existing_user_id_is_valid(
+    promo_sheet,
+    incoming_reason,
+    existing_reason,
+):
+    promo_sheet.rows.append([
+        "M0376", "Existing User", "", "", "", "player move request", "", "M0376-Existing-User",
+        "384926516792131584", "785", "", "open", existing_reason, "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0376",
+        thread_id=785,
+        status="open",
+        review_reason=incoming_reason,
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == ""
+
+
+def test_patch_promo_metadata_preserves_explicit_new_lookup_failure_for_valid_user_id(promo_sheet):
+    promo_sheet.rows.append([
+        "M0377", "Lookup Failed", "", "", "", "player move request", "", "M0377-Lookup-Failed",
+        "384926516792131584", "786", "", "open", "", "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0377",
+        thread_id=786,
+        status="open",
+        review_reason="discord_user_lookup_failed",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == "discord_user_lookup_failed"
+
+
+def test_patch_promo_metadata_blank_existing_user_id_legacy_reason_becomes_missing(promo_sheet):
+    promo_sheet.rows.append([
+        "M0378", "Missing User", "", "", "", "player move request", "", "M0378-Missing-User",
+        "", "787", "", "open", "", "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0378",
+        thread_id=787,
+        status="open",
+        review_reason="user_id_unresolved",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == ""
+    assert row["review_reason"] == "missing_user_id"
+
+
+def test_patch_promo_metadata_existing_malformed_user_id_sets_invalid_reason(promo_sheet):
+    promo_sheet.rows.append([
+        "M0379", "Bad User", "", "", "", "player move request", "", "M0379-Bad-User",
+        "not-a-snowflake", "788", "", "open", "", "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0379",
+        thread_id=788,
+        status="open",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "not-a-snowflake"
+    assert row["review_reason"] == "invalid_user_id"
+
+
+def test_patch_promo_metadata_preserves_unrelated_review_reason(promo_sheet):
+    promo_sheet.rows.append([
+        "M0380", "Other Review", "", "", "", "player move request", "", "M0380-Other-Review",
+        "384926516792131584", "789", "", "open", "manual_review_needed", "", "", "pending",
+        "pending", "pending", "", "2026", "July", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="M0380",
+        thread_id=789,
+        status="open",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] == "manual_review_needed"
+
+
+def test_patch_promo_metadata_clan_lead_move_uses_ticket_creator_user_id(promo_sheet):
+    result = onboarding_sheets.patch_promo_ticket_metadata(
+        ticket="L0060",
+        username="Lead",
+        thread_name="L0060-Lead",
+        user_id=384926516792131584,
+        thread_id=784,
+        status="open",
+    )
+
+    assert result == "inserted"
+    row = _row_map(promo_sheet)
+    assert row["type"] == ""
+    assert row["user_id"] == "384926516792131584"
+    assert row["review_reason"] != "user_id_unresolved"
+    assert row["review_reason"] == ""
 
 
 def test_patch_promo_metadata_missing_required_header_skips_without_header_rewrite(monkeypatch):


### PR DESCRIPTION
### Motivation

- Standardize and disambiguate promo ticket `review_reason` values related to user ID resolution instead of relying on the legacy freeform string used by callers.
- Ensure metadata patching can repair stale/legacy rows by inferring existing `userid` and clearing or tightening `review_reason` when appropriate.
- Preserve explicit lookup failure indicators while avoiding reintroducing unresolved markers for valid user IDs.

### Description

- Replaced the ad-hoc `user_id unresolved from Ticket Tool intro message` reason with a normalized `missing_user_id` and adjusted the watcher log message in `modules/onboarding/watcher_promo.py`.
- Added `_LEGACY_USER_ID_REVIEW_REASONS` and `_USER_ID_REVIEW_REASONS` and implemented `_promo_user_id_review_reason` in `shared/sheets/onboarding.py` to centralize and normalize review-reason classification logic.
- In `patch_promo_ticket_metadata` the code now derives an `effective_user_id` from the existing sheet row when incoming `user_id` is blank and uses the new helper to compute the precise `reviewreason`, and the update-skipping logic was refined to allow clearing legacy unresolved flags when a valid `userid` is present.
- Updated and extended tests in `tests/onboarding/test_promo_metadata_persistence.py` to cover the new normalization rules and behaviors for valid, missing, malformed, and lookup-failure user IDs.

### Testing

- Ran the onboarding promo metadata unit tests in `tests/onboarding/test_promo_metadata_persistence.py` which include the new and updated cases for `missing_user_id`, `invalid_user_id`, and `discord_user_lookup_failed` behaviors and they passed.
- No automated test failures were observed in the modified test module after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a348166e08323a0567a0cfffde28a)