### PR TITLE
Render all promo move request fields in Recruitment Summary

### DIFF
--- a/modules/recruitment/summary_embed.py
+++ b/modules/recruitment/summary_embed.py
@@ -338,10 +338,30 @@ def _resolved_value(
     gid = field.get("gid")
     if not gid:
         return ""
-    if visible_gids and gid not in visible_gids:
-        return ""
-    raw = answers.get(gid)
+    candidate_gids = [gid, *field.get("fallback_gids", [])]
+    raw = None
+    for candidate_gid in candidate_gids:
+        if not candidate_gid:
+            continue
+        if visible_gids and candidate_gid not in visible_gids:
+            continue
+        candidate_raw = answers.get(candidate_gid)
+        candidate_formatted = _format_value(field, candidate_raw)
+        if not should_hide_value(candidate_formatted) or (
+            field.get("show_hide_tokens") and candidate_formatted
+        ):
+            raw = candidate_raw
+            break
+    else:
+        if visible_gids and gid not in visible_gids:
+            return ""
+        raw = answers.get(gid)
     formatted = _format_value(field, raw)
+    hide_if_present = field.get("hide_if_present")
+    if hide_if_present:
+        hide_value = _format_value({}, answers.get(hide_if_present))
+        if not should_hide_value(hide_value):
+            return ""
     required_gid = field.get("requires")
     if required_gid:
         required_value = _format_value({}, answers.get(required_gid))
@@ -355,6 +375,8 @@ def _resolved_value(
     if formatted and hide_tokens and formatted.strip().lower() in hide_tokens:
         return ""
     force_show = bool(field.get("force_show"))
+    if field.get("show_hide_tokens") and formatted:
+        return formatted
     if should_hide_value(formatted, force_show=force_show):
         if force_show:
             return "—"

--- a/modules/recruitment/summary_map.py
+++ b/modules/recruitment/summary_map.py
@@ -189,20 +189,41 @@ SUMMARY_LAYOUTS = {
         },
         "sections": [
             {
-                "name": "identity",
-                "title": "🧭 Player & current placement",
+                "name": "move",
+                "title": "🧭 Move request",
                 "fields": [
                     {"gid": "pm_ign", "label": "Player"},
                     {
-                        "gid": "pm_power",
-                        "label": "Power",
-                        "inline_with": "pm_level_detail",
-                        "fmt": "abbr_number",
+                        "gid": "pm_cur_clan",
+                        "label": "Current clan",
+                        "fallback_gids": ["pm_current_clan"],
                     },
-                    {"gid": "pm_level_detail", "label": "Bracket", "inline": True},
+                    {
+                        "gid": "pm_new_clan",
+                        "label": "Requested new clan / fit",
+                        "fallback_gids": ["pm_clan_type"],
+                    },
+                    {"gid": "pm_move_date", "label": "Move date"},
+                    {"gid": "pm_lead_inform", "label": "Lead informed", "show_hide_tokens": True},
+                ],
+            },
+            {
+                "name": "player",
+                "title": "👤 Player snapshot",
+                "fields": [
+                    {
+                        "gid": "pm_ppower",
+                        "label": "Player power",
+                        "fmt": "abbr_number",
+                        "fallback_gids": ["pm_power"],
+                    },
+                    {"gid": "pm_level_detail", "label": "Bracket"},
+                    {
+                        "gid": "pm_level",
+                        "label": "Bracket",
+                        "hide_if_present": "pm_level_detail",
+                    },
                     {"gid": "pm_playstyle", "label": "Playstyle"},
-                    {"gid": "pm_current_clan", "label": "Current clan"},
-                    {"gid": "pm_clan_type", "label": "Looking for"},
                 ],
             },
             {
@@ -256,7 +277,6 @@ SUMMARY_LAYOUTS = {
                 "title": "🧭 Move intent & notes",
                 "fields": [
                     {"gid": "pm_move_urgency", "label": "Move urgency"},
-                    {"gid": "pm_move_date", "label": "Move date"},
                     {"gid": "pm_move_reason", "label": "Move reason", "truncate": 200},
                     {"gid": "pm_notes", "label": "Anything else we should know", "truncate": 280},
                 ],

--- a/tests/recruitment/test_promo_summary_embed.py
+++ b/tests/recruitment/test_promo_summary_embed.py
@@ -219,3 +219,56 @@ def test_build_promo_leadership_summary_renders_collected_move_payload():
 
     notes_section = next(field for field in embed.fields if "Extra notes" in field.name)
     assert notes_section.value == "I dunno what else to tell you"
+
+
+def test_promo_m_summary_renders_exact_move_payload_context():
+    answers = {
+        "pm_cur_clan": "C1CD",
+        "pm_lead_inform": "no",
+        "pm_ign": "smurf",
+        "pm_ppower": "12m",
+        "pm_playstyle": "active",
+        "pm_level": "mid game",
+        "pm_level_detail": {"value": "Mid Game", "label": "Mid Game"},
+        "pm_new_clan": "chat",
+        "pm_CB": {"value": "Nightmare", "label": "Nightmare"},
+        "pm_hydra_diff": [{"value": "Brutal", "label": "Brutal"}],
+        "pm_hydra_clash": "1b",
+        "pm_chimera_diff": [{"value": "Brutal", "label": "Brutal"}],
+        "pm_chimera_clash": "1b",
+        "pm_siege": "yes",
+        "pm_siege_detail": "offense",
+        "pm_cvc": {"value": "5", "label": "5"},
+        "pm_cvc_points": "500k",
+        "pm_move_date": "asap",
+    }
+
+    embed = build_promo_summary_embed("promo.m", answers, _visibility_map(answers), author=None)
+
+    move_section = next(field for field in embed.fields if field.name == "🧭 Move request")
+    assert "Player:** smurf" in move_section.value
+    assert "Current clan:** C1CD" in move_section.value
+    assert "Requested new clan / fit:** chat" in move_section.value
+    assert "Move date:** asap" in move_section.value
+    assert "Lead informed:** no" in move_section.value
+
+    player_section = next(field for field in embed.fields if field.name == "👤 Player snapshot")
+    assert "Player power:** 12 M" in player_section.value
+    assert "Bracket:** Mid Game" in player_section.value
+    assert "Playstyle:** active" in player_section.value
+    assert "mid game" not in player_section.value
+
+    performance_section = next(
+        field for field in embed.fields if field.name == "🧩 Performance snapshot"
+    )
+    assert "Clan Boss (one-key top chest):** Nightmare" in performance_section.value
+    assert "Hydra:** Brutal" in performance_section.value
+    assert "Avg Hydra Clash:** 1b" in performance_section.value
+    assert "Chimera:** Brutal" in performance_section.value
+    assert "Avg Chimera Clash:** 1b" in performance_section.value
+
+    war_section = next(field for field in embed.fields if field.name == "⚔️ War Modes")
+    assert "Siege participation:** yes" in war_section.value
+    assert "Siege setup:** offense" in war_section.value
+    assert "CvC priority:** High" in war_section.value
+    assert "Minimum CvC points:** 500 K" in war_section.value


### PR DESCRIPTION
### Motivation
- The promo move request summary was omitting several populated move-request fields (current clan, lead informed, player power, requested new clan/fit, raw level) despite the form collecting them.  
- The summary must render all populated `pm_…` keys from the collected payload while preserving existing performance and war rendering rules.

### Description
- Reworked the `promo.m` layout in `modules/recruitment/summary_map.py` to add a compact `🧭 Move request` section and a `👤 Player snapshot` section and to include fields `pm_cur_clan`, `pm_new_clan`, `pm_move_date`, `pm_lead_inform`, `pm_ppower`, `pm_level`, and `pm_level_detail` with sensible `fallback_gids`, `hide_if_present`, and `show_hide_tokens` where required.  
- Enhanced the renderer in `modules/recruitment/summary_embed.py` (`_resolved_value`) to support `fallback_gids`, to honor `hide_if_present` (suppress `pm_level` when `pm_level_detail` is present), and to allow explicit display of meaningful hide-token answers (e.g., show `no` for `pm_lead_inform`) via `show_hide_tokens`.  
- Kept existing performance and war field handling unchanged (same labels and formatters like `abbr_number` and `cvc_priority`).  
- Added a regression test to `tests/recruitment/test_promo_summary_embed.py` using the exact provided payload to assert the move, player snapshot, performance snapshot, and war modes render the expected values.

### Testing
- Ran the targeted tests with `pytest -q tests/recruitment/test_promo_summary_embed.py` and the full test suite with `pytest -q tests/recruitment`, both of which completed successfully.  
- Ran linter checks with `ruff` on the modified files and they passed.  
- New test added: `test_promo_m_summary_renders_exact_move_payload_context` which verifies `pm_cur_clan`, `pm_lead_inform`, `pm_ign`, `pm_ppower`, `pm_playstyle`, `pm_level_detail`, `pm_new_clan`, `pm_move_date`, performance fields, and war fields are present in the rendered summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a5c6b57f08323b4325970f3de3734)