### PR TITLE
Fail-closed grouped fusion reminders when sent-reminder dedupe is unavailable

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -20,6 +20,8 @@ log = logging.getLogger("c1c.community.fusion.reminders")
 
 _DEDUP_TIMEOUT_BACKOFF_SEC = max(60, int(os.getenv("FUSION_REMINDER_DEDUPE_BACKOFF_SEC", "300")))
 _DEDUP_TIMEOUT_SEC = max(1.0, float(os.getenv("FUSION_REMINDER_DEDUPE_TIMEOUT_SEC", "10")))
+_DEDUP_READ_RETRY_DELAY_SEC = max(0.0, float(os.getenv("FUSION_REMINDER_DEDUPE_RETRY_DELAY_SEC", "1")))
+_DEDUP_CACHE_TTL_SEC = max(0.0, float(os.getenv("FUSION_REMINDER_DEDUPE_CACHE_TTL_SEC", "30")))
 _GROUPED_REMINDER_TYPE = "grouped_daily"
 _GROUPED_EVENT_ID_PREFIX = "grouped_daily"
 
@@ -28,6 +30,11 @@ _MEMORY_SENT_KEYS: set[tuple[str, str, str]] = set()
 _DEDUP_DEGRADED_SINCE_MONOTONIC: float = 0.0
 _DEDUP_DEGRADED_ALERTED_KEYS: set[tuple[str, str]] = set()
 _DEDUP_DEGRADED_ALERT_AFTER_SEC = 600.0
+_SENT_KEYS_CACHE: dict[str, tuple[float, set[tuple[str, str]]]] = {}
+
+_DEDUPE_SKIP_WARNING = (
+    "fusion grouped reminders skipped because sent-reminder dedupe could not be verified"
+)
 
 
 def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
@@ -253,71 +260,82 @@ def _select_grouped_events(
     return live_events, upcoming_events, ending_events, skipped
 
 
-async def _load_grouped_sent_keys(target: fusion_sheets.FusionRow) -> tuple[set[tuple[str, str]], bool]:
+async def _load_grouped_sent_keys(target: fusion_sheets.FusionRow) -> tuple[set[tuple[str, str]] | None, bool]:
     dedupe_meta = fusion_sheets.reminder_dedupe_backend_metadata()
     dedupe_backend = dedupe_meta.get("backend_type", "unknown")
     dedupe_tab = dedupe_meta.get("tab_name", "")
     dedupe_config_key = dedupe_meta.get("config_key", "")
-    durable_dedupe_available = time.monotonic() >= _DEDUP_BACKOFF_UNTIL_MONOTONIC
+    now_monotonic = time.monotonic()
+
+    cached = _SENT_KEYS_CACHE.get(target.fusion_id)
+    if cached is not None:
+        cached_at, cached_keys = cached
+        if now_monotonic - cached_at <= _DEDUP_CACHE_TTL_SEC:
+            return set(cached_keys), True
+        _SENT_KEYS_CACHE.pop(target.fusion_id, None)
+
+    durable_dedupe_available = now_monotonic >= _DEDUP_BACKOFF_UNTIL_MONOTONIC
+    context = {
+        "fusion_id": target.fusion_id,
+        "timeout_sec": _DEDUP_TIMEOUT_SEC,
+        "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
+        "dedupe_backend": dedupe_backend,
+        "dedupe_tab": dedupe_tab,
+        "dedupe_config_key": dedupe_config_key,
+        "operation": "read_sent_reminder_keys",
+    }
     if not durable_dedupe_available:
         _register_dedupe_degraded_mode()
-        log.warning(
-            "fusion grouped reminder durable dedupe in backoff window; using in-memory fallback",
-            extra={
-                "fusion_id": target.fusion_id,
-                "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
-                "dedupe_backend": dedupe_backend,
-                "dedupe_tab": dedupe_tab,
-                "dedupe_config_key": dedupe_config_key,
-                "operation": "read_sent_reminder_keys",
-            },
-        )
-        return set(), False
-    try:
-        sent_keys = await asyncio.wait_for(
-            fusion_sheets.get_sent_reminder_keys(target.fusion_id),
-            timeout=_DEDUP_TIMEOUT_SEC,
-        )
-        _recover_from_dedupe_backoff()
-        return sent_keys, True
-    except TimeoutError as exc:
-        _register_dedupe_timeout_backoff()
-        context = {
-            "fusion_id": target.fusion_id,
-            "timeout_sec": _DEDUP_TIMEOUT_SEC,
-            "retry_backoff_sec": _DEDUP_TIMEOUT_BACKOFF_SEC,
-            "dedupe_backend": dedupe_backend,
-            "dedupe_tab": dedupe_tab,
-            "dedupe_config_key": dedupe_config_key,
-            "operation": "read_sent_reminder_keys",
-        }
-        log.exception("fusion grouped reminder durable dedupe timed out; using in-memory fallback", extra=context)
+        log.warning(_DEDUPE_SKIP_WARNING, extra={**context, "reason": "dedupe_backoff_active"})
         await fusion_logs.send_ops_alert(
             component="reminders",
-            summary="grouped_dedupe_unavailable_degraded_mode",
+            summary="grouped_dedupe_unavailable_reminders_skipped",
             dedupe_key=f"fusion:grouped_reminders:dedupe:{target.fusion_id}",
-            error=exc,
+            reason="dedupe_backoff_active",
             fields=context,
         )
-        return set(), False
-    except Exception as exc:
-        _register_dedupe_degraded_mode()
-        context = {
-            "fusion_id": target.fusion_id,
-            "dedupe_backend": dedupe_backend,
-            "dedupe_tab": dedupe_tab,
-            "dedupe_config_key": dedupe_config_key,
-            "operation": "read_sent_reminder_keys",
-        }
-        log.exception("fusion grouped reminder failed to load durable dedupe; using in-memory fallback", extra=context)
-        await fusion_logs.send_ops_alert(
-            component="reminders",
-            summary="grouped_dedupe_unavailable_degraded_mode",
-            dedupe_key=f"fusion:grouped_reminders:dedupe:{target.fusion_id}",
-            error=exc,
-            fields=context,
-        )
-        return set(), False
+        return None, False
+
+    last_exc: BaseException | None = None
+    for attempt in (1, 2):
+        try:
+            sent_keys = await asyncio.wait_for(
+                fusion_sheets.get_sent_reminder_keys(target.fusion_id),
+                timeout=_DEDUP_TIMEOUT_SEC,
+            )
+            keys = set(sent_keys)
+            _SENT_KEYS_CACHE[target.fusion_id] = (time.monotonic(), keys)
+            _recover_from_dedupe_backoff()
+            return set(keys), True
+        except TimeoutError as exc:
+            last_exc = exc
+            log.warning(
+                "fusion grouped reminder sent-reminder dedupe read timed out; retrying"
+                if attempt == 1
+                else _DEDUPE_SKIP_WARNING,
+                extra={**context, "attempt": attempt, "max_attempts": 2},
+            )
+        except Exception as exc:
+            last_exc = exc
+            log.warning(
+                "fusion grouped reminder sent-reminder dedupe read failed; retrying"
+                if attempt == 1
+                else _DEDUPE_SKIP_WARNING,
+                extra={**context, "attempt": attempt, "max_attempts": 2, "error_type": type(exc).__name__},
+                exc_info=True,
+            )
+        if attempt == 1 and _DEDUP_READ_RETRY_DELAY_SEC > 0:
+            await asyncio.sleep(_DEDUP_READ_RETRY_DELAY_SEC)
+
+    _register_dedupe_timeout_backoff()
+    await fusion_logs.send_ops_alert(
+        component="reminders",
+        summary="grouped_dedupe_unavailable_reminders_skipped",
+        dedupe_key=f"fusion:grouped_reminders:dedupe:{target.fusion_id}",
+        error=last_exc,
+        fields=context,
+    )
+    return None, False
 
 
 async def _resolve_channel_role_status(bot: commands.Bot, target: fusion_sheets.FusionRow) -> dict[str, object]:
@@ -416,6 +434,9 @@ async def collect_fusion_reminder_startup_summary(
 
     try:
         sent_keys, _durable = await _load_grouped_sent_keys(target)
+        if sent_keys is None:
+            lines.append("• skipped=sent_reminder_dedupe_unavailable")
+            return lines
         last_sent = await fusion_sheets.get_last_reminder_sent_at(target.fusion_id, reminder_type=_GROUPED_REMINDER_TYPE)
     except Exception as exc:
         await fusion_logs.send_ops_alert(
@@ -526,6 +547,13 @@ async def process_fusion_reminders(
         return
 
     sent_keys, durable_dedupe_available = await _load_grouped_sent_keys(target)
+    if sent_keys is None or not durable_dedupe_available:
+        await _maybe_alert_prolonged_dedupe_degradation(
+            target.fusion_id,
+            reminder_type=_GROUPED_REMINDER_TYPE,
+            backend=fusion_sheets.reminder_dedupe_backend_metadata().get("backend_type", "unknown"),
+        )
+        return
     grouped_event_id = _grouped_event_id_for_date(reference.date())
     grouped_key = (grouped_event_id, _GROUPED_REMINDER_TYPE)
     memory_key = (target.fusion_id, grouped_event_id, _GROUPED_REMINDER_TYPE)

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -292,3 +292,98 @@ def test_disabled_grouped_config_logs_resolved_source(monkeypatch):
             },
         }
     ]
+
+
+def test_grouped_reminder_skips_when_dedupe_read_times_out_after_retry(monkeypatch, caplog):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-start", start_at=now)
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    alerts = []
+    attempts = 0
+
+    async def _get_sent_keys(_fusion_id: str):
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("dedupe unavailable")
+
+    async def _send_ops_alert(**kwargs):
+        alerts.append(kwargs)
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row(opt_in_role_id=777)))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    monkeypatch.setattr(reminders.fusion_logs, "send_ops_alert", _send_ops_alert)
+    monkeypatch.setattr(reminders, "_DEDUP_READ_RETRY_DELAY_SEC", 0)
+    monkeypatch.setattr(reminders, "_DEDUP_BACKOFF_UNTIL_MONOTONIC", 0.0)
+    reminders._MEMORY_SENT_KEYS.clear()
+    reminders._SENT_KEYS_CACHE.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert attempts == 2
+    assert channel.sent == []
+    fusion_sheets.mark_reminder_sent.assert_not_awaited()
+    assert "reminders skipped because sent-reminder dedupe could not be verified" in caplog.text
+    assert alerts[-1]["summary"] == "grouped_dedupe_unavailable_reminders_skipped"
+
+
+def test_grouped_reminder_retries_dedupe_then_sends_when_retry_succeeds(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-start", start_at=now)
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    attempts = 0
+
+    async def _get_sent_keys(_fusion_id: str):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise TimeoutError("first attempt")
+        return set()
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings()))
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    monkeypatch.setattr(reminders, "_DEDUP_READ_RETRY_DELAY_SEC", 0)
+    monkeypatch.setattr(reminders, "_DEDUP_BACKOFF_UNTIL_MONOTONIC", 0.0)
+    reminders._MEMORY_SENT_KEYS.clear()
+    reminders._SENT_KEYS_CACHE.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert attempts == 2
+    assert len(channel.sent) == 1
+    fusion_sheets.mark_reminder_sent.assert_awaited_once()
+
+
+def test_grouped_reminder_reuses_brief_dedupe_cache(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 11, 59, tzinfo=dt.timezone.utc)
+    calls = 0
+
+    async def _get_sent_keys(_fusion_id: str):
+        nonlocal calls
+        calls += 1
+        return set()
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", _get_sent_keys)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", AsyncMock(return_value=_settings(grouped_post_time_utc="12:00")))
+    monkeypatch.setattr(reminders, "_DEDUP_BACKOFF_UNTIL_MONOTONIC", 0.0)
+    reminders._SENT_KEYS_CACHE.clear()
+    reminders._MEMORY_SENT_KEYS.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(seconds=10)))
+
+    assert calls == 1


### PR DESCRIPTION
### Motivation
- Ensure grouped fusion reminders never send without durable sent-reminder dedupe verification, to avoid duplicate notifications when Sheets dedupe is down.
- Add a lightweight retry and short-lived cache to reduce pressure on the dedupe sheet while still failing safe if the dedupe backend is unavailable.
- Provide a clear, auditable warning when reminders are skipped because dedupe could not be verified. 

### Description
- Make `_load_grouped_sent_keys` perform one retry and short-circuit to a fail-closed state if the dedupe read still fails, changing its return to `tuple[set|None, bool]` where `None` indicates dedupe could not be verified. 
- Add configurable constants ` _DEDUP_READ_RETRY_DELAY_SEC` and `_DEDUP_CACHE_TTL_SEC` and a per-fusion short-lived `_SENT_KEYS_CACHE` to avoid repeated reads in one reminder run. 
- When dedupe is in backoff or still unreadable after retry, skip sending grouped reminders, log a clear warning string `"fusion grouped reminders skipped because sent-reminder dedupe could not be verified"`, and emit an ops alert with summary `grouped_dedupe_unavailable_reminders_skipped` instead of using the previous in-memory fallback. 
- Update startup diagnostics to report a skip (`• skipped=sent_reminder_dedupe_unavailable`) when dedupe cannot be verified during startup summary collection. 
- Add unit tests that assert (1) reminders are skipped when dedupe read times out after retry, (2) a successful retry results in sending, and (3) the brief dedupe cache is reused during a single run. 

### Testing
- Ran `pytest -q tests/community/test_fusion_reminders.py` which passed and covers the new retry, skip, and cache behaviors. 
- Ran `pytest -q tests/community/test_fusion_role_cleanup.py tests/community/test_fusion_reminders.py` which passed to validate no regressions in related fusion flows. 
- No CI guardrail changes, intents, OAuth scopes, or sheet ID values were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b5c0f3af08323b63cfa9781dd3280)