### PR TITLE
Batch Google Sheets writes for helpseed and add rate-limit handling

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -73,6 +73,7 @@ from shared.sheets.async_core import (
     afetch_records,
 )
 from shared.sheets.recruitment import get_config_value_async, get_reports_tab_name
+import shared.sheets.core as sheets_core
 from modules.common.config_sheets import SHEET_TARGETS, SheetTarget
 
 from c1c_coreops.config import CoreOpsSettings, load_coreops_settings, normalize_command_text
@@ -393,6 +394,35 @@ def _column_label(index: int) -> str:
         value, rem = divmod(value - 1, 26)
         label = chr(65 + rem) + label
     return label
+
+
+async def _helpseed_append_rows(worksheet: Any, rows: list[list[str]]) -> None:
+    if not rows:
+        return
+    append_rows = getattr(worksheet, "append_rows", None)
+    if not callable(append_rows):
+        raise RuntimeError(
+            "Help registry seed requires worksheet.append_rows for batched writes."
+        )
+    await acall_with_backoff(append_rows, rows, value_input_option="RAW")
+
+
+async def _helpseed_update_rows(
+    worksheet: Any, rows: list[tuple[int, list[str]]], header_count: int
+) -> None:
+    if not rows:
+        return
+    batch_update = getattr(worksheet, "batch_update", None)
+    if not callable(batch_update):
+        raise RuntimeError(
+            "Help registry seed requires worksheet.batch_update for batched updates."
+        )
+    end_col = _column_label(header_count)
+    payload = [
+        {"range": f"A{row_number}:{end_col}{row_number}", "values": [row]}
+        for row_number, row in rows
+    ]
+    await acall_with_backoff(batch_update, payload, value_input_option="RAW")
 
 
 
@@ -1707,7 +1737,7 @@ class CoreOpsCog(commands.Cog):
                 "RECRUITMENT_SHEET_ID is required for help registry seed."
             )
 
-        tab_name = await get_config_value_async("HELP_COMMANDS_TAB", None, force=True)
+        tab_name = await get_config_value_async("HELP_COMMANDS_TAB", None)
         if not tab_name or not str(tab_name).strip():
             raise RuntimeError(
                 "Config key HELP_COMMANDS_TAB is required and must not be empty."
@@ -1750,6 +1780,10 @@ class CoreOpsCog(commands.Cog):
         for command_key, reason in skipped:
             logger.info("helpseed skipped command=%s reason=%s", command_key, reason)
 
+        rows_to_append: list[list[str]] = []
+        rows_to_update: list[tuple[int, list[str]]] = []
+        command_logs: list[tuple[str, str, list[str]]] = []
+
         for command in commands_iter:
             seed = self._build_help_seed_row(command)
             values_by_header = _help_registry_row_values(seed)
@@ -1758,9 +1792,7 @@ class CoreOpsCog(commands.Cog):
             action = "created"
             if existing is None:
                 row_values = [values_by_header.get(header, "") for header in headers]
-                await acall_with_backoff(
-                    worksheet.append_row, row_values, value_input_option="RAW"
-                )
+                rows_to_append.append(row_values)
                 result.created += 1
             else:
                 row_number, row = existing
@@ -1772,13 +1804,7 @@ class CoreOpsCog(commands.Cog):
                 for header in ("category", "summary", "details"):
                     if not str(row[header_map[header]] or "").strip():
                         row[header_map[header]] = values_by_header[header]
-                end_col = _column_label(len(headers))
-                await acall_with_backoff(
-                    worksheet.update,
-                    f"A{row_number}:{end_col}{row_number}",
-                    [row[: len(headers)]],
-                    value_input_option="RAW",
-                )
+                rows_to_update.append((row_number, row[: len(headers)]))
                 result.updated += 1
                 action = "updated"
 
@@ -1805,9 +1831,23 @@ class CoreOpsCog(commands.Cog):
             ):
                 result.missing_sort_order += 1
                 missing_fields.append("sort_order")
+            command_logs.append((seed.command_key, action, missing_fields))
+
+        logger.info(
+            "helpseed sheet calls existing_rows=%s append_rows=%s update_rows=%s",
+            max(0, len(rows) - 1),
+            len(rows_to_append),
+            len(rows_to_update),
+        )
+        if rows_to_append:
+            await _helpseed_append_rows(worksheet, rows_to_append)
+        if rows_to_update:
+            await _helpseed_update_rows(worksheet, rows_to_update, len(headers))
+
+        for command_key, action, missing_fields in command_logs:
             logger.info(
                 "helpseed command=%s action=%s missing=%s",
-                seed.command_key,
+                command_key,
                 action,
                 ",".join(missing_fields) if missing_fields else "none",
             )
@@ -3937,7 +3977,13 @@ class CoreOpsCog(commands.Cog):
     async def ops_helpseed(self, ctx: commands.Context) -> None:
         try:
             await self._helpseed_impl(ctx)
-        except RuntimeError as exc:
+        except Exception as exc:
+            if sheets_core._is_rate_limited_error(exc):
+                logger.exception("helpseed hit Google Sheets rate limits")
+                await ctx.reply(
+                    "⚠️ Help registry seed hit Google Sheets rate limits. Wait a minute and try again."
+                )
+                return
             logger.warning("helpseed failed: %s", exc)
             await ctx.reply(str(sanitize_text(f"⚠️ Help registry seed failed: {exc}")))
 

--- a/packages/c1c-coreops/tests/test_helpseed.py
+++ b/packages/c1c-coreops/tests/test_helpseed.py
@@ -49,19 +49,31 @@ class FakeWorksheet:
     def __init__(self, rows):
         self.rows = [list(row) for row in rows]
         self.appended = []
+        self.appended_batches = []
         self.updated = []
+        self.updated_batches = []
+        self.get_all_values_calls = 0
 
     def get_all_values(self):
+        self.get_all_values_calls += 1
         return [list(row) for row in self.rows]
 
     def append_row(self, row, value_input_option="RAW"):
         self.appended.append((list(row), value_input_option))
         self.rows.append(list(row))
 
+    def append_rows(self, rows, value_input_option="RAW"):
+        rows = [list(row) for row in rows]
+        self.appended_batches.append((rows, value_input_option))
+        self.rows.extend(rows)
+
     def update(self, range_name, rows, value_input_option="RAW"):
         self.updated.append(
             (range_name, [list(row) for row in rows], value_input_option)
         )
+
+    def batch_update(self, updates, value_input_option="RAW"):
+        self.updated_batches.append((updates, value_input_option))
 
 
 HEADERS = list(coreops_cog.HELP_REGISTRY_HEADERS)
@@ -86,10 +98,15 @@ def _command(name="sample", *, help_text="Detailed help", brief="Summary", extra
 
 def _patch_sheet(monkeypatch, worksheet, tab="HelpCommands"):
     monkeypatch.setenv("RECRUITMENT_SHEET_ID", "sheet")
+
+    async def fake_get_config_value_async(*args, **kwargs):
+        assert kwargs.get("force") is not True
+        return tab
+
     monkeypatch.setattr(
         coreops_cog,
         "get_config_value_async",
-        lambda *a, **k: asyncio.sleep(0, result=tab),
+        fake_get_config_value_async,
     )
     monkeypatch.setattr(
         coreops_cog,
@@ -157,7 +174,9 @@ def test_helpseed_existing_rows_preserve_manual_fields(monkeypatch):
         _patch_sheet(monkeypatch, worksheet)
         result = await cog._helpseed_impl(DummyCtx())
         assert result.updated == 1
-        updated = worksheet.updated[0][1][0]
+        assert worksheet.get_all_values_calls == 1
+        assert worksheet.updated == []
+        updated = worksheet.updated_batches[0][0][0]["values"][0]
         assert updated[0] == "TRUE"
         assert updated[5] == "manualcat"
         assert updated[7] == "manual summary"
@@ -178,7 +197,9 @@ def test_helpseed_new_rows_append_disabled_blank_sort(monkeypatch):
         _patch_sheet(monkeypatch, worksheet)
         result = await cog._helpseed_impl(DummyCtx())
         assert result.created == 1
-        row = worksheet.appended[0][0]
+        assert worksheet.get_all_values_calls == 1
+        assert worksheet.appended == []
+        row = worksheet.appended_batches[0][0][0]
         assert row[0] == "FALSE"
         assert row[10] == ""
 
@@ -234,5 +255,90 @@ def test_helpseed_admin_check_blocks_non_admin(monkeypatch):
             except commands.CheckFailure:
                 failures += 1
         assert failures >= 1
+
+    asyncio.run(run())
+
+
+def test_helpseed_batches_multiple_created_rows(monkeypatch):
+    async def run():
+        bot = SimpleNamespace(
+            walk_commands=lambda: [
+                _command("alpha", extras={"function_group": "general", "access_tier": "user"}),
+                _command("beta", extras={"function_group": "general", "access_tier": "user"}),
+            ]
+        )
+        cog = _make_cog(bot)
+        worksheet = FakeWorksheet([HEADERS])
+        _patch_sheet(monkeypatch, worksheet)
+        result = await cog._helpseed_impl(DummyCtx())
+        assert result.created == 2
+        assert worksheet.appended == []
+        assert len(worksheet.appended_batches) == 1
+        assert len(worksheet.appended_batches[0][0]) == 2
+
+    asyncio.run(run())
+
+
+def test_helpseed_rate_limit_reply_is_friendly(monkeypatch):
+    async def run():
+        bot = SimpleNamespace(walk_commands=lambda: [])
+        cog = _make_cog(bot)
+        ctx = DummyCtx()
+
+        async def fail(_ctx):
+            raise RuntimeError('429 RESOURCE_EXHAUSTED ReadRequestsPerMinutePerUser traceback details')
+
+        monkeypatch.setattr(cog, "_helpseed_impl", fail)
+        await CoreOpsCog.ops_helpseed.callback(cog, ctx)
+        assert ctx.replies == [
+            "⚠️ Help registry seed hit Google Sheets rate limits. Wait a minute and try again."
+        ]
+
+    asyncio.run(run())
+
+
+def test_helpseed_missing_append_rows_fails_without_append_row_fallback(monkeypatch):
+    async def run():
+        class NoAppendRowsWorksheet(FakeWorksheet):
+            append_rows = None
+
+        cmd = _command(extras={"function_group": "general", "access_tier": "user"})
+        bot = SimpleNamespace(walk_commands=lambda: [cmd])
+        cog = _make_cog(bot)
+        worksheet = NoAppendRowsWorksheet([HEADERS])
+        _patch_sheet(monkeypatch, worksheet)
+        with pytest.raises(RuntimeError, match="requires worksheet.append_rows"):
+            await cog._helpseed_impl(DummyCtx())
+        assert worksheet.appended == []
+
+    asyncio.run(run())
+
+
+def test_helpseed_missing_batch_update_fails_without_update_fallback(monkeypatch):
+    async def run():
+        class NoBatchUpdateWorksheet(FakeWorksheet):
+            batch_update = None
+
+        cmd = _command(extras={"function_group": "newcat", "access_tier": "admin"})
+        bot = SimpleNamespace(walk_commands=lambda: [cmd])
+        cog = _make_cog(bot)
+        existing = [
+            "TRUE",
+            "woadkeeper",
+            "sample",
+            "!old",
+            "!old",
+            "manualcat",
+            "staff",
+            "manual summary",
+            "manual details",
+            "manual note",
+            "9",
+        ]
+        worksheet = NoBatchUpdateWorksheet([HEADERS, existing])
+        _patch_sheet(monkeypatch, worksheet)
+        with pytest.raises(RuntimeError, match="requires worksheet.batch_update"):
+            await cog._helpseed_impl(DummyCtx())
+        assert worksheet.updated == []
 
     asyncio.run(run())


### PR DESCRIPTION
### Motivation
- Reduce the number of Google Sheets API calls during the help registry seed to improve performance and avoid rate limits.
- Surface a friendly user message when the Sheets API returns rate-limit errors instead of a generic failure reply.

### Description
- Added `shared.sheets.core` import and two helpers ` _helpseed_append_rows` and `_helpseed_update_rows` to perform batched `append_rows` and `batch_update` calls with backoff.
- Changed `_helpseed_impl` to accumulate `rows_to_append` and `rows_to_update` and execute them via the new batched helpers, and to collect per-command logs for cleaner logging.
- Removed the `force=True` usage when calling `get_config_value_async` and adjusted error handling to detect Sheets rate-limit errors via `sheets_core._is_rate_limited_error`, replying with a friendly message when hit.
- Updated logging to report planned sheet operations and switched exception handling in `ops_helpseed` to catch `Exception` and specially handle rate-limit cases.

### Testing
- Ran the helpseed unit tests with `pytest packages/c1c-coreops/tests/test_helpseed.py`, which exercise batch append/update behavior, missing method error paths, and rate-limit reply handling, and they passed.
- Added and ran new tests `test_helpseed_batches_multiple_created_rows`, `test_helpseed_rate_limit_reply_is_friendly`, `test_helpseed_missing_append_rows_fails_without_append_row_fallback`, and `test_helpseed_missing_batch_update_fails_without_update_fallback`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b5cd0bcec8323aef41e972eca3f78)