### PR TITLE
Fail-closed retry for Fusion grouped reminder settings and fix Sheets sync/async retry usage

### DIFF
--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -22,6 +22,8 @@ _DEDUP_TIMEOUT_BACKOFF_SEC = max(60, int(os.getenv("FUSION_REMINDER_DEDUPE_BACKO
 _DEDUP_TIMEOUT_SEC = max(1.0, float(os.getenv("FUSION_REMINDER_DEDUPE_TIMEOUT_SEC", "10")))
 _DEDUP_READ_RETRY_DELAY_SEC = max(0.0, float(os.getenv("FUSION_REMINDER_DEDUPE_RETRY_DELAY_SEC", "1")))
 _DEDUP_CACHE_TTL_SEC = max(0.0, float(os.getenv("FUSION_REMINDER_DEDUPE_CACHE_TTL_SEC", "30")))
+_SETTINGS_LOAD_RETRY_DELAY_SEC = max(0.0, float(os.getenv("FUSION_REMINDER_SETTINGS_RETRY_DELAY_SEC", "1")))
+_SETTINGS_LOAD_TIMEOUT_SEC = float(os.getenv("FUSION_REMINDER_SETTINGS_TIMEOUT_SEC", "0") or "0")
 _GROUPED_REMINDER_TYPE = "grouped_daily"
 _GROUPED_EVENT_ID_PREFIX = "grouped_daily"
 
@@ -162,6 +164,82 @@ def _group_events_config_fields(settings: fusion_sheets.FusionReminderSettings) 
     if source.duplicate_count:
         fields["group_events_duplicate_count"] = source.duplicate_count
     return fields
+
+
+def _settings_unavailable_context(
+    *,
+    target: fusion_sheets.FusionRow,
+    attempt: int,
+    max_attempts: int,
+    exc: BaseException,
+) -> dict[str, object]:
+    return {
+        "fusion_id": target.fusion_id,
+        "operation": "load_fusion_reminder_settings",
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "timeout_sec": _SETTINGS_LOAD_TIMEOUT_SEC if _SETTINGS_LOAD_TIMEOUT_SEC > 0 else "not_configured",
+        "retry_delay_sec": _SETTINGS_LOAD_RETRY_DELAY_SEC,
+        "exception_type": type(exc).__name__,
+        "settings_source_tab": "unavailable",
+        "settings_sheet_id_tail": "unavailable",
+        "settings_cache": "not_used",
+        "cached_settings_used": False,
+        "reminder_tick_skipped": attempt >= max_attempts,
+    }
+
+
+async def _load_grouped_settings_with_retry(
+    target: fusion_sheets.FusionRow,
+    *,
+    reference: dt.datetime,
+) -> fusion_sheets.FusionReminderSettings | None:
+    max_attempts = 2
+    last_exc: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            coro = fusion_sheets.get_fusion_reminder_settings(now=reference)
+            if _SETTINGS_LOAD_TIMEOUT_SEC > 0:
+                return await asyncio.wait_for(coro, timeout=_SETTINGS_LOAD_TIMEOUT_SEC)
+            return await coro
+        except TimeoutError as exc:
+            last_exc = exc
+            context = _settings_unavailable_context(
+                target=target, attempt=attempt, max_attempts=max_attempts, exc=exc
+            )
+            log.warning(
+                "fusion grouped reminder settings unavailable; retrying"
+                if attempt < max_attempts
+                else "fusion grouped reminders skipped because settings could not be verified",
+                extra=context,
+            )
+        except Exception as exc:
+            last_exc = exc
+            context = _settings_unavailable_context(
+                target=target, attempt=attempt, max_attempts=max_attempts, exc=exc
+            )
+            log.warning(
+                "fusion grouped reminder settings unavailable; retrying"
+                if attempt < max_attempts
+                else "fusion grouped reminders skipped because settings could not be verified",
+                extra=context,
+                exc_info=True,
+            )
+        if attempt < max_attempts and _SETTINGS_LOAD_RETRY_DELAY_SEC > 0:
+            await asyncio.sleep(_SETTINGS_LOAD_RETRY_DELAY_SEC)
+
+    if last_exc is not None:
+        context = _settings_unavailable_context(
+            target=target, attempt=max_attempts, max_attempts=max_attempts, exc=last_exc
+        )
+        await fusion_logs.send_ops_alert(
+            component="reminders",
+            summary="grouped_settings_unavailable_reminders_skipped",
+            dedupe_key=f"fusion:grouped_reminders:settings:{target.fusion_id}",
+            error=last_exc,
+            fields=context,
+        )
+    return None
 
 
 def _parse_grouped_post_time_utc(raw: object) -> dt.time | None:
@@ -512,18 +590,8 @@ async def process_fusion_reminders(
     if target is None:
         return
 
-    try:
-        settings = await fusion_sheets.get_fusion_reminder_settings(now=reference)
-    except Exception as exc:
-        context = {"fusion_id": target.fusion_id}
-        log.exception("fusion grouped reminder failed to load settings", extra=context)
-        await fusion_logs.send_ops_alert(
-            component="reminders",
-            summary="grouped_load_settings_failed",
-            dedupe_key=f"fusion:grouped_reminders:settings:{target.fusion_id}",
-            error=exc,
-            fields=context,
-        )
+    settings = await _load_grouped_settings_with_retry(target, reference=reference)
+    if settings is None:
         return
 
     if not settings.group_events:

--- a/shared/sheets/core.py
+++ b/shared/sheets/core.py
@@ -73,6 +73,8 @@ def _retry_with_backoff(
     if tries <= 0:
         raise ValueError("attempts must be positive")
 
+    _ensure_no_running_loop_for_sync_retry()
+
     last_exc: Exception | None = None
     for attempt in range(tries):
         try:
@@ -149,20 +151,26 @@ def _next_backoff_delay(delay: float, *, multiplier: float, jitter_ratio: float 
     return random.uniform(low, high)
 
 
+def _ensure_no_running_loop_for_sync_retry() -> None:
+    """Reject sync retry usage from async contexts before any Sheets call starts."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    raise RuntimeError(
+        "_retry_with_backoff must not run inside an active event loop; use the async variant"
+    )
+
+
 def _sleep_with_new_loop(delay: float) -> None:
     """Sleep for ``delay`` seconds only when no event loop is active."""
 
     if delay <= 0:
         return
 
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        time.sleep(delay)
-        return
-    raise RuntimeError(
-        "_retry_with_backoff must not run inside an active event loop; use the async variant"
-    )
+    _ensure_no_running_loop_for_sync_retry()
+    time.sleep(delay)
 
 
 def _resolve_sheet_id(sheet_id: str | None) -> str:

--- a/tests/community/test_fusion_reminders.py
+++ b/tests/community/test_fusion_reminders.py
@@ -387,3 +387,117 @@ def test_grouped_reminder_reuses_brief_dedupe_cache(monkeypatch):
     asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now + dt.timedelta(seconds=10)))
 
     assert calls == 1
+
+
+def test_grouped_settings_timeout_retry_success_proceeds_normally(monkeypatch):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    event = _event(event_id="e-start", start_at=now)
+    channel = _DummyChannel()
+    announcement = _DummyAnnouncementMessage("https://discord.test/jump", channel)
+    attempts = 0
+
+    async def _get_settings(*, now=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise TimeoutError("settings unavailable")
+        return _settings()
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", _get_settings)
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=announcement))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    monkeypatch.setattr(reminders, "_SETTINGS_LOAD_RETRY_DELAY_SEC", 0)
+    reminders._MEMORY_SENT_KEYS.clear()
+    reminders._SENT_KEYS_CACHE.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert attempts == 2
+    assert len(channel.sent) == 1
+    fusion_sheets.get_fusion_events.assert_awaited_once_with("f-1")
+    fusion_sheets.mark_reminder_sent.assert_awaited_once()
+
+
+def test_grouped_settings_repeated_timeout_skips_before_events_dedupe_or_send(monkeypatch, caplog):
+    now = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    channel = _DummyChannel()
+    alerts = []
+    attempts = 0
+
+    async def _get_settings(*, now=None):
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("settings unavailable")
+
+    async def _send_ops_alert(**kwargs):
+        alerts.append(kwargs)
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", _get_settings)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[]))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=_DummyAnnouncementMessage("url", channel)))
+    monkeypatch.setattr(reminders.fusion_logs, "send_ops_alert", _send_ops_alert)
+    monkeypatch.setattr(reminders, "_SETTINGS_LOAD_RETRY_DELAY_SEC", 0)
+    reminders._MEMORY_SENT_KEYS.clear()
+    reminders._SENT_KEYS_CACHE.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=now))
+
+    assert attempts == 2
+    assert channel.sent == []
+    fusion_sheets.get_sent_reminder_keys.assert_not_awaited()
+    fusion_sheets.get_fusion_events.assert_not_awaited()
+    fusion_sheets.mark_reminder_sent.assert_not_awaited()
+    reminders.ensure_fusion_announcement.assert_not_awaited()
+    assert "settings could not be verified" in caplog.text
+    assert alerts[-1]["summary"] == "grouped_settings_unavailable_reminders_skipped"
+    fields = alerts[-1]["fields"]
+    assert fields["fusion_id"] == "f-1"
+    assert fields["operation"] == "load_fusion_reminder_settings"
+    assert fields["attempt"] == 2
+    assert fields["max_attempts"] == 2
+    assert fields["exception_type"] == "TimeoutError"
+    assert fields["cached_settings_used"] is False
+    assert fields["reminder_tick_skipped"] is True
+
+
+def test_grouped_settings_timeout_tick_recovers_on_later_tick(monkeypatch):
+    first = dt.datetime(2026, 4, 10, 12, 0, tzinfo=dt.timezone.utc)
+    second = first + dt.timedelta(hours=1)
+    event = _event(event_id="e-start", start_at=first)
+    channel = _DummyChannel()
+    calls = 0
+
+    async def _get_settings(*, now=None):
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            raise TimeoutError("settings unavailable")
+        return _settings()
+
+    monkeypatch.setattr(fusion_sheets, "get_publishable_fusion", AsyncMock(return_value=_fusion_row()))
+    monkeypatch.setattr(fusion_sheets, "get_fusion_reminder_settings", _get_settings)
+    monkeypatch.setattr(fusion_sheets, "get_fusion_events", AsyncMock(return_value=[event]))
+    monkeypatch.setattr(fusion_sheets, "get_valid_event_timing", lambda event, **_kwargs: (event.start_at_utc, event.end_at_utc))
+    monkeypatch.setattr(fusion_sheets, "get_sent_reminder_keys", AsyncMock(return_value=set()))
+    monkeypatch.setattr(fusion_sheets, "mark_reminder_sent", AsyncMock())
+    monkeypatch.setattr(reminders, "ensure_fusion_announcement", AsyncMock(return_value=_DummyAnnouncementMessage("https://discord.test/jump", channel)))
+    monkeypatch.setattr(reminders, "build_fusion_opt_in_view", lambda _target: "view")
+    monkeypatch.setattr(reminders.fusion_logs, "send_ops_alert", AsyncMock())
+    monkeypatch.setattr(reminders, "_SETTINGS_LOAD_RETRY_DELAY_SEC", 0)
+    reminders._MEMORY_SENT_KEYS.clear()
+    reminders._SENT_KEYS_CACHE.clear()
+
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=first))
+    asyncio.run(reminders.process_fusion_reminders(bot=object(), now=second))
+
+    assert calls == 3
+    assert len(channel.sent) == 1
+    fusion_sheets.mark_reminder_sent.assert_awaited_once()

--- a/tests/shared/sheets/test_async_core.py
+++ b/tests/shared/sheets/test_async_core.py
@@ -75,3 +75,38 @@ def test_a_to_thread_with_backoff_retries_with_async_sleep_not_time_sleep(monkey
     assert calls == ["call", "call"]
     assert len(sleeps) == 1
     assert 0.1875 <= sleeps[0] <= 0.3125
+
+
+def test_acall_with_backoff_does_not_use_sync_retry_inside_event_loop(monkeypatch):
+    sync_retry_calls = []
+
+    def fail_sync_retry(*_args, **_kwargs):
+        sync_retry_calls.append(True)
+        raise AssertionError("sync retry helper must not run inside the event loop")
+
+    async def fake_async_retry(func, *args, **_kwargs):
+        return await func(*args)
+
+    async def fake_arun(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(core, "_retry_with_backoff", fail_sync_retry)
+    monkeypatch.setattr(core, "_retry_with_backoff_async", fake_async_retry)
+    monkeypatch.setattr(core.async_adapter, "arun", fake_arun)
+
+    result = asyncio.run(async_core.acall_with_backoff(lambda value: f"{value}-ok", "async"))
+
+    assert result == "async-ok"
+    assert sync_retry_calls == []
+
+
+def test_sync_call_with_backoff_rejects_active_event_loop():
+    async def run_inside_loop():
+        return core.call_with_backoff(lambda: "unsafe")
+
+    try:
+        asyncio.run(run_inside_loop())
+    except RuntimeError as exc:
+        assert "active event loop" in str(exc)
+    else:  # pragma: no cover - failure path assertion
+        raise AssertionError("sync retry helper should reject active event loops")


### PR DESCRIPTION
### Motivation
- Fusion grouped reminders must not send when reminder settings cannot be verified, and transient Sheets timeouts should skip the current tick and allow normal recovery on the next tick. 
- Logs showed long Google Sheets timeouts and the sync retry helper being invoked from async contexts, causing the runtime error `_retry_with_backoff must not run inside an active event loop; use the async variant`.

### Description
- Added configurable settings-load controls `FUSION_REMINDER_SETTINGS_RETRY_DELAY_SEC` and `FUSION_REMINDER_SETTINGS_TIMEOUT_SEC` and implemented a fail-closed loader `async def _load_grouped_settings_with_retry(...)` that retries once then returns `None` when settings remain unavailable. 
- Replaced the previous broad `grouped_load_settings_failed` path with clearer handling that emits the new ops alert `grouped_settings_unavailable_reminders_skipped` and logs actionable context including `fusion_id`, `operation`, `attempt`, `max_attempts`, `timeout_sec`, `retry_delay_sec`, `exception_type`, `settings` source metadata, whether cached settings were used, and whether the tick was skipped. 
- Ensured fail-closed behavior by returning early when settings could not be verified so no events are read, no dedupe reads/writes occur, no announcements are resolved, and no reminders are sent or marked. 
- Hardened the shared Sheets sync retry helper by adding `_ensure_no_running_loop_for_sync_retry()` and adjusting `_sleep_with_new_loop()` so the sync `_retry_with_backoff` now rejects usage from active event loops (forcing async callers to use the async helpers). 
- Added regression tests covering settings retry-success, repeated settings timeout skipping (no side effects), later-tick recovery, and async/sync retry safety to prevent regressions (`tests/community/test_fusion_reminders.py` and `tests/shared/sheets/test_async_core.py`).

### Testing
- Ran linting via `ruff` on the modified files and it succeeded. 
- Ran the targeted test matrix `pytest -q tests/community/test_fusion_reminders.py tests/shared/sheets/test_async_core.py` and all tests passed. 
- Added tests assert that when settings time out twice the scheduler tick is skipped with `grouped_settings_unavailable_reminders_skipped` and that async callers do not invoke the sync retry helper inside an active event loop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b811d3c8483239d9d7dbe053e9900)