### PR TITLE
Add hidden bare `!helpseed` admin alias (delegates to existing ops helpseed)

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -3961,6 +3961,19 @@ class CoreOpsCog(commands.Cog):
     async def ops_config(self, ctx: commands.Context) -> None:
         await self._config_impl(ctx)
 
+    async def _helpseed_command_impl(self, ctx: commands.Context) -> None:
+        try:
+            await self._helpseed_impl(ctx)
+        except Exception as exc:
+            if sheets_core._is_rate_limited_error(exc):
+                logger.exception("helpseed hit Google Sheets rate limits")
+                await ctx.reply(
+                    "⚠️ Help registry seed hit Google Sheets rate limits. Wait a minute and try again."
+                )
+                return
+            logger.warning("helpseed failed: %s", exc)
+            await ctx.reply(str(sanitize_text(f"⚠️ Help registry seed failed: {exc}")))
+
     @tier("admin")
     @help_metadata(
         function_group="operational", section="sheet_tools", access_tier="admin"
@@ -3975,17 +3988,27 @@ class CoreOpsCog(commands.Cog):
     @ops_only()
     @admin_only()
     async def ops_helpseed(self, ctx: commands.Context) -> None:
-        try:
-            await self._helpseed_impl(ctx)
-        except Exception as exc:
-            if sheets_core._is_rate_limited_error(exc):
-                logger.exception("helpseed hit Google Sheets rate limits")
-                await ctx.reply(
-                    "⚠️ Help registry seed hit Google Sheets rate limits. Wait a minute and try again."
-                )
-                return
-            logger.warning("helpseed failed: %s", exc)
-            await ctx.reply(str(sanitize_text(f"⚠️ Help registry seed failed: {exc}")))
+        await self._helpseed_command_impl(ctx)
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational",
+        section="sheet_tools",
+        access_tier="hidden",
+        flags=("hidden", "maintenance"),
+    )
+    @commands.command(
+        name="helpseed",
+        hidden=True,
+        help="Hidden admin alias that seeds the help registry sheet.",
+        brief="Hidden admin alias for help registry seeding.",
+        extras={"hide_in_help": True},
+    )
+    @guild_only_denied_msg()
+    @ops_only()
+    @admin_only()
+    async def helpseed(self, ctx: commands.Context) -> None:
+        await self._helpseed_command_impl(ctx)
 
     @tier("admin")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")

--- a/packages/c1c-coreops/tests/test_helpseed.py
+++ b/packages/c1c-coreops/tests/test_helpseed.py
@@ -279,6 +279,80 @@ def test_helpseed_batches_multiple_created_rows(monkeypatch):
     asyncio.run(run())
 
 
+def test_bare_helpseed_is_hidden_admin_maintenance_alias():
+    command = CoreOpsCog.helpseed
+    assert command.hidden is True
+    assert command.extras.get("hide_in_help") is True
+    assert command.extras.get("access_tier") == "hidden"
+    assert command.extras.get("help_flags") == ["hidden", "maintenance"]
+    assert _should_show(command) is False
+
+
+def test_bare_helpseed_delegates_to_same_command_impl(monkeypatch):
+    async def run():
+        bot = SimpleNamespace(walk_commands=lambda: [])
+        cog = _make_cog(bot)
+        ctx = DummyCtx()
+        calls = []
+
+        async def fake_impl(received_ctx):
+            calls.append(received_ctx)
+            await received_ctx.reply("seeded")
+
+        monkeypatch.setattr(cog, "_helpseed_impl", fake_impl)
+        await CoreOpsCog.helpseed.callback(cog, ctx)
+        assert calls == [ctx]
+        assert ctx.replies == ["seeded"]
+
+    asyncio.run(run())
+
+
+def test_ops_helpseed_delegates_to_same_command_impl(monkeypatch):
+    async def run():
+        bot = SimpleNamespace(walk_commands=lambda: [])
+        cog = _make_cog(bot)
+        ctx = DummyCtx()
+        calls = []
+
+        async def fake_impl(received_ctx):
+            calls.append(received_ctx)
+
+        monkeypatch.setattr(cog, "_helpseed_impl", fake_impl)
+        await CoreOpsCog.ops_helpseed.callback(cog, ctx)
+        assert calls == [ctx]
+
+    asyncio.run(run())
+
+
+def test_bare_helpseed_admin_check_blocks_non_admin(monkeypatch):
+    async def run():
+        monkeypatch.setattr(coreops_rbac.discord, "Member", DummyMember)
+        ctx = DummyCtx(administrator=False)
+        failures = 0
+        for check in CoreOpsCog.helpseed.checks:
+            try:
+                await check(ctx)
+            except commands.CheckFailure:
+                failures += 1
+        assert failures >= 1
+
+    asyncio.run(run())
+
+
+def test_bare_helpseed_is_not_exported_into_helpcommands(monkeypatch):
+    async def run():
+        bot = SimpleNamespace(walk_commands=lambda: [CoreOpsCog.helpseed])
+        cog = _make_cog(bot)
+        worksheet = FakeWorksheet([HEADERS])
+        _patch_sheet(monkeypatch, worksheet)
+        result = await cog._helpseed_impl(DummyCtx())
+        assert result.created == 0
+        assert result.skipped == 1
+        assert worksheet.appended_batches == []
+
+    asyncio.run(run())
+
+
 def test_helpseed_rate_limit_reply_is_friendly(monkeypatch):
     async def run():
         bot = SimpleNamespace(walk_commands=lambda: [])


### PR DESCRIPTION
### Motivation
- Provide a consistent bare `!helpseed` admin entry point to match Reminder/Achievements while preserving the existing `!ops helpseed` behavior.
- Ensure the new alias reuses the same implementation, Google Sheets behavior, and admin gating to avoid duplicating logic or widening access.

### Description
- Introduced a shared wrapper `_helpseed_command_impl` that centralizes success/failure handling and delegates to the existing `_helpseed_impl`. (modified: `packages/c1c-coreops/src/c1c_coreops/cog.py`)
- Kept the existing `!ops helpseed` command unchanged and updated it to call the shared wrapper. (modified: `packages/c1c-coreops/src/c1c_coreops/cog.py`)
- Added a hidden bare `!helpseed` admin alias that uses the same decorators (`guild_only_denied_msg`, `ops_only`, `admin_only`) and is marked with hidden/admin-maintenance metadata (`access_tier: hidden`, `help_flags: [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b86a2b01c8323a47b5581005dade8)