### PR TITLE
Promo onboarding: improve promo thread parsing, failure logging to sheets, and context resolution

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -54,6 +54,58 @@ UTC = dt.timezone.utc
 log = logging.getLogger("c1c.onboarding.promo_watcher")
 
 
+async def _log_promo_failure_row(
+    *,
+    reason: str,
+    source: str,
+    thread: object | None = None,
+    actor: object | None = None,
+    target_user_id: int | str | None = None,
+    target_message_id: int | str | None = None,
+    message_id: int | str | None = None,
+    promo_flow: str | None = None,
+    ticket_code: str | None = None,
+) -> None:
+    guild = getattr(thread, "guild", None)
+    parent = getattr(thread, "parent", None)
+    thread_id = getattr(thread, "id", None)
+    note = {
+        "promo_ticket_parse_failed": "promo_ticket_parse_failed before dialog start",
+        "close_context_unresolved": "close_context_unresolved before clan prompt",
+        "context_not_found": "context_not_found during close/startup backfill",
+    }.get(reason, str(reason or "promo failure"))
+    payload = {
+        "flow": "promo",
+        "source": source,
+        "result": "failure",
+        "reason": reason,
+        "guild_id": getattr(guild, "id", None),
+        "parent_channel_id": getattr(parent, "id", None),
+        "thread_id": thread_id,
+        "thread_name": getattr(thread, "name", None),
+        "actor_id": getattr(actor, "id", None),
+        "actor_name": onboarding_logs.format_actor_handle(actor) if actor is not None else None,
+        "target_user_id": target_user_id,
+        "target_message_id": target_message_id,
+        "message_id": message_id,
+        "promo_flow": promo_flow,
+        "ticket_code": ticket_code,
+    }
+    try:
+        result = await asyncio.to_thread(
+            onboarding_sheets.update_ticket_finalization_state,
+            "promo",
+            ticket=ticket_code,
+            thread_id=thread_id,
+            finalization_status="skipped_unresolved",
+            finalization_note=note,
+        )
+    except Exception:
+        log.exception("promo failure promo-row update failed", extra=payload)
+    else:
+        log.warning("promo failure promo-row updated", extra={**payload, "sheet_result": result})
+
+
 def _promo_headers_for_write(*, ticket: str | None = None) -> list[str]:
     try:
         return onboarding_sheets.get_live_promo_headers()
@@ -420,12 +472,34 @@ class PromoTicketWatcher(commands.Cog):
         now = getattr(thread, "created_at", None) or dt.datetime.now(UTC)
         created_str = _format_timestamp(now)
         found = None
+        found_source = None
         parts = None
+        session_row = None
         try:
-            found = await asyncio.to_thread(onboarding_sheets.find_promo_row_by_thread_id, getattr(thread, "id", None))
+            session_row = onboarding_sessions.get_by_thread_id(getattr(thread, "id", None))
+        except Exception:
+            session_row = None
+        if session_row:
+            parts = parse_promo_thread_name(session_row.get("thread_name") or getattr(thread, "name", ""))
+        if parts is None:
+            parts = parse_promo_thread_name(thread.name)
+
+        if parts is not None:
+            try:
+                found = await asyncio.to_thread(onboarding_sheets.find_promo_row, parts.ticket_code)
+                if found is not None:
+                    found_source = "sheet_ticket"
+            except Exception:
+                log.exception("failed to read promo row during context ensure", extra={"ticket": parts.ticket_code})
+                found = None
+        try:
+            if found is None:
+                found = await asyncio.to_thread(onboarding_sheets.find_promo_row_by_thread_id, getattr(thread, "id", None))
+                if found is not None:
+                    found_source = "sheet_thread_id"
         except Exception:
             log.exception("close_context_resolved failed reading promo row by thread_id", extra={"thread_id": getattr(thread, "id", None)})
-        if found:
+        if found and found_source == "sheet_thread_id":
             _, values = found
             ticket = (values.get("ticket number") or values.get("ticket_number") or values.get("ticket") or "").strip()
             username = (values.get("username") or values.get("thread_name") or getattr(thread, "name", "") or "unknown").strip(" -_")
@@ -450,20 +524,32 @@ class PromoTicketWatcher(commands.Cog):
             except (TypeError, ValueError):
                 context.user_id = None
             self._tickets[thread.id] = context
-            log.info("close_context_resolved", extra={"flow": "promo", "thread_id": thread.id, "ticket": context.ticket_number, "source": "sheet_thread_id"})
+            log.info("close_context_resolved", extra={"flow": "promo", "thread_id": thread.id, "ticket": context.ticket_number, "source": found_source})
             return context
-
-        try:
-            session_row = onboarding_sessions.get_by_thread_id(getattr(thread, "id", None))
-        except Exception:
-            session_row = None
-        if session_row:
-            parts = parse_promo_thread_name(session_row.get("thread_name") or getattr(thread, "name", ""))
-
         if parts is None:
-            parts = parse_promo_thread_name(thread.name)
-        if parts is None:
-            log.warning("close_context_unresolved", extra={"flow": "promo", "thread_id": getattr(thread, "id", None), "thread_name": getattr(thread, "name", None)})
+            target_user_id = None
+            target_message_id = None
+            try:
+                welcome_message = await locate_welcome_message(thread)
+                target_user_id, target_message_id = extract_target_from_message(welcome_message)
+            except Exception:
+                pass
+            log.warning(
+                "close_context_unresolved",
+                extra={
+                    "flow": "promo",
+                    "thread_id": getattr(thread, "id", None),
+                    "thread_name": getattr(thread, "name", None),
+                    "target_user_id": target_user_id,
+                },
+            )
+            await _log_promo_failure_row(
+                reason="close_context_unresolved",
+                source="message",
+                thread=thread,
+                target_user_id=target_user_id,
+                target_message_id=target_message_id,
+            )
             return None
 
         context = PromoTicketContext(
@@ -476,12 +562,6 @@ class PromoTicketWatcher(commands.Cog):
             month=now.strftime("%B"),
         )
 
-        try:
-            found = await asyncio.to_thread(onboarding_sheets.find_promo_row, parts.ticket_code)
-        except Exception:
-            log.exception("failed to read promo row during context ensure", extra={"ticket": parts.ticket_code})
-            found = None
-
         if found:
             _, values = found
             context.clan_tag = values.get("clantag", "") or context.clan_tag
@@ -492,6 +572,25 @@ class PromoTicketWatcher(commands.Cog):
             context.year = values.get("year", "") or context.year
             context.month = values.get("month", "") or context.month
             context.join_month = values.get("join_month", "") or context.join_month
+
+        if context.user_id is None and session_row:
+            try:
+                uid = str(session_row.get("user_id") or "").strip()
+                context.user_id = int(uid) if uid else None
+            except (TypeError, ValueError):
+                context.user_id = None
+        if context.user_id is None and found:
+            try:
+                uid = str(found[1].get("user_id") or "").strip()
+                context.user_id = int(uid) if uid else None
+            except (TypeError, ValueError):
+                context.user_id = None
+        if context.user_id is None:
+            try:
+                welcome_message = await locate_welcome_message(thread)
+                context.user_id, _ = extract_target_from_message(welcome_message)
+            except Exception:
+                context.user_id = None
 
         self._tickets[thread.id] = context
         return context
@@ -1662,6 +1761,12 @@ class PromoTicketWatcher(commands.Cog):
                 except Exception:
                     summary["error"] += 1
                 log.warning("close_context_unresolved", extra={"flow": "promo", "trigger": "startup_backfill", "thread_id": thread_id, "ticket": ticket})
+                await _log_promo_failure_row(
+                    reason="close_context_unresolved",
+                    source="message",
+                    thread=SimpleNamespace(id=thread_id, name=values.get("thread_name")),
+                    ticket_code=ticket,
+                )
                 await _send_placement_log_line(flow="promo", outcome="unresolved", ticket=ticket, player=player, trigger="startup_backfill", reason="context_not_found", action="skipped", thread=values.get("thread_name"))
                 continue
             if not sheet_closed and not thread_closed:
@@ -1677,6 +1782,12 @@ class PromoTicketWatcher(commands.Cog):
                     await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=ticket, thread_id=thread_id, finalization_status="skipped_unresolved", finalization_note="context unresolved during startup/backfill")
                 except Exception:
                     summary["error"] += 1
+                await _log_promo_failure_row(
+                    reason="close_context_unresolved",
+                    source="message",
+                    thread=thread,
+                    ticket_code=ticket,
+                )
                 await _send_placement_log_line(flow="promo", outcome="unresolved", ticket=ticket, player=player, trigger="startup_backfill", reason="context_not_found", action="skipped", thread=getattr(thread, "name", None))
                 continue
             try:

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -71,8 +71,7 @@ _TICKET_CODE_RE = re.compile(r"(W?\d{4})", re.IGNORECASE)
 _WELCOME_TICKET_THREAD_NAME_RE = re.compile(r"^W\d{4}-")
 _PROMO_TICKET_CODE_RE = re.compile(r"([RML]\d{4})", re.IGNORECASE)
 _PROMO_THREAD_NAME_RE = re.compile(
-    r"^(?P<prefix>[RML])(?P<digits>\d{4})[-_\s]+(?P<slug>[A-Za-z0-9][A-Za-z0-9._-]*)"
-    r"(?:[-_\s]+(?P<tag>[A-Za-z0-9]+))?$",
+    r"^(?P<prefix>[RML])(?P<digits>\d{4})(?P<display>.*)$",
     re.IGNORECASE,
 )
 _CLOSED_MESSAGE_TOKEN = "ticket closed"
@@ -264,32 +263,22 @@ def parse_promo_thread_name(name: str | None) -> Optional["PromoThreadNameParts"
 
     prefix = match.group("prefix")
     digits = match.group("digits")
-    slug = (match.group("slug") or "").strip(" -_")
     ticket_code = _normalize_promo_ticket(f"{prefix}{digits}")
     if not ticket_code:
-        return None
-    if not slug:
         return None
 
     promo_type = _PROMO_TYPE_MAP.get(ticket_code[:1], "")
     if not promo_type:
         return None
-    clan_tag = (match.group("tag") or "").strip(" -_") or None
-    if clan_tag is None:
-        slug_parts = re.split(r"[-_\s]+", slug)
-        if (
-            len(slug_parts) > 1
-            and slug_parts[-1].isalpha()
-            and slug_parts[-1].isupper()
-        ):
-            clan_tag = slug_parts.pop().strip() or None
-            slug = "-".join(part for part in slug_parts if part)
+    display_text = (match.group("display") or "").strip(" -_")
 
     return PromoThreadNameParts(
         ticket_code=ticket_code,
-        username=slug,
+        prefix=ticket_code[:1],
+        digits=digits,
         promo_type=promo_type,
-        clan_tag=clan_tag,
+        promo_flow=f"promo.{ticket_code[:1].lower()}",
+        display_text=display_text,
     )
 
 
@@ -1600,9 +1589,23 @@ class ThreadNameParts:
 @dataclass(frozen=True)
 class PromoThreadNameParts:
     ticket_code: str
-    username: str
+    prefix: str
+    digits: str
     promo_type: str
-    clan_tag: Optional[str] = None
+    promo_flow: str
+    display_text: str = ""
+
+    @property
+    def username(self) -> str:
+        """Legacy display-only tail for callers that still log a username."""
+
+        return self.display_text or "unknown"
+
+    @property
+    def clan_tag(self) -> None:
+        """Promo thread names no longer encode a structured clan tag."""
+
+        return None
 
 
 @dataclass(frozen=True)

--- a/modules/onboarding/welcome_flow.py
+++ b/modules/onboarding/welcome_flow.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
+import asyncio
+
 import discord
 from discord.ext import commands
 
@@ -20,6 +22,7 @@ from modules.onboarding.controllers.welcome_controller import (
 )
 from modules.onboarding.ui import panels
 from modules.onboarding.watcher_welcome import parse_promo_thread_name
+from shared.sheets import onboarding as onboarding_sheets
 from shared.sheets import onboarding_questions
 
 __all__ = ["resolve_onboarding_flow", "start_welcome_dialog"]
@@ -46,7 +49,7 @@ def resolve_onboarding_flow(thread: discord.Thread) -> FlowResolution:
             return FlowResolution(None, error="promo_ticket_parse_failed")
 
         prefix = (parts.ticket_code or "")[:1].upper()
-        flow = _PROMO_FLOW_MAP.get(prefix)
+        flow = parts.promo_flow or _PROMO_FLOW_MAP.get(prefix)
         if not flow:
             return FlowResolution(None, ticket_code=parts.ticket_code, error="promo_ticket_unknown_prefix")
 
@@ -72,7 +75,7 @@ async def start_welcome_dialog(
 
     resolution = resolve_onboarding_flow(thread)
     flow = resolution.flow or "unknown"
-    actor = initiator if isinstance(initiator, (discord.Member, discord.User)) else None
+    actor = initiator if initiator is not None else None
 
     def _context(
         extra: dict[str, Any] | None = None,
@@ -85,7 +88,14 @@ async def start_welcome_dialog(
         payload = logs.thread_context(thread)
         payload["flow"] = flow
         payload["source"] = source
+        guild = getattr(thread, "guild", None)
+        parent = getattr(thread, "parent", None)
+        payload["guild_id"] = getattr(guild, "id", None)
+        payload["parent_channel_id"] = getattr(parent, "id", None)
+        payload["thread_id"] = getattr(thread, "id", None)
+        payload["thread_name"] = getattr(thread, "name", None)
         payload["actor"] = logs.format_actor(resolved_actor)
+        payload["actor_id"] = getattr(resolved_actor, "id", None)
         handle = logs.format_actor_handle(resolved_actor)
         if handle:
             payload["actor_name"] = handle
@@ -103,6 +113,51 @@ async def start_welcome_dialog(
     if resolution.ticket_code:
         context_defaults["ticket_code"] = resolution.ticket_code
 
+    target_user_id: int | None = None
+    target_message_id: int | None = None
+    try:
+        welcome_message = await locate_welcome_message(thread)
+    except Exception as exc:  # pragma: no cover - defensive network path
+        if resolution.flow is not None:
+            await logs.send_welcome_exception(
+                "warn",
+                exc,
+                **_context({"result": "target_lookup_failed"}),
+            )
+    else:
+        target_user_id, target_message_id = extract_target_from_message(welcome_message)
+
+    if target_user_id is not None:
+        context_defaults["target_user_id"] = target_user_id
+    if target_message_id is not None:
+        context_defaults["target_message_id"] = target_message_id
+
+    async def _log_promo_failure_to_sheet(reason: str) -> None:
+        payload = _context(
+            {
+                "flow": "promo",
+                "result": "failure",
+                "reason": reason,
+                **context_defaults,
+            }
+        )
+        if resolution.flow:
+            payload["promo_flow"] = resolution.flow
+        note = {
+            "promo_ticket_parse_failed": "promo_ticket_parse_failed before dialog start",
+        }.get(reason, str(reason or "promo failure before dialog start"))
+        try:
+            await asyncio.to_thread(
+                onboarding_sheets.update_ticket_finalization_state,
+                "promo",
+                ticket=resolution.ticket_code,
+                thread_id=getattr(thread, "id", None),
+                finalization_status="pending_review",
+                finalization_note=note,
+            )
+        except Exception as exc:  # pragma: no cover - sheet/network path
+            await logs.send_welcome_exception("error", exc, **payload)
+
     if resolution.flow is None:
         await logs.send_welcome_log(
             "warn",
@@ -115,28 +170,12 @@ async def start_welcome_dialog(
             ),
         )
         if resolution.error and resolution.error.startswith("promo_ticket"):
+            await _log_promo_failure_to_sheet(resolution.error)
             await _safe_notify(
                 "⚠️ I couldn't start the promo dialog for this ticket. Please check the promo ticket number and try again."
             )
         return
 
-    target_user_id: int | None = None
-    target_message_id: int | None = None
-    try:
-        welcome_message = await locate_welcome_message(thread)
-    except Exception as exc:  # pragma: no cover - defensive network path
-        await logs.send_welcome_exception(
-            "warn",
-            exc,
-            **_context({"result": "target_lookup_failed"}),
-        )
-    else:
-        target_user_id, target_message_id = extract_target_from_message(welcome_message)
-
-    if target_user_id is not None:
-        context_defaults["target_user_id"] = target_user_id
-    if target_message_id is not None:
-        context_defaults["target_message_id"] = target_message_id
     anchor_message_id: int | None = None
     if panel_message is not None:
         raw_id = getattr(panel_message, "id", None)

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -1574,6 +1574,16 @@ def update_ticket_finalization_state(
         if col < 0:
             raise RuntimeError(f"{normalized} finalization header missing for {field}: {final_headers[field]!r}")
         row[col] = str(value)
+    updated_col = next(
+        (
+            idx
+            for idx, name in enumerate(_normalize_header_name(h) for h in header)
+            if name == "updatedat"
+        ),
+        -1,
+    )
+    if updated_col >= 0:
+        row[updated_col] = datetime.now(timezone.utc).isoformat()
     end_col = _col_to_a1(len(header) - 1)
     core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row[: len(header)]])
     return "updated"

--- a/tests/onboarding/test_watcher_sheet_logging.py
+++ b/tests/onboarding/test_watcher_sheet_logging.py
@@ -361,3 +361,111 @@ def test_welcome_auto_close_logging_failure_mentions_admin(monkeypatch, caplog):
         "sheet_update=failed" in record.message and "<@&5150>" in record.message
         for record in caplog.records
     )
+
+
+def test_promo_close_context_unresolved_writes_failure_log(monkeypatch):
+    watcher = PromoTicketWatcher(bot=MagicMock())
+    thread = SimpleNamespace(
+        id=12345,
+        name="not-a-promo-ticket",
+        parent=SimpleNamespace(id=77),
+        guild=SimpleNamespace(id=88),
+    )
+    updates: list[dict[str, object]] = []
+
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sessions, "get_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo, "locate_welcome_message", AsyncMock(return_value=SimpleNamespace(id=999)))
+    monkeypatch.setattr(watcher_promo, "extract_target_from_message", lambda _message: (456, 999))
+    monkeypatch.setattr(
+        watcher_promo.onboarding_sheets,
+        "update_ticket_finalization_state",
+        lambda *args, **kwargs: updates.append(kwargs) or "updated",
+    )
+
+    result = asyncio.run(watcher._ensure_context(thread))
+
+    assert result is None
+    assert updates and updates[0]["thread_id"] == thread.id
+    assert updates[0]["finalization_status"] == "skipped_unresolved"
+    assert updates[0]["finalization_note"] == "close_context_unresolved before clan prompt"
+
+
+def test_promo_context_rich_thread_keeps_intro_target_user(monkeypatch):
+    watcher = PromoTicketWatcher(bot=MagicMock())
+    thread = SimpleNamespace(
+        id=45678,
+        name="L0061-C1C WarWalker / C1C Cholula",
+        created_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        parent=SimpleNamespace(id=77),
+        guild=SimpleNamespace(id=88),
+    )
+    updates: list[dict[str, object]] = []
+
+    monkeypatch.setattr(watcher_promo.onboarding_sessions, "get_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda _ticket: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo, "locate_welcome_message", AsyncMock(return_value=SimpleNamespace(id=999)))
+    monkeypatch.setattr(watcher_promo, "extract_target_from_message", lambda _message: (98765, 999))
+    monkeypatch.setattr(
+        watcher_promo.onboarding_sheets,
+        "update_ticket_finalization_state",
+        lambda *args, **kwargs: updates.append(kwargs) or "updated",
+    )
+
+    context = asyncio.run(watcher._ensure_context(thread))
+
+    assert context is not None
+    assert context.ticket_number == "L0061"
+    assert context.user_id == 98765
+    assert updates == []
+
+
+def test_promo_context_uses_session_row_by_thread_id(monkeypatch):
+    watcher = PromoTicketWatcher(bot=MagicMock())
+    thread = SimpleNamespace(
+        id=56789,
+        name="promo display text changed",
+        created_at=datetime(2025, 6, 2, tzinfo=timezone.utc),
+        parent=SimpleNamespace(id=77),
+        guild=SimpleNamespace(id=88),
+    )
+
+    monkeypatch.setattr(
+        watcher_promo.onboarding_sessions,
+        "get_by_thread_id",
+        lambda _thread_id: {
+            "thread_name": "L0061-C1C WarWalker / C1C Cholula",
+            "user_id": "24680",
+        },
+    )
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda _ticket: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo, "locate_welcome_message", AsyncMock(return_value=SimpleNamespace(id=999)))
+
+    context = asyncio.run(watcher._ensure_context(thread))
+
+    assert context is not None
+    assert context.ticket_number == "L0061"
+    assert context.user_id == 24680
+
+
+def test_promo_failure_no_row_found_logs_context_without_crashing(monkeypatch, caplog):
+    watcher = PromoTicketWatcher(bot=MagicMock())
+    thread = SimpleNamespace(id=67890, name="not-a-promo-ticket", parent=SimpleNamespace(id=77), guild=SimpleNamespace(id=88))
+
+    def missing_row(*_args, **_kwargs):
+        raise RuntimeError("promo finalization row not found")
+
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo.onboarding_sessions, "get_by_thread_id", lambda _thread_id: None)
+    monkeypatch.setattr(watcher_promo, "locate_welcome_message", AsyncMock(return_value=SimpleNamespace(id=999)))
+    monkeypatch.setattr(watcher_promo, "extract_target_from_message", lambda _message: (13579, 999))
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", missing_row)
+
+    with caplog.at_level("ERROR", logger="c1c.onboarding.promo_watcher"):
+        result = asyncio.run(watcher._ensure_context(thread))
+
+    assert result is None
+    assert any("promo failure promo-row update failed" in record.message for record in caplog.records)
+    assert any(getattr(record, "target_user_id", None) == 13579 for record in caplog.records)

--- a/tests/onboarding/test_welcome_flow_promo_flows.py
+++ b/tests/onboarding/test_welcome_flow_promo_flows.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from modules.common import feature_flags
 from modules.onboarding import thread_scopes, welcome_flow
+from shared.sheets import onboarding as onboarding_sheets
 from shared.sheets import onboarding_questions
 
 
@@ -146,3 +147,116 @@ def test_start_welcome_dialog_uses_promo_subflow(monkeypatch):
     assert captured.get("flow") == "promo.m"
     assert captured.get("controller_flow") == "promo.m"
     assert not thread.sent_messages
+
+
+def test_no_onboarding_logs_tab_writer_exists():
+    assert not hasattr(onboarding_sheets, "append_onboarding_event_log_row")
+    assert not hasattr(onboarding_sheets, "_resolve_onboarding_and_log_tab")
+
+
+def test_promo_ticket_parse_failure_writes_sheet_before_public_error(monkeypatch):
+    monkeypatch.setattr(thread_scopes, "is_welcome_parent", lambda _thread: False)
+    monkeypatch.setattr(thread_scopes, "is_promo_parent", lambda _thread: True)
+    thread = DummyThread("not-a-promo-ticket")
+    actor = SimpleNamespace(id=42, display_name="Recruit", bot=False)
+    events: list[str] = []
+    updates: list[dict[str, object]] = []
+
+    async def fake_locate(_thread):
+        return SimpleNamespace(id=555)
+
+    async def fake_send(content=None, **_kwargs):
+        events.append("send")
+        thread.sent_messages.append(content)
+
+    def fake_update(*_args, **kwargs):
+        events.append("sheet")
+        updates.append(kwargs)
+        return "updated"
+
+    async def fake_log(*_args, **_kwargs):
+        return None
+
+    thread.send = fake_send
+    monkeypatch.setattr(welcome_flow, "locate_welcome_message", fake_locate)
+    monkeypatch.setattr(welcome_flow, "extract_target_from_message", lambda _msg: (123, 555))
+    monkeypatch.setattr(welcome_flow.logs, "send_welcome_log", fake_log)
+    monkeypatch.setattr(welcome_flow.logs, "send_welcome_exception", fake_log)
+    monkeypatch.setattr(welcome_flow.onboarding_sheets, "update_ticket_finalization_state", fake_update)
+
+    asyncio.run(welcome_flow.start_welcome_dialog(thread, actor, source="button", bot=SimpleNamespace()))
+
+    assert events == ["sheet", "send"]
+    assert updates[0]["thread_id"] == thread.id
+    assert updates[0]["finalization_status"] == "pending_review"
+    assert updates[0]["finalization_note"] == "promo_ticket_parse_failed before dialog start"
+
+
+def test_promo_parser_accepts_context_rich_names(monkeypatch):
+    monkeypatch.setattr(thread_scopes, "is_welcome_parent", lambda _thread: False)
+    monkeypatch.setattr(thread_scopes, "is_promo_parent", lambda _thread: True)
+
+    result = welcome_flow.resolve_onboarding_flow(DummyThread("L0061-C1C WarWalker / C1C Cholula"))
+
+    assert result.flow == "promo.l"
+    assert result.ticket_code == "L0061"
+
+
+def test_promo_parser_accepts_ticket_code_with_optional_free_text():
+    examples = {
+        "L0061-C1C WarWalker / C1C Cholula": ("L", "0061", "L0061", "promo.l", "C1C WarWalker / C1C Cholula"),
+        "L0061 C1C WarWalker / C1C Cholula": ("L", "0061", "L0061", "promo.l", "C1C WarWalker / C1C Cholula"),
+        "L0061_C1C WarWalker / C1C Cholula": ("L", "0061", "L0061", "promo.l", "C1C WarWalker / C1C Cholula"),
+        "M0042-player name with spaces": ("M", "0042", "M0042", "promo.m", "player name with spaces"),
+        "R0188-Player.Name": ("R", "0188", "R0188", "promo.r", "Player.Name"),
+        "R0188-player/name": ("R", "0188", "R0188", "promo.r", "player/name"),
+        "M0042-player 😈": ("M", "0042", "M0042", "promo.m", "player 😈"),
+        "L0061": ("L", "0061", "L0061", "promo.l", ""),
+    }
+
+    for name, expected in examples.items():
+        result = welcome_flow.parse_promo_thread_name(name)
+
+        assert result is not None, name
+        assert (result.prefix, result.digits, result.ticket_code, result.promo_flow, result.display_text) == expected
+
+
+def test_context_rich_promo_thread_starts_dialog(monkeypatch):
+    monkeypatch.setattr(thread_scopes, "is_welcome_parent", lambda _thread: False)
+    monkeypatch.setattr(thread_scopes, "is_promo_parent", lambda _thread: True)
+
+    thread = DummyThread("L0061-C1C WarWalker / C1C Cholula")
+    actor = SimpleNamespace(id=42, display_name="Recruit", bot=False)
+    captured: dict[str, object] = {}
+
+    async def fake_locate(_thread):
+        return SimpleNamespace(id=555)
+
+    async def fake_log(*_args, **_kwargs):
+        captured.setdefault("logs", []).append(_kwargs)
+
+    class DummyController:
+        def __init__(self, _bot, *, flow: str):
+            self.flow = flow
+            self._panel_messages = {}
+            self._prefetched_panels = {}
+            self._sources = {}
+
+        async def run(self, *_args, **_kwargs):
+            captured["controller_flow"] = self.flow
+
+    monkeypatch.setattr(welcome_flow, "PromoController", DummyController)
+    monkeypatch.setattr(welcome_flow, "locate_welcome_message", fake_locate)
+    monkeypatch.setattr(welcome_flow, "extract_target_from_message", lambda _msg: (123, 555))
+    monkeypatch.setattr(welcome_flow.logs, "send_welcome_log", fake_log)
+    monkeypatch.setattr(welcome_flow.logs, "send_welcome_exception", fake_log)
+    monkeypatch.setattr(welcome_flow.logs, "log_onboarding_panel_lifecycle", fake_log)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda _name: True)
+    monkeypatch.setattr(onboarding_questions, "get_questions", lambda _flow: [object()])
+    monkeypatch.setattr(onboarding_questions, "schema_hash", lambda _flow: "schema")
+
+    asyncio.run(welcome_flow.start_welcome_dialog(thread, actor, source="ticket", bot=SimpleNamespace()))
+
+    assert captured["controller_flow"] == "promo.l"
+    assert not thread.sent_messages
+    assert all(log.get("reason") != "promo_ticket_parse_failed" for log in captured.get("logs", []))


### PR DESCRIPTION
### Motivation
- Improve robustness and observability when promo ticket threads cannot be parsed or context cannot be resolved by recording failures to the onboarding sheet and richer logs.
- Accept promo thread names that include free-form display text while preserving legacy behavior that exposes a display username for existing callers.
- Ensure user identity is recovered from session rows or intro messages when the promo sheet row is missing or out-of-date.

### Description
- Add `_log_promo_failure_row` to write promo failure finalization state to the onboarding sheet and to emit contextual logs when promo flows fail to resolve.
- Update `PromoTicketWatcher._ensure_context` to prefer session rows via `onboarding_sessions.get_by_thread_id`, attempt to find sheet rows by ticket id as well as thread id while tracking `found_source`, and populate `context.user_id` from session rows, sheet rows, or the welcome intro message; call `_log_promo_failure_row` when unresolved.
- Relax promo thread name parsing in `parse_promo_thread_name` to allow an optional free-text display tail, and change `PromoThreadNameParts` to include `prefix`, `digits`, `promo_flow`, and `display_text` while providing a legacy `username` property and returning `None` for `clan_tag`.
- In `welcome_flow`, use the new `parts.promo_flow` mapping in `resolve_onboarding_flow`, capture target user/message ids earlier, and add `_log_promo_failure_to_sheet` to record parse failures before notifying the channel.
- Update `onboarding.update_ticket_finalization_state` to populate an `updatedAt` column (if present) with the current UTC ISO timestamp when updating a finalization row.
- Add and update unit tests covering the new promo parsing behavior, failure-sheet writes, session-based user resolution, and defensive logging when sheet updates raise errors.

### Testing
- Ran onboarding unit tests in `tests/onboarding/test_watcher_sheet_logging.py` which include `test_promo_close_context_unresolved_writes_failure_log`, `test_promo_context_rich_thread_keeps_intro_target_user`, `test_promo_context_uses_session_row_by_thread_id`, and `test_promo_failure_no_row_found_logs_context_without_crashing`, and they passed.
- Ran onboarding unit tests in `tests/onboarding/test_welcome_flow_promo_flows.py` which include `test_promo_ticket_parse_failure_writes_sheet_before_public_error`, `test_promo_parser_accepts_context_rich_names`, `test_promo_parser_accepts_ticket_code_with_optional_free_text`, and `test_context_rich_promo_thread_starts_dialog`, and they passed.
- No integration or networked sheet calls were executed during tests because sheet operations are exercised via monkeypatches and `AsyncMock` stubs in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba70c223c832388a6549849a1160a)