### PR TITLE
Store Discord IDs as sheet-safe text and centralize promo reminder sheet touch

### DIFF
--- a/modules/onboarding/sessions.py
+++ b/modules/onboarding/sessions.py
@@ -77,9 +77,9 @@ class Session:
     # === Sheet persistence helpers ===
     def to_dict(self) -> dict[str, Any]:
         return {
-            "thread_id": self.thread_id,
-            "applicant_id": self.applicant_id,
-            "panel_message_id": self.panel_message_id,
+            "thread_id": str(self.thread_id),
+            "applicant_id": str(self.applicant_id),
+            "panel_message_id": str(self.panel_message_id or ""),
             "step_index": self.step_index,
             "answers": dict(self.answers),
             "completed": self.completed,
@@ -98,7 +98,7 @@ class Session:
             "user_id": str(self.applicant_id),
             "thread_id": str(self.thread_id),
             "thread_name": self.thread_name or "",
-            "panel_message_id": int(self.panel_message_id or 0),
+            "panel_message_id": str(self.panel_message_id or ""),
             "step_index": int(self.step_index),
             "answers": self.answers,
             "completed": bool(self.completed),
@@ -119,7 +119,7 @@ class Session:
             "user_id": str(self.applicant_id),
             "thread_id": str(self.thread_id),
             "thread_name": self.thread_name or "",
-            "panel_message_id": int(self.panel_message_id or 0),
+            "panel_message_id": str(self.panel_message_id or ""),
             "step_index": int(self.step_index),
             "answers": self.answers,
             "completed": bool(self.completed),

--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -1617,7 +1617,7 @@ class PromoTicketWatcher(commands.Cog):
 
         channel_id = get_promo_channel_id()
         if not channel_id:
-            line = log_lifecycle(
+            log_lifecycle(
                 log,
                 "promo",
                 "enabled",
@@ -1634,7 +1634,7 @@ class PromoTicketWatcher(commands.Cog):
             channel_id_int = int(channel_id)
         except (TypeError, ValueError):
             self.channel_id = None
-            line = log_lifecycle(
+            log_lifecycle(
                 log,
                 "promo",
                 "enabled",
@@ -1649,7 +1649,7 @@ class PromoTicketWatcher(commands.Cog):
         self.channel_id = channel_id_int
 
         if not feature_flags.is_enabled("promo_enabled"):
-            line = log_lifecycle(
+            log_lifecycle(
                 log,
                 "promo",
                 "enabled",
@@ -1661,7 +1661,7 @@ class PromoTicketWatcher(commands.Cog):
             return
 
         if not feature_flags.is_enabled("enable_promo_hook"):
-            line = log_lifecycle(
+            log_lifecycle(
                 log,
                 "promo",
                 "enabled",

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -423,15 +423,18 @@ async def persist_session_for_thread(
     append_session_row: bool = True,
 ) -> None:
     thread_id = int(getattr(thread, "id", 0))
-    thread_name = getattr(thread, "name", "")
+    thread_name = str(getattr(thread, "name", "") or "")
+    text_thread_id = str(thread_id)
+    text_user_id = str(user_id) if user_id is not None else ""
+    text_panel_message_id = str(panel_message_id) if panel_message_id is not None else ""
     created = _normalize_dt(created_at)
 
     try:
         onboarding_sessions.upsert_session(
-            thread_id=thread_id,
+            thread_id=text_thread_id,
             thread_name=thread_name,
-            user_id=user_id if user_id is not None else "",
-            panel_message_id=panel_message_id,
+            user_id=text_user_id,
+            panel_message_id=text_panel_message_id,
             updated_at=created,
         )
     except Exception:
@@ -1168,6 +1171,22 @@ async def _process_promo_thread(
 
     mention = f"<@{applicant_id}>"
     recruiter_ping = _recruiter_ping()
+
+    async def _touch_promo_reminder_sheet(*, phase: str, user_ref: str) -> None:
+        promo_watcher = bot.get_cog("PromoTicketWatcher")
+        if promo_watcher is None:
+            return
+        promo_context = await promo_watcher._ensure_context(thread)
+        if not promo_context:
+            return
+        await promo_watcher._touch_promo_sheet_for_reminder(
+            phase=phase,
+            thread=thread,
+            context=promo_context,
+            created_at=created_at,
+            user_ref=user_ref,
+        )
+
     if action == "reminder_empty":
         content = (
             f"Hey {mention}, your move request ticket is open but we haven't seen any details yet. "
@@ -1183,14 +1202,7 @@ async def _process_promo_thread(
             )
             return
         await _persist_reminder_state(session, action=action, timestamp=now)
-        if watcher and context:
-            await watcher._touch_promo_sheet_for_reminder(
-                phase="reminder_3h",
-                thread=thread,
-                context=context,
-                created_at=created_at,
-                user_ref=mention,
-            )
+        await _touch_promo_reminder_sheet(phase="reminder_3h", user_ref=mention)
         log.info(
             "promo empty reminder posted",
             extra={
@@ -1215,14 +1227,7 @@ async def _process_promo_thread(
             )
             return
         await _persist_reminder_state(session, action=action, timestamp=now)
-        if watcher and context:
-            await watcher._touch_promo_sheet_for_reminder(
-                phase="reminder_3h",
-                thread=thread,
-                context=context,
-                created_at=created_at,
-                user_ref=mention,
-            )
+        await _touch_promo_reminder_sheet(phase="reminder_3h", user_ref=mention)
         log.info(
             "promo incomplete reminder posted",
             extra={
@@ -1249,14 +1254,7 @@ async def _process_promo_thread(
             )
             return
         await _persist_reminder_state(session, action=action, timestamp=now)
-        if watcher and context:
-            await watcher._touch_promo_sheet_for_reminder(
-                phase="reminder_24h",
-                thread=thread,
-                context=context,
-                created_at=created_at,
-                user_ref=audience,
-            )
+        await _touch_promo_reminder_sheet(phase="reminder_24h", user_ref=audience)
         await _post_inactivity_log(
             bot,
             scope="promo",
@@ -1290,14 +1288,7 @@ async def _process_promo_thread(
             )
             return
         await _persist_reminder_state(session, action=action, timestamp=now)
-        if watcher and context:
-            await watcher._touch_promo_sheet_for_reminder(
-                phase="reminder_24h",
-                thread=thread,
-                context=context,
-                created_at=created_at,
-                user_ref=audience,
-            )
+        await _touch_promo_reminder_sheet(phase="reminder_24h", user_ref=audience)
         await _post_inactivity_log(
             bot,
             scope="promo",

--- a/shared/sheets/onboarding_sessions.py
+++ b/shared/sheets/onboarding_sessions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-import asyncio
 import json
 import logging
 from typing import Any, Dict, Iterable, Optional, Sequence
@@ -38,6 +37,17 @@ _REQUIRED_COLUMNS = {"thread_id", "thread_name", "updated_at"}
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _id_text(value: Any) -> str:
+    """Return a Discord snowflake value as sheet-safe text."""
+
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text in {"", "0"}:
+        return ""
+    return text
 
 
 def _sheet():
@@ -269,7 +279,7 @@ def upsert_session(
         "thread_id": str(thread_id),
         "thread_name": thread_name,
         "user_id": str(user_id),
-        "panel_message_id": panel_message_id,
+        "panel_message_id": _id_text(panel_message_id),
         "step_index": 0,
         "completed": False,
         "completed_at": None,
@@ -394,10 +404,9 @@ def _record_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     return {
         "thread_name": str(payload.get("thread_name") or ""),
-        "user_id": str(payload.get("user_id") or ""),
-        "thread_id": str(payload.get("thread_id") or ""),
-        "panel_message_id": _safe_int(payload.get("panel_message_id"), default="")
-        or "",
+        "user_id": _id_text(payload.get("user_id")),
+        "thread_id": _id_text(payload.get("thread_id")),
+        "panel_message_id": _id_text(payload.get("panel_message_id")),
         "step_index": _safe_int(payload.get("step_index"), default=0) or 0,
         "completed": completed_flag,
         "completed_at": completed_at_value,
@@ -407,22 +416,19 @@ def _record_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "first_reminder_at": reminder_at,
         "warning_sent_at": warning_at,
         "auto_closed_at": auto_closed_at,
-        "recruiter_summary_message_id": _safe_int(
-            payload.get("recruiter_summary_message_id"), default=""
-        )
-        or "",
-        "recruiter_summary_posted_at": payload.get("recruiter_summary_posted_at") or "",
-        "recruiter_summary_player_id": str(
-            payload.get("recruiter_summary_player_id") or ""
+        "recruiter_summary_message_id": _id_text(
+            payload.get("recruiter_summary_message_id")
         ),
-        "summary_screenshot_prompt_message_id": _safe_int(
-            payload.get("summary_screenshot_prompt_message_id"), default=""
-        )
-        or "",
-        "summary_screenshot_prompt_summary_message_id": _safe_int(
-            payload.get("summary_screenshot_prompt_summary_message_id"), default=""
-        )
-        or "",
+        "recruiter_summary_posted_at": payload.get("recruiter_summary_posted_at") or "",
+        "recruiter_summary_player_id": _id_text(
+            payload.get("recruiter_summary_player_id")
+        ),
+        "summary_screenshot_prompt_message_id": _id_text(
+            payload.get("summary_screenshot_prompt_message_id")
+        ),
+        "summary_screenshot_prompt_summary_message_id": _id_text(
+            payload.get("summary_screenshot_prompt_summary_message_id")
+        ),
     }
 
 

--- a/tests/onboarding/test_onboarding_sessions_mapping.py
+++ b/tests/onboarding/test_onboarding_sessions_mapping.py
@@ -37,6 +37,39 @@ def test_onboarding_sessions_row_mapping(monkeypatch, headers):
     assert row[headers.index("auto_closed_at")] == ""
 
 
+def test_onboarding_sessions_discord_ids_are_sheet_safe_text(headers):
+    snowflake = "1523691234567890123"
+    payload = {
+        "thread_name": "R1234-smurf",
+        "user_id": int(snowflake),
+        "thread_id": snowflake,
+        "panel_message_id": 1523691234567890456,
+        "recruiter_summary_message_id": 1523691234567890789,
+        "recruiter_summary_player_id": 1523691234567890111,
+        "summary_screenshot_prompt_message_id": 1523691234567890222,
+        "summary_screenshot_prompt_summary_message_id": 1523691234567890333,
+    }
+
+    row = sheet_module.build_row(payload, headers=headers)
+
+    for column in (
+        "user_id",
+        "thread_id",
+        "panel_message_id",
+        "recruiter_summary_message_id",
+        "recruiter_summary_player_id",
+        "summary_screenshot_prompt_message_id",
+        "summary_screenshot_prompt_summary_message_id",
+    ):
+        value = row[headers.index(column)]
+        assert isinstance(value, str)
+        assert value.isdecimal()
+        assert "e" not in value.lower()
+
+    assert row[headers.index("thread_name")] == "R1234-smurf"
+    assert row[headers.index("thread_id")] == snowflake
+
+
 class _FakeSheet:
     def __init__(self, rows):
         self._rows = rows

--- a/tests/onboarding/test_watcher_welcome_sessions.py
+++ b/tests/onboarding/test_watcher_welcome_sessions.py
@@ -9,13 +9,14 @@ from modules.onboarding import watcher_welcome
 
 
 class DummyThread:
-    def __init__(self, name: str, thread_id: int = 4242) -> None:
+    def __init__(self, name: str, thread_id: int = 4242, panel_message_id: int = 9999) -> None:
         self.name = name
         self.id = thread_id
+        self.panel_message_id = panel_message_id
         self.parent = SimpleNamespace()
 
     async def send(self, *_args, **_kwargs):  # pragma: no cover - patched behavior verified via outcome
-        return SimpleNamespace(id=9999)
+        return SimpleNamespace(id=self.panel_message_id)
 
 
 @pytest.fixture(autouse=True)
@@ -68,9 +69,9 @@ def test_welcome_trigger_creates_session(monkeypatch):
     assert saved
     payload = saved[0]
     assert payload["thread_name"] == "W0603-smurf"
-    assert payload["thread_id"] == 4242
-    assert payload["user_id"] == 12345
-    assert payload["panel_message_id"] == 9999
+    assert payload["thread_id"] == "4242"
+    assert payload["user_id"] == "12345"
+    assert payload["panel_message_id"] == "9999"
     assert payload["step_index"] == 0
     assert payload["completed"] is False
     assert payload["answers"] == {}
@@ -87,10 +88,13 @@ def test_promo_trigger_creates_session(monkeypatch):
 
     monkeypatch.setattr(watcher_welcome.onboarding_sessions, "upsert_session", _record)
 
-    thread = DummyThread("R1234-smurf")
+    thread_id = 1523691234567890123
+    user_id = 1523691234567890456
+    panel_message_id = 1523691234567890789
+    thread = DummyThread("R1234-smurf", thread_id=thread_id, panel_message_id=panel_message_id)
     trigger_message = SimpleNamespace(
-        mentions=[SimpleNamespace(id=67890)],
-        content="✅ Promo ticket <@67890>",
+        mentions=[SimpleNamespace(id=user_id)],
+        content=f"✅ Promo ticket <@{user_id}>",
     )
 
     outcome = asyncio.run(
@@ -103,13 +107,13 @@ def test_promo_trigger_creates_session(monkeypatch):
         )
     )
 
-    assert outcome.panel_message_id == 9999
+    assert outcome.panel_message_id == panel_message_id
     assert saved
     payload = saved[0]
     assert payload["thread_name"] == "R1234-smurf"
-    assert payload["thread_id"] == 4242
-    assert payload["user_id"] == 67890
-    assert payload["panel_message_id"] == 9999
+    assert payload["thread_id"] == str(thread_id)
+    assert payload["user_id"] == str(user_id)
+    assert payload["panel_message_id"] == str(panel_message_id)
     assert payload["step_index"] == 0
     assert payload["completed"] is False
     assert payload["answers"] == {}
@@ -171,7 +175,7 @@ def test_explicit_subject_user_id_used_when_present(monkeypatch):
     assert outcome.panel_message_id == 9999
     assert saved
     payload = saved[0]
-    assert payload["user_id"] == 77777
+    assert payload["user_id"] == "77777"
 
 
 def test_welcome_session_saves_subject_not_actor(monkeypatch):
@@ -200,5 +204,5 @@ def test_welcome_session_saves_subject_not_actor(monkeypatch):
     assert outcome.panel_message_id == 9999
     assert saved
     payload = saved[0]
-    assert payload["user_id"] == 44444
-    assert payload["thread_id"] == thread.id
+    assert payload["user_id"] == "44444"
+    assert payload["thread_id"] == str(thread.id)


### PR DESCRIPTION
### Motivation

- Prevent loss or formatting of large Discord snowflake IDs when persisting sessions to sheets by ensuring IDs are stored as text. 
- Avoid duplicated logic for touching the promo reminder sheet and simplify reminder code paths.

### Description

- Add `_id_text` helper in `shared/sheets/onboarding_sessions.py` and use it to serialize all Discord ID fields into sheet-safe text values instead of raw integers. 
- Convert ID fields to strings in session persistence paths by updating `Session.to_dict`, `Session.save_to_sheet`, `Session.asave_to_sheet`, and `persist_session_for_thread` to pass `str(...)`/text values for `thread_id`, `user_id`/`applicant_id`, and `panel_message_id`. 
- Update `_record_from_payload` mappings to emit string IDs for `user_id`, `thread_id`, `panel_message_id`, `recruiter_summary_message_id`, `recruiter_summary_player_id`, and summary prompt IDs. 
- Introduce a helper `async def _touch_promo_reminder_sheet` inside `_process_promo_thread` in `modules/onboarding/watcher_promo.py` and replace multiple duplicated `watcher._touch_promo_sheet_for_reminder` calls with centralized calls to this helper. 
- Remove unused assignment of `line =` for several `log_lifecycle(...)` invocations. 
- Update and add tests to reflect stringified ID behavior and to validate that sheet rows contain decimal string IDs (new test `test_onboarding_sessions_discord_ids_are_sheet_safe_text`).

### Testing

- Ran the onboarding unit tests including `tests/onboarding/test_onboarding_sessions_mapping.py` and `tests/onboarding/test_watcher_welcome_sessions.py`, and the modified/new tests passed. 
- The updated mapping and session persistence tests executed successfully and validated stringified ID behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bb818fb088323b5cdad505d34d1ea)