### PR TITLE
Add canonical Milestones Config resolver and migrate sheet access to async with improved logging and suppression

### DIFF
--- a/cogs/housekeeping_c1c_ad.py
+++ b/cogs/housekeeping_c1c_ad.py
@@ -28,16 +28,33 @@ class C1CAdCog(commands.Cog):
     async def c1cad(self, ctx: commands.Context) -> None:
         try:
             result = await run_c1c_ad_job(self.bot, trigger="manual", force=True)
-        except Exception:
-            log.exception("C1C ad manual refresh failed")
-            await ctx.send(
-                "C1C ad update failed. Please check the bot logs for details."
+        except Exception as exc:
+            author = getattr(ctx, "author", None)
+            guild = getattr(ctx, "guild", None)
+            channel = getattr(ctx, "channel", None)
+            log.exception(
+                "C1C ad manual refresh failed",
+                extra={
+                    "command": "c1cad",
+                    "operation": "manual_refresh",
+                    "actor_id": getattr(author, "id", None),
+                    "actor_name": str(author) if author is not None else None,
+                    "guild_id": getattr(guild, "id", None),
+                    "guild_name": getattr(guild, "name", None),
+                    "channel_id": getattr(channel, "id", None),
+                    "channel_name": getattr(channel, "name", None),
+                    "exception_type": type(exc).__name__,
+                    "exception_message": str(exc),
+                },
             )
+            await ctx.send("C1C ad update failed due to a config, sheet, cache, or posting error.")
             return
         if result.status == "success":
             await ctx.send("C1C recruitment ad refreshed.")
         elif result.message == "feature toggle off":
             await ctx.send("C1C recruitment ad is disabled by feature toggle.")
+        elif result.status == "failed":
+            await ctx.send(f"C1C recruitment ad failed: {result.message}.")
         else:
             await ctx.send(f"C1C recruitment ad skipped: {result.message}.")
 

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -61,6 +61,7 @@ Missing any **Required** key causes the bot to exit with an error at startup. If
 | `ONBOARDING_SHEET_ID` | string | — | Google Sheet ID for onboarding trackers. |
 | `REMINDER_SHEET_ID` | string | — | Google Sheet ID for reminders (service-specific). |
 | `MILESTONES_SHEET_ID` | string | — | Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific). |
+| `MILESTONES_CONFIG_TAB` | string | required | Deployment checklist: set `MILESTONES_CONFIG_TAB=Config` in Render for prod before deploy if it is not already configured. |
 | `RECRUITMENT_CONFIG_TAB` | string | `Config` | Worksheet name containing recruitment config. |
 | `ONBOARDING_CONFIG_TAB` | string | `Config` | Worksheet name containing onboarding config. |
 | `WORKSHEET_NAME` | string | `bot_info` | Fallback for the `clans_tab` worksheet when sheet config is missing. |
@@ -307,6 +308,9 @@ Feature Toggles:
 - `welcome_watcher_enabled`, `promo_watcher_enabled`, `resume_command_enabled` — gate onboarding watcher registration and `!onb resume`; these default to ON when rows are missing so existing deployments remain unchanged.
 
 ### Milestones sheet keys
+
+Deployment checklist: set `MILESTONES_CONFIG_TAB=Config` in Render for prod before deploy if it is not already configured. The canonical Milestones Config resolver intentionally does not hardcode or fall back to `Config`.
+
 - `SHARD_MERCY_TAB` — worksheet name that stores the Shard & Mercy tracker rows
   inside `MILESTONES_SHEET_ID`. No defaults; the config tab must provide the
   exact tab name.

--- a/modules/community/fusion/reminders.py
+++ b/modules/community/fusion/reminders.py
@@ -33,11 +33,33 @@ _DEDUP_DEGRADED_SINCE_MONOTONIC: float = 0.0
 _DEDUP_DEGRADED_ALERTED_KEYS: set[tuple[str, str]] = set()
 _DEDUP_DEGRADED_ALERT_AFTER_SEC = 600.0
 _SENT_KEYS_CACHE: dict[str, tuple[float, set[tuple[str, str]]]] = {}
+_SETTINGS_FAILURE_STATE: dict[str, object] = {"key": None, "failures": 0}
 
 _DEDUPE_SKIP_WARNING = (
     "fusion grouped reminders skipped because sent-reminder dedupe could not be verified"
 )
 
+
+
+def _settings_failure_key(exc: BaseException) -> str:
+    return f"reminders:{_GROUPED_REMINDER_TYPE}:load_fusion_reminder_settings:{type(exc).__name__}:{str(exc)}"
+
+def _should_report_settings_failure(exc: BaseException) -> bool:
+    key = _settings_failure_key(exc)
+    previous = _SETTINGS_FAILURE_STATE.get("key")
+    if previous == key:
+        _SETTINGS_FAILURE_STATE["failures"] = int(_SETTINGS_FAILURE_STATE.get("failures") or 0) + 1
+        return False
+    _SETTINGS_FAILURE_STATE.update({"key": key, "failures": 1})
+    return True
+
+def _record_settings_success() -> None:
+    if _SETTINGS_FAILURE_STATE.get("key"):
+        log.info(
+            "fusion grouped reminder settings recovered",
+            extra={"component": "fusion_reminders", "operation": "load_fusion_reminder_settings", "suppressed_failures": _SETTINGS_FAILURE_STATE.get("failures")},
+        )
+    _SETTINGS_FAILURE_STATE.update({"key": None, "failures": 0})
 
 def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
     if now is None:
@@ -200,45 +222,38 @@ async def _load_grouped_settings_with_retry(
         try:
             coro = fusion_sheets.get_fusion_reminder_settings(now=reference)
             if _SETTINGS_LOAD_TIMEOUT_SEC > 0:
-                return await asyncio.wait_for(coro, timeout=_SETTINGS_LOAD_TIMEOUT_SEC)
-            return await coro
-        except TimeoutError as exc:
+                result = await asyncio.wait_for(coro, timeout=_SETTINGS_LOAD_TIMEOUT_SEC)
+            else:
+                result = await coro
+            _record_settings_success()
+            return result
+        except (TimeoutError, Exception) as exc:
             last_exc = exc
-            context = _settings_unavailable_context(
-                target=target, attempt=attempt, max_attempts=max_attempts, exc=exc
-            )
-            log.warning(
-                "fusion grouped reminder settings unavailable; retrying"
-                if attempt < max_attempts
-                else "fusion grouped reminders skipped because settings could not be verified",
-                extra=context,
-            )
-        except Exception as exc:
-            last_exc = exc
-            context = _settings_unavailable_context(
-                target=target, attempt=attempt, max_attempts=max_attempts, exc=exc
-            )
-            log.warning(
-                "fusion grouped reminder settings unavailable; retrying"
-                if attempt < max_attempts
-                else "fusion grouped reminders skipped because settings could not be verified",
-                extra=context,
-                exc_info=True,
-            )
-        if attempt < max_attempts and _SETTINGS_LOAD_RETRY_DELAY_SEC > 0:
-            await asyncio.sleep(_SETTINGS_LOAD_RETRY_DELAY_SEC)
+            if attempt < max_attempts and _SETTINGS_LOAD_RETRY_DELAY_SEC > 0:
+                await asyncio.sleep(_SETTINGS_LOAD_RETRY_DELAY_SEC)
 
     if last_exc is not None:
         context = _settings_unavailable_context(
             target=target, attempt=max_attempts, max_attempts=max_attempts, exc=last_exc
         )
-        await fusion_logs.send_ops_alert(
-            component="reminders",
-            summary="grouped_settings_unavailable_reminders_skipped",
-            dedupe_key=f"fusion:grouped_reminders:settings:{target.fusion_id}",
-            error=last_exc,
-            fields=context,
-        )
+        if _should_report_settings_failure(last_exc):
+            log.warning(
+                "fusion grouped reminders skipped because settings could not be verified",
+                extra=context,
+                exc_info=not isinstance(last_exc, TimeoutError),
+            )
+            await fusion_logs.send_ops_alert(
+                component="reminders",
+                summary="grouped_settings_unavailable_reminders_skipped",
+                dedupe_key=f"fusion:grouped_reminders:settings:{target.fusion_id}:{type(last_exc).__name__}:{last_exc}",
+                error=last_exc,
+                fields=context,
+            )
+        else:
+            log.info(
+                "repeated fusion grouped reminder settings failure suppressed",
+                extra={**context, "suppressed_failures": _SETTINGS_FAILURE_STATE.get("failures")},
+            )
     return None
 
 
@@ -339,7 +354,7 @@ def _select_grouped_events(
 
 
 async def _load_grouped_sent_keys(target: fusion_sheets.FusionRow) -> tuple[set[tuple[str, str]] | None, bool]:
-    dedupe_meta = fusion_sheets.reminder_dedupe_backend_metadata()
+    dedupe_meta = await fusion_sheets.areminder_dedupe_backend_metadata()
     dedupe_backend = dedupe_meta.get("backend_type", "unknown")
     dedupe_tab = dedupe_meta.get("tab_name", "")
     dedupe_config_key = dedupe_meta.get("config_key", "")
@@ -619,7 +634,7 @@ async def process_fusion_reminders(
         await _maybe_alert_prolonged_dedupe_degradation(
             target.fusion_id,
             reminder_type=_GROUPED_REMINDER_TYPE,
-            backend=fusion_sheets.reminder_dedupe_backend_metadata().get("backend_type", "unknown"),
+            backend=(await fusion_sheets.areminder_dedupe_backend_metadata()).get("backend_type", "unknown"),
         )
         return
     grouped_event_id = _grouped_event_id_for_date(reference.date())
@@ -628,7 +643,7 @@ async def process_fusion_reminders(
     await _maybe_alert_prolonged_dedupe_degradation(
         target.fusion_id,
         reminder_type=_GROUPED_REMINDER_TYPE,
-        backend=fusion_sheets.reminder_dedupe_backend_metadata().get("backend_type", "unknown"),
+        backend=(await fusion_sheets.areminder_dedupe_backend_metadata()).get("backend_type", "unknown"),
     )
     if grouped_key in sent_keys or memory_key in _MEMORY_SENT_KEYS:
         return

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -16,9 +16,10 @@ from modules.common import feature_flags
 from modules.common import runtime as rt
 from modules.community.reset_reminders.models import ResetReminder
 from modules.community.reset_reminders.views import ResetReminderView
-from shared.config import cfg, get_milestones_sheet_id
+from shared.config import get_milestones_sheet_id
 from shared.dedupe import EventDeduper
 from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
+from shared.sheets import milestones_config
 
 if TYPE_CHECKING:
     from modules.common.runtime import Runtime
@@ -86,11 +87,8 @@ def _sheet_id() -> str:
     return sheet_id
 
 
-def _tab_name() -> str:
-    tab_name = str(cfg.get(_RESET_REMINDER_TAB_KEY) or "").strip()
-    if not tab_name:
-        raise RuntimeError(f"{_RESET_REMINDER_TAB_KEY} missing in milestones Config tab")
-    return tab_name
+async def _tab_name() -> str:
+    return await milestones_config.arequire_value(_RESET_REMINDER_TAB_KEY)
 
 
 def _cell(row: list[Any], index: int) -> str:
@@ -147,7 +145,7 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
     started = time.monotonic()
     tab_name = "unknown"
     try:
-        tab_name = _tab_name()
+        tab_name = await _tab_name()
         sheet_id = _sheet_id()
         stage = "sheet_fetch"
         log.info("reset reminder sheet load started", extra={"tab": tab_name, "active_only": active_only})
@@ -162,17 +160,6 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
         setattr(exc, "reset_reminder_stage", stage)
         setattr(exc, "reset_reminder_tab", tab_name)
         setattr(exc, "reset_reminder_elapsed", elapsed)
-        log.exception(
-            "reset reminder load failed",
-            extra={
-                "scheduler": "reset_reminders",
-                "config_key": _RESET_REMINDER_TAB_KEY,
-                "tab": tab_name,
-                "operation": stage,
-                "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
-                "elapsed_s": round(elapsed, 3),
-            },
-        )
         raise
     records: list[_ResetReminderRecord] = []
     invalid_rows: list[dict[str, Any]] = []
@@ -364,7 +351,7 @@ async def _send_ops_log(message: str) -> None:
 def _load_failure_key(exc: Exception) -> str:
     stage = getattr(exc, "reset_reminder_stage", "unknown")
     tab = getattr(exc, "reset_reminder_tab", "unknown")
-    return f"{type(exc).__name__}:{stage}:{tab}"
+    return f"reset_reminders:{_RESET_REMINDER_TAB_KEY}:{stage}:{tab}:{type(exc).__name__}:{str(exc)}"
 
 
 async def _record_load_failure(exc: Exception) -> None:
@@ -378,18 +365,21 @@ async def _record_load_failure(exc: Exception) -> None:
     stage = getattr(exc, "reset_reminder_stage", "unknown")
     tab = getattr(exc, "reset_reminder_tab", "unknown")
     elapsed = getattr(exc, "reset_reminder_elapsed", None)
-    log.exception(
-        "failed to load reset reminders; scheduler tick skipped",
-        extra={
-            "scheduler": "reset_reminders",
-            "config_key": _RESET_REMINDER_TAB_KEY,
-            "tab": tab,
-            "operation": stage,
-            "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
-            "elapsed_s": round(float(elapsed), 3) if isinstance(elapsed, (int, float)) else None,
-            "failure_count": state["failures"],
-        },
-    )
+    log_extra = {
+        "scheduler": "reset_reminders",
+        "config_key": _RESET_REMINDER_TAB_KEY,
+        "tab": tab,
+        "operation": stage,
+        "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
+        "elapsed_s": round(float(elapsed), 3) if isinstance(elapsed, (int, float)) else None,
+        "failure_count": state["failures"],
+        "exception_type": type(exc).__name__,
+        "exception_message": str(exc),
+    }
+    if previous_key != key or int(state["failures"]) == 1:
+        log.error("failed to load reset reminders; scheduler tick skipped", extra=log_extra, exc_info=(type(exc), exc, exc.__traceback__))
+    else:
+        log.info("repeated reset reminder load failure suppressed", extra=log_extra)
 
     last_alert = float(state.get("last_alert") or 0.0)
     should_send = int(state["failures"]) >= _LOAD_FAILURE_ALERT_THRESHOLD and (

--- a/modules/community/shard_tracker/data.py
+++ b/modules/community/shard_tracker/data.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Sequence
 
 from shared.config import cfg as runtime_config, get_milestones_sheet_id
-from shared.sheets import async_core
+from shared.sheets import async_core, milestones_config
 
 log = logging.getLogger("c1c.shards.data")
 _CONFIG_LOG_EMITTED = False
@@ -231,8 +231,15 @@ class ShardSheetStore:
                 return self._config_cache
 
             sheet_id = (get_milestones_sheet_id() or "").strip()
-            tab_value = _config_value("shard_mercy_tab", "")
-            tab_name = str(tab_value or "").strip()
+            try:
+                tab_name = await milestones_config.arequire_value("SHARD_MERCY_TAB")  # shard_mercy_tab
+            except milestones_config.MilestonesConfigError as exc:
+                log.warning(
+                    "shard tracker config resolution failed",
+                    extra=exc.context(component="shard_tracker", operation="resolve_tab"),
+                    exc_info=True,
+                )
+                raise ShardTrackerConfigError(str(exc)) from exc
 
             raw_env = (os.getenv("SHARD_MERCY_CHANNEL_ID") or "").strip()
             env_channel_id = _parse_channel_id(raw_env)
@@ -255,10 +262,7 @@ class ShardSheetStore:
             )
 
             if not sheet_id:
-                raise ShardTrackerConfigError("MILESTONES_SHEET_ID missing")
-
-            if not tab_name:
-                raise ShardTrackerConfigError("SHARD_MERCY_TAB missing in milestones Config tab")
+                raise ShardTrackerConfigError("milestones sheet ID unavailable")
 
             if channel_id <= 0:
                 raise ShardTrackerConfigError("SHARD_MERCY_CHANNEL_ID missing or invalid")

--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -10,6 +10,7 @@ import discord
 
 from modules.common import feature_flags
 from shared.sheets import core as sheets_core
+from shared.sheets import async_core
 from shared.sheets import recruitment
 from shared.sheets.recruitment import afetch_reports_tab
 from shared.sheets.export_utils import ImageExportError, export_pdf_as_png, get_tab_gid
@@ -96,13 +97,7 @@ def _header_map(headers: list[Any]) -> dict[str, int]:
     }
 
 
-def _resolve_config() -> tuple[C1CAdConfig | None, str | None]:
-    values: dict[str, str] = {}
-    for key in CONFIG_KEYS:
-        value = recruitment.get_config_value(key, None)
-        if not value:
-            return None, f"missing Config key {key}"
-        values[key] = value
+def _build_config(values: Mapping[str, str]) -> tuple[C1CAdConfig | None, str | None]:
     try:
         text_row = int(values["C1C_AD_TEXT_ROW"])
         thread_id = int(values["C1C_AD_TARGET_THREAD_ID"])
@@ -126,6 +121,26 @@ def _resolve_config() -> tuple[C1CAdConfig | None, str | None]:
     )
 
 
+def _resolve_config() -> tuple[C1CAdConfig | None, str | None]:
+    values: dict[str, str] = {}
+    for key in CONFIG_KEYS:
+        value = recruitment.get_config_value(key, None)
+        if not value:
+            return None, f"missing Config key {key}"
+        values[key] = value
+    return _build_config(values)
+
+
+async def _resolve_config_async() -> tuple[C1CAdConfig | None, str | None]:
+    values: dict[str, str] = {}
+    for key in CONFIG_KEYS:
+        value = await recruitment.get_config_value_async(key, None)
+        if not value:
+            return None, f"missing Config key {key}"
+        values[key] = value
+    return _build_config(values)
+
+
 def _get_sheet_id() -> tuple[str | None, str | None]:
     sheet_id = recruitment.get_recruitment_sheet_id()
     if not sheet_id:
@@ -133,11 +148,13 @@ def _get_sheet_id() -> tuple[str | None, str | None]:
     return sheet_id, None
 
 
-def _read_text_row(
+async def _read_text_row(
     sheet_id: str, config: C1CAdConfig
 ) -> tuple[dict[str, str] | None, dict[str, int] | None, str | None]:
     values = (
-        sheets_core.sheets_read(sheet_id, f"{config.text_tab}!1:{config.text_row}")
+        await async_core.a_to_thread_with_backoff(
+            sheets_core.sheets_read, sheet_id, f"{config.text_tab}!1:{config.text_row}"
+        )
         or []
     )
     if not values:
@@ -155,13 +172,15 @@ def _read_text_row(
     return row, headers, None
 
 
-def _write_status(
+async def _write_status(
     sheet_id: str,
     config: C1CAdConfig,
     headers: Mapping[str, int],
     updates: Mapping[str, str],
 ) -> None:
-    worksheet = sheets_core.get_worksheet(sheet_id, config.text_tab)
+    worksheet = await async_core.a_to_thread_with_backoff(
+        sheets_core.get_worksheet, sheet_id, config.text_tab
+    )
     cells = []
     for header, value in updates.items():
         col = headers.get(header)
@@ -171,7 +190,9 @@ def _write_status(
             {"range": f"{_column_letter(col)}{config.text_row}", "values": [[value]]}
         )
     if cells:
-        sheets_core.call_with_backoff(worksheet.batch_update, cells)
+        await async_core.a_to_thread_with_backoff(
+            sheets_core.call_with_backoff, worksheet.batch_update, cells
+        )
 
 
 def _normalize_header(label: str) -> str:
@@ -266,8 +287,8 @@ def _split_brackets(value: str) -> list[str]:
     return [part.strip() for part in str(value or "").split(",") if part.strip()]
 
 
-def _get_reports_tab_name_required() -> str:
-    tab_name = recruitment.get_config_value("REPORTS_TAB", None)
+async def _get_reports_tab_name_required() -> str:
+    tab_name = await async_core.a_to_thread_with_backoff(recruitment.get_config_value, "REPORTS_TAB", None)
     if not str(tab_name or "").strip():
         raise ValueError("reports tab config missing")
     return str(tab_name).strip()
@@ -317,7 +338,7 @@ async def _resolve_dynamic_placeholders(ad_text: str, row: Mapping[str, str]) ->
     if not empty_text:
         raise ValueError("open_spots_empty_text empty")
 
-    tab_name = _get_reports_tab_name_required()
+    tab_name = await _get_reports_tab_name_required()
     try:
         stats_rows = await afetch_reports_tab(tab_name)
     except Exception as exc:
@@ -366,6 +387,29 @@ def _due_for_refresh(
     return now - last >= dt.timedelta(days=refresh_days)
 
 
+def _log_job_failure(
+    reason: str,
+    *,
+    operation: str,
+    config_key: str | None = None,
+    sheet_tab: str | None = None,
+    target_thread_id: int | None = None,
+    exc: BaseException | None = None,
+) -> None:
+    extra = {
+        "operation": operation,
+        "config_key": config_key,
+        "sheet_tab": sheet_tab,
+        "target_thread_id": target_thread_id,
+        "exception_type": type(exc).__name__ if exc is not None else None,
+        "exception_message": str(exc) if exc is not None else None,
+    }
+    if exc is not None:
+        log.exception("❌ C1C ad failed: %s", reason, extra=extra)
+    else:
+        log.error("❌ C1C ad failed: %s", reason, extra=extra)
+
+
 async def _resolve_thread(bot: discord.Client, thread_id: int) -> Any | None:
     channel = bot.get_channel(thread_id)
     if channel is None:
@@ -410,7 +454,7 @@ async def run_c1c_ad_job(
         log.info("⚠️ C1C ad skipped: feature toggle off")
         return C1CAdResult("skipped", "feature toggle off")
 
-    config, error = _resolve_config()
+    config, error = await _resolve_config_async()
     if config is None:
         log.warning("⚠️ C1C ad skipped: %s", error)
         return C1CAdResult("skipped", str(error))
@@ -419,7 +463,7 @@ async def run_c1c_ad_job(
         log.warning("⚠️ C1C ad skipped: %s", error)
         return C1CAdResult("skipped", str(error))
 
-    row, headers, error = _read_text_row(sheet_id, config)
+    row, headers, error = await _read_text_row(sheet_id, config)
     if row is None or headers is None:
         log.warning("⚠️ C1C ad skipped: %s", error)
         return C1CAdResult("skipped", str(error))
@@ -429,8 +473,8 @@ async def run_c1c_ad_job(
         log.info("⚠️ C1C ad skipped: refresh not due")
         return C1CAdResult("skipped", "refresh not due")
 
-    def fail(reason: str) -> C1CAdResult:
-        _write_status(
+    async def fail(reason: str) -> C1CAdResult:
+        await _write_status(
             sheet_id,
             config,
             headers,
@@ -440,11 +484,16 @@ async def run_c1c_ad_job(
                 "updated_at_utc": _timestamp(now),
             },
         )
-        log.error("❌ C1C ad failed: %s", reason)
+        _log_job_failure(
+            reason,
+            operation="write_failure_status",
+            sheet_tab=config.text_tab,
+            target_thread_id=config.target_thread_id,
+        )
         return C1CAdResult("failed", reason)
 
-    def fail_resolved_text_too_long(char_count: int) -> C1CAdResult:
-        _write_status(
+    async def fail_resolved_text_too_long(char_count: int) -> C1CAdResult:
+        await _write_status(
             sheet_id,
             config,
             headers,
@@ -458,26 +507,31 @@ async def run_c1c_ad_job(
             "❌ C1C ad failed: resolved ad text exceeds Discord limit chars=%s limit=%s",
             char_count,
             DISCORD_TEXT_LIMIT,
+            extra={
+                "operation": "validate_resolved_text",
+                "sheet_tab": config.text_tab,
+                "target_thread_id": config.target_thread_id,
+            },
         )
         return C1CAdResult("failed", RESOLVED_TEXT_TOO_LONG_ERROR)
 
     ad_text = str(row.get("ad_text", "")).strip()
     if not ad_text:
-        return fail("ad_text empty")
+        return await fail("ad_text empty")
 
     try:
         ad_text = await _resolve_dynamic_placeholders(ad_text, row)
     except ValueError as exc:
-        return fail(str(exc))
+        return await fail(str(exc))
 
     resolved_text_length = len(ad_text)
     if resolved_text_length > DISCORD_TEXT_LIMIT:
-        return fail_resolved_text_too_long(resolved_text_length)
+        return await fail_resolved_text_too_long(resolved_text_length)
 
     if ":" not in config.image_range:
-        return fail("image range invalid")
+        return await fail("image range invalid")
     try:
-        gid = get_tab_gid(sheet_id, config.image_tab)
+        gid = await async_core.a_to_thread_with_backoff(get_tab_gid, sheet_id, config.image_tab)
         png_bytes = await export_pdf_as_png(
             sheet_id,
             gid,
@@ -492,17 +546,24 @@ async def run_c1c_ad_job(
             crop_to_content=True,
         )
     except ImageExportError as exc:
-        return fail(str(exc))
-    except Exception:
-        log.exception("❌ C1C ad failed: image render exception")
-        return fail("image render failed")
+        return await fail(str(exc))
+    except Exception as exc:
+        _log_job_failure(
+            "image render failed",
+            operation="render_image",
+            config_key="C1C_AD_TAB",
+            sheet_tab=config.image_tab,
+            target_thread_id=config.target_thread_id,
+            exc=exc,
+        )
+        return await fail("image render failed")
     if not png_bytes:
-        return fail("image render failed")
+        return await fail("image render failed")
 
     channel = await _resolve_thread(bot, config.target_thread_id)
     if channel is None:
         reason = f"target thread not found thread_id={config.target_thread_id}"
-        _write_status(
+        await _write_status(
             sheet_id,
             config,
             headers,
@@ -512,30 +573,30 @@ async def run_c1c_ad_job(
                 "updated_at_utc": _timestamp(now),
             },
         )
-        log.warning("⚠️ C1C ad skipped: %s", reason)
+        log.warning("⚠️ C1C ad skipped: %s", reason, extra={"operation": "resolve_target_thread", "target_thread_id": config.target_thread_id})
         return C1CAdResult("skipped", reason)
 
     await _delete_old_messages(channel, row)
     try:
         text_message = await channel.send(ad_text)
-    except Exception:
-        log.exception("❌ C1C ad failed: Discord text post failed")
-        return fail("Discord post failed")
+    except Exception as exc:
+        _log_job_failure("Discord post failed", operation="post_text", sheet_tab=config.text_tab, target_thread_id=config.target_thread_id, exc=exc)
+        return await fail("Discord post failed")
 
     try:
         image_message = await channel.send(
             file=discord.File(io.BytesIO(png_bytes), filename="c1c_recruitment_ad.png")
         )
-    except Exception:
-        log.exception("❌ C1C ad failed: Discord image post failed")
+    except Exception as exc:
+        _log_job_failure("Discord post failed", operation="post_image", sheet_tab=config.image_tab, target_thread_id=config.target_thread_id, exc=exc)
         try:
             await text_message.delete()
         except Exception:
             log.warning("⚠️ C1C ad cleanup failed: new text message delete failed")
-        return fail("Discord post failed")
+        return await fail("Discord post failed")
 
     stamp = _timestamp(now)
-    _write_status(
+    await _write_status(
         sheet_id,
         config,
         headers,

--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -561,8 +561,17 @@ async def run_role_and_visitor_audit(
     scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
     try:
         fusion_cleanup_summaries = await fusion_role_cleanup.load_unreported_role_cleanup_summaries()
-    except Exception:
-        log.warning("failed to load fusion role cleanup summaries", exc_info=True)
+    except Exception as exc:
+        log.warning(
+            "failed to load fusion role cleanup summaries",
+            extra={
+                "component": "role_audit",
+                "operation": "load_fusion_role_cleanup_summaries",
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+            },
+            exc_info=True,
+        )
         fusion_cleanup_summaries = fusion_role_cleanup.get_recent_role_cleanup_summaries()
     aggregated = AuditResult(
         checked=0,
@@ -688,8 +697,17 @@ async def run_role_and_visitor_audit(
     if actor_normalized == "scheduled":
         try:
             await fusion_role_cleanup.mark_role_cleanup_summaries_reported(fusion_cleanup_summaries)
-        except Exception:
-            log.warning("failed to mark fusion role cleanup summaries reported", exc_info=True)
+        except Exception as exc:
+            log.warning(
+                "failed to mark fusion role cleanup summaries reported",
+                extra={
+                    "component": "role_audit",
+                    "operation": "mark_fusion_role_cleanup_summaries_reported",
+                    "exception_type": type(exc).__name__,
+                    "exception_message": str(exc),
+                },
+                exc_info=True,
+            )
 
     return True, "-"
 

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -211,6 +211,7 @@ _DIGEST_SHEET_BUCKETS: Tuple[Tuple[str, str], ...] = (
     ("clans", "ClanInfo"),
     ("templates", "Templates"),
     ("clan_tags", "ClanTags"),
+    ("clan_ad_messages", "Clan Ad Messages"),
 )
 _TELEMETRY_REQUIRED_KEYS: Tuple[str, ...] = (
     "ttl_sec",
@@ -2282,10 +2283,12 @@ class CoreOpsCog(commands.Cog):
             retries = self._snapshot_int(snapshot, "retries")
 
             last_result = self._snapshot_str(snapshot, "last_result")
+            result_norm = (last_result or "").strip().lower()
             last_error = self._snapshot_str(snapshot, "last_error")
+            if result_norm in {"ok", "retry_ok"}:
+                last_error = None
 
             status = "n/a"
-            result_norm = (last_result or "").strip().lower()
             has_error = bool(last_error) or (
                 bool(result_norm) and result_norm not in {"ok", "retry_ok"}
             )
@@ -2785,7 +2788,8 @@ class CoreOpsCog(commands.Cog):
                 latest_latency = self._snapshot_int(snapshot, "last_latency_ms")
                 latest_retries = self._snapshot_int(snapshot, "retries")
                 latest_result = self._snapshot_str(snapshot, "last_result")
-                latest_error = self._snapshot_str(snapshot, "last_error")
+                latest_result_norm = (latest_result or "").strip().lower()
+                latest_error = None if latest_result_norm in {"ok", "retry_ok"} else self._snapshot_str(snapshot, "last_error")
 
             result_text = self._snapshot_str(snapshot, "last_result")
             result_norm = (result_text or "").strip().lower()
@@ -2806,10 +2810,11 @@ class CoreOpsCog(commands.Cog):
                 last_success_age = None
 
         summary_error = failure_error
-        if summary_error is None and latest_error:
+        latest_norm = (latest_result or "").strip().lower()
+        if summary_error is None and latest_norm not in {"ok", "retry_ok"} and latest_error:
             summary_error = self._trim_error_text(latest_error)
-        if summary_error is None and latest_result:
-            summary_error = self._trim_error_text(latest_result)
+        if summary_error is None and latest_norm and latest_norm not in {"ok", "retry_ok"}:
+            summary_error = self._trim_error_text(latest_result or "")
 
         return DigestSheetsClientSummary(
             last_success_age=last_success_age,

--- a/packages/c1c-coreops/src/c1c_coreops/render.py
+++ b/packages/c1c-coreops/src/c1c_coreops/render.py
@@ -349,9 +349,20 @@ def build_config_embed(
 
 
 def _maybe_build_tip(entries: Sequence[DigestSheetEntry]) -> str | None:
-    if entries:
+    failed = [entry for entry in entries if str(entry.status or "").lower() == "fail"]
+    if not failed:
+        return None
+    failed_names = {str(entry.display_name or "").strip().lower() for entry in failed}
+    failed_errors = " ".join(str(entry.error or "") for entry in failed).lower()
+    if "_retry_with_backoff must not run inside an active event loop" in failed_errors:
+        return "Sheet refresh hit an event-loop guard; this needs code attention, not a ClanInfo refresh."
+    if failed_names == {"claninfo"}:
         return 'Need latest openings? run "!ops refresh clansinfo" and retry.'
-    return None
+    if failed_names == {"templates"}:
+        return "Templates refresh failed; this likely needs template sheet/config attention."
+    if "fusion" in failed_errors or "config" in failed_errors:
+        return "Sheet Config/client issue detected; check the failing bucket and Config key shown above."
+    return "One or more sheet buckets failed; refresh or investigate the specific failing bucket shown above."
 
 
 @dataclass(frozen=True)

--- a/packages/c1c-coreops/tests/test_digest_accuracy.py
+++ b/packages/c1c-coreops/tests/test_digest_accuracy.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+
+from c1c_coreops.cog import CoreOpsCog
+from c1c_coreops import cog as coreops_cog
+from c1c_coreops.render import DigestSheetEntry, _maybe_build_tip
+
+
+def _cog():
+    return object.__new__(CoreOpsCog)
+
+
+def test_digest_bucket_success_ignores_stale_last_error(monkeypatch):
+    monkeypatch.setattr(coreops_cog, "_list_bucket_names", lambda: {"clans"})
+    monkeypatch.setattr(
+        coreops_cog,
+        "_gather_snapshot_dicts",
+        lambda names: {
+            "clans": {
+                "available": True,
+                "last_result": "ok",
+                "last_error": "old _retry_with_backoff must not run inside an active event loop",
+                "last_refresh_at": datetime.now(timezone.utc),
+            }
+        },
+    )
+
+    entries = _cog()._collect_sheet_bucket_entries()
+    clan = next(entry for entry in entries if entry.display_name == "ClanInfo")
+
+    assert clan.status == "ok"
+    assert clan.error == "—"
+
+
+def test_digest_sheets_client_success_ignores_stale_global_error(monkeypatch):
+    monkeypatch.setattr(coreops_cog, "_list_bucket_names", lambda: {"fusion"})
+    monkeypatch.setattr(
+        coreops_cog,
+        "_gather_snapshot_dicts",
+        lambda names: {
+            "fusion": {
+                "available": True,
+                "last_result": "ok",
+                "last_error": "FUSION_TAB missing in milestones Config tab",
+                "last_refresh_at": datetime.now(timezone.utc),
+                "last_latency_ms": 12,
+                "retries": 0,
+            }
+        },
+    )
+
+    summary = _cog()._collect_sheets_client_summary(datetime.now(timezone.utc))
+
+    assert summary is not None
+    assert summary.last_error is None
+
+
+def test_digest_tip_targets_failing_bucket_not_claninfo_for_templates_or_code_error():
+    templates = [
+        DigestSheetEntry(
+            display_name="Templates",
+            status="fail",
+            age_seconds=None,
+            next_refresh_delta_seconds=None,
+            next_refresh_at=None,
+            retries=1,
+            error="template sheet failed",
+        )
+    ]
+    guard = [
+        DigestSheetEntry(
+            display_name="ClanInfo",
+            status="fail",
+            age_seconds=None,
+            next_refresh_delta_seconds=None,
+            next_refresh_at=None,
+            retries=1,
+            error="_retry_with_backoff must not run inside an active event loop; use the async variant",
+        )
+    ]
+
+    assert "templates" in (_maybe_build_tip(templates) or "").lower()
+    assert "clansinfo" not in (_maybe_build_tip(templates) or "").lower()
+    assert "code attention" in (_maybe_build_tip(guard) or "").lower()

--- a/shared/sheets/cache_service.py
+++ b/shared/sheets/cache_service.py
@@ -194,6 +194,7 @@ class CacheService:
                 b.value = new_val
                 b.last_refresh = dt.datetime.now(UTC)
                 b.last_item_count = _count_items(new_val)
+                err_text = None
         except asyncio.CancelledError:
             # Let the runtime cancel this task; finally will still run
             result = "cancelled"

--- a/shared/sheets/feature_refresh.py
+++ b/shared/sheets/feature_refresh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import Awaitable, Callable
 
-from shared.config import get_milestones_sheet_id
+from shared.sheets import milestones_config
 from shared.sheets import async_core
 from shared.sheets import recruitment
 from shared.sheets.cache_service import cache
@@ -21,7 +21,7 @@ def _missing_config_key(key: str) -> RuntimeError:
 
 def _recruitment_config_tab_loader(config_key: str) -> Loader:
     async def _load() -> list[list[str]]:
-        tab_name = recruitment.get_config_value(config_key, None, force=True)
+        tab_name = await async_core.a_to_thread_with_backoff(recruitment.get_config_value, config_key, None, force=True)
         if not tab_name:
             raise _missing_config_key(config_key)
         try:
@@ -36,23 +36,11 @@ def _recruitment_config_tab_loader(config_key: str) -> Loader:
 
 def _milestones_config_tab_loader(config_key: str) -> Loader:
     async def _load() -> list[list[str]]:
-        from shared.config import cfg as runtime_config
-
-        getter = getattr(runtime_config, "get", None)
-        tab_name = ""
-        if callable(getter):
-            tab_name = str(getter(config_key, "") or "").strip()
-        else:
-            tab_name = str(getattr(runtime_config, config_key, "") or "").strip()
-        if not tab_name:
-            raise _missing_config_key(config_key)
-        sheet_id = (get_milestones_sheet_id() or "").strip()
-        if not sheet_id:
-            raise RuntimeError("MILESTONES_SHEET_ID missing")
         try:
-            return await async_core.afetch_values(sheet_id, tab_name)
-        except Exception as exc:
-            raise RuntimeError(f"could not read configured tab {tab_name}") from exc
+            _sheet_id, _tab_name, values = await milestones_config.arequire_tab_values(config_key)
+            return values
+        except milestones_config.MilestonesConfigKeyMissing as exc:
+            raise _missing_config_key(config_key) from exc
 
     return _load
 

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from shared.config import cfg, get_milestones_sheet_id
+from shared.sheets import milestones_config
 from shared.sheets.async_core import (
     acall_with_backoff,
     afetch_records,
@@ -192,11 +193,8 @@ class FusionReminderSettings:
     group_events_source: FusionReminderSettingSource = field(default_factory=FusionReminderSettingSource)
 
 
-def _resolve_tab_name(key: str) -> str:
-    value = cfg.get(key)
-    if isinstance(value, str) and value.strip():
-        return value.strip()
-    raise RuntimeError(f"{key} missing in milestones Config tab")
+async def _resolve_tab_name(key: str) -> str:
+    return await milestones_config.arequire_value(key)
 
 
 def _normalize(row: Mapping[str, object]) -> dict[str, object]:
@@ -391,41 +389,53 @@ def _column_label(index: int) -> str:
     return label or "A"
 
 
-def _resolve_reminder_sheet_schema(
+async def _resolve_reminder_sheet_schema(
     *,
     include_sent_at: bool,
 ) -> tuple[str, tuple[str, ...]]:
-    tab_name = _resolve_tab_name(_FUSION_REMINDER_TAB_KEY)
+    tab_name = await _resolve_tab_name(_FUSION_REMINDER_TAB_KEY)
     required_fields: list[str] = ["fusion_id", "event_id", "reminder_type"]
     if include_sent_at:
         required_fields.append("sent_at_utc")
     return tab_name, tuple(required_fields)
 
 
-def _reminder_schema_debug() -> dict[str, str]:
-    keys = (_FUSION_REMINDER_TAB_KEY,)
-    debug: dict[str, str] = {}
-    for key in keys:
-        value = cfg.get(key)
-        debug[key] = str(value if value is not None else "").strip()
+async def _reminder_schema_debug() -> dict[str, str]:
+    debug: dict[str, str] = {"config_key": _FUSION_REMINDER_TAB_KEY}
+    try:
+        debug[_FUSION_REMINDER_TAB_KEY] = await _resolve_tab_name(_FUSION_REMINDER_TAB_KEY)
+    except Exception as exc:
+        debug["error_type"] = type(exc).__name__
+        debug["error_message"] = str(exc)
     return debug
 
 
 def reminder_dedupe_backend_metadata() -> dict[str, str]:
-    """Return non-secret metadata for reminder durable dedupe diagnostics."""
+    """Return non-secret sync metadata without consulting stale runtime config."""
 
-    debug = _reminder_schema_debug()
-    tab_name = str(debug.get(_FUSION_REMINDER_TAB_KEY, "") or "").strip()
     return {
         "backend_type": "google_sheets",
         "config_key": _FUSION_REMINDER_TAB_KEY,
-        "tab_name": tab_name,
     }
 
 
+async def areminder_dedupe_backend_metadata() -> dict[str, str]:
+    """Return non-secret metadata for reminder durable dedupe diagnostics."""
 
-def _resolve_traditional_progress_sheet_schema() -> tuple[str, dict[str, str]]:
-    tab_name = _resolve_tab_name(_FUSION_TRADITIONAL_PROGRESS_TAB_KEY)
+    debug = await _reminder_schema_debug()
+    tab_name = str(debug.get(_FUSION_REMINDER_TAB_KEY, "") or "").strip()
+    payload = reminder_dedupe_backend_metadata()
+    if tab_name:
+        payload["tab_name"] = tab_name
+    if "error_type" in debug:
+        payload["error_type"] = debug["error_type"]
+        payload["error_message"] = debug.get("error_message", "")
+    return payload
+
+
+
+async def _resolve_traditional_progress_sheet_schema() -> tuple[str, dict[str, str]]:
+    tab_name = await _resolve_tab_name(_FUSION_TRADITIONAL_PROGRESS_TAB_KEY)
     return tab_name, dict(_FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES)
 
 
@@ -452,8 +462,8 @@ def _resolve_traditional_progress_header_indices(*, tab_name: str, header: list[
         for field in required_fields
     }
 
-def _resolve_progress_sheet_schema() -> tuple[str, dict[str, str]]:
-    tab_name = _resolve_tab_name(_FUSION_PROGRESS_TAB_KEY)
+async def _resolve_progress_sheet_schema() -> tuple[str, dict[str, str]]:
+    tab_name = await _resolve_tab_name(_FUSION_PROGRESS_TAB_KEY)
     return tab_name, dict(_FUSION_PROGRESS_COLUMN_ALIASES)
 
 
@@ -610,7 +620,7 @@ def _require_fusion_headers(*, tab_name: str, header: list[str], required: tuple
 
 
 async def _load_fusions() -> tuple[FusionRow, ...]:
-    tab_name = _resolve_tab_name("FUSION_TAB")
+    tab_name = await _resolve_tab_name("FUSION_TAB")
     rows = await afetch_records(_sheet_id(), tab_name)
     parsed: list[FusionRow] = []
     parse_errors: dict[str, str] = {}
@@ -710,7 +720,7 @@ def get_last_fusion_parse_errors() -> dict[str, str]:
 
 
 async def _load_fusion_events() -> tuple[FusionEventRow, ...]:
-    tab_name = _resolve_tab_name("FUSION_EVENT_TAB")
+    tab_name = await _resolve_tab_name("FUSION_EVENT_TAB")
     rows = await afetch_records(_sheet_id(), tab_name)
     parsed: list[FusionEventRow] = []
     for raw in rows or []:
@@ -931,7 +941,7 @@ async def get_active_events(
 
 
 async def get_fusion_reminder_settings(*, now: dt.datetime | None = None) -> FusionReminderSettings:
-    tab_name = _resolve_tab_name(_FUSION_REMINDER_SETTINGS_TAB_KEY)
+    tab_name = await _resolve_tab_name(_FUSION_REMINDER_SETTINGS_TAB_KEY)
     sheet_id, values, header = await _load_fusion_sheet_matrix(tab_name)
     key_idx = _resolve_header_index(
         tab_name=tab_name,
@@ -1030,9 +1040,9 @@ async def get_sent_reminder_keys(fusion_id: str) -> set[tuple[str, str]]:
     """Return durable reminder keys previously sent for ``fusion_id``."""
 
     try:
-        tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
+        tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=False)
     except Exception as exc:
-        debug_config = _reminder_schema_debug()
+        debug_config = await _reminder_schema_debug()
         raise RuntimeError(
             "Fusion reminder durable dedupe config invalid "
             f"(config={debug_config})"
@@ -1070,7 +1080,7 @@ async def get_last_reminder_sent_at(
 ) -> dt.datetime | None:
     """Return the latest sent_at marker for one fusion/reminder type."""
 
-    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=True)
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return None
@@ -1108,9 +1118,9 @@ async def mark_reminder_sent(
     """Persist a sent reminder marker with a durable fusion/event/type key."""
 
     try:
-        tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+        tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=True)
     except Exception as exc:
-        debug_config = _reminder_schema_debug()
+        debug_config = await _reminder_schema_debug()
         raise RuntimeError(
             "Fusion reminder durable dedupe config invalid for write "
             f"(config={debug_config})"
@@ -1172,7 +1182,7 @@ async def upsert_role_cleanup_summary(
 ) -> None:
     """Persist an unreported Fusion role-cleanup summary in existing reminder storage."""
 
-    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=True)
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         raise RuntimeError(
@@ -1228,7 +1238,7 @@ async def upsert_role_cleanup_summary(
 async def get_unreported_role_cleanup_summaries() -> list[dict[str, object]]:
     """Read unreported Fusion role-cleanup summaries from existing reminder storage."""
 
-    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=True)
+    tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=True)
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return []
@@ -1264,7 +1274,7 @@ async def get_unreported_role_cleanup_summaries() -> list[dict[str, object]]:
 async def has_role_cleanup_summary(fusion_id: str) -> bool:
     """Return True when a cleanup summary row already exists for a fusion."""
 
-    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
+    tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=False)
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return False
@@ -1293,7 +1303,7 @@ async def mark_role_cleanup_summaries_reported(row_numbers: list[int]) -> None:
 
     if not row_numbers:
         return
-    tab_name, required_fields = _resolve_reminder_sheet_schema(include_sent_at=False)
+    tab_name, required_fields = await _resolve_reminder_sheet_schema(include_sent_at=False)
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return
@@ -1320,7 +1330,7 @@ def _normalize_progress_status(value: object) -> str:
 async def get_user_event_progress(fusion_id: str, user_id: str) -> dict[str, str]:
     """Return per-event progress status for a fusion/user tuple."""
 
-    tab_name, _progress_aliases = _resolve_progress_sheet_schema()
+    tab_name, _progress_aliases = await _resolve_progress_sheet_schema()
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         return {}
@@ -1426,14 +1436,14 @@ async def get_progress_sheet_diagnostics() -> dict[str, object]:
     tab_name = ""
     headers: list[str] = []
     try:
-        tab_name, _aliases = _resolve_progress_sheet_schema()
+        tab_name, _aliases = await _resolve_progress_sheet_schema()
         matrix = await afetch_values(_sheet_id(), tab_name)
         if matrix:
             headers = [str(cell or "").strip().lower() for cell in matrix[0]]
     except Exception as exc:
         return {
             "progress_config_key": _FUSION_PROGRESS_TAB_KEY,
-            "tab_name": tab_name or str(cfg.get(_FUSION_PROGRESS_TAB_KEY) or "").strip(),
+            "tab_name": tab_name,
             "headers_resolved": ",".join(headers),
             "diagnostics_error": str(exc),
         }
@@ -1461,7 +1471,7 @@ async def upsert_user_event_progress(
             "Invalid fusion progress status; expected one of "
             f"{sorted(_PROGRESS_ALLOWED_STATUSES)}, got={status!r}"
         )
-    tab_name, _progress_aliases = _resolve_progress_sheet_schema()
+    tab_name, _progress_aliases = await _resolve_progress_sheet_schema()
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         raise RuntimeError(
@@ -1621,7 +1631,7 @@ def _progress_save_log_fields(result: FusionProgressSaveResult) -> dict[str, obj
 async def get_user_traditional_progress(fusion_id: str, user_id: str) -> FusionTraditionalUserProgressRow:
     """Return champion-prep progress for one traditional fusion/user tuple."""
 
-    tab_name, _aliases = _resolve_traditional_progress_sheet_schema()
+    tab_name, _aliases = await _resolve_traditional_progress_sheet_schema()
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         raise RuntimeError(
@@ -1669,7 +1679,7 @@ async def upsert_user_traditional_progress(
 ) -> FusionTraditionalUserProgressRow:
     """Create or update champion-prep progress for one traditional fusion/user tuple."""
 
-    tab_name, _aliases = _resolve_traditional_progress_sheet_schema()
+    tab_name, _aliases = await _resolve_traditional_progress_sheet_schema()
     matrix = await afetch_values(_sheet_id(), tab_name)
     if not matrix:
         raise RuntimeError(
@@ -1792,7 +1802,7 @@ async def update_fusion_publication(
 ) -> None:
     """Write publish metadata back to the fusion row in the configured sheet."""
 
-    tab_name = _resolve_tab_name("FUSION_TAB")
+    tab_name = await _resolve_tab_name("FUSION_TAB")
     sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
     row_idx = _resolve_fusion_row_index(
         fusion_id=fusion_id,
@@ -1841,7 +1851,7 @@ async def update_fusion_announcement_refresh_state(
 ) -> None:
     """Persist announcement refresh metadata for scheduler dedupe/restart safety."""
 
-    tab_name = _resolve_tab_name("FUSION_TAB")
+    tab_name = await _resolve_tab_name("FUSION_TAB")
     sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
     row_idx = _resolve_fusion_row_index(
         fusion_id=fusion_id,
@@ -1877,7 +1887,7 @@ async def update_fusion_announcement_refresh_state(
 async def transition_fusion_to_ended(fusion_id: str) -> bool:
     """Set the configured Fusion row status to ended, if not already ended."""
 
-    tab_name = _resolve_tab_name("FUSION_TAB")
+    tab_name = await _resolve_tab_name("FUSION_TAB")
     sheet_id, matrix, header = await _load_fusion_sheet_matrix(tab_name)
     row_idx = _resolve_fusion_row_index(
         fusion_id=fusion_id,
@@ -1925,6 +1935,7 @@ __all__ = [
     "get_unreported_role_cleanup_summaries",
     "has_role_cleanup_summary",
     "reminder_dedupe_backend_metadata",
+    "areminder_dedupe_backend_metadata",
     "get_user_event_progress",
     "get_user_traditional_progress",
     "get_progress_sheet_diagnostics",

--- a/shared/sheets/milestones_config.py
+++ b/shared/sheets/milestones_config.py
@@ -1,0 +1,213 @@
+"""Canonical Milestones Config resolution helpers.
+
+All Milestones workbook tab names used by runtime features should resolve through
+this module so failures distinguish sheet-id, Config-load, missing-key, blank
+value, and downstream tab-open errors.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+from typing import Any, Mapping, Sequence
+
+from shared.config import get_milestones_sheet_id
+from shared.sheets import async_core
+from shared.sheets import core as sheets_core
+
+
+class MilestonesConfigError(RuntimeError):
+    reason = "config_error"
+
+    def __init__(self, message: str, *, key: str | None = None, normalized_key: str | None = None,
+                 sheet_id: str | None = None, source_tab: str | None = None,
+                 keys_loaded: int | None = None, present: bool | None = None,
+                 nearest: Sequence[str] = (), resolved_value: str | None = None) -> None:
+        super().__init__(message)
+        self.key = key
+        self.normalized_key = normalized_key
+        self.sheet_id = sheet_id
+        self.source_tab = source_tab
+        self.keys_loaded = keys_loaded
+        self.present = present
+        self.nearest = tuple(nearest)
+        self.resolved_value = resolved_value
+
+    @property
+    def sheet_id_tail(self) -> str:
+        return _tail(self.sheet_id)
+
+    def context(self, *, component: str = "", operation: str = "config_resolve") -> dict[str, Any]:
+        return {
+            "component": component,
+            "operation": operation,
+            "config_key": self.key,
+            "normalized_config_key": self.normalized_key,
+            "sheet_id_tail": self.sheet_id_tail,
+            "config_source_tab": self.source_tab,
+            "config_keys_loaded": self.keys_loaded,
+            "config_key_present": self.present,
+            "nearest_config_keys": self.nearest,
+            "resolved_config_value": self.resolved_value,
+            "exception_type": type(self).__name__,
+            "exception_message": str(self),
+        }
+
+
+class MilestonesSheetIdUnavailable(MilestonesConfigError):
+    reason = "sheet_id_unavailable"
+
+
+class MilestonesConfigSourceUnavailable(MilestonesConfigError):
+    reason = "config_source_unavailable"
+
+
+class MilestonesConfigLoadFailed(MilestonesConfigError):
+    reason = "config_load_failed"
+
+
+class MilestonesConfigEmpty(MilestonesConfigError):
+    reason = "config_loaded_with_no_keys"
+
+
+class MilestonesConfigKeyMissing(MilestonesConfigError):
+    reason = "key_missing"
+
+
+class MilestonesConfigValueBlank(MilestonesConfigError):
+    reason = "key_value_blank"
+
+
+class MilestonesResolvedTabUnavailable(MilestonesConfigError):
+    reason = "resolved_tab_unavailable"
+
+
+def _source_tab() -> str:
+    tab = (os.getenv("MILESTONES_CONFIG_TAB") or "").strip()
+    if not tab:
+        raise MilestonesConfigSourceUnavailable("milestones Config source unavailable")
+    return tab
+
+
+def _tail(value: str | None) -> str:
+    text = str(value or "").strip()
+    return text[-6:] if text else "unavailable"
+
+
+def normalize_key(key: object) -> str:
+    return str(key or "").strip().upper()
+
+
+def _parse(rows: Sequence[Mapping[str, object]]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for row in rows or []:
+        found_key = ""
+        found_value: object = ""
+        has_value_column = False
+        for col, raw in row.items():
+            col_norm = str(col or "").strip().lower()
+            text = str(raw or "").strip()
+            if col_norm == "key":
+                found_key = text
+            elif col_norm in {"value", "val"}:
+                found_value = raw
+                has_value_column = True
+        norm = normalize_key(found_key)
+        if norm:
+            out[norm] = str(found_value or "").strip() if has_value_column else ""
+    return out
+
+
+def _sheet_id() -> str:
+    sheet_id = (get_milestones_sheet_id() or "").strip()
+    if not sheet_id:
+        raise MilestonesSheetIdUnavailable("milestones sheet ID unavailable")
+    return sheet_id
+
+
+def _missing(key: str, config: Mapping[str, str], sheet_id: str, tab: str) -> MilestonesConfigKeyMissing:
+    norm = normalize_key(key)
+    nearest = difflib.get_close_matches(norm, list(config.keys()), n=3, cutoff=0.55)
+    return MilestonesConfigKeyMissing(
+        f"{norm} missing in milestones Config tab",
+        key=key, normalized_key=norm, sheet_id=sheet_id, source_tab=tab,
+        keys_loaded=len(config), present=False, nearest=nearest,
+    )
+
+
+def load_values() -> tuple[str, str, dict[str, str]]:
+    sheet_id = _sheet_id()
+    tab = _source_tab()
+    try:
+        rows = sheets_core.fetch_records(sheet_id, tab)
+    except Exception as exc:
+        raise MilestonesConfigLoadFailed(
+            f"Milestones Config load failed: {type(exc).__name__}: {exc}",
+            sheet_id=sheet_id, source_tab=tab,
+        ) from exc
+    config = _parse(rows)
+    if not config:
+        raise MilestonesConfigEmpty(
+            "Milestones Config loaded with no keys", sheet_id=sheet_id, source_tab=tab, keys_loaded=0
+        )
+    return sheet_id, tab, config
+
+
+async def aload_values() -> tuple[str, str, dict[str, str]]:
+    sheet_id = _sheet_id()
+    tab = _source_tab()
+    try:
+        rows = await async_core.afetch_records(sheet_id, tab)
+    except Exception as exc:
+        raise MilestonesConfigLoadFailed(
+            f"Milestones Config load failed: {type(exc).__name__}: {exc}",
+            sheet_id=sheet_id, source_tab=tab,
+        ) from exc
+    config = _parse(rows)
+    if not config:
+        raise MilestonesConfigEmpty(
+            "Milestones Config loaded with no keys", sheet_id=sheet_id, source_tab=tab, keys_loaded=0
+        )
+    return sheet_id, tab, config
+
+
+def require_value(key: str) -> str:
+    sheet_id, tab, config = load_values()
+    norm = normalize_key(key)
+    if norm not in config:
+        raise _missing(key, config, sheet_id, tab)
+    value = str(config[norm] or "").strip()
+    if not value:
+        raise MilestonesConfigValueBlank(
+            f"{norm} value blank in milestones Config tab", key=key, normalized_key=norm,
+            sheet_id=sheet_id, source_tab=tab, keys_loaded=len(config), present=True, resolved_value=value,
+        )
+    return value
+
+
+async def arequire_value(key: str) -> str:
+    sheet_id, tab, config = await aload_values()
+    norm = normalize_key(key)
+    if norm not in config:
+        raise _missing(key, config, sheet_id, tab)
+    value = str(config[norm] or "").strip()
+    if not value:
+        raise MilestonesConfigValueBlank(
+            f"{norm} value blank in milestones Config tab", key=key, normalized_key=norm,
+            sheet_id=sheet_id, source_tab=tab, keys_loaded=len(config), present=True, resolved_value=value,
+        )
+    return value
+
+
+async def arequire_tab_values(key: str) -> tuple[str, str, list[list[Any]]]:
+    sheet_id = _sheet_id()
+    tab_name = await arequire_value(key)
+    try:
+        values = await async_core.afetch_values(sheet_id, tab_name)
+    except Exception as exc:
+        raise MilestonesResolvedTabUnavailable(
+            f"resolved tab unavailable for {normalize_key(key)}: {tab_name}",
+            key=key, normalized_key=normalize_key(key), sheet_id=sheet_id,
+            source_tab=_source_tab(), resolved_value=tab_name,
+        ) from exc
+    return sheet_id, tab_name, values

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -242,6 +242,39 @@ def _load_config(force: bool = False) -> Dict[str, str]:
     return parsed
 
 
+
+async def _aload_config(force: bool = False) -> Dict[str, str]:
+    global _CONFIG_CACHE, _CONFIG_CACHE_TS
+    now = time.time()
+    if not force and _CONFIG_CACHE and (now - _CONFIG_CACHE_TS) < _CONFIG_TTL:
+        return _CONFIG_CACHE
+
+    records = await afetch_records(_sheet_id(), _config_tab())
+    parsed: Dict[str, str] = {}
+    for row in records:
+        key_value: Optional[str] = None
+        stored_value: Optional[str] = None
+        for col, value in row.items():
+            col_norm = (col or "").strip().lower()
+            if col_norm == "key":
+                key_value = str(value).strip().lower() if value is not None else ""
+            elif col_norm in {"value", "val"}:
+                stored_value = str(value).strip() if value is not None else ""
+        if key_value and stored_value:
+            parsed[key_value] = stored_value
+
+    _CONFIG_CACHE = parsed
+    _CONFIG_CACHE_TS = now
+    return parsed
+
+
+async def _aconfig_lookup(key: str, default: Optional[str] = None) -> Optional[str]:
+    want = (key or "").strip().lower()
+    if not want:
+        return default
+    config = await _aload_config()
+    return config.get(want, default)
+
 def _config_lookup(key: str, default: Optional[str] = None) -> Optional[str]:
     want = (key or "").strip().lower()
     if not want:
@@ -319,6 +352,10 @@ def _promo_tab() -> str:
 
 def _clanlist_tab() -> str:
     return _config_lookup("clanlist_tab", "ClanList") or "ClanList"
+
+
+async def _aclanlist_tab() -> str:
+    return await _aconfig_lookup("clanlist_tab", "ClanList") or "ClanList"
 
 
 def _worksheet(tab: str):
@@ -1742,7 +1779,7 @@ _TTL_CLAN_TAGS_SEC = 7 * 24 * 60 * 60
 async def _load_clan_tags_async() -> List[str]:
     _ensure_service_account_credentials()
     sheet_id = _sheet_id()
-    tab = _clanlist_tab()
+    tab = await _aclanlist_tab()
     values = await afetch_values(sheet_id, tab)
     tags: List[str] = []
     for row in values:

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -543,9 +543,23 @@ def _clans_tab() -> str:
     )
 
 
+async def _aclans_tab() -> str:
+    return (
+        await _aconfig_lookup("clans_tab", os.getenv("WORKSHEET_NAME", "bot_info"))
+        or "bot_info"
+    )
+
+
 def _templates_tab() -> str:
     return (
         _config_lookup("welcome_templates_tab", "WelcomeTemplates")
+        or "WelcomeTemplates"
+    )
+
+
+async def _atemplates_tab() -> str:
+    return (
+        await _aconfig_lookup("welcome_templates_tab", "WelcomeTemplates")
         or "WelcomeTemplates"
     )
 
@@ -600,13 +614,19 @@ def get_reports_tab_name(default: str = "Statistics") -> str:
     return text or default
 
 
+async def get_reports_tab_name_async(default: str = "Statistics") -> str:
+    value = await _aconfig_lookup("reports_tab", default) or default
+    text = str(value or "").strip()
+    return text or default
+
+
 async def afetch_reports_tab(tab_name: str | None = None) -> List[List[str]]:
     """Fetch the recruitment reports worksheet as a raw matrix."""
 
     _ensure_service_account_credentials()
     sheet_id = _sheet_id()
-    tab = tab_name or get_reports_tab_name()
-    normalized = tab.strip() or get_reports_tab_name()
+    tab = tab_name or await get_reports_tab_name_async()
+    normalized = tab.strip() or await get_reports_tab_name_async()
     return await afetch_values(sheet_id, normalized)
 
 
@@ -740,7 +760,7 @@ _TTL_TEMPLATES_SEC = 7 * 24 * 60 * 60
 async def _load_clans_async() -> List[List[str]]:
     _ensure_service_account_credentials()
     sheet_id = _sheet_id()
-    tab = _clans_tab()
+    tab = await _aclans_tab()
     rows = await afetch_values(sheet_id, tab)
     now = time.time()
     sanitized = _process_clan_sheet(rows, now, tab, sheet_id=sheet_id)
@@ -757,7 +777,7 @@ async def _load_clans_async() -> List[List[str]]:
 async def _load_templates_async() -> List[Dict[str, Any]]:
     _ensure_service_account_credentials()
     sheet_id = _sheet_id()
-    tab = _templates_tab()
+    tab = await _atemplates_tab()
     return await afetch_records(sheet_id, tab)
 
 

--- a/tests/community/test_reset_reminder_suppression.py
+++ b/tests/community/test_reset_reminder_suppression.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+
+from modules.community.reset_reminders import scheduler
+
+
+def _exc(message="config boom", *, stage="config_load", tab="unknown"):
+    exc = RuntimeError(message)
+    setattr(exc, "reset_reminder_stage", stage)
+    setattr(exc, "reset_reminder_tab", tab)
+    setattr(exc, "reset_reminder_elapsed", 0.01)
+    return exc
+
+
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(scheduler, "_LOAD_FAILURE_ALERT_THRESHOLD", 1)
+    monkeypatch.setattr(scheduler, "_LOAD_FAILURE_ALERT_COOLDOWN_SEC", 9999.0)
+    scheduler._load_failure_state.update(
+        {"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False}
+    )
+
+
+def test_reset_reminder_first_distinct_failure_logs_full_context(monkeypatch, caplog):
+    sent = []
+
+    async def fake_send(message):
+        sent.append(message)
+
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(scheduler, "_send_ops_log", fake_send)
+    caplog.set_level(logging.INFO, logger="c1c.community.reset_reminders.scheduler")
+
+    asyncio.run(scheduler._record_load_failure(_exc(tab="unknown")))
+
+    full_logs = [
+        record
+        for record in caplog.records
+        if record.message == "failed to load reset reminders; scheduler tick skipped"
+    ]
+    assert len(full_logs) == 1
+    record = full_logs[0]
+    assert record.exc_info is not None
+    assert record.scheduler == "reset_reminders"
+    assert record.config_key == "RESET_REMINDER_TAB"
+    assert record.operation == "config_load"
+    assert record.tab == "unknown"
+    assert record.exception_type == "RuntimeError"
+    assert record.exception_message == "config boom"
+    assert len(sent) == 1
+
+
+def test_reset_reminder_repeated_failure_full_logs_once(monkeypatch, caplog):
+    sent = []
+
+    async def fake_send(message):
+        sent.append(message)
+
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(scheduler, "_send_ops_log", fake_send)
+    caplog.set_level(logging.INFO, logger="c1c.community.reset_reminders.scheduler")
+
+    asyncio.run(scheduler._record_load_failure(_exc()))
+    asyncio.run(scheduler._record_load_failure(_exc()))
+
+    assert caplog.text.count("failed to load reset reminders; scheduler tick skipped") == 1
+    assert "repeated reset reminder load failure suppressed" in caplog.text
+    assert len(sent) == 1
+
+
+def test_reset_reminder_changed_failure_reports_again(monkeypatch, caplog):
+    sent = []
+
+    async def fake_send(message):
+        sent.append(message)
+
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(scheduler, "_send_ops_log", fake_send)
+    caplog.set_level(logging.INFO, logger="c1c.community.reset_reminders.scheduler")
+
+    asyncio.run(scheduler._record_load_failure(_exc("first")))
+    asyncio.run(scheduler._record_load_failure(_exc("second")))
+
+    assert caplog.text.count("failed to load reset reminders; scheduler tick skipped") == 2
+    assert len(sent) == 2
+
+
+def test_reset_reminder_success_resets_suppression(monkeypatch, caplog):
+    sent = []
+
+    async def fake_send(message):
+        sent.append(message)
+
+    _reset_state(monkeypatch)
+    monkeypatch.setattr(scheduler, "_send_ops_log", fake_send)
+    caplog.set_level(logging.INFO, logger="c1c.community.reset_reminders.scheduler")
+
+    asyncio.run(scheduler._record_load_failure(_exc("first")))
+    asyncio.run(scheduler._record_load_failure(_exc("first")))
+    asyncio.run(scheduler._record_load_success())
+    asyncio.run(scheduler._record_load_failure(_exc("first")))
+
+    assert caplog.text.count("failed to load reset reminders; scheduler tick skipped") == 2
+    assert "reset reminder recovery message sent" in caplog.text
+    assert scheduler._load_failure_state["failures"] == 1
+    assert len(sent) == 3

--- a/tests/shared/sheets/test_cache_error_clearing.py
+++ b/tests/shared/sheets/test_cache_error_clearing.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from shared.sheets.cache_service import CacheService
+
+
+def test_successful_cache_refresh_clears_previous_error(monkeypatch):
+    cache = CacheService()
+    calls = 0
+
+    async def no_sleep(_seconds):
+        return None
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("old failure")
+        return ["ok"]
+
+    monkeypatch.setattr("shared.sheets.cache_service.asyncio.sleep", no_sleep)
+    cache.register("bucket", 60, loader)
+
+    asyncio.run(cache.refresh_now("bucket", actor="test"))
+    bucket = cache.get_bucket("bucket")
+    assert bucket.last_result == "retry_ok"
+    assert bucket.last_error is None
+    assert bucket.value == ["ok"]

--- a/tests/shared/sheets/test_fusion_metadata.py
+++ b/tests/shared/sheets/test_fusion_metadata.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from shared.sheets import fusion
+
+
+def test_reminder_dedupe_metadata_does_not_read_stale_cfg(monkeypatch):
+    def stale_cfg_get(*args, **kwargs):
+        raise AssertionError("stale cfg.get used")
+
+    async def resolved(key):
+        assert key == "FUSION_REMINDER_TAB"
+        return "FusionReminderLog"
+
+    class StaleCfg:
+        def get(self, *args, **kwargs):
+            return stale_cfg_get(*args, **kwargs)
+
+    monkeypatch.setattr(fusion, "cfg", StaleCfg())
+    monkeypatch.setattr(fusion, "_resolve_tab_name", resolved)
+
+    sync_meta = fusion.reminder_dedupe_backend_metadata()
+    async_meta = asyncio.run(fusion.areminder_dedupe_backend_metadata())
+
+    assert sync_meta == {"backend_type": "google_sheets", "config_key": "FUSION_REMINDER_TAB"}
+    assert async_meta["tab_name"] == "FusionReminderLog"

--- a/tests/shared/sheets/test_milestones_config.py
+++ b/tests/shared/sheets/test_milestones_config.py
@@ -1,0 +1,102 @@
+import asyncio
+
+import pytest
+
+from shared.sheets import milestones_config
+
+
+def test_parse_normalizes_headers_keys_and_values():
+    rows = [
+        {" KEY ": " FUSION_TAB ", " VALUE ": " fusion "},
+        {"key": " FUSION_EVENT_TAB ", "value": " fusion_events "},
+        {"KEY": " FUSION_REMINDER_SETTINGS_TAB ", "VALUE": " FusionReminderSettings "},
+        {"Key": " RESET_REMINDER_TAB ", "Value": " ResetReminder "},
+        {"key": " SHARD_MERCY_TAB ", "value": " ShardTracker "},
+        {"key": "BLANK_WITH_NOTE", "value": " ", "notes": "not a config value"},
+    ]
+
+    parsed = milestones_config._parse(rows)
+
+    assert parsed["FUSION_TAB"] == "fusion"
+    assert parsed["FUSION_EVENT_TAB"] == "fusion_events"
+    assert parsed["FUSION_REMINDER_SETTINGS_TAB"] == "FusionReminderSettings"
+    assert parsed["RESET_REMINDER_TAB"] == "ResetReminder"
+    assert parsed["SHARD_MERCY_TAB"] == "ShardTracker"
+    assert parsed["BLANK_WITH_NOTE"] == ""
+
+
+def test_require_value_blank_missing_and_load_failures(monkeypatch):
+    async def _run():
+        monkeypatch.setenv("MILESTONES_CONFIG_TAB", "ConfigFromEnv")
+        monkeypatch.setattr(milestones_config, "get_milestones_sheet_id", lambda: "sheet-abcdef")
+
+        async def blank_records(sheet_id, tab):
+            return [{"KEY": "FUSION_TAB", "VALUE": "   "}]
+
+        monkeypatch.setattr(milestones_config.async_core, "afetch_records", blank_records)
+        with pytest.raises(milestones_config.MilestonesConfigValueBlank) as blank:
+            await milestones_config.arequire_value("FUSION_TAB")
+        assert blank.value.reason == "key_value_blank"
+        assert blank.value.present is True
+
+        async def missing_records(sheet_id, tab):
+            return [{"KEY": "FUSION_TBA", "VALUE": "fusion"}]
+
+        monkeypatch.setattr(milestones_config.async_core, "afetch_records", missing_records)
+        with pytest.raises(milestones_config.MilestonesConfigKeyMissing) as missing:
+            await milestones_config.arequire_value("FUSION_TAB")
+        assert missing.value.reason == "key_missing"
+        assert missing.value.keys_loaded == 1
+        assert "FUSION_TBA" in missing.value.nearest
+
+        async def load_fails(sheet_id, tab):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(milestones_config.async_core, "afetch_records", load_fails)
+        with pytest.raises(milestones_config.MilestonesConfigLoadFailed) as load_failed:
+            await milestones_config.arequire_value("FUSION_TAB")
+        assert load_failed.value.reason == "config_load_failed"
+
+        monkeypatch.delenv("MILESTONES_CONFIG_TAB", raising=False)
+        with pytest.raises(milestones_config.MilestonesConfigSourceUnavailable) as no_source:
+            await milestones_config.arequire_value("FUSION_TAB")
+        assert no_source.value.reason == "config_source_unavailable"
+
+        monkeypatch.setenv("MILESTONES_CONFIG_TAB", "ConfigFromEnv")
+        monkeypatch.setattr(milestones_config, "get_milestones_sheet_id", lambda: "")
+        with pytest.raises(milestones_config.MilestonesSheetIdUnavailable) as no_sheet:
+            await milestones_config.arequire_value("FUSION_TAB")
+        assert no_sheet.value.reason == "sheet_id_unavailable"
+
+    asyncio.run(_run())
+
+
+def test_milestones_config_tab_env_selects_config_without_fallback(monkeypatch):
+    seen = {}
+    monkeypatch.setenv("MILESTONES_CONFIG_TAB", "Config")
+    monkeypatch.setattr(milestones_config, "get_milestones_sheet_id", lambda: "sheet-abcdef")
+
+    async def records(sheet_id, tab):
+        seen["sheet_id"] = sheet_id
+        seen["tab"] = tab
+        return [{"KEY": "FUSION_TAB", "VALUE": "fusion"}]
+
+    monkeypatch.setattr(milestones_config.async_core, "afetch_records", records)
+
+    value = asyncio.run(milestones_config.arequire_value("FUSION_TAB"))
+
+    assert value == "fusion"
+    assert seen == {"sheet_id": "sheet-abcdef", "tab": "Config"}
+
+
+def test_milestones_config_does_not_fallback_to_config_when_source_missing(monkeypatch):
+    monkeypatch.delenv("MILESTONES_CONFIG_TAB", raising=False)
+    monkeypatch.setattr(milestones_config, "get_milestones_sheet_id", lambda: "sheet-abcdef")
+
+    async def records(*args, **kwargs):
+        raise AssertionError("Config tab should not be loaded without explicit source")
+
+    monkeypatch.setattr(milestones_config.async_core, "afetch_records", records)
+
+    with pytest.raises(milestones_config.MilestonesConfigSourceUnavailable):
+        asyncio.run(milestones_config.arequire_value("FUSION_TAB"))

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -86,6 +86,11 @@ def harness(monkeypatch):
         "get_config_value",
         lambda key, default=None: config.get(key, default),
     )
+
+    async def get_config_value_async(key, default=None, *, force=False):
+        return config.get(key, default)
+
+    monkeypatch.setattr(c1c_ad.recruitment, "get_config_value_async", get_config_value_async)
     monkeypatch.setattr(
         c1c_ad.recruitment, "get_recruitment_sheet_id", lambda: "sheet123"
     )
@@ -133,6 +138,37 @@ def test_missing_config_skips_without_post(harness):
     assert result.status == "skipped"
     assert "missing Config key C1C_AD_IMAGE_RANGE" == result.message
     assert harness.channel.sent == []
+
+
+
+
+def test_run_c1c_ad_job_uses_async_config_loading(monkeypatch, harness):
+    def forbidden_sync_resolver():
+        raise AssertionError("sync C1C ad Config resolver called")
+
+    monkeypatch.setattr(c1c_ad, "_resolve_config", forbidden_sync_resolver)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+
+
+def test_run_c1c_ad_job_does_not_trigger_sync_retry_guard_during_config(monkeypatch, harness):
+    guard_message = "_retry_with_backoff must not run inside an active event loop; use the async variant"
+
+    def forbidden_sync_config(*args, **kwargs):
+        raise RuntimeError(guard_message)
+
+    async def async_config(key, default=None, *, force=False):
+        return harness.config.get(key, default)
+
+    monkeypatch.setattr(c1c_ad.recruitment, "get_config_value", forbidden_sync_config)
+    monkeypatch.setattr(c1c_ad.recruitment, "get_config_value_async", async_config)
+
+    result = asyncio.run(c1c_ad.run_c1c_ad_job(harness.bot, force=True))
+
+    assert result.status == "success"
+    assert guard_message not in result.message
 
 
 def test_missing_header_skips_without_post(harness):


### PR DESCRIPTION
### Motivation
- Create a single, reliable resolver for the Milestones workbook Config so features can distinguish sheet-id, source-tab, missing-key, blank-value, and tab-load errors.
- Migrate code paths that read the Milestones Config or other sheet-backed config to async-safe resolutions to avoid sync-in-async guards and event-loop issues.
- Improve operational observability by enriching exception logging with contextual metadata (component, operation, actor, sheet/tab, exception details) and suppress repeated noisy alerts.
- Harden the sheet-backed cache and feature refresh flows to clear stale error state on subsequent successful refreshes.

### Description
- Add a new canonical resolver `shared/sheets/milestones_config.py` with synchronous and async APIs (`require_value`, `arequire_value`, `arequire_tab_values`) and rich `MilestonesConfigError` subclasses for distinct failure modes.
- Migrate multiple modules to use the async Milestones resolver and async sheet helpers, including `shared/sheets/fusion.py`, `shared/sheets/recruitment.py`, `modules/housekeeping/c1c_ad.py`, `modules/community/reset_reminders/scheduler.py`, `modules/community/shard_tracker/data.py`, `shared/sheets/feature_refresh.py`, and `shared/sheets/onboarding.py` to avoid sync-in-async calls and to use `async_core` helpers where appropriate.
- Add `areminder_dedupe_backend_metadata()` and other async-aware helpers in `shared/sheets/fusion.py` to separate cheap sync metadata from async tab resolution and to avoid reading stale runtime `cfg` during diagnostics.
- Improve error handling and logging: enrich logs with `extra` context (actor, guild/channel, operation, exception_type/message) in `cogs/housekeeping_c1c_ad.py`, `modules/housekeeping/c1c_ad.py`, `modules/housekeeping/role_audit.py`, `modules/community/reset_reminders/scheduler.py`, and others; implement suppression logic for repeated failures in reminders and reset reminders; add `_log_job_failure` helper for C1C ad.
- Fix async-safe interactions in `modules/housekeeping/c1c_ad.py` (async config resolution, sheet reads/writes via `async_core.a_to_thread_with_backoff`, image export tab gid resolution) and ensure failure paths write status and log context.
- Clear previous bucket `last_error` on successful refresh in `shared/sheets/cache_service.py` to avoid stale errors lingering in telemetry.
- Small UX/diagnostic improvements in core ops rendering to better surface state-to-tip logic and normalize error visibility.
- Update documentation in `docs/ops/Config.md` to highlight `MILESTONES_CONFIG_TAB` deployment checklist.
- Add unit tests covering milestones config parsing and errors, cache error clearing, fusion metadata diagnostics, reset reminder suppression behavior, C1C ad async config flow, and digest tip logic (files added: `tests/shared/sheets/test_milestones_config.py`, `tests/shared/sheets/test_cache_error_clearing.py`, `tests/shared/sheets/test_fusion_metadata.py`, `tests/community/test_reset_reminder_suppression.py`, `packages/c1c-coreops/tests/test_digest_accuracy.py`, and updates to `tests/test_c1c_ad.py`).

### Testing
- Ran the unit tests including the new milestones config and reminder suppression suites via `pytest`, namely `tests/shared/sheets/test_milestones_config.py`, `tests/shared/sheets/test_cache_error_clearing.py`, `tests/shared/sheets/test_fusion_metadata.py`, `tests/community/test_reset_reminder_suppression.py`, `packages/c1c-coreops/tests/test_digest_accuracy.py`, and the updated `tests/test_c1c_ad.py`.
- All new and modified tests executed and passed under the CI test run. 
- Existing integration of async sheet helpers was exercised through the unit tests to validate no sync-in-async guard violations and correct error-suppression/logging behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc765698083239ba8e792c3082c0e)