### PR TITLE
Fix !ops checksheet embed pagination

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -38,7 +38,7 @@ from c1c_coreops.render import (
     DigestSheetsClientSummary,
     RefreshEmbedRow,
     build_config_embed,
-    build_checksheet_tabs_embed,
+    build_checksheet_tabs_embeds,
     build_digest_embed,
     build_digest_line,
     build_env_embed,
@@ -2724,7 +2724,7 @@ class CoreOpsCog(commands.Cog):
             else:
                 results.append(result)
 
-        embed = build_checksheet_tabs_embed(
+        embeds = build_checksheet_tabs_embeds(
             ChecksheetEmbedData(
                 sheets=results,
                 bot_version=bot_version,
@@ -2733,7 +2733,22 @@ class CoreOpsCog(commands.Cog):
             )
         )
 
-        await ctx.reply(embed=sanitize_embed(embed))
+        await self._reply_with_checksheet_embeds(ctx, [sanitize_embed(embed) for embed in embeds])
+
+    async def _reply_with_checksheet_embeds(
+        self, ctx: commands.Context, embeds: Sequence[discord.Embed]
+    ) -> None:
+        if not embeds:
+            return
+
+        first, *rest = embeds
+        await ctx.reply(
+            embed=first,
+            mention_author=False,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
+        for embed in rest:
+            await ctx.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
 
     @tier("admin")
     @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")

--- a/packages/c1c-coreops/src/c1c_coreops/render.py
+++ b/packages/c1c-coreops/src/c1c_coreops/render.py
@@ -14,6 +14,85 @@ from c1c_coreops.help import COREOPS_VERSION, build_coreops_footer
 from shared import logfmt
 from shared.utils import humanize_duration
 
+
+_DISCORD_FIELD_NAME_LIMIT = 256
+_DISCORD_FIELD_VALUE_LIMIT = 1024
+_DISCORD_FIELDS_PER_EMBED = 25
+_DISCORD_EMBED_TEXT_LIMIT = 6000
+
+
+def _embed_text_len(embed: discord.Embed) -> int:
+    total = len(embed.title or "") + len(embed.description or "")
+    total += len(getattr(embed.footer, "text", None) or "")
+    total += len(getattr(embed.author, "name", None) or "")
+    for field in embed.fields:
+        total += len(field.name or "") + len(field.value or "")
+    return total
+
+
+def _split_field_value(value: str, limit: int = _DISCORD_FIELD_VALUE_LIMIT) -> list[str]:
+    text = value or "—"
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    current = ""
+    for line in text.splitlines(keepends=True):
+        if len(line) > limit:
+            if current:
+                chunks.append(current.rstrip("\n") or "—")
+                current = ""
+            start = 0
+            while start < len(line):
+                chunks.append(line[start : start + limit].rstrip("\n") or "—")
+                start += limit
+            continue
+        if len(current) + len(line) > limit:
+            chunks.append(current.rstrip("\n") or "—")
+            current = line
+        else:
+            current += line
+    if current or not chunks:
+        chunks.append(current.rstrip("\n") or "—")
+    return chunks
+
+
+def _continued_field_name(base_name: str, index: int) -> str:
+    clean = _sanitize_inline(base_name, allow_empty=True)[:_DISCORD_FIELD_NAME_LIMIT] or "​"
+    if index == 0:
+        return clean
+    stem = "Continued" if clean == "​" else f"{clean} continued"
+    suffix = "" if index == 1 else f" {index}"
+    return f"{stem}{suffix}"[:_DISCORD_FIELD_NAME_LIMIT]
+
+
+def _new_checksheet_embed(colour: discord.Colour, footer_text: str, *, index: int = 0) -> discord.Embed:
+    title = "Checksheet — Tabs & Headers"
+    if index:
+        title = f"{title} ({index + 1})"
+    embed = discord.Embed(title=title, colour=colour)
+    embed.set_footer(text=footer_text)
+    return embed
+
+
+def _add_paginated_field(
+    embeds: list[discord.Embed],
+    *,
+    colour: discord.Colour,
+    footer_text: str,
+    name: str,
+    value: str,
+    inline: bool = False,
+) -> None:
+    for idx, chunk in enumerate(_split_field_value(value)):
+        field_name = _continued_field_name(name, idx)
+        current = embeds[-1]
+        projected = _embed_text_len(current) + len(field_name) + len(chunk)
+        if len(current.fields) >= _DISCORD_FIELDS_PER_EMBED or projected > _DISCORD_EMBED_TEXT_LIMIT:
+            embeds.append(_new_checksheet_embed(colour, footer_text, index=len(embeds)))
+            current = embeds[-1]
+        current.add_field(name=field_name, value=chunk, inline=inline)
+
 def _hms(seconds: float) -> str:
     s = int(max(0, seconds))
     h, s = divmod(s, 3600)
@@ -428,12 +507,25 @@ class ChecksheetEmbedData:
     debug: bool = False
 
 
-def build_checksheet_tabs_embed(data: ChecksheetEmbedData) -> discord.Embed:
+def build_checksheet_tabs_embeds(data: ChecksheetEmbedData) -> list[discord.Embed]:
     colour_factory = getattr(discord.Colour, "dark_teal", None)
     colour = colour_factory() if callable(colour_factory) else discord.Colour.teal()
-    embed = discord.Embed(title="Checksheet — Tabs & Headers", colour=colour)
+    footer_parts = [
+        logfmt.LOG_EMOJI["lifecycle"],
+        f"Bot v{_sanitize_inline(data.bot_version)}",
+        f"CoreOps v{_sanitize_inline(data.coreops_version)}",
+    ]
+    footer_text = " · ".join(part for part in footer_parts if part)
+    embeds = [_new_checksheet_embed(colour, footer_text)]
 
-    embed.add_field(name="Google Sheets", value="Public client", inline=False)
+    _add_paginated_field(
+        embeds,
+        colour=colour,
+        footer_text=footer_text,
+        name="Google Sheets",
+        value="Public client",
+        inline=False,
+    )
 
     for sheet in data.sheets:
         lines: list[str] = []
@@ -474,7 +566,14 @@ def build_checksheet_tabs_embed(data: ChecksheetEmbedData) -> discord.Embed:
                 lines.append(f"Error: {_sanitize_inline(tab.error)}")
 
         block = "\n".join(lines) if lines else "—"
-        embed.add_field(name="​", value=block, inline=False)
+        _add_paginated_field(
+            embeds,
+            colour=colour,
+            footer_text=footer_text,
+            name="​",
+            value=block,
+            inline=False,
+        )
 
         if data.debug:
             config_tab = _sanitize_inline(sheet.config_tab or "Config") or "Config"
@@ -519,15 +618,20 @@ def build_checksheet_tabs_embed(data: ChecksheetEmbedData) -> discord.Embed:
             debug_lines = [f"config_tab: {config_tab}", f"first_rows: {first_rows_value or '—'}"]
             if joined_tabs_value:
                 debug_lines.append(f"discovered: {joined_tabs_value}")
-            embed.add_field(name="Debug preview", value="\n".join(debug_lines), inline=False)
+            _add_paginated_field(
+                embeds,
+                colour=colour,
+                footer_text=footer_text,
+                name="Debug preview",
+                value="\n".join(debug_lines),
+                inline=False,
+            )
 
-    footer_parts = [
-        logfmt.LOG_EMOJI["lifecycle"],
-        f"Bot v{_sanitize_inline(data.bot_version)}",
-        f"CoreOps v{_sanitize_inline(data.coreops_version)}",
-    ]
-    embed.set_footer(text=" · ".join(part for part in footer_parts if part))
-    return embed
+    return embeds
+
+
+def build_checksheet_tabs_embed(data: ChecksheetEmbedData) -> discord.Embed:
+    return build_checksheet_tabs_embeds(data)[0]
 
 def build_health_embed(
     *,
@@ -658,6 +762,7 @@ __all__ = [
     "build_digest_line",
     "build_digest_embed",
     "build_checksheet_tabs_embed",
+    "build_checksheet_tabs_embeds",
     "build_health_embed",
     "build_env_embed",
     "build_refresh_embed",

--- a/packages/c1c-coreops/tests/test_checksheet_render.py
+++ b/packages/c1c-coreops/tests/test_checksheet_render.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "packages" / "c1c-coreops" / "src"
+for path in (ROOT, SRC):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+from c1c_coreops.render import (
+    ChecksheetEmbedData,
+    ChecksheetSheetEntry,
+    ChecksheetTabEntry,
+    build_checksheet_tabs_embed,
+    build_checksheet_tabs_embeds,
+)
+
+
+def _field_text(embeds):
+    return "\n".join(str(field.value) for embed in embeds for field in embed.fields)
+
+
+def _assert_discord_embed_limits(embeds):
+    assert embeds
+    for embed in embeds:
+        assert len(embed.fields) <= 25
+        total = len(embed.title or "") + len(embed.description or "")
+        total += len(getattr(embed.footer, "text", None) or "")
+        for field in embed.fields:
+            assert len(field.name) <= 256
+            assert len(field.value) <= 1024
+            total += len(field.name) + len(field.value)
+        assert total <= 6000
+
+
+def test_checksheet_long_field_value_is_split_safely_and_preserved():
+    long_error = "schema-error-" * 120
+    data = ChecksheetEmbedData(
+        sheets=[
+            ChecksheetSheetEntry(
+                title="Templates",
+                sheet_id="sheet-1",
+                tabs=[
+                    ChecksheetTabEntry(
+                        name="Templates",
+                        ok=False,
+                        rows="42",
+                        headers="Name, Body",
+                        error=long_error,
+                    )
+                ],
+            )
+        ],
+        bot_version="test",
+    )
+
+    embeds = build_checksheet_tabs_embeds(data)
+
+    _assert_discord_embed_limits(embeds)
+    values = [field.value for embed in embeds for field in embed.fields]
+    assert any("schema-error-" in value for value in values)
+    assert long_error in _field_text(embeds).replace("\n", "")
+
+
+def test_checksheet_multiple_long_sections_produce_valid_embeds_with_full_text():
+    errors = [f"section-{idx}-" * 180 for idx in range(8)]
+    sheets = [
+        ChecksheetSheetEntry(
+            title=f"Sheet {idx}",
+            sheet_id=f"sheet-{idx}",
+            tabs=[
+                ChecksheetTabEntry(
+                    name=f"Tab {idx}",
+                    ok=False,
+                    rows="n/a",
+                    headers="Expected, Headers",
+                    error=error,
+                )
+            ],
+        )
+        for idx, error in enumerate(errors)
+    ]
+
+    embeds = build_checksheet_tabs_embeds(ChecksheetEmbedData(sheets=sheets, bot_version="test"))
+
+    _assert_discord_embed_limits(embeds)
+    combined = _field_text(embeds).replace("\n", "")
+    for error in errors:
+        assert error in combined
+    assert len(embeds) > 1 or sum(len(embed.fields) for embed in embeds) > len(sheets)
+
+
+def test_checksheet_many_errors_never_exceed_field_count():
+    sheets = [
+        ChecksheetSheetEntry(
+            title=f"Sheet {idx}",
+            sheet_id=f"sheet-{idx}",
+            tabs=[
+                ChecksheetTabEntry(
+                    name=f"Tab {idx}",
+                    ok=False,
+                    rows="1",
+                    headers="H",
+                    error="error details " * 90,
+                )
+            ],
+        )
+        for idx in range(40)
+    ]
+
+    embeds = build_checksheet_tabs_embeds(ChecksheetEmbedData(sheets=sheets, bot_version="test"))
+
+    _assert_discord_embed_limits(embeds)
+    assert len(embeds) >= 2
+
+
+def test_checksheet_short_output_matches_legacy_single_embed_shape():
+    data = ChecksheetEmbedData(
+        sheets=[
+            ChecksheetSheetEntry(
+                title="Recruitment",
+                sheet_id="sheet-short",
+                tabs=[
+                    ChecksheetTabEntry(name="Templates", ok=True, rows="3", headers="Name, Body")
+                ],
+            )
+        ],
+        bot_version="test",
+    )
+
+    embeds = build_checksheet_tabs_embeds(data)
+    legacy = build_checksheet_tabs_embed(data)
+
+    _assert_discord_embed_limits(embeds)
+    assert len(embeds) == 1
+    assert embeds[0].to_dict() == legacy.to_dict()
+    assert embeds[0].fields[0].name == "Google Sheets"
+    assert embeds[0].fields[0].value == "Public client"
+    assert "✅ Templates — 3 rows" in embeds[0].fields[1].value


### PR DESCRIPTION
### Motivation
- `!ops checksheet` could build embed field values > 1024 chars and crash with Discord's "Invalid Form Body" error, losing operator visibility.
- The change preserves the full checksheet diagnostics while guaranteeing all generated embeds respect Discord limits and do not crash the command.

### Description
- Reworked checksheet rendering to paginate safely: added `_split_field_value`, `_continued_field_name`, `_add_paginated_field`, and helper limits for field name (256), field value (1024), max fields per embed (25), and total embed text (6000). (`packages/c1c-coreops/src/c1c_coreops/render.py`)
- `build_checksheet_tabs_embed` now wraps a new `build_checksheet_tabs_embeds` that returns a list of embeds for long output, preserving single-embed compatibility for short output. (`packages/c1c-coreops/src/c1c_coreops/render.py`)
- Updated `!ops checksheet` to send all generated embeds in order by replying with the first embed and sending continuation embeds afterward. Added a checksheet-specific reply helper to ensure ordered delivery. (`packages/c1c-coreops/src/c1c_coreops/cog.py`)
- Added regression tests exercising long-field splitting, multiple long sections, embed/field limit enforcement, full diagnostic preservation, and unchanged short-output behavior. (`packages/c1c-coreops/tests/test_checksheet_render.py`)

### Testing
- Ran `pytest packages/c1c-coreops/tests/test_checksheet_render.py -q` and the new checksheet render tests passed. ✅
- Ran `PYTHONPATH=packages/c1c-coreops/src:. pytest packages/c1c-coreops/tests/test_coreops_imports.py packages/c1c-coreops/tests/test_checksheet_render.py -q` and both test modules passed. ✅
- Verified modules compile with `python -m py_compile packages/c1c-coreops/src/c1c_coreops/render.py packages/c1c-coreops/src/c1c_coreops/cog.py`. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bee40c32c8323bd585486d4e07e16)