### PR TITLE
Improve Woadkeeper help metadata

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -243,12 +243,14 @@ class AppAdmin(commands.Cog):
         function_group="operational",
         section="utilities",
         access_tier="admin",
+        usage="!servermap refresh",
     )
     @commands.group(
         name="servermap",
         invoke_without_command=True,
         hidden=True,
-        help="Admin tools for the automated #server-map post.",
+        help="Hidden admin group for the automated #server-map post. The refresh subcommand rebuilds the configured server-map channel from the live guild category/channel structure, deletes/replaces prior bot map messages as needed, replies with counts, and logs failures.",
+        brief="Refresh the automated server-map channel post.",
     )
     @admin_only()
     async def servermap(self, ctx: commands.Context) -> None:
@@ -299,11 +301,12 @@ class AppAdmin(commands.Cog):
         function_group="operational",
         section="utilities",
         access_tier="admin",
+        usage="!next [component]",
     )
     @commands.command(
         name="next",
         hidden=True,
-        help="Show upcoming scheduled jobs. Optionally filter by component.",
+        help="Hidden admin scheduler viewer. Replies with upcoming scheduled jobs from the active runtime; optional component filters by scheduler component/tag text such as cleanup, leagues, mirralith, fusion, or other registered runtime job names.",
     )
     @admin_only()
     async def next_jobs(self, ctx: commands.Context, component: str | None = None) -> None:
@@ -324,11 +327,13 @@ class AppAdmin(commands.Cog):
         function_group="operational",
         section="utilities",
         access_tier="admin",
+        usage="!whoweare",
     )
     @commands.command(
         name="whoweare",
         hidden=True,
-        help="Generate the live Who We Are overview from the WhoWeAre sheet.",
+        help="Hidden admin command that reads the configured role-map/Who We Are sheet tab, renders the current guild role overview, removes previous bot-authored overview messages in the configured channel, posts the refreshed overview there, replies in-channel, and logs status.",
+        brief="Refresh the Who We Are role overview post.",
     )
     @admin_only()
     async def whoweare(self, ctx: commands.Context) -> None:

--- a/cogs/clanrole_management.py
+++ b/cogs/clanrole_management.py
@@ -138,14 +138,14 @@ class ClanRoleTargetView(discord.ui.View):
 
 class ClanRoleManagementCog(commands.Cog):
     @tier("user")
-    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
-    @commands.group(name="clanrole", invoke_without_command=True)
+    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff", usage="!clanrole remove <member query>")
+    @commands.group(name="clanrole", invoke_without_command=True, help="Staff clan-role tools. Use remove with a mention, Discord ID, or exact member name to remove clan roles and run Raid/Wandering Souls cleanup; ambiguous matches open an in-channel selection UI.", brief="Staff tool for clan-role removal and related cleanup.")
     async def clanrole(self, ctx: commands.Context) -> None:
         await ctx.reply("Usage: `!clanrole remove <member query>`", mention_author=False)
 
     @tier("user")
-    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff")
-    @clanrole.command(name="remove", help="Remove a member from a clan role and run Raid/Wandering Souls cleanup.")
+    @help_metadata(function_group="recruitment", section="recruitment", access_tier="staff", usage="!clanrole remove <member query>")
+    @clanrole.command(name="remove", help="Staff-only removal by mention, Discord ID, or exact name. Removes clan role assignments and runs Raid/Wandering Souls cleanup; replies in-channel and may open a target picker for ambiguous matches.", brief="Remove clan roles and related Raid/Wandering Souls state.")
     async def clanrole_remove(self, ctx: commands.Context, *, member_query: str | None = None) -> None:
         if ctx.guild is None or not isinstance(ctx.author, discord.Member):
             await ctx.reply("⚠️ This command can only be used in a server.", mention_author=False)

--- a/cogs/housekeeping_mirralith.py
+++ b/cogs/housekeeping_mirralith.py
@@ -20,12 +20,12 @@ class MirralithOverviewCog(commands.Cog):
         self._last_manual_run: float | None = None
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!mirralith refresh")
     @commands.group(
         name="mirralith",
         invoke_without_command=True,
-        help="Post or refresh the Mirralith overview.",
-        brief="Post or refresh the Mirralith overview.",
+        help="Admin Mirralith overview group. Current action is refresh, which regenerates sheet-backed Mirralith overview images/posts in the configured Mirralith channel and replies with visible start/result messages; subject to a manual cooldown.",
+        brief="Refresh the Mirralith overview channel post.",
     )
     @admin_only()
     async def mirralith_group(self, ctx: commands.Context) -> None:
@@ -33,8 +33,8 @@ class MirralithOverviewCog(commands.Cog):
             await ctx.send('Use "!mirralith refresh" to regenerate the Mirralith overview.')
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
-    @mirralith_group.command(name="refresh")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!mirralith refresh")
+    @mirralith_group.command(name="refresh", help="Regenerate and post the Mirralith overview to the configured Mirralith channel from sheet-backed overview data; replies with start/result messages and enforces a 5-minute manual cooldown.", brief="Regenerate and post Mirralith overview.")
     @admin_only()
     async def mirralith_refresh(self, ctx: commands.Context) -> None:
         now = asyncio.get_event_loop().time()

--- a/cogs/recruitment_clan_ads.py
+++ b/cogs/recruitment_clan_ads.py
@@ -14,14 +14,14 @@ class ClanAdsCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(
-        function_group="operational", section="recruitment", access_tier="admin"
+        function_group="operational", section="recruitment", access_tier="admin", usage="!clanads post <all|clantag>"
     )
-    @commands.group(name="clanads", invoke_without_command=True)
+    @commands.group(name="clanads", invoke_without_command=True, help="Admin clan-ad publishing tools. Use post all to evaluate every configured clan, or post <clantag> to publish one clan ad; posts to the configured clan-ad channel and replies with a run summary.", brief="Publish configured clan recruitment ads.")
     @admin_only()
     async def clanads(self, ctx: commands.Context):
         await ctx.send("Usage: `!clanads post all` or `!clanads post <clantag>`")
 
-    @clanads.group(name="post", invoke_without_command=True)
+    @clanads.group(name="post", invoke_without_command=True, help="Posts clan ads for all configured clans or one clan tag from Sheets-backed clan data; replies with success/failure counts and may delete the command response in the ad channel.", brief="Post all clan ads or one clan ad.")
     @admin_only()
     async def post(self, ctx: commands.Context, clantag: str | None = None):
         if not clantag:

--- a/cogs/recruitment_member.py
+++ b/cogs/recruitment_member.py
@@ -15,12 +15,12 @@ class RecruitmentMember(commands.Cog):
         self.ctrl = MemberPanelControllerLegacy(bot)
 
     @tier("user")
-    @help_metadata(function_group="recruitment", section="recruitment", access_tier="user")
+    @help_metadata(function_group="recruitment", section="recruitment", access_tier="user", usage="!clansearch")
     @commands.cooldown(1, 2, commands.BucketType.user)
     @commands.command(
         name="clansearch",
-        help="Opens the member clan search panel so recruits can filter available clans.",
-        brief="Opens the member clan search panel.",
+        help="Opens the interactive member clan search/filter panel in-channel so recruits can browse available clans. It takes no arguments; use !clan <tag or name> for a specific clan profile.",
+        brief="Open the interactive clan search/filter panel.",
     )
     async def clansearch(
         self, ctx: commands.Context, *, extra: str | None = None

--- a/cogs/recruitment_reporting.py
+++ b/cogs/recruitment_reporting.py
@@ -25,11 +25,12 @@ class RecruitmentReporting(commands.Cog):
         function_group="operational",
         section="utilities",
         access_tier="admin",
+        usage="!report recruiters [all]",
     )
     @commands.command(
         name="report",
-        help="Posts the Daily Recruiter Update to the configured channel immediately.",
-        brief="Posts the Daily Recruiter Update immediately.",
+        help="Admin manual recruitment reporting. `!report recruiters` posts the Daily Recruiter Update to its configured channel. `!report recruiters all` runs the full recruiter report bundle: daily report, role/visitor audit, and open-ticket report, then replies with each result. Other report types are not supported.",
+        brief="Post recruiter reports; optional all runs the full bundle.",
     )
     @admin_only()
     async def report_group(self, ctx: commands.Context, *args: str) -> None:
@@ -92,10 +93,10 @@ class RecruitmentReporting(commands.Cog):
                 await ctx.reply("Failed to post report. Check log channel.", mention_author=False)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!roleaudit [preview|apply CONFIRM [override]]")
     @commands.command(
         name="roleaudit",
-        help="Preview or apply role-audit role mutations.",
+        help="Admin role/visitor audit. `preview` (default) dry-runs proposed member role removals/additions and replies with the first 20 affected members. `apply CONFIRM` mutates Discord roles with the normal safety cap; add `override` to allow over-cap application. Applies role changes only when explicitly confirmed.",
         brief="Preview or apply role-audit role mutations.",
     )
     @admin_only()

--- a/cogs/recruitment_welcome.py
+++ b/cogs/recruitment_welcome.py
@@ -57,11 +57,11 @@ class WelcomeBridge(commands.Cog):
         await self._service.post_welcome(ctx, clan, tail=note)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="welcome_templates", access_tier="admin")
+    @help_metadata(function_group="operational", section="welcome_templates", access_tier="admin", usage="!welcome-refresh")
     @commands.command(
         name="welcome-refresh",
-        help="Reloads the WelcomeTemplates cache bucket so fresh messages are ready for staff.",
-        brief="Reloads the WelcomeTemplates cache bucket.",
+        help="Admin cache refresh for WelcomeTemplates. Reloads the sheet-backed welcome template cache used by !welcome and replies with visible refresh status; does not post a welcome message or change sheet schema.",
+        brief="Refresh sheet-backed WelcomeTemplates cache.",
     )
     @admin_only()
     async def welcome_refresh(self, ctx: commands.Context) -> None:

--- a/modules/community/fusion/cog.py
+++ b/modules/community/fusion/cog.py
@@ -407,12 +407,13 @@ class FusionCog(commands.Cog):
         function_group="milestones",
         section="community",
         access_tier="user",
-        usage="!fusion debug",
+        usage="!fusion [debug|refresh-announcement|publish]",
     )
     @commands.group(
         name="fusion",
         invoke_without_command=True,
-        help="Fusion reminder data commands.",
+        help=("Shows the current Fusion tracker announcement in-channel for users. Admin subcommands: debug reads active Fusion rows/events from Sheets cache; refresh-announcement edits the stored announcement in place; publish posts the configured announcement channel."),
+        brief="Shows Fusion tracker status and admin announcement tools.",
     )
     async def fusion(self, ctx: commands.Context) -> None:
         await self._tracker_entrypoint(
@@ -429,7 +430,8 @@ class FusionCog(commands.Cog):
     @commands.group(
         name="titan",
         invoke_without_command=True,
-        help="Titan reminder data commands.",
+        help=("Shows the current Titan tracker announcement in-channel for users. Admin subcommand: publish posts the configured Titan announcement to its announcement channel."),
+        brief="Shows Titan tracker status and admin publish tools.",
     )
     async def titan(self, ctx: commands.Context) -> None:
         await self._tracker_entrypoint(ctx, tracker_kind="titan", tracker_label="titan")
@@ -442,7 +444,7 @@ class FusionCog(commands.Cog):
         usage="!fusion debug",
     )
     @fusion.command(
-        name="debug", help="Debug active fusion + first events from sheets cache."
+        name="debug", help="Admin-only debug output for active Fusion rows and the first events read from the Sheets cache; replies in-channel and does not mutate state."
     )
     @commands.guild_only()
     @admin_only()
@@ -515,7 +517,7 @@ class FusionCog(commands.Cog):
     )
     @fusion.command(
         name="refresh-announcement",
-        help="Refresh the stored fusion announcement in place.",
+        help="Admin-only refresh that edits the existing configured Fusion announcement message in place from cached Sheets data.",
     )
     @commands.guild_only()
     @admin_only()
@@ -534,7 +536,7 @@ class FusionCog(commands.Cog):
         usage="!fusion publish",
     )
     @fusion.command(
-        name="publish", help="Publish fusion announcement to the configured channel."
+        name="publish", help="Admin-only publish that posts the Fusion announcement from Sheets/cache to the configured announcement channel."
     )
     @commands.guild_only()
     @admin_only()
@@ -554,7 +556,7 @@ class FusionCog(commands.Cog):
         usage="!titan publish",
     )
     @titan.command(
-        name="publish", help="Publish titan announcement to the configured channel."
+        name="publish", help="Admin-only publish that posts the Titan announcement from Sheets/cache to the configured announcement channel."
     )
     @commands.guild_only()
     @admin_only()

--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -471,11 +471,12 @@ class LeaguesCog(commands.Cog):
 
     # === Commands ===
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!leagues post")
     @commands.group(
         name="leagues",
         invoke_without_command=True,
-        help="C1C Leagues admin commands.",
+        help="Admin C1C Leagues command group. Current action is post, which manually runs the league posting job from the C1C_Leagues sheet/config and sends status to the invoking channel; scheduled reminders/approval prompts are handled separately.",
+        brief="Run C1C Leagues posting tools.",
     )
     @admin_only()
     async def leagues(self, ctx: commands.Context) -> None:
@@ -484,8 +485,8 @@ class LeaguesCog(commands.Cog):
         await ctx.send("Usage: !leagues post")
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
-    @leagues.command(name="post", help="Manually run the C1C Leagues posting job.")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!leagues post")
+    @leagues.command(name="post", help="Manually run the C1C Leagues posting job from configured sheet data and report status in the invoking channel.", brief="Manually run the C1C Leagues posting job.")
     @admin_only()
     async def leagues_post(self, ctx: commands.Context) -> None:
         await self.run_leagues_job(trigger="command", status_channel=ctx.channel)

--- a/modules/community/reaction_roles.py
+++ b/modules/community/reaction_roles.py
@@ -287,11 +287,11 @@ class ReactionRolesCog(commands.Cog):
         )
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="permissions", access_tier="admin")
+    @help_metadata(function_group="operational", section="permissions", access_tier="admin", usage="!reactrole <key>")
     @commands.command(
         name="reactrole",
-        help="Manage reaction role mappings.",
-        brief="Manage reaction role mappings.",
+        help="Admin command used while replying to a target message. `<key>` is the reaction-role mapping key from the sheet-backed reaction-role configuration; the command attaches all active rows for that key to the replied-to message and adds reactions. It replies in-channel if the key/message cannot be used.",
+        brief="Attach a sheet-configured reaction-role key to a message.",
     )
     @commands.guild_only()
     @admin_only()

--- a/modules/coreops/cmd_cfg.py
+++ b/modules/coreops/cmd_cfg.py
@@ -28,8 +28,7 @@ class ConfigCmd(commands.Cog):
     @commands.command(
         name="cfg",
         help=(
-            "Admin-only snapshot of the merged config registry. Provide a key to "
-            "see the current value and source sheet tail (defaults to ONBOARDING_TAB)."
+            "Admin-only merged config lookup. With KEY, replies in-channel with the current cached value, redacted source sheet tail, and merged key count. Without KEY, defaults to ONBOARDING_TAB. Reads runtime config only and does not write Sheets."
         ),
     )
     @commands.has_permissions(administrator=True)

--- a/modules/housekeeping/cleanup.py
+++ b/modules/housekeeping/cleanup.py
@@ -1526,12 +1526,13 @@ class CleanupCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(
-        function_group="operational", section="housekeeping", access_tier="admin"
+        function_group="operational", section="housekeeping", access_tier="admin", usage="!cleanup run"
     )
     @commands.group(
         name="cleanup",
         invoke_without_command=True,
-        help="Housekeeping cleanup admin commands.",
+        help="Admin housekeeping cleanup group. Current supported action is `run`, which starts the cleanup job immediately, scans configured housekeeping targets, runs with writeback enabled and writes cleanup state as the job requires, sends log-channel notices, and replies with start/completion status.",
+        brief="Run the housekeeping cleanup job.",
     )
     @commands.guild_only()
     @admin_only()
@@ -1540,9 +1541,9 @@ class CleanupCog(commands.Cog):
 
     @tier("admin")
     @help_metadata(
-        function_group="operational", section="housekeeping", access_tier="admin"
+        function_group="operational", section="housekeeping", access_tier="admin", usage="!cleanup run"
     )
-    @cleanup.command(name="run", help="Run housekeeping cleanup immediately.")
+    @cleanup.command(name="run", help="Admin action that starts housekeeping cleanup immediately with writeback enabled; replies when started and when complete/failing, and posts operational log notices.", brief="Start housekeeping cleanup immediately.")
     @commands.guild_only()
     @admin_only()
     async def cleanup_run(self, ctx: commands.Context) -> None:

--- a/modules/ops/permissions_ui.py
+++ b/modules/ops/permissions_ui.py
@@ -1114,11 +1114,11 @@ class PermissionsUICog(commands.Cog):
         self.bot = bot
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="permissions", access_tier="admin")
+    @help_metadata(function_group="operational", section="permissions", access_tier="admin", usage="!perm")
     @commands.command(
         name="perm",
-        help="Launches the interactive permissions UI.",
-        brief="Open the permissions UI.",
+        help="Admin/manage-channels command that opens the interactive permissions UI in-channel. The UI manages channel/category permission overwrites while respecting configured blacklist IDs; it mutates Discord permissions only through the interactive controls.",
+        brief="Open the interactive permissions management UI.",
     )
     @admin_only()
     async def perm(self, ctx: commands.Context) -> None:

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -2149,11 +2149,11 @@ class CoreOpsCog(commands.Cog):
         logger.info(log_msg, extra=extra)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="config_health", access_tier="admin")
+    @help_metadata(function_group="operational", section="config_health", access_tier="admin", usage="!ops health")
     @ops.command(
         name="health",
-        help="Checks the bot’s internal health status.",
-        brief="Checks the bot’s internal health status.",
+        help="Admin health check that replies in-channel with an embed showing environment, version, uptime, Discord latency, heartbeat age, and watchdog thresholds. It does not mutate Sheets or runtime state.",
+        brief="Show bot health, latency, heartbeat, and watchdog status.",
     )
     @ops_only()
     async def ops_health(self, ctx: commands.Context) -> None:
@@ -2751,11 +2751,11 @@ class CoreOpsCog(commands.Cog):
             await ctx.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")
+    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin", usage="!ops checksheet [debug]")
     @ops.command(
         name="checksheet",
-        help="Shows loaded tabs and headers.",
-        brief="Shows loaded tabs and headers.",
+        help="Admin sheet diagnostics for recruitment/onboarding configuration. Replies with loaded worksheet tabs, discovered headers, and cache/config status; adding debug includes extra discovery details. Does not write to Sheets.",
+        brief="Show configured Sheets tabs, headers, and discovery status.",
     )
     @guild_only_denied_msg()
     @ops_only()
@@ -3970,11 +3970,11 @@ class CoreOpsCog(commands.Cog):
         await ctx.reply(embed=sanitize_embed(embed))
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")
+    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin", usage="!ops config")
     @ops.command(
         name="config",
-        help="Shows current configuration values.",
-        brief="Shows current configuration values.",
+        help="Admin config snapshot that replies in-channel with merged runtime configuration source/status and selected non-secret operational values. It reads current cache/config state and does not write Sheets.",
+        brief="Show merged runtime config source and status.",
     )
     @guild_only_denied_msg()
     @ops_only()
@@ -4077,11 +4077,11 @@ class CoreOpsCog(commands.Cog):
         await self._reload_impl(ctx, reboot=reboot)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin", usage="!ops reload [--reboot]")
     @ops.command(
         name="reload",
-        help="Reloads runtime configs and command modules.",
-        brief="Reloads runtime configs and command modules.",
+        help="Admin runtime reload. With no flags, reloads runtime config and command modules; --reboot additionally requests the configured reboot path. Unknown flags are rejected. Replies with reload status and may affect live bot modules/config.",
+        brief="Reload runtime config/modules; optional --reboot.",
     )
     @guild_only_denied_msg()
     @ops_only()
@@ -4117,12 +4117,12 @@ class CoreOpsCog(commands.Cog):
         await self._refresh_root(ctx)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")
+    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin", usage="!ops refresh [bucket]")
     @ops.group(
         name="refresh",
         invoke_without_command=True,
-        help="Refreshes a single data bucket from Google Sheets.",
-        brief="Refreshes a single data bucket from Google Sheets.",
+        help="Admin cache refresh from Google Sheets. With a bucket name, refreshes that registered cache bucket and replies with telemetry; with no bucket, lists available refresh commands. Valid buckets are the runtime cache registry names, for example clansinfo when registered; use !ops refresh all for every registered bucket.",
+        brief="Refresh one registered Sheets cache bucket.",
     )
     @guild_only_denied_msg()
     @ops_only()
@@ -4223,11 +4223,11 @@ class CoreOpsCog(commands.Cog):
         await self._refresh_all_impl(ctx)
 
     @tier("admin")
-    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin")
+    @help_metadata(function_group="operational", section="sheet_tools", access_tier="admin", usage="!ops refresh all")
     @ops_refresh.command(
         name="all",
-        help="Reloads all data from Sheets.",
-        brief="Reloads all data from Sheets.",
+        help="Admin refresh of every registered Sheets cache bucket. Runs each cache refresh, replies with an in-channel summary/embed of bucket results, and logs refresh telemetry; does not change sheet schema.",
+        brief="Refresh all registered Sheets cache buckets.",
     )
     @guild_only_denied_msg()
     @ops_only()

--- a/packages/c1c-coreops/tests/test_helpseed.py
+++ b/packages/c1c-coreops/tests/test_helpseed.py
@@ -416,3 +416,101 @@ def test_helpseed_missing_batch_update_fails_without_update_fallback(monkeypatch
         assert worksheet.updated == []
 
     asyncio.run(run())
+
+
+def test_helpseed_fills_blank_curated_fields_from_metadata(monkeypatch):
+    async def run():
+        cmd = _command(
+            extras={"function_group": "newcat", "access_tier": "admin"},
+            brief="Generated summary",
+            help_text="Generated details",
+        )
+        bot = SimpleNamespace(walk_commands=lambda: [cmd])
+        cog = _make_cog(bot)
+        existing = [
+            "TRUE",
+            "woadkeeper",
+            "sample",
+            "!old",
+            "!old",
+            "",
+            "staff",
+            "",
+            "",
+            "manual note",
+            "7",
+        ]
+        worksheet = FakeWorksheet([HEADERS, existing])
+        _patch_sheet(monkeypatch, worksheet)
+        result = await cog._helpseed_impl(DummyCtx())
+        assert result.updated == 1
+        updated = worksheet.updated_batches[0][0][0]["values"][0]
+        assert updated[5] == "newcat"
+        assert updated[7] == "Generated summary"
+        assert updated[8] == "Generated details"
+        assert updated[9] == "manual note"
+        assert updated[10] == "7"
+
+    asyncio.run(run())
+
+
+def test_touched_woadkeeper_command_metadata_is_useful() -> None:
+    from cogs.app_admin import AppAdmin
+    from cogs.clanrole_management import ClanRoleManagementCog
+    from cogs.housekeeping_mirralith import MirralithOverviewCog
+    from cogs.recruitment_clan_ads import ClanAdsCog
+    from cogs.recruitment_member import RecruitmentMember
+    from cogs.recruitment_reporting import RecruitmentReporting
+    from cogs.recruitment_welcome import WelcomeBridge
+    from modules.community.fusion.cog import FusionCog
+    from modules.community.leagues.cog import LeaguesCog
+    from modules.community.reaction_roles import ReactionRolesCog
+    from modules.coreops.cmd_cfg import ConfigCmd
+    from modules.housekeeping.cleanup import CleanupCog
+    from modules.ops.permissions_ui import PermissionsUICog
+
+    commands_by_name = {
+        "cfg": ConfigCmd.cfg_cmd,
+        "fusion": FusionCog.fusion,
+        "titan": FusionCog.titan,
+        "clanrole": ClanRoleManagementCog.clanrole,
+        "clanads": ClanAdsCog.clanads,
+        "next": AppAdmin.next_jobs,
+        "servermap": AppAdmin.servermap,
+        "whoweare": AppAdmin.whoweare,
+        "report": RecruitmentReporting.report_group,
+        "roleaudit": RecruitmentReporting.roleaudit,
+        "cleanup": CleanupCog.cleanup,
+        "welcome-refresh": WelcomeBridge.welcome_refresh,
+        "mirralith": MirralithOverviewCog.mirralith_group,
+        "leagues": LeaguesCog.leagues,
+        "reactrole": ReactionRolesCog.reactrole_cmd,
+        "perm": PermissionsUICog.perm,
+        "clansearch": RecruitmentMember.clansearch,
+        "ops health": CoreOpsCog.ops_health,
+        "ops checksheet": CoreOpsCog.ops_checksheet,
+        "ops config": CoreOpsCog.ops_config,
+        "ops refresh": CoreOpsCog.ops_refresh,
+        "ops refresh all": CoreOpsCog.ops_refresh_all,
+        "ops reload": CoreOpsCog.ops_reload,
+    }
+    required_terms = {
+        "reactrole": ["<key>", "mapping key"],
+        "ops refresh": ["bucket", "registered"],
+        "ops reload": ["--reboot", "Unknown flags"],
+        "next": ["component", "scheduled jobs"],
+        "roleaudit": ["preview", "apply CONFIRM"],
+        "cleanup": ["run", "writeback"],
+        "report": ["recruiters", "all"],
+        "clansearch": ["takes no arguments", "!clan <tag or name>"],
+    }
+
+    cog = _make_cog(SimpleNamespace())
+    for name, command in commands_by_name.items():
+        row = cog._build_help_seed_row(command)
+        details = row.details
+        assert row.summary, name
+        assert details and len(details) >= 40, name
+        assert row.usage.startswith("!"), name
+        for term in required_terms.get(name, []):
+            assert term in f"{row.usage} {row.summary} {details}", name


### PR DESCRIPTION
### Motivation
- Make the Woadkeeper command metadata (usage, short summary, detailed help) accurate and actionable so `!helpseed` can populate the shared `HelpCommands` sheet with useful rows. 
- Clarify ambiguous usages and document subcommands/flags/argument semantics for specific commands used by staff/admin workflows. 
- Preserve any manually-curated sheet fields (enabled, category, summary, details, notes, sort_order) when seeding, and avoid changing runtime behavior beyond documentation/metadata. 

### Description
- Updated help/usage/brief metadata and decorator `help_metadata(..., usage=...)` across CoreOps and cogs for touched commands, including but not limited to `fusion`, `titan`, `clanrole`, `clanads`, `cfg`, `ops health`, `ops checksheet`, `ops config`, `ops refresh [bucket]`, `ops refresh all`, `ops reload [--reboot]`, `next [component]`, `perm`, `reactrole <key>`, `roleaudit`, `cleanup`, `report recruiters [all]`, `welcome-refresh`, `servermap`, `whoweare`, `mirralith`, `leagues`, and `clansearch` (files changed include `packages/c1c-coreops/src/c1c_coreops/cog.py`, `modules/community/fusion/cog.py`, `cogs/clanrole_management.py`, `cogs/recruitment_clan_ads.py`, `modules/coreops/cmd_cfg.py`, `cogs/app_admin.py`, `cogs/recruitment_reporting.py`, `modules/housekeeping/cleanup.py`, `modules/community/reaction_roles.py`, `modules/ops/permissions_ui.py`, `cogs/recruitment_member.py`, `cogs/housekeeping_mirralith.py`, `modules/community/leagues/cog.py`).
- Improved each touched command's help text to state: accurate usage, a short `summary` suitable for `HelpCommands.summary`, a longer `details` paragraph for `HelpCommands.details`, who can run it, what it posts/changes/refreshes, and whether it replies in-channel, posts elsewhere, refreshes Sheets-backed caches, or mutates state. 
- Added unit coverage for `!helpseed` behavior and metadata quality by extending `packages/c1c-coreops/tests/test_helpseed.py` with tests that ensure blank curated sheet fields are filled from command metadata while non-empty curated fields remain preserved, and added a metadata-coverage assertion test that verifies touched commands expose non-empty summaries/details/usages and include required terms (e.g., `<key>` for `!reactrole`, `bucket` for `!ops refresh`, `--reboot` for `!ops reload`, etc.).

### Testing
- Ran repository checks and bytecode compile: `git diff --check` and `python -m py_compile` on modified modules with no syntax errors reported. 
- Ran targeted unit tests: `pytest -q packages/c1c-coreops/tests/test_helpseed.py packages/c1c-coreops/tests/test_command_metadata_overrides.py` and all tests passed. 
- Verified `!helpseed` behavior in tests still preserves curated sheet fields and fills blanks from metadata via the new tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c108307ac8323a7067d980101cdda)