### PR TITLE
Persist promo source prompt, atomic final-close patch, and add detailed finalization logging

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from time import monotonic
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any
 
 import discord
 from discord.ext import commands
@@ -35,7 +35,6 @@ from modules.onboarding.watcher_welcome import (
     cleanup_reservation_for_ticket_close,
     PanelOutcome,
     parse_promo_thread_name,
-    persist_session_for_thread,
     post_open_questions_panel,
     resolve_subject_user_id,
 )
@@ -46,7 +45,6 @@ from shared.logs import log_lifecycle
 from shared.cache import telemetry as cache_telemetry
 from shared.sheets import onboarding as onboarding_sheets
 from shared.sheets import onboarding_sessions
-from shared.sheets import promo_tickets
 from shared.sheets import recruitment as recruitment_sheets
 from shared.sheets import reservations as reservations_sheets
 
@@ -106,13 +104,68 @@ async def _log_promo_failure_row(
         log.warning("promo failure promo-row updated", extra={**payload, "sheet_result": result})
 
 
+
+def _promo_log_transition(
+    phase: str,
+    *,
+    thread: object | None = None,
+    context: "PromoTicketContext" | None = None,
+    actor: object | None = None,
+    raw_message_content: str | None = None,
+    metadata_row_number: int | None = None,
+    session_row_number: int | None = None,
+    status_before: str | None = None,
+    status_after: str | None = None,
+    finalization_status_before: str | None = None,
+    finalization_status_after: str | None = None,
+    missing_config_key: str | None = None,
+    missing_schema_field: str | None = None,
+    write_skipped: bool | str | None = None,
+    reason: str | None = None,
+    **extra: Any,
+) -> None:
+    payload: dict[str, Any] = {
+        "flow": "promo",
+        "phase": phase,
+        "ticket": getattr(context, "ticket_number", None),
+        "thread_id": getattr(thread, "id", None) or getattr(context, "thread_id", None),
+        "thread_name": getattr(thread, "name", None),
+        "acting_user_id": getattr(actor, "id", None),
+        "raw_message_content": raw_message_content,
+        "source_clan_tag": getattr(context, "source_clan_tag", None),
+        "destination_clan_tag": getattr(context, "clan_tag", None),
+        "metadata_row_number": metadata_row_number,
+        "session_row_number": session_row_number,
+        "status_before": status_before,
+        "status_after": status_after,
+        "finalization_status_before": finalization_status_before,
+        "finalization_status_after": finalization_status_after,
+        "missing_config_key": missing_config_key,
+        "missing_schema_field": missing_schema_field,
+        "write_skipped": write_skipped,
+        "reason": reason,
+    }
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    log.info("promo_finalization_transition", extra=payload)
+
+
+def _valid_promo_year(value: object) -> str:
+    text = str(value or "").strip()
+    try:
+        year = int(text)
+    except (TypeError, ValueError):
+        return ""
+    if year <= 1900:
+        return ""
+    return str(year)
+
 def _promo_headers_for_write(*, ticket: str | None = None) -> list[str]:
     try:
         return onboarding_sheets.get_live_promo_headers()
     except Exception:
         log.exception(
-            "promo source clan header mapping unavailable; cannot write Promo row",
-            extra={"ticket": ticket or "-"},
+            "promo live header read failed; promo write skipped",
+            extra={"ticket": ticket or "-", "write_skipped": True, "reason": "live_header_read_failed"},
         )
         raise
 
@@ -464,6 +517,22 @@ class PromoTicketWatcher(commands.Cog):
         self._clan_tags = normalized
         return self._clan_tags
 
+    async def _clan_name_for_tag(self, tag: str) -> str:
+        tag = (tag or "").strip().upper()
+        if not tag:
+            return ""
+        try:
+            found = await asyncio.to_thread(_find_promo_clan_row, tag, force=True)
+            header_map = await asyncio.to_thread(recruitment_sheets.get_clan_header_map)
+        except Exception:
+            log.exception("promo destination clan name resolution failed", extra={"clan_tag": tag})
+            return ""
+        if not found:
+            return ""
+        _, row = found
+        name_idx = header_map.get("clan_name")
+        return str(row[name_idx] if name_idx is not None and name_idx < len(row) else "").strip()
+
     async def _ensure_context(self, thread: discord.Thread) -> Optional[PromoTicketContext]:
         context = self._tickets.get(thread.id)
         if context is not None:
@@ -667,7 +736,7 @@ class PromoTicketWatcher(commands.Cog):
         review_reason: str | None = None,
         created_at: dt.datetime | None = None,
         updated_at: dt.datetime | None = None,
-    ) -> str | None:
+    ) -> bool:
         resolved_user_id = user_id if user_id is not None else context.user_id
         reason = review_reason
         if resolved_user_id is None and not reason:
@@ -695,13 +764,13 @@ class PromoTicketWatcher(commands.Cog):
                 "promo metadata write failed",
                 extra={"phase": phase, "ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
             )
-            return None
+            return False
         log.info(
             "promo metadata write %s",
             result,
             extra={"phase": phase, "ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)},
         )
-        return result
+        return True
 
     async def _ensure_row_initialized(self, thread: discord.Thread, context: PromoTicketContext) -> None:
         try:
@@ -729,6 +798,43 @@ class PromoTicketWatcher(commands.Cog):
             "promo watcher could not locate ticket row for closure; skipping append",
             extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
         )
+
+    async def _persist_prompt_source(self, thread: discord.Thread, context: PromoTicketContext, *, actor: discord.abc.User | None = None, raw_message_content: str | None = None) -> bool:
+        source = (context.source_clan_tag or "").strip().upper()
+        if not source:
+            _promo_log_transition("source_persist_skipped", thread=thread, context=context, actor=actor, raw_message_content=raw_message_content, write_skipped=True, reason="missing_runtime_source")
+            return False
+        try:
+            found = await asyncio.to_thread(onboarding_sheets.find_promo_row, context.ticket_number)
+        except Exception as exc:
+            log.exception("promo source persist row lookup failed; write skipped", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None), "phase": "source_persist", "write_skipped": True, "reason": str(exc)})
+            _promo_log_transition("source_persist_failed", thread=thread, context=context, actor=actor, raw_message_content=raw_message_content, write_skipped=True, reason="row_lookup_exception", exception=str(exc))
+            await thread.send("⚠️ I couldn't read the promo metadata row, so I skipped writing source context. Please try again or finish manually.")
+            return False
+        row_no = found[0] if found else None
+        values = found[1] if found else {}
+        before_state = _promo_finalization_state(values)
+        existing_source = _source_clan_from_promo_values(values, ticket=context.ticket_number) if values else ""
+        if existing_source:
+            context.source_clan_tag = existing_source.strip().upper()
+            _promo_log_transition("source_persist_skipped", thread=thread, context=context, actor=actor, raw_message_content=raw_message_content, metadata_row_number=row_no, finalization_status_before=before_state.get("finalization_status"), finalization_status_after=before_state.get("finalization_status"), write_skipped=True, reason="source_already_persisted")
+            return True
+        try:
+            result = await asyncio.to_thread(
+                onboarding_sheets.patch_promo_prompt_source,
+                ticket=context.ticket_number,
+                thread_id=getattr(thread, "id", None),
+                source_clan_tag=source,
+                finalization_status="prompt_required",
+                finalization_note="source clan persisted; awaiting destination",
+            )
+        except Exception as exc:
+            log.exception("promo source persist write failed", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)})
+            _promo_log_transition("source_persist_failed", thread=thread, context=context, actor=actor, raw_message_content=raw_message_content, metadata_row_number=row_no, missing_schema_field=str(exc), write_skipped=True, reason="write_failed")
+            await thread.send("⚠️ I couldn't persist the promo source clan before asking for destination. Please try again or finish manually.")
+            return False
+        _promo_log_transition("source_persisted", thread=thread, context=context, actor=actor, raw_message_content=raw_message_content, metadata_row_number=row_no, finalization_status_before=before_state.get("finalization_status"), finalization_status_after="prompt_required", reason=str(result))
+        return True
 
     async def _send_invalid_tag_notice(self, thread: discord.Thread, actor: discord.abc.User | None, candidate: str) -> None:
         notice = (
@@ -767,21 +873,31 @@ class PromoTicketWatcher(commands.Cog):
             context.state = "awaiting_destination_clan"
             await self._complete_close(thread, context, progression=context.progression, clan_name=context.clan_name, phase="close", previous_final=context.source_clan_tag, trigger=trigger)
             return
-        try:
-            await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=context.ticket_number, thread_id=getattr(thread, "id", None), finalization_status="prompt_required", finalization_note="missing source/destination, prompted staff")
-        except Exception:
-            log.exception("promo prompt finalization state update failed", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)})
-
-        context.state = "awaiting_source_clan"
-        content = (
-            f"Where did the member come from?\n"
-            f"Where is the member going?\n"
-            f"First select the source clan for {context.username} (ticket {context.ticket_number}).\n"
-            f"Use **{_NO_PLACEMENT_TAG}** only when there was no source placement.\n{CLAN_TAG_PROMPT_HELPER}"
-        )
-        source_tags = [tag for tag in tags if tag != _NO_PLACEMENT_TAG]
-        source_tags.insert(0, _NO_PLACEMENT_TAG)
-        view = PromoClanSelectView(self, context, source_tags, role="source")
+        if context.source_clan_tag:
+            if not await self._persist_prompt_source(thread, context):
+                return
+            context.state = "awaiting_destination_clan"
+            content = (
+                f"Source recorded as **{context.source_clan_tag}**. Where is the member going?\n"
+                f"Select the destination clan for {context.username} (ticket {context.ticket_number}).\n"
+                f"{CLAN_TAG_PROMPT_HELPER}"
+            )
+            view = PromoClanSelectView(self, context, tags, role="destination")
+        else:
+            try:
+                await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=context.ticket_number, thread_id=getattr(thread, "id", None), finalization_status="prompt_required", finalization_note="missing source/destination, prompted staff")
+            except Exception:
+                log.exception("promo prompt finalization state update failed", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)})
+            context.state = "awaiting_source_clan"
+            content = (
+                f"Where did the member come from?\n"
+                f"Where is the member going?\n"
+                f"First select the source clan for {context.username} (ticket {context.ticket_number}).\n"
+                f"Use **{_NO_PLACEMENT_TAG}** only when there was no source placement.\n{CLAN_TAG_PROMPT_HELPER}"
+            )
+            source_tags = [tag for tag in tags if tag != _NO_PLACEMENT_TAG]
+            source_tags.insert(0, _NO_PLACEMENT_TAG)
+            view = PromoClanSelectView(self, context, source_tags, role="source")
         try:
             message = await thread.send(content, view=view)
         except Exception:
@@ -801,48 +917,12 @@ class PromoTicketWatcher(commands.Cog):
             status="prompt_required",
             updated_at=getattr(message, "created_at", None),
         )
+        _promo_log_transition("prompt", thread=thread, context=context, status_after="prompt_required", finalization_status_after="prompt_required", reason="destination" if context.source_clan_tag else "source_destination")
         log.info("close_prompt_started", extra={"flow": "promo", "trigger": trigger, "thread_id": getattr(thread, "id", None), "ticket": context.ticket_number})
         await _send_placement_log_line(flow="promo", outcome="prompt", ticket=context.ticket_number, player=context.username, trigger=trigger, finalization_status="prompt_required", reason="missing_source_destination", action="prompted_staff")
 
-        if context.user_id is None:
-            log.warning(
-                "promo watcher: skipping session persist; no resolved user id",
-                extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
-            )
-            return
-
-        ticket_username = None
-        try:
-            _, ticket_username = (getattr(thread, "name", "") or "").split("-", 1)
-            ticket_username = ticket_username.strip()
-        except ValueError:
-            ticket_username = None
-
-        created_at = getattr(message, "created_at", None) or dt.datetime.now(UTC)
-        try:
-            await persist_session_for_thread(
-                flow="promo",
-                ticket_number=context.ticket_number,
-                thread=thread,
-                user_id=context.user_id,
-                username=context.username,
-                created_at=created_at,
-                panel_message_id=message.id,
-            )
-        except Exception:
-            log.exception(
-                "promo watcher: failed to persist onboarding session at panel creation",
-                extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
-            )
-        else:
-            if context.ticket_number and ticket_username:
-                try:
-                    await promo_tickets.save(context.ticket_number, ticket_username)
-                except Exception:
-                    log.exception(
-                        "failed to persist promo ticket log",
-                        extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
-                    )
+        # Promo close/finalization recovery state lives in Promo ticket metadata;
+        # do not create empty OnboardingSessions placeholders from this prompt path.
 
 
     async def source_from_interaction(
@@ -890,6 +970,8 @@ class PromoTicketWatcher(commands.Cog):
             return
 
         context.source_clan_tag = source_tag
+        if not await self._persist_prompt_source(thread, context, actor=actor):
+            return
         context.state = "awaiting_destination_clan"
         if view is not None:
             view.stop()
@@ -962,7 +1044,40 @@ class PromoTicketWatcher(commands.Cog):
             await self._send_invalid_tag_notice(thread, actor, final_tag)
             return
 
+        found = None
+        try:
+            found = await asyncio.to_thread(onboarding_sheets.find_promo_row, context.ticket_number)
+        except Exception as exc:
+            log.exception("promo destination row lookup failed; finalization skipped", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None), "phase": "destination_continue", "write_skipped": True, "reason": str(exc)})
+            _promo_log_transition("destination_failed", thread=thread, context=context, actor=actor, write_skipped=True, reason="row_lookup_exception", exception=str(exc))
+            await thread.send("⚠️ I couldn't read the promo metadata row, so I skipped finalization. Please try again or finish manually.")
+            return
+        if found:
+            row_no, values = found
+            persisted_source = _source_clan_from_promo_values(values, ticket=context.ticket_number)
+            if persisted_source:
+                context.source_clan_tag = persisted_source.strip().upper()
+            elif context.source_clan_tag:
+                if context.state == "awaiting_destination_clan" and not await self._persist_prompt_source(thread, context, actor=actor):
+                    return
+            elif context.state == "awaiting_clan":
+                context.source_clan_tag = str(values.get("clantag") or _NO_PLACEMENT_TAG).strip().upper()
+            else:
+                _promo_log_transition("destination_failed", thread=thread, context=context, actor=actor, metadata_row_number=row_no, reason="missing_persisted_source_context")
+                await thread.send("⚠️ Promo source clan context is missing from the ticket metadata row, so I can't safely finalize this move. Please re-select the source clan or use `!finishplacement` with source and destination tags.")
+                return
+        elif context.source_clan_tag:
+            if context.state == "awaiting_destination_clan" and not await self._persist_prompt_source(thread, context, actor=actor):
+                return
+        elif context.state == "awaiting_clan":
+            context.source_clan_tag = _NO_PLACEMENT_TAG
+        else:
+            _promo_log_transition("destination_failed", thread=thread, context=context, actor=actor, reason="missing_source_context_no_row")
+            await thread.send("⚠️ Promo source clan context is missing and no promo metadata row could be loaded. Please use `!finishplacement` with source and destination tags.")
+            return
+
         context.clan_tag = final_tag
+        _promo_log_transition("destination_received", thread=thread, context=context, actor=actor, metadata_row_number=(found[0] if found else None))
 
         if view is not None:
             view.stop()
@@ -973,12 +1088,13 @@ class PromoTicketWatcher(commands.Cog):
                 prompt_message = None
 
         previous_final: str | None = (context.source_clan_tag or "").strip().upper()
+        destination_clan_name = await self._clan_name_for_tag(final_tag)
 
         await self._complete_close(
             thread,
             context,
             progression="",
-            clan_name="",
+            clan_name=destination_clan_name,
             previous_final=previous_final,
         )
         if context.state != "closed":
@@ -1017,6 +1133,7 @@ class PromoTicketWatcher(commands.Cog):
                 context.state = "closed"
                 return
             await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=context.ticket_number, thread_id=getattr(thread, "id", None), finalization_status="in_progress", finalization_note=f"finalization started by {trigger}")
+            _promo_log_transition("start", thread=thread, context=context, metadata_row_number=found_state[0] if found_state else None, finalization_status_before=finalization_state.get("finalization_status"), finalization_status_after="in_progress", reason=f"trigger={trigger}")
         except Exception:
             log.exception("promo finalization state preflight failed", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)})
             try:
@@ -1026,41 +1143,63 @@ class PromoTicketWatcher(commands.Cog):
             await _send_placement_log_line(flow="promo", outcome="failed", ticket=context.ticket_number, reason="finalization_state_preflight_failed", action="manual_check")
             return
         log.info("close_finalization_started", extra={"flow": "promo", "trigger": trigger, "thread_id": getattr(thread, "id", None), "ticket": context.ticket_number})
-        try:
-            promo_headers = _promo_headers_for_write(ticket=context.ticket_number)
-        except Exception:
-            await thread.send("⚠️ Promo source clan header mapping is missing. Please fix Config before closing this promo ticket.")
-            return
 
-        row_map = {
-            "ticketnumber": context.ticket_number,
-            "username": context.username,
-            "clantag": context.clan_tag,
-            "sourceclantag": context.source_clan_tag,
-            "dateclosed": timestamp,
-            "type": context.promo_type,
-            "threadcreated": context.thread_created,
-            "year": context.year,
-            "month": context.month,
-            "joinmonth": context.join_month,
-            "clanname": clan_name,
-            "progression": progression,
-        }
-        row = [
-            row_map.get(
-                "".join(ch for ch in str(header or "").lower() if ch.isalnum()),
-                "",
-            )
-            for header in promo_headers
-        ]
-        try:
-            await self._patch_ticket_metadata(
-                phase="finalization_metadata",
+        async def mark_failed_after_start(reason: str, note: str, *, exc: Exception | None = None) -> None:
+            _promo_log_transition(
+                "finalization_failed",
                 thread=thread,
                 context=context,
-                panel_message_id=context.prompt_message_id,
-                status="closed",
+                metadata_row_number=(found_state[0] if found_state else None),
+                finalization_status_after="failed",
+                write_skipped=True,
+                reason=reason,
+                exception=str(exc) if exc else None,
             )
+            try:
+                await asyncio.to_thread(
+                    onboarding_sheets.update_ticket_finalization_state,
+                    "promo",
+                    ticket=context.ticket_number,
+                    thread_id=getattr(thread, "id", None),
+                    finalization_status="failed",
+                    finalization_note=note,
+                )
+            except Exception:
+                log.exception(
+                    "promo finalization failed marker update failed",
+                    extra={
+                        "ticket": context.ticket_number,
+                        "thread_id": getattr(thread, "id", None),
+                        "phase": reason,
+                    },
+                )
+
+        persisted_source = _source_clan_from_promo_values(found_state[1], ticket=context.ticket_number) if found_state else ""
+        if persisted_source:
+            context.source_clan_tag = persisted_source.strip().upper()
+        elif (context.source_clan_tag or "").strip().upper() and (context.source_clan_tag or "").strip().upper() != _NO_PLACEMENT_TAG and context.state == "awaiting_destination_clan":
+            if not await self._persist_prompt_source(thread, context):
+                await mark_failed_after_start(
+                    "source_persist_failed_after_start",
+                    "finalization started but source persistence failed before close fields were written",
+                )
+                return
+        elif (context.source_clan_tag or "").strip().upper() and (context.source_clan_tag or "").strip().upper() != _NO_PLACEMENT_TAG:
+            context.source_clan_tag = (context.source_clan_tag or "").strip().upper()
+        elif (context.source_clan_tag or "").strip().upper() == _NO_PLACEMENT_TAG:
+            context.source_clan_tag = _NO_PLACEMENT_TAG
+        elif context.state == "awaiting_clan" and found_state:
+            context.source_clan_tag = str(found_state[1].get("clantag") or _NO_PLACEMENT_TAG).strip().upper()
+        else:
+            await mark_failed_after_start(
+                "missing_source_context",
+                "finalization started but source clan context was missing before close fields were written",
+            )
+            await thread.send("⚠️ Promo source clan context is missing from the promo metadata row. Please provide the source clan before closing this promo ticket.")
+            return
+        close_year = str(dt.datetime.now(UTC).year)
+        safe_context_year = _valid_promo_year(context.year) or close_year
+        try:
             result = await log_sheet_write(
                 flow="promo",
                 phase=phase or "close",
@@ -1069,15 +1208,35 @@ class PromoTicketWatcher(commands.Cog):
                 thread=thread,
                 user=context.username,
                 write_coro=lambda: asyncio.to_thread(
-                    onboarding_sheets.upsert_promo, row, promo_headers
+                    onboarding_sheets.patch_promo_final_close,
+                    ticket=context.ticket_number,
+                    thread_id=getattr(thread, "id", None),
+                    clan_tag=context.clan_tag,
+                    source_clan_tag=context.source_clan_tag,
+                    date_closed=timestamp,
+                    clan_name=clan_name,
+                    progression=progression,
+                    year=safe_context_year,
+                    month=context.month or dt.datetime.now(UTC).strftime("%B"),
+                    join_month=context.join_month,
+                    status="closed",
                 ),
             )
-        except Exception:
+            _promo_log_transition("sheet_write", thread=thread, context=context, metadata_row_number=(found_state[0] if found_state else None), status_after="closed", reason=str(result))
+        except Exception as exc:
             log.exception(
-                "failed to finalize promo closure",
-                extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number},
+                "failed to patch required promo close fields; status not closed",
+                extra={"thread_id": getattr(thread, "id", None), "ticket": context.ticket_number, "phase": "final_close_patch", "write_skipped": True, "reason": str(exc)},
             )
-            await thread.send("⚠️ I couldn't update the promo log. Please try again later.")
+            _promo_log_transition("finalization_failed", thread=thread, context=context, metadata_row_number=(found_state[0] if found_state else None), write_skipped=True, reason="final_close_patch_failed", exception=str(exc))
+            try:
+                await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=context.ticket_number, thread_id=getattr(thread, "id", None), finalization_status="failed", finalization_note=f"final close patch failed: {exc}")
+            except Exception:
+                log.exception("promo final close failure marker update failed", extra={"ticket": context.ticket_number, "thread_id": getattr(thread, "id", None)})
+            try:
+                await thread.send("⚠️ I couldn't write the required promo close fields, so this ticket was not marked closed. Please try again later.")
+            except Exception:
+                log.debug("failed to notify promo thread about final close patch failure", exc_info=True)
             return
 
         context.clan_name = clan_name
@@ -1207,10 +1366,16 @@ class PromoTicketWatcher(commands.Cog):
         finalization_note = "finalized by close handler" if cleanup.ok else (cleanup.reason or "reservation/clan update partially failed")
         try:
             await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=ticket_id_final, thread_id=getattr(thread, "id", None), finalization_status=finalization_status, reservation_status=reservation_status, clan_update_status=clan_update_status, finalization_note=finalization_note)
+            _promo_log_transition("success" if finalization_status == "done" else "failure", thread=thread, context=context, metadata_row_number=(found_state[0] if found_state else None), status_after="closed", finalization_status_after=finalization_status, reason=finalization_note)
         except Exception:
             finalization_status = "partial"
             logging_channel_result = "state_error"
             log.exception("promo finalization state completion update failed", extra={"ticket": ticket_id_final, "thread_id": getattr(thread, "id", None)})
+            try:
+                await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=ticket_id_final, thread_id=getattr(thread, "id", None), finalization_status="failed", reservation_status=reservation_status, clan_update_status=clan_update_status, finalization_note="finalization completion state update failed after close fields were written")
+                finalization_status = "failed"
+            except Exception:
+                log.exception("promo finalization failed marker update after completion failure failed", extra={"ticket": ticket_id_final, "thread_id": getattr(thread, "id", None)})
         outcome = "success" if finalization_status == "done" else "partial"
         await _send_placement_log_line(flow="promo", outcome=outcome, ticket=ticket_id_final, player=context.username, source=source_tag or None, destination=final_tag or _NO_PLACEMENT_TAG, trigger=trigger, reservation=reservation_status, clan_update=clan_update_status, finalization_status=finalization_status, action=(None if outcome == "success" else "manual_check"))
         try:
@@ -1537,10 +1702,13 @@ class PromoTicketWatcher(commands.Cog):
             if not candidate:
                 return
             tags = await self._load_clan_tags()
-            valid = set(tags) | ({_NO_PLACEMENT_TAG} if context.state == "awaiting_source_clan" else set())
-            if candidate not in valid:
+            valid_tags = set(tags)
+            if context.state == "awaiting_source_clan":
+                valid_tags.add(_NO_PLACEMENT_TAG)
+            if candidate not in valid_tags:
                 await self._send_invalid_tag_notice(thread, message.author, candidate)
                 return
+            _promo_log_transition("prompt_message_received", thread=thread, context=context, actor=message.author, raw_message_content=candidate)
             if context.state == "awaiting_source_clan":
                 await self._set_source_clan_tag(
                     thread,

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -1410,7 +1410,7 @@ def append_promo_ticket_row(
 ) -> str:
     sheet_id, tab = _resolve_onboarding_and_promo_tab()
     ws = core.get_worksheet(sheet_id, tab)
-    header = _ensure_promo_headers(ws)
+    header = _read_promo_live_header_row(ws)
     source_header = require_promo_source_clan_header(header)
     ticket_value = _fmt_ticket(ticket)
     created, updated = _normalize_ticket_timestamps(created_at, updated_at)
@@ -1544,6 +1544,151 @@ def get_ticket_finalization_state(flow: str, row_values: Dict[str, str] | Sequen
     require_finalization_headers(flow, base_headers)
     return {field: str(row_map.get(header, "") or "").strip() for field, header in headers.items()}
 
+
+
+def patch_promo_prompt_source(
+    *,
+    ticket: str | None,
+    thread_id: int | str | None = None,
+    source_clan_tag: str,
+    finalization_status: str | None = None,
+    finalization_note: str | None = None,
+) -> str:
+    """Patch only Promo source/finalization prompt fields on an existing row."""
+
+    sheet_id, tab = _resolve_onboarding_and_promo_tab()
+    ws = core.get_worksheet(sheet_id, tab)
+    header = _ensure_promo_headers(ws)
+    source_header = require_promo_source_clan_header(header)
+    final_headers = require_finalization_headers("promo", header)
+    values = core.call_with_backoff(ws.get_all_values)
+    row_number, row = _promo_find_row_in_values(
+        header,
+        values,
+        ticket=_fmt_ticket(ticket) if ticket else "",
+        thread_id=str(thread_id or "").strip(),
+    )
+    if row_number is None or row is None:
+        raise RuntimeError(f"promo prompt source row not found for ticket={ticket or '-'} thread_id={thread_id or '-'}")
+    if len(row) < len(header):
+        row.extend("" for _ in range(len(header) - len(row)))
+
+    updates: dict[str, str] = {source_header: str(source_clan_tag or "").strip()}
+    if finalization_status is not None:
+        updates[final_headers["finalization_status"]] = str(finalization_status)
+    if finalization_note is not None:
+        updates[final_headers["finalization_note"]] = str(finalization_note)
+    updated_col = next(
+        (idx for idx, name in enumerate(_normalize_header_name(h) for h in header) if name == "updatedat"),
+        -1,
+    )
+    if updated_col >= 0:
+        row[updated_col] = datetime.now(timezone.utc).isoformat()
+
+    for header_name, value in updates.items():
+        col = _column_index(header, header_name, default=-1)
+        if col < 0:
+            raise RuntimeError(f"promo prompt source header missing: {header_name!r}")
+        row[col] = value
+
+    end_col = _col_to_a1(len(header) - 1)
+    core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row[: len(header)]])
+    return "updated"
+
+
+def patch_promo_final_close(
+    *,
+    ticket: str | None,
+    thread_id: int | str | None = None,
+    clan_tag: str,
+    source_clan_tag: str,
+    date_closed: str,
+    clan_name: str | None = None,
+    progression: str | None = None,
+    year: str | None = None,
+    month: str | None = None,
+    join_month: str | None = None,
+    status: str | None = None,
+) -> str:
+    """Patch only intended Promo final-close fields on an existing row."""
+
+    sheet_id, tab = _resolve_onboarding_and_promo_tab()
+    ws = core.get_worksheet(sheet_id, tab)
+    header = _read_promo_live_header_row(ws)
+    source_header = get_promo_source_clan_tag_header()
+    values = core.call_with_backoff(ws.get_all_values)
+    row_number, row = _promo_find_row_in_values(
+        header,
+        values,
+        ticket=_fmt_ticket(ticket) if ticket else "",
+        thread_id=str(thread_id or "").strip(),
+    )
+    if row_number is None or row is None:
+        raise RuntimeError(f"promo final close row not found for ticket={ticket or '-'} thread_id={thread_id or '-'}")
+    if len(row) < len(header):
+        row.extend("" for _ in range(len(header) - len(row)))
+
+    normalized_to_col = {_normalize_header_name(name): idx for idx, name in enumerate(header)}
+    required_updates: dict[str, str] = {
+        "clantag": str(clan_tag or "").strip(),
+        _normalize_header_name(source_header): str(source_clan_tag or "").strip(),
+        "dateclosed": str(date_closed or "").strip(),
+    }
+    if status is not None:
+        required_updates["status"] = str(status or "").strip()
+    for normalized in required_updates:
+        if normalized not in normalized_to_col:
+            raise RuntimeError(
+                "promo final close missing required header "
+                f"normalized_field={normalized!r} ticket={ticket or '-'} thread_id={thread_id or '-'} "
+                "operation=promo final close"
+            )
+
+    optional_updates: dict[str, str] = {}
+    if clan_name is not None:
+        optional_updates["clanname"] = str(clan_name or "").strip()
+    if progression is not None:
+        optional_updates["progression"] = str(progression or "").strip()
+
+    year_text = str(year or "").strip()
+    try:
+        valid_year = int(year_text) > 1900
+    except (TypeError, ValueError):
+        valid_year = False
+    if valid_year:
+        optional_updates["year"] = year_text
+        if str(month or "").strip():
+            optional_updates["month"] = str(month or "").strip()
+        if str(join_month or "").strip():
+            optional_updates["joinmonth"] = str(join_month or "").strip()
+
+    updated_col = normalized_to_col.get("updatedat")
+    if updated_col is not None:
+        row[updated_col] = datetime.now(timezone.utc).isoformat()
+
+    changed = False
+    for normalized, value in {**required_updates, **optional_updates}.items():
+        col = normalized_to_col.get(normalized)
+        if col is None:
+            continue
+        if normalized in required_updates and not value:
+            raise RuntimeError(
+                "promo final close missing required value "
+                f"normalized_field={normalized!r} ticket={ticket or '-'} thread_id={thread_id or '-'} "
+                "operation=promo final close"
+            )
+        if not value and normalized not in {"clanname", "progression"}:
+            continue
+        if str(row[col] if col < len(row) else "") == value:
+            continue
+        row[col] = value
+        changed = True
+
+    if not changed and updated_col is None:
+        return "unchanged"
+    end_col = _col_to_a1(len(header) - 1)
+    core.call_with_backoff(ws.update, f"A{row_number}:{end_col}{row_number}", [row[: len(header)]])
+    return "updated" if changed else "updated_timestamp"
 
 def update_ticket_finalization_state(
     flow: str,

--- a/tests/onboarding/test_promo_close_clan_prompt.py
+++ b/tests/onboarding/test_promo_close_clan_prompt.py
@@ -31,6 +31,14 @@ def _promo_source_header_config(monkeypatch):
         "shared.sheets.onboarding.find_promo_row",
         lambda *_args, **_kwargs: (2, {"clantag": "", "source_clan_tag": "NONE", "finalization_status": "pending"}),
     )
+    monkeypatch.setattr(
+        "shared.sheets.onboarding.patch_promo_final_close",
+        lambda **_kwargs: "updated",
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.recruitment_sheets.get_clan_header_map",
+        lambda *_args, **_kwargs: {},
+    )
 
     async def no_reservations(*_args, **_kwargs):
         return []
@@ -157,6 +165,46 @@ def test_typed_tag_while_awaiting_clan_finalizes(monkeypatch):
     message = SimpleNamespace(channel=thread, author=DummyAuthor(bot=False, user_id=77), content="c1ce")
     asyncio.run(watcher.on_message(message))
     watcher._finalize_clan_tag.assert_awaited_once()
+
+
+def test_natural_language_destination_text_is_rejected(monkeypatch):
+    watcher = _setup_watcher(monkeypatch)
+    ctx = _context(state="awaiting_destination_clan", source_clan_tag="C1CB")
+    watcher._ensure_context = AsyncMock(return_value=ctx)
+    watcher._load_clan_tags = AsyncMock(return_value=["C1CB", "C1CE"])
+    watcher._finalize_clan_tag = AsyncMock()
+    watcher._send_invalid_tag_notice = AsyncMock()
+
+    thread = DummyThread(55)
+    message = SimpleNamespace(
+        channel=thread,
+        author=DummyAuthor(bot=False, user_id=77),
+        content="zealots to vindicators mate",
+    )
+    asyncio.run(watcher.on_message(message))
+
+    watcher._finalize_clan_tag.assert_not_awaited()
+    watcher._send_invalid_tag_notice.assert_awaited_once()
+
+
+def test_typed_source_tag_stores_source_before_destination_prompt(monkeypatch):
+    watcher = _setup_watcher(monkeypatch)
+    ctx = _context(state="awaiting_source_clan", source_clan_tag="")
+    watcher._ensure_context = AsyncMock(return_value=ctx)
+    watcher._load_clan_tags = AsyncMock(return_value=["C1CB", "C1CE"])
+    watcher._persist_prompt_source = AsyncMock(return_value=True)
+
+    thread = DummyThread(56)
+    message = SimpleNamespace(
+        channel=thread,
+        author=DummyAuthor(bot=False, user_id=77),
+        content="c1cb",
+    )
+    asyncio.run(watcher.on_message(message))
+
+    assert ctx.source_clan_tag == "C1CB"
+    assert ctx.state == "awaiting_destination_clan"
+    watcher._persist_prompt_source.assert_awaited_once()
 
 
 def test_dropdown_selection_finalizes(monkeypatch):

--- a/tests/onboarding/test_promo_metadata_persistence.py
+++ b/tests/onboarding/test_promo_metadata_persistence.py
@@ -676,3 +676,148 @@ def test_promo_startup_backfill_loader_error_logs_reason(monkeypatch, caplog):
     errors = [record for record in caplog.records if record.name == "c1c.onboarding.promo_watcher" and record.levelname == "ERROR"]
     assert errors
     assert "RuntimeError: Promo backfill missing required header(s): finalization_status" == errors[-1].reason
+
+def test_patch_promo_final_close_preserves_unrelated_metadata(promo_sheet):
+    original = [
+        "M0392", "M0392-J_Turbo", "", "C1C2", "", "move", "2026-07-01 12:00:00",
+        "Closed-M0392-J_Turbo", "111", "222", "333", "prompt_required", "keep-review",
+        "created-value", "updated-value", "in_progress", "pending", "pending",
+        "finalization started by ticket_tool", "1899", "", "", "", "",
+    ]
+    promo_sheet.rows.append(original)
+
+    result = onboarding_sheets.patch_promo_final_close(
+        ticket="M0392",
+        thread_id=222,
+        clan_tag="C1CV",
+        source_clan_tag="C1C2",
+        date_closed="2026-07-07",
+        clan_name="Vindicators",
+        progression="TH16",
+        year="",
+        month="",
+        join_month="",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["clantag"] == "C1CV"
+    assert row["source_clan_tag"] == "C1C2"
+    assert row["date closed"] == "2026-07-07"
+    assert row["clan name"] == "Vindicators"
+    assert row["progression"] == "TH16"
+    assert row["review_reason"] == "keep-review"
+    assert row["created_at"] == "created-value"
+    assert row["user_id"] == "111"
+    assert row["thread_id"] == "222"
+    assert row["panel_message_id"] == "333"
+    assert row["status"] == "prompt_required"
+    assert row["finalization_status"] == "in_progress"
+    assert row["reservation_status"] == "pending"
+    assert row["clan_update_status"] == "pending"
+    assert row["finalization_note"] == "finalization started by ticket_tool"
+    assert row["year"] == "1899"
+    assert row["month"] == ""
+    assert row["join_month"] == ""
+    assert row["updated_at"] != "updated-value"
+
+
+def test_patch_promo_final_close_missing_row_fails(promo_sheet):
+    with pytest.raises(RuntimeError, match="promo final close row not found"):
+        onboarding_sheets.patch_promo_final_close(
+            ticket="M404",
+            thread_id=404,
+            clan_tag="C1CV",
+            source_clan_tag="C1C2",
+            date_closed="2026-07-07",
+            clan_name="Vindicators",
+        )
+
+@pytest.mark.parametrize(
+    ("missing_header", "normalized_field"),
+    [
+        ("clantag", "clantag"),
+        ("source_clan_tag", "sourceclantag"),
+        ("date closed", "dateclosed"),
+    ],
+)
+def test_patch_promo_final_close_missing_required_headers_fail(monkeypatch, missing_header, normalized_field):
+    headers = [h for h in LIVE_PROMO_HEADERS if h != missing_header]
+    worksheet = FakeWorksheet(headers=headers)
+    worksheet.rows.append(["M0392" if h == "ticket number" else "222" if h == "thread_id" else "keep" for h in headers])
+    monkeypatch.setattr(onboarding_sheets.core, "call_with_backoff", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "PromoFromConfig"))
+    monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        onboarding_sheets.patch_promo_final_close(
+            ticket="M0392",
+            thread_id=222,
+            clan_tag="C1CV",
+            source_clan_tag="C1C2",
+            date_closed="2026-07-07",
+        )
+
+    message = str(excinfo.value)
+    assert "operation=promo final close" in message
+    assert f"normalized_field='{normalized_field}'" in message
+    assert "ticket=M0392" in message
+    assert "thread_id=222" in message
+
+
+def test_patch_promo_final_close_missing_optional_headers_do_not_fail(monkeypatch):
+    optional = {"clan name", "progression", "year", "month", "join_month", "updated_at"}
+    headers = [h for h in LIVE_PROMO_HEADERS if h not in optional]
+    worksheet = FakeWorksheet(headers=headers)
+    worksheet.rows.append(["M0392" if h == "ticket number" else "222" if h == "thread_id" else "keep" for h in headers])
+    monkeypatch.setattr(onboarding_sheets.core, "call_with_backoff", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(onboarding_sheets, "_resolve_onboarding_and_promo_tab", lambda: ("sheet", "PromoFromConfig"))
+    monkeypatch.setattr(onboarding_sheets.core, "get_worksheet", lambda sheet_id, tab: worksheet)
+    monkeypatch.setattr(onboarding_sheets, "get_promo_source_clan_tag_header", lambda **kwargs: "source_clan_tag")
+
+    result = onboarding_sheets.patch_promo_final_close(
+        ticket="M0392",
+        thread_id=222,
+        clan_tag="C1CV",
+        source_clan_tag="C1C2",
+        date_closed="2026-07-07",
+        clan_name="Vindicators",
+        progression="TH16",
+        year="2026",
+        month="July",
+        join_month="July",
+    )
+
+    assert result == "updated"
+    row = dict(zip(worksheet.rows[0], worksheet.rows[1]))
+    assert row["clantag"] == "C1CV"
+    assert row["source_clan_tag"] == "C1C2"
+    assert row["date closed"] == "2026-07-07"
+
+
+def test_patch_promo_final_close_can_atomically_mark_closed(promo_sheet):
+    promo_sheet.rows.append([
+        "M0392", "M0392-J_Turbo", "", "C1C2", "", "move", "2026-07-01 12:00:00",
+        "Closed-M0392-J_Turbo", "111", "222", "333", "prompt_required", "keep-review",
+        "created-value", "updated-value", "in_progress", "pending", "pending",
+        "finalization started by ticket_tool", "", "", "", "", "",
+    ])
+
+    result = onboarding_sheets.patch_promo_final_close(
+        ticket="M0392",
+        thread_id=222,
+        clan_tag="C1CV",
+        source_clan_tag="C1C2",
+        date_closed="2026-07-07",
+        status="closed",
+    )
+
+    assert result == "updated"
+    row = _row_map(promo_sheet)
+    assert row["clantag"] == "C1CV"
+    assert row["source_clan_tag"] == "C1C2"
+    assert row["date closed"] == "2026-07-07"
+    assert row["status"] == "closed"
+    assert row["review_reason"] == "keep-review"
+    assert row["created_at"] == "created-value"

--- a/tests/onboarding/test_ticket_close_finalization.py
+++ b/tests/onboarding/test_ticket_close_finalization.py
@@ -477,3 +477,149 @@ def test_promo_finalization_in_progress_write_failure_blocks_side_effects(monkey
     assert side_effects == []
     assert [update["finalization_status"] for update in updates] == ["in_progress", "failed"]
     assert discord_logs == [{"flow": "promo", "outcome": "failed", "ticket": "M2002", "reason": "finalization_state_preflight_failed", "action": "manual_check"}]
+
+
+def test_promo_final_close_patch_failure_does_not_mark_closed(monkeypatch):
+    _seed_finalization_config(monkeypatch)
+    updates = []
+    metadata_statuses = []
+    side_effects = []
+
+    watcher = watcher_promo.PromoTicketWatcher(SimpleNamespace())
+    row = {"ticket number": "M2003", "username": "PatchFail", "clantag": "", "source_clan_tag": "C1CB", "finalization_status": "pending", "reservation_status": "pending", "clan_update_status": "pending", "finalization_note": ""}
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda ticket: (2, row))
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *a, **k: updates.append(k) or "updated")
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_final_close", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("required close write failed")))
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "upsert_promo", lambda *a, **k: side_effects.append("upsert"))
+
+    async def fake_metadata(**kwargs):
+        metadata_statuses.append(kwargs.get("status"))
+        return True
+
+    monkeypatch.setattr(watcher, "_patch_ticket_metadata", fake_metadata)
+    monkeypatch.setattr(watcher_promo, "cleanup_reservation_for_ticket_close", lambda *a, **k: side_effects.append("cleanup"))
+    monkeypatch.setattr(watcher_promo, "_send_placement_log_line", lambda **kwargs: asyncio.sleep(0))
+
+    context = watcher_promo.PromoTicketContext(thread_id=123, ticket_number="M2003", username="PatchFail", promo_type="move", thread_created="", year="2026", month="June", source_clan_tag="C1CB", clan_tag="C1CD")
+    asyncio.run(watcher._complete_close(_BackfillThread(name="M2003-PatchFail"), context, "", "", trigger="ticket_tool"))
+
+    assert "closed" not in metadata_statuses
+    assert side_effects == []
+    assert [update["finalization_status"] for update in updates] == ["in_progress", "failed"]
+    assert "final close patch failed" in updates[-1]["finalization_note"]
+
+
+def test_promo_missing_source_after_start_records_failed_finalization(monkeypatch):
+    _seed_finalization_config(monkeypatch)
+    updates = []
+    side_effects = []
+
+    watcher = watcher_promo.PromoTicketWatcher(SimpleNamespace())
+    row = {"ticket number": "M2007", "username": "NoSource", "clantag": "", "source_clan_tag": "", "finalization_status": "pending", "reservation_status": "pending", "clan_update_status": "pending", "finalization_note": ""}
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda ticket: (2, row))
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *a, **k: updates.append(k) or "updated")
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_final_close", lambda **kwargs: side_effects.append("final_close"))
+    monkeypatch.setattr(watcher_promo, "cleanup_reservation_for_ticket_close", lambda *a, **k: side_effects.append("cleanup"))
+
+    sent = []
+
+    class Thread(_BackfillThread):
+        async def send(self, message):
+            sent.append(message)
+
+    context = watcher_promo.PromoTicketContext(thread_id=123, ticket_number="M2007", username="NoSource", promo_type="move", thread_created="", year="2026", month="June", source_clan_tag="", clan_tag="C1CD")
+    asyncio.run(watcher._complete_close(Thread(name="M2007-NoSource"), context, "", "", trigger="ticket_tool"))
+
+    assert [update["finalization_status"] for update in updates] == ["in_progress", "failed"]
+    assert "source clan context was missing" in updates[-1]["finalization_note"]
+    assert side_effects == []
+    assert context.state != "closed"
+    assert sent
+
+
+def test_promo_success_closes_in_final_close_patch_not_metadata(monkeypatch):
+    _seed_finalization_config(monkeypatch)
+    operations = []
+    updates = []
+
+    class Thread(_BackfillThread):
+        guild = None
+
+        async def edit(self, **kwargs):
+            operations.append(("thread_edit", kwargs))
+
+    watcher = watcher_promo.PromoTicketWatcher(SimpleNamespace())
+    row = {"ticket number": "M2006", "username": "OrderOk", "clantag": "", "source_clan_tag": "C1CB", "finalization_status": "pending", "reservation_status": "pending", "clan_update_status": "pending", "finalization_note": ""}
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "find_promo_row", lambda ticket: (2, row))
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "update_ticket_finalization_state", lambda *a, **k: operations.append(("state", k.get("finalization_status"))) or updates.append(k) or "updated")
+
+    def fake_final_close(**kwargs):
+        operations.append(("final_close", kwargs.get("status"), kwargs.get("source_clan_tag"), kwargs.get("clan_tag"), kwargs.get("date_closed")))
+        return "updated"
+
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_final_close", fake_final_close)
+
+    async def fail_metadata(**kwargs):
+        raise AssertionError("successful promo close must not use metadata status patch")
+
+    monkeypatch.setattr(watcher, "_patch_ticket_metadata", fail_metadata)
+    monkeypatch.setattr(watcher_promo, "_normalize_clan_math_targets", lambda tags: {})
+    monkeypatch.setattr(watcher_promo, "_clan_math_column_indices", lambda: {})
+    monkeypatch.setattr(watcher_promo, "_capture_clan_snapshots", lambda *a, **k: {})
+
+    async def fake_cleanup(**kwargs):
+        operations.append(("cleanup", None))
+        return SimpleNamespace(
+            skipped=True,
+            ok=True,
+            reason=None,
+            reservation_row=None,
+            old_status=None,
+            new_status=None,
+            recomputed_tags=[],
+            decision_line="decision: ok",
+            reservation_label="none",
+            applied_open_deltas={},
+            source_clan_lookup_key="C1CB",
+            source_clan_row_found=True,
+            source_clan_row_number=9,
+            previous_is_real=True,
+            source_clan_not_real_reason=None,
+            source_clan_lookup_mode="tag",
+        )
+
+    monkeypatch.setattr(watcher_promo, "cleanup_reservation_for_ticket_close", fake_cleanup)
+    monkeypatch.setattr(watcher_promo, "_send_placement_log_line", lambda **kwargs: operations.append(("placement_log", kwargs.get("outcome"))) or asyncio.sleep(0))
+    monkeypatch.setattr(watcher_promo, "_log_clan_math_event", lambda *a, **k: asyncio.sleep(0))
+    monkeypatch.setattr(watcher_promo.onboarding_sessions, "mark_completed", lambda thread_id: operations.append(("session_complete", thread_id)))
+
+    context = watcher_promo.PromoTicketContext(thread_id=123, ticket_number="M2006", username="OrderOk", promo_type="move", thread_created="", year="2026", month="June", source_clan_tag="C1CB", clan_tag="C1CD")
+    asyncio.run(watcher._complete_close(Thread(name="M2006-OrderOk"), context, "", "Destination", trigger="ticket_tool"))
+
+    assert operations[0] == ("state", "in_progress")
+    assert operations[1][:4] == ("final_close", "closed", "C1CB", "C1CD")
+    assert operations[1][4]
+    assert operations[2] == ("cleanup", None)
+    assert updates[0]["finalization_status"] == "in_progress"
+    assert updates[-1]["finalization_status"] == "done"
+    assert context.state == "closed"
+
+
+def test_promo_patch_ticket_metadata_returns_explicit_bool(monkeypatch):
+    watcher = watcher_promo.PromoTicketWatcher(SimpleNamespace())
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_ticket_metadata", lambda **kwargs: "updated")
+    context = watcher_promo.PromoTicketContext(thread_id=123, ticket_number="M2004", username="MetaOk", promo_type="move", thread_created="", year="2026", month="June")
+
+    result = asyncio.run(watcher._patch_ticket_metadata(phase="test", thread=_BackfillThread(name="M2004-MetaOk"), context=context, status="closed"))
+
+    assert result is True
+
+
+def test_promo_patch_ticket_metadata_failure_returns_false(monkeypatch):
+    watcher = watcher_promo.PromoTicketWatcher(SimpleNamespace())
+    monkeypatch.setattr(watcher_promo.onboarding_sheets, "patch_promo_ticket_metadata", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("metadata write failed")))
+    context = watcher_promo.PromoTicketContext(thread_id=123, ticket_number="M2005", username="MetaFail", promo_type="move", thread_created="", year="2026", month="June")
+
+    result = asyncio.run(watcher._patch_ticket_metadata(phase="test", thread=_BackfillThread(name="M2005-MetaFail"), context=context, status="closed"))
+
+    assert result is False


### PR DESCRIPTION
### Motivation
- Make Promo finalization more robust by persisting the source clan selected during the prompt flow and atomically patching only the final-close fields instead of overwriting rows. 
- Improve observability for promo finalization with structured transition logs to diagnose failures and skipped writes. 
- Surface and guard against partial writes so tickets are not marked closed unless required close fields are successfully written.

### Description
- Add structured transition logging via `_promo_log_transition` and a `_valid_promo_year` helper to normalize year input. 
- Implement `patch_promo_prompt_source` and `patch_promo_final_close` in `shared.sheets.onboarding` to support targeted updates to promo rows instead of full upserts. 
- Add `_persist_prompt_source` and `_clan_name_for_tag` to `PromoTicketWatcher` and wire persistence into the prompt flow so a source tag is written before prompting/finishing destination. 
- Harden `_finalize_clan_tag` and `_complete_close` with row lookups, recovery logic for missing source context, and guard paths that mark finalization `failed` when required writes fail; ensure `_patch_ticket_metadata` now returns an explicit boolean. 
- Update prompt/message handling to log prompt-message receipts and avoid creating empty session placeholders from the prompt path. 
- Improve logging messages when live header reads fail and annotate write-skipped reasons in logs. 
- Add and adjust unit tests under `tests/onboarding` to cover source persistence, destination rejection, final-close patch behavior, and metadata persistence return values.

### Testing
- Ran the onboarding unit tests in `tests/onboarding` including newly added tests `test_patch_promo_final_close_*`, `test_natural_language_destination_text_is_rejected`, and other promo finalization scenarios; all tests passed locally. 
- Exercised `shared.sheets.onboarding` changes with the new promo patch tests that verify preservation of unrelated metadata and error handling, which succeeded. 
- Executed targeted promo watcher tests that validate prompt flows and failure handling, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d22d3def48323adf27d103b656390)