### PR TITLE
Reset reminder: clarify wording and remove redundant embed timestamp

### DIFF
--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -257,9 +257,23 @@ def _next_reset_description(base_description: str, reset_time_utc: dt.datetime |
     if reset_time_utc is None:
         return base_description
     unix_seconds = int(reset_time_utc.astimezone(dt.timezone.utc).timestamp())
-    countdown = f"Next reset: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
+    countdown = f"Current cycle resets at: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
     base = str(base_description or "").rstrip()
     return f"{base}\n\n{countdown}" if base else countdown
+
+
+def _reset_reminder_footer(
+    configured_footer: str,
+    reset_time_utc: dt.datetime,
+    cycle_days: int,
+) -> str:
+    following_cycle_reset_time = reset_time_utc.astimezone(dt.timezone.utc) + dt.timedelta(days=cycle_days)
+    following_cycle_text = (
+        "Following cycle reset: "
+        f"{following_cycle_reset_time.strftime('%Y-%m-%d %H:%M UTC')}"
+    )
+    footer = str(configured_footer or "").strip()
+    return f"{footer} • {following_cycle_text}" if footer else following_cycle_text
 
 
 def _custom_emoji_id(value: str) -> int | None:
@@ -847,10 +861,14 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 title=reminder.embed_title or reminder.label,
                 description=_next_reset_description(reminder.embed_description, reset_time),
                 color=get_embed_colour("community"),
-                timestamp=reset_time,
             )
-            if reminder.embed_footer:
-                embed.set_footer(text=reminder.embed_footer)
+            embed.set_footer(
+                text=_reset_reminder_footer(
+                    reminder.embed_footer,
+                    reset_time,
+                    reminder.cycle_days,
+                )
+            )
 
             view = ResetReminderView(
                 role_id=reminder.role_id,

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -594,8 +594,9 @@ def test_doom_tower_regression_uses_next_scheduled_post_not_reference_date(monke
 
     assert len(channel.sent) == 1
     embed = channel.sent[0]["embed"]
-    assert embed.timestamp == reset_time
+    assert embed.timestamp is None
     assert f"<t:{int(reset_time.timestamp())}:R>" in embed.description
+    assert embed.footer.text == "footer • Following cycle reset: 2026-08-07 07:30 UTC"
     assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc)
 
 
@@ -899,7 +900,7 @@ def test_missing_emoji_logs_warning_and_posts_without_icon(monkeypatch, caplog) 
     assert "reset reminder image emoji could not be resolved" in caplog.text
 
 
-def test_embed_includes_next_reset_timestamps_inside_description(monkeypatch) -> None:
+def test_embed_includes_current_cycle_reset_timestamps_inside_description(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), embed_description="Reset incoming")
     channel, _updates = _run_reset_process(
@@ -907,11 +908,11 @@ def test_embed_includes_next_reset_timestamps_inside_description(monkeypatch) ->
     )
     unix_seconds = int(reference.timestamp())
     desc = channel.sent[0]["embed"].description
-    assert desc == f"Reset incoming\n\nNext reset: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
+    assert desc == f"Reset incoming\n\nCurrent cycle resets at: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
     assert f"<t:{unix_seconds}:R>" not in channel.sent[0]["content"]
 
 
-def test_timestamp_uses_reset_time_not_reminder_time(monkeypatch) -> None:
+def test_description_uses_reset_time_not_reminder_time(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=120, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc))
     channel, _updates = _run_reset_process(
@@ -959,3 +960,37 @@ def test_configured_emoji_with_missing_target_guild_logs_warning(monkeypatch, ca
 
     assert channel.sent[0]["content"] == "<@&999>"
     assert "target guild unavailable" in caplog.text
+
+
+def test_footer_uses_following_cycle_reset_without_embed_timestamp(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        cycle_days=14,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        embed_footer="Configured footer",
+    )
+
+    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+
+    embed = channel.sent[0]["embed"]
+    assert embed.timestamp is None
+    assert embed.footer.text == "Configured footer • Following cycle reset: 2026-06-12 10:00 UTC"
+
+
+def test_footer_uses_following_cycle_reset_when_configured_footer_blank(monkeypatch) -> None:
+    reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        cycle_days=14,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        embed_footer="",
+    )
+
+    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+
+    embed = channel.sent[0]["embed"]
+    assert embed.timestamp is None
+    assert embed.footer.text == "Following cycle reset: 2026-06-12 10:00 UTC"


### PR DESCRIPTION
### Motivation
- The reminder embed labeled the displayed reset as "Next reset" which is misleading for the currently active cycle and the embed `timestamp` caused Discord to render a redundant footer timestamp.
- The post must keep the client-side relative countdown, avoid editing the message every minute, and present the following-cycle reset as plain UTC text in the footer.

### Description
- Rename the embed body line from `Next reset:` to `Current cycle resets at:` while preserving the `<t:...:F>` and `<t:...:R>` timestamps in `_next_reset_description`.
- Stop setting `embed.timestamp` for reset reminders so Discord no longer shows the auto "Today at ..." footer timestamp.
- Add `_reset_reminder_footer(configured_footer, reset_time_utc, cycle_days)` which appends a plain-text following-cycle reset (`YYYY-MM-DD HH:MM UTC`) to the configured footer or uses that text alone when the configured footer is blank, and use this to set `embed.footer`.
- Update scheduler tests to assert the new body wording, absence of `embed.timestamp`, and correct footer text for both configured and blank footers while leaving send/attachment/scheduling logic unchanged.

### Testing
- Ran `pytest -q tests/community/test_reset_reminder_scheduler.py` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d5b2cfb508323a272abb5f6347774)