### PR TITLE
Use shared Config-driven clan-row resolver for availability updates

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -249,41 +249,28 @@ async def _ensure_fresh_clans_for_placement(*, actor: str, ticket: str, user: st
 
 
 def _find_promo_clan_row(clan_tag: str, *, force: bool = False) -> tuple[int, List[str]] | None:
-    """Resolve promo clans with the same configured bot_info tag column used by availability writes."""
+    """Resolve promo clans with the shared Config-driven availability row resolver."""
 
-    try:
-        headers = availability._resolve_availability_headers()  # type: ignore[attr-defined]
-        entry = availability._find_availability_clan_row(clan_tag, headers)  # type: ignore[attr-defined]
-        if entry is not None:
-            return entry
-    except Exception:
-        log.debug(
-            "promo clan lookup falling back to recruitment.find_clan_row",
-            exc_info=True,
-            extra={"clan_tag": clan_tag},
-        )
-    try:
-        return recruitment_sheets.find_clan_row(clan_tag, force=force)
-    except TypeError:
-        return recruitment_sheets.find_clan_row(clan_tag)
+    headers = availability._resolve_availability_headers()  # type: ignore[attr-defined]
+    return availability.resolve_availability_clan_row(clan_tag, headers)
 
 
-_find_promo_clan_row.lookup_mode = "availability_configured_clan_tag_header_with_recruitment_fallback"  # type: ignore[attr-defined]
+_find_promo_clan_row.lookup_mode = "shared_configured_availability_clan_row"  # type: ignore[attr-defined]
 
 
 def _find_promo_availability_clan_row(
     clan_tag: str, headers: availability.AvailabilityHeaderResolution
 ) -> tuple[int, List[str]] | None:
-    entry = availability._find_availability_clan_row(clan_tag, headers)  # type: ignore[attr-defined]
-    if entry is not None:
-        return entry
-    try:
-        return recruitment_sheets.find_clan_row(clan_tag, force=True)
-    except TypeError:
-        return recruitment_sheets.find_clan_row(clan_tag)
+    return availability.resolve_availability_clan_row(clan_tag, headers)
 
 
-_find_promo_availability_clan_row.lookup_mode = "availability_configured_clan_tag_header_with_recruitment_fallback"  # type: ignore[attr-defined]
+_find_promo_availability_clan_row.lookup_mode = "shared_configured_availability_clan_row"  # type: ignore[attr-defined]
+
+
+async def _adjust_promo_manual_open_spots(clan_tag: str, delta: int) -> int:
+    return await availability.adjust_manual_open_spots(
+        clan_tag, delta, find_clan_row_fn=_find_promo_availability_clan_row
+    )
 
 
 async def _recompute_promo_clan_availability(
@@ -1340,7 +1327,7 @@ class PromoTicketWatcher(commands.Cog):
             find_active_reservations_fn=reservations_sheets.find_active_reservations_for_recruit,
             find_clan_row_fn=_find_promo_clan_row,
             update_reservation_status_fn=reservations_sheets.update_reservation_status,
-            adjust_manual_open_spots_fn=availability.adjust_manual_open_spots,
+            adjust_manual_open_spots_fn=_adjust_promo_manual_open_spots,
             recompute_clan_availability_fn=_recompute_promo_clan_availability,
         )
         if cleanup.skipped:

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -113,6 +113,36 @@ async def _ensure_fresh_clans_for_placement(
     return True
 
 
+
+def _find_configured_availability_clan_row(clan_tag: str, *, force: bool = False) -> tuple[int, List[str]] | None:
+    """Resolve clan rows through the shared Config-driven availability row resolver."""
+
+    headers = availability._resolve_availability_headers()  # type: ignore[attr-defined]
+    return availability.resolve_availability_clan_row(clan_tag, headers)
+
+
+_find_configured_availability_clan_row.lookup_mode = "shared_configured_availability_clan_row"  # type: ignore[attr-defined]
+
+
+def _find_configured_availability_clan_row_with_headers(
+    clan_tag: str, headers: availability.AvailabilityHeaderResolution
+) -> tuple[int, List[str]] | None:
+    return availability.resolve_availability_clan_row(clan_tag, headers)
+
+
+async def _adjust_configured_manual_open_spots(clan_tag: str, delta: int) -> int:
+    return await availability.adjust_manual_open_spots(
+        clan_tag, delta, find_clan_row_fn=_find_configured_availability_clan_row_with_headers
+    )
+
+
+async def _recompute_configured_clan_availability(
+    clan_tag: str, *, guild: discord.Guild | None = None
+) -> None:
+    await availability.recompute_clan_availability(
+        clan_tag, guild=guild, find_clan_row_fn=_find_configured_availability_clan_row_with_headers
+    )
+
 def _inspect_stable_welcome_intro_message(
     message: discord.Message | None,
     *,
@@ -1892,10 +1922,10 @@ async def cleanup_reservation_for_ticket_close(
     event_log = logger or log
     ensure_fresh = ensure_fresh_fn or _ensure_fresh_clans_for_placement
     find_active_reservations = find_active_reservations_fn or reservations_sheets.find_active_reservations_for_recruit
-    find_clan_row = find_clan_row_fn or recruitment_sheets.find_clan_row
+    find_clan_row = find_clan_row_fn or _find_configured_availability_clan_row
     update_reservation_status = update_reservation_status_fn or reservations_sheets.update_reservation_status
-    adjust_manual_open_spots = adjust_manual_open_spots_fn or availability.adjust_manual_open_spots
-    recompute_clan_availability = recompute_clan_availability_fn or availability.recompute_clan_availability
+    adjust_manual_open_spots = adjust_manual_open_spots_fn or _adjust_configured_manual_open_spots
+    recompute_clan_availability = recompute_clan_availability_fn or _recompute_configured_clan_availability
     normalized_scope = (scope or "welcome").strip().lower() or "welcome"
     normalized_final = (final_tag or "").strip().upper()
     normalized_previous = (previous_final or "").strip().upper()
@@ -4415,7 +4445,7 @@ class WelcomeTicketWatcher(commands.Cog):
             final_is_real = False
         else:
             final_entry = (
-                _call_find_clan_row(recruitment_sheets.find_clan_row, final_tag, force=True)
+                _call_find_clan_row(_find_configured_availability_clan_row, final_tag, force=True)
                 if final_tag != _NO_PLACEMENT_TAG
                 else None
             )
@@ -4470,7 +4500,7 @@ class WelcomeTicketWatcher(commands.Cog):
             for tag, delta in preflight_targets.items():
                 try:
                     await availability.preflight_clan_availability_update(
-                        tag, delta=delta
+                        tag, delta=delta, find_clan_row_fn=_find_configured_availability_clan_row_with_headers
                     )
                 except Exception:
                     preflight_failed = True
@@ -4540,7 +4570,7 @@ class WelcomeTicketWatcher(commands.Cog):
                 try:
                     column_map = _clan_math_column_indices()
                     before_snapshots = _capture_clan_snapshots(
-                        row_targets, column_map, force=True
+                        row_targets, column_map, force=True, find_clan_row_fn=_find_configured_availability_clan_row
                     )
                 except Exception:
                     column_map = None
@@ -4612,7 +4642,7 @@ class WelcomeTicketWatcher(commands.Cog):
             decision.open_deltas.items() if clans_fresh and not row_missing else ()
         ):
             try:
-                adjust_result = availability.adjust_manual_open_spots(tag, delta)
+                adjust_result = _adjust_configured_manual_open_spots(tag, delta)
                 if hasattr(adjust_result, "__await__"):
                     await adjust_result
                 applied_open_deltas[tag] = applied_open_deltas.get(tag, 0) + delta
@@ -4633,7 +4663,7 @@ class WelcomeTicketWatcher(commands.Cog):
         )
         for tag in recompute_tags:
             try:
-                recompute_result = availability.recompute_clan_availability(tag, guild=thread.guild)
+                recompute_result = _recompute_configured_clan_availability(tag, guild=thread.guild)
                 if hasattr(recompute_result, "__await__"):
                     await recompute_result
             except Exception:
@@ -4645,7 +4675,7 @@ class WelcomeTicketWatcher(commands.Cog):
 
         if not row_missing and row_targets and column_map is not None:
             after_snapshots = _capture_clan_snapshots(
-                row_targets, column_map, force=True
+                row_targets, column_map, force=True, find_clan_row_fn=_find_configured_availability_clan_row
             )
             row_change_lines = _build_clan_math_row_lines(
                 row_targets, before_snapshots, after_snapshots

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -74,6 +74,7 @@ class ManualOpenSpotAdjustmentPlan:
     seen_range: str
     combined_range: str | None
     resolved_clan_tag: str
+    headers: AvailabilityHeaderResolution
 
 
 def _mask_sheet_id(sheet_id: str | None) -> str:
@@ -116,6 +117,7 @@ def _log_availability_diagnostics(
     configured_header_value: str | None = None,
     clan_tag: str | None = None,
     sheet_row: int | None = None,
+    operation: str | None = None,
 ) -> None:
     raw_values = _diagnostic_header_values(header_row)
     normalized_values = {
@@ -137,11 +139,25 @@ def _log_availability_diagnostics(
         "configured_headers": dict(configured_headers or {}),
         "clan_tag": _normalize_tag(clan_tag),
         "bot_info_row_number": sheet_row,
+        "operation": operation,
     }
     log_method = log.info if reason in {"resolved", "preflight_ok"} else log.warning
+    if reason == "bot_info_row_not_found" and clan_tag:
+        extra.update(_known_clan_tag_column_report(
+            AvailabilityHeaderResolution(
+                tab_name=tab_name,
+                sheet_id_masked=_mask_sheet_id(sheet_id),
+                header_row_index=header_row_index,
+                header_row=tuple(str(cell) if cell is not None else "" for cell in header_row),
+                header_map=dict(header_map or {}),
+                configured_headers=dict(configured_headers or {}),
+            ),
+            clan_tag,
+        ))
     log_method(
-        "bot_info availability header diagnostics: tab=%r sheet_id=%s header_row_index=%s "
+        "bot_info availability header diagnostics: operation=%s tab=%r sheet_id=%s header_row_index=%s "
         "reason=%s missing_config_key=%s configured_header_value=%r raw=%s normalized=%s header_map=%s",
+        operation,
         tab_name,
         _mask_sheet_id(sheet_id),
         header_row_index,
@@ -253,6 +269,48 @@ def _find_availability_clan_row(
     return None
 
 
+
+def _known_clan_tag_column_report(headers: AvailabilityHeaderResolution, clan_tag: str) -> dict[str, object]:
+    normalized_target = _normalize_tag(clan_tag)
+    known_indices: dict[str, int] = {}
+    if "clan_tag" in headers.header_map:
+        known_indices["configured_clan_tag"] = headers.header_map["clan_tag"]
+    try:
+        for key, index in recruitment.get_clan_header_map().items():
+            text = f"{key} {headers.header_row[index] if index < len(headers.header_row) else ''}"
+            normalized = _normalize_configured_header(text)
+            if "clan" in normalized and "tag" in normalized:
+                known_indices[f"header_map:{key}"] = int(index)
+    except Exception:
+        pass
+    try:
+        clan_rows = recruitment.fetch_clans(force=True)
+    except TypeError:
+        clan_rows = recruitment.fetch_clans()
+    except Exception:
+        clan_rows = []
+    matches: list[str] = []
+    for label, index in known_indices.items():
+        for offset, row in enumerate(clan_rows):
+            value = row[index] if index < len(row) else ""
+            if _normalize_tag(value) == normalized_target:
+                matches.append(f"{label}:{_column_label(index)}:row{offset + headers.header_row_index + 1}")
+                break
+    return {
+        "known_clan_tag_columns": {label: _column_label(index) for label, index in known_indices.items()},
+        "searched_tag": normalized_target,
+        "tag_found_in_known_clan_tag_column": bool(matches),
+        "tag_column_matches": matches,
+    }
+
+
+def resolve_availability_clan_row(
+    clan_tag: str, headers: AvailabilityHeaderResolution
+) -> tuple[int, list[str]] | None:
+    """Resolve a clan row using only the Config-defined clan_tag header."""
+
+    return _find_availability_clan_row(clan_tag, headers)
+
 def resolve_configured_clan_tag(clan_tag: str) -> str:
     """Resolve a clan tag from bot_info using the Config-provided clan_tag header."""
     headers = _resolve_availability_headers()
@@ -267,6 +325,7 @@ def resolve_configured_clan_tag(clan_tag: str) -> str:
             configured_headers=headers.configured_headers,
             header_map=headers.header_map,
             clan_tag=clan_tag,
+            operation="resolve_configured_clan_tag",
         )
         raise ValueError(f"Unknown clan tag: {clan_tag}")
     _sheet_row, row = entry
@@ -279,6 +338,7 @@ async def preflight_clan_availability_update(
     clan_tag: str,
     *,
     delta: int = 0,
+    operation: str = "preflight_clan_availability_update",
     find_clan_row_fn: Callable[
         [str, AvailabilityHeaderResolution], tuple[int, list[str]] | None
     ]
@@ -316,6 +376,7 @@ async def preflight_clan_availability_update(
             configured_headers=headers.configured_headers,
             header_map=headers.header_map,
             clan_tag=clan_tag,
+            operation=operation,
         )
         raise ValueError(f"Unknown clan tag: {clan_tag}")
 
@@ -355,6 +416,7 @@ async def preflight_clan_availability_update(
         header_map=headers.header_map,
         clan_tag=clan_tag,
         sheet_row=sheet_row,
+        operation="preflight_clan_availability_update",
     )
     return AvailabilityPreflightPlan(
         clan_tag=clan_tag,
@@ -434,10 +496,18 @@ def _parse_required_int(
 
 
 async def preflight_manual_open_spots_adjustment(
-    clan_tag: str, delta: int
+    clan_tag: str,
+    delta: int,
+    *,
+    find_clan_row_fn: Callable[
+        [str, AvailabilityHeaderResolution], tuple[int, list[str]] | None
+    ]
+    | None = None,
 ) -> ManualOpenSpotAdjustmentPlan:
     """Resolve and validate the row, configured headers, parseable cells, and writable worksheet."""
-    plan = await preflight_clan_availability_update(clan_tag, delta=delta)
+    plan = await preflight_clan_availability_update(
+        clan_tag, delta=delta, operation="adjust_manual_open_spots", find_clan_row_fn=find_clan_row_fn
+    )
     header_map = plan.headers.header_map
     row = plan.row
     sheet_row = plan.sheet_row
@@ -490,6 +560,7 @@ async def preflight_manual_open_spots_adjustment(
         seen_range=seen_range,
         combined_range=combined_range,
         resolved_clan_tag=resolved_clan_tag,
+        headers=plan.headers,
     )
 
 
@@ -515,13 +586,23 @@ async def set_manual_open_spots(clan_tag: str, open_spots: int) -> tuple[int, in
     return old_value, new_value, plan.resolved_clan_tag
 
 
-async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
+async def adjust_manual_open_spots(
+    clan_tag: str,
+    delta: int,
+    *,
+    find_clan_row_fn: Callable[
+        [str, AvailabilityHeaderResolution], tuple[int, list[str]] | None
+    ]
+    | None = None,
+) -> int:
     """Adjust manual open spots for ``clan_tag`` and return the new value."""
     plan: ManualOpenSpotAdjustmentPlan | None = None
     write_range = ""
     try:
         log.info("adjust_manual_open_spots:start clan_tag=%s delta=%s", clan_tag, delta)
-        plan = await preflight_manual_open_spots_adjustment(clan_tag, delta)
+        plan = await preflight_manual_open_spots_adjustment(
+            clan_tag, delta, find_clan_row_fn=find_clan_row_fn
+        )
         rebase_manual_open_spots = plan.manual_open != plan.seen_manual_open
         log.info(
             "adjust_manual_open_spots:resolved_row clan_tag=%s sheet_row=%s",
@@ -622,7 +703,8 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
             clan_tag,
             cache_result,
         )
-        refreshed = recruitment.find_clan_row(clan_tag, force=True)
+        refresh_lookup = find_clan_row_fn or _find_availability_clan_row
+        refreshed = refresh_lookup(clan_tag, plan.headers)
         if refreshed is None:
             raise RuntimeError(f"clan cache refresh failed for {clan_tag}")
         _, refreshed_row = refreshed
@@ -696,7 +778,7 @@ async def recompute_clan_availability(
     """Recompute Config-resolved bot_info availability for ``clan_tag`` and refresh cache."""
 
     plan = await preflight_clan_availability_update(
-        clan_tag, delta=0, find_clan_row_fn=find_clan_row_fn
+        clan_tag, delta=0, operation="recompute_clan_availability", find_clan_row_fn=find_clan_row_fn
     )
     sheet_row = plan.sheet_row
     row = plan.row
@@ -864,6 +946,7 @@ __all__ = [
     "adjust_manual_open_spots",
     "preflight_manual_open_spots_adjustment",
     "preflight_clan_availability_update",
+    "resolve_availability_clan_row",
     "resolve_configured_clan_tag",
     "recompute_clan_availability",
 ]

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -802,3 +802,60 @@ def test_availability_header_config_resolves_production_columns(monkeypatch):
         "manual_open_spots_seen": "AJ",
         "clan_tag": "AK",
     }
+
+
+def test_adjust_and_recompute_accept_same_configured_row_resolver(monkeypatch):
+    worksheet = StubWorksheet()
+    row = [""] * 42
+    row[5] = "C1CD"
+    row[6] = "4"
+    row[20] = "4"
+    row[32] = "0"
+    row[33] = "0"
+    row[34] = ""
+    row[36] = "4"
+    header = [""] * 42
+    header[5] = "Live Clan Tag"
+    header[6] = "Manual open spots"
+    header[20] = "Effective open spots"
+    header[32] = "Inactives"
+    header[33] = "Reservation count"
+    header[34] = "Reservation summary"
+    header[36] = "Manual open spots seen"
+    config = {
+        "clans_header_clan_tag": "Live Clan Tag",
+        "clans_header_manual_open_spots": "Manual open spots",
+        "clans_header_open_spots": "Effective open spots",
+        "clans_header_inactives": "Inactives",
+        "clans_header_reservation_count": "Reservation count",
+        "clans_header_reservation_summary": "Reservation summary",
+        "clans_header_manual_open_spots_seen": "Manual open spots seen",
+    }
+    monkeypatch.setattr(availability.recruitment, "get_config_value", lambda key, default=None: config.get(key, default))
+    monkeypatch.setattr(availability.recruitment, "get_clan_header_row", lambda force=True: header)
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name", lambda: "bot_info")
+    monkeypatch.setattr(availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet123456")
+    monkeypatch.setattr(availability.recruitment, "fetch_clans", lambda force=True: [list(row)])
+    monkeypatch.setattr(availability.recruitment, "update_cached_clan_row", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(availability.recruitment, "get_clan_header_map", lambda: {"clan_tag": 2})
+    monkeypatch.setattr(availability.reservations, "get_active_reservations_for_clan", lambda tag: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(availability.reservations, "resolve_reservation_names", lambda *a, **k: asyncio.sleep(0, result=[]))
+
+    async def fake_aget(_sheet_id: str, _tab_name: str):
+        return worksheet
+
+    async def fake_acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_acall)
+
+    calls = []
+
+    def resolver(tag, headers):
+        calls.append((tag, headers.header_map["clan_tag"]))
+        return availability.resolve_availability_clan_row(tag, headers)
+
+    assert asyncio.run(availability.adjust_manual_open_spots("C1CD", -1, find_clan_row_fn=resolver)) == 3
+    asyncio.run(availability.recompute_clan_availability("C1CD", find_clan_row_fn=resolver))
+    assert calls == [("C1CD", 5), ("C1CD", 5), ("C1CD", 5)]


### PR DESCRIPTION
### Motivation
- Welcome and promo ticket-close paths were using different clan-row lookup logic which caused failing open-spot writes and recompute errors (e.g. `recompute_clan_availability_failed:C1CD` and `row ?: snapshot unavailable`).
- The root cause was inconsistent resolution of the configured clan-tag column and subsequent divergence between snapshot lookup and write paths.
- The change centralizes row resolution behind a single, Config-driven resolver so both welcome and promo share a consistent lookup and failure diagnostics.

### Description
- Added a shared resolver `resolve_availability_clan_row` and diagnostics helper `_known_clan_tag_column_report` to `modules/recruitment/availability.py` and extended diagnostics to include an `operation` context for clearer failure logs.
- Made preflight and manual-adjust flows accept a `find_clan_row_fn` and wired `preflight_manual_open_spots_adjustment` and `adjust_manual_open_spots` to use the same resolver for lookup and cache refresh, and ensured `adjust_manual_open_spots` uses the provided resolver when verifying refreshed rows.
- Routed welcome and promo close flows to use the shared resolver and added small wrappers in `modules/onboarding/watcher_welcome.py` and `modules/onboarding/watcher_promo.py` so snapshots, manual open-spot writes, and recompute all use the same Config-driven path without changing UX.
- Added a regression test `test_adjust_and_recompute_accept_same_configured_row_resolver` to `tests/recruitment/test_availability_recompute.py` that proves `adjust_manual_open_spots` and `recompute_clan_availability` use the same configured clan-tag column resolver.

### Testing
- Ran `pytest tests/recruitment/test_availability_recompute.py -q` and the suite passed after the fix.
- Added and executed the new test `test_adjust_and_recompute_accept_same_configured_row_resolver` which passed and asserts the shared resolver is used by both adjust and recompute paths.
- Compiled modules with `python3 -m compileall` to validate syntax and module imports which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e17959d248323873fcf65b336b4ec)