### PR TITLE
Add async Sheets/config APIs and migrate runtime to async-safe sheet access

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1549,7 +1549,7 @@ class Runtime:
         try:
             rehydrate_tiers(self.bot)
             audit_tiers(self.bot, log)
-            merged = shared_config.merge_onboarding_config_early()
+            merged = await shared_config.amerge_onboarding_config_early()
             log.debug("runtime: onboarding config preload merged %d keys", merged)
         except Exception as exc:
             _startup_phase_log("config validation", "fail", error=repr(exc))

--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -16,7 +16,7 @@ from modules.community.leagues.config import (
     LeagueBundle,
     LeagueSpec,
     LeaguesConfigError,
-    load_league_bundles,
+    aload_league_bundles,
 )
 from shared.logfmt import channel_label, user_label
 from shared.sheets.async_core import acall_with_backoff, afetch_records, afetch_values, aget_worksheet
@@ -621,7 +621,7 @@ class LeaguesCog(commands.Cog):
             return False
 
         try:
-            bundles = load_league_bundles(sheet_id, config_tab=self._config_tab_name())
+            bundles = await aload_league_bundles(sheet_id, config_tab=self._config_tab_name())
         except LeaguesConfigError as exc:
             await self._post_status(
                 status_channel,

--- a/modules/community/leagues/config.py
+++ b/modules/community/leagues/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Iterable, Iterator, Mapping
 
 from shared.sheets import core as sheets_core
+from shared.sheets.async_core import afetch_records
 
 
 class LeaguesConfigError(RuntimeError):
@@ -40,8 +41,21 @@ def _normalize(text: str | None) -> str:
 
 
 def _iter_league_rows(sheet_id: str, config_tab: str) -> Iterator[Mapping[str, object]]:
+    """Yield league Config rows for sync scripts/tools/tests only.
+
+    Live Discord runtime must use :func:`aload_league_bundles` so blocking
+    Google Sheets reads never execute inside the bot event loop.
+    """
+
     records = sheets_core.fetch_records(sheet_id, config_tab)
     yield from records or []
+
+
+async def _aiter_league_rows(sheet_id: str, config_tab: str) -> list[Mapping[str, object]]:
+    """Return league Config rows using the async Sheets boundary for bot runtime."""
+
+    records = await afetch_records(sheet_id, config_tab)
+    return list(records or [])
 
 
 def _parse_bool(value: str | object | None) -> bool:
@@ -203,5 +217,20 @@ def load_league_bundles_from_rows(rows: Iterable[Mapping[str, object]]) -> list[
 
 
 def load_league_bundles(sheet_id: str, *, config_tab: str = "Config") -> list[LeagueBundle]:
+    """Load league bundles synchronously for scripts/tools/tests only.
+
+    Do not call this from Discord commands, listeners, schedulers, view
+    callbacks, or background jobs. Use :func:`aload_league_bundles` instead.
+    The sync Sheets retry guard intentionally raises when this path is used
+    from an active event loop.
+    """
+
     rows = list(_iter_league_rows(sheet_id, config_tab))
+    return load_league_bundles_from_rows(rows)
+
+
+async def aload_league_bundles(sheet_id: str, *, config_tab: str = "Config") -> list[LeagueBundle]:
+    """Load league bundles through async Sheets access for live bot runtime."""
+
+    rows = await _aiter_league_rows(sheet_id, config_tab)
     return load_league_bundles_from_rows(rows)

--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -151,12 +151,9 @@ def _get_sheet_id() -> tuple[str | None, str | None]:
 async def _read_text_row(
     sheet_id: str, config: C1CAdConfig
 ) -> tuple[dict[str, str] | None, dict[str, int] | None, str | None]:
-    values = (
-        await async_core.a_to_thread_with_backoff(
-            sheets_core.sheets_read, sheet_id, f"{config.text_tab}!1:{config.text_row}"
-        )
-        or []
-    )
+    values = await async_core.asheets_read(
+        sheet_id, f"{config.text_tab}!1:{config.text_row}"
+    ) or []
     if not values:
         return None, None, "missing C1C_AD_TEXT headers"
     headers = _header_map(list(values[0]))
@@ -178,9 +175,7 @@ async def _write_status(
     headers: Mapping[str, int],
     updates: Mapping[str, str],
 ) -> None:
-    worksheet = await async_core.a_to_thread_with_backoff(
-        sheets_core.get_worksheet, sheet_id, config.text_tab
-    )
+    worksheet = await async_core.aget_worksheet(sheet_id, config.text_tab)
     cells = []
     for header, value in updates.items():
         col = headers.get(header)
@@ -190,9 +185,7 @@ async def _write_status(
             {"range": f"{_column_letter(col)}{config.text_row}", "values": [[value]]}
         )
     if cells:
-        await async_core.a_to_thread_with_backoff(
-            sheets_core.call_with_backoff, worksheet.batch_update, cells
-        )
+        await async_core.acall_with_backoff(worksheet.batch_update, cells)
 
 
 def _normalize_header(label: str) -> str:

--- a/shared/config.py
+++ b/shared/config.py
@@ -89,6 +89,7 @@ __all__ = [
     "redact_ids",
     "redact_value",
     "merge_onboarding_config_early",
+    "amerge_onboarding_config_early",
     "onboarding_config_merge_count",
     "get_ticket_tool_bot_id",
     "features",
@@ -331,6 +332,32 @@ def _load_onboarding_config_values() -> tuple[str, Dict[str, str]]:
     return sheet_id, normalized
 
 
+async def _aload_onboarding_config_values() -> tuple[str, Dict[str, str]]:
+    """Return onboarding config values via async Sheets access for bot runtime."""
+
+    sheet_id = (os.getenv("ONBOARDING_SHEET_ID") or "").strip()
+    if not sheet_id:
+        raise RuntimeError("ONBOARDING_SHEET_ID not set")
+
+    onboarding_sheets = sys.modules.get("shared.sheets.onboarding")
+    if onboarding_sheets is None:
+        from shared.sheets import onboarding as onboarding_sheets  # type: ignore
+
+    async_loader = getattr(onboarding_sheets, "_aload_config", None)
+    if not callable(async_loader):
+        raise RuntimeError("async onboarding Config loader unavailable")
+
+    raw_config = await async_loader(force=True)
+    normalized: Dict[str, str] = {}
+    for key, value in raw_config.items():
+        key_norm = (key or "").strip().upper()
+        if not key_norm:
+            continue
+        text = "" if value is None else str(value).strip()
+        normalized[key_norm] = text
+    return sheet_id, normalized
+
+
 def _merge_onboarding_tab(config: Dict[str, object]) -> None:
     """Merge the onboarding questions tab name from sheet config."""
 
@@ -386,6 +413,15 @@ def _load_milestones_config_values() -> tuple[str, Dict[str, str]]:
     return sheet_id, _parse_sheet_config(rows)
 
 
+async def _aload_milestones_config_values() -> tuple[str, Dict[str, str]]:
+    """Return Milestones config values via async Sheets access for bot runtime."""
+
+    from shared.sheets import milestones_config
+
+    sheet_id, _tab_name, values = await milestones_config.aload_values()
+    return sheet_id, values
+
+
 def _merge_milestones_tab(config: Dict[str, object]) -> None:
     """Merge shard tracker settings from the milestones Config tab."""
 
@@ -413,6 +449,41 @@ def merge_onboarding_config_early() -> int:
     for key, value in values.items():
         _CONFIG[key] = value
         merged += 1
+
+    global _LAST_ONBOARDING_CONFIG_KEYS
+    _LAST_ONBOARDING_CONFIG_KEYS = len(values)
+
+    tail = sheet_id[-6:] if len(sheet_id) >= 6 else sheet_id
+    display = f"…{tail}" if len(sheet_id) > len(tail) else tail
+    result = "ok" if merged else "empty"
+    log.info(
+        "🧩 Config — merged onboarding tab • sheet=%s • keys=%d • result=%s",
+        display,
+        len(values),
+        result,
+        extra={"sheet_tail": tail, "keys": len(values), "result": result},
+    )
+    return len(values)
+
+
+async def amerge_onboarding_config_early() -> int:
+    """Async bot-runtime variant of :func:`merge_onboarding_config_early`."""
+
+    sheet_id, values = await _aload_onboarding_config_values()
+
+    merged = 0
+    for key, value in values.items():
+        _CONFIG[key] = value
+        merged += 1
+
+    try:
+        _, milestone_values = await _aload_milestones_config_values()
+    except RuntimeError:
+        log.debug("config: milestones sheet id not configured; skipping async tab merge")
+    except Exception as exc:  # pragma: no cover - network or credential failures
+        log.warning("config: failed to async-load milestones Config tab: %s", exc)
+    else:
+        _CONFIG.update(milestone_values)
 
     global _LAST_ONBOARDING_CONFIG_KEYS
     _LAST_ONBOARDING_CONFIG_KEYS = len(values)

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -156,6 +156,80 @@ def test_league_approval_marks_failed_and_last_error_on_post_failure(monkeypatch
     assert "RuntimeError: boom" in row["values"]["last_error"]
 
 
+def test_reaction_approval_runtime_uses_async_league_config_loader(monkeypatch):
+    import asyncio
+
+    from modules.community.leagues import cog as leagues_cog
+    from shared.sheets import core as sheets_core
+
+    row = _approval_row()
+    updates = []
+    calls = {"async_loader": 0}
+
+    monkeypatch.setenv("LEAGUES_SHEET_ID", "leagues-sheet")
+    monkeypatch.setenv("LEAGUES_LEGENDARY_THREAD_ID", "1")
+    monkeypatch.setenv("LEAGUES_RISING_THREAD_ID", "2")
+    monkeypatch.setenv("LEAGUES_STORMFORGED_THREAD_ID", "3")
+    monkeypatch.setenv("ANNOUNCEMENT_CHANNEL_ID", "4")
+    monkeypatch.delenv("LEAGUE_ADMIN_IDS", raising=False)
+    monkeypatch.setattr(leagues_cog, "is_admin_member", lambda member: True)
+
+    def _sync_retry_forbidden(*_args, **_kwargs):
+        raise AssertionError("sync Sheets retry must not be used by reaction_approval runtime")
+
+    async def _async_loader(sheet_id, *, config_tab="Config"):
+        calls["async_loader"] += 1
+        assert sheet_id == "leagues-sheet"
+        assert config_tab == "Config"
+        return [_bundle("legendary", "Legendary League"), _bundle("rising", "Rising Stars League"), _bundle("storm", "Stormforged League")]
+
+    class _Channel:
+        def __init__(self, channel_id):
+            self.id = channel_id
+            self.sent = []
+
+        async def send(self, *args, **kwargs):
+            message = SimpleNamespace(id=len(self.sent) + 10, jump_url=f"https://discord.test/{self.id}/{len(self.sent)}")
+            self.sent.append((args, kwargs, message))
+            return message
+
+    channels = {channel_id: _Channel(channel_id) for channel_id in (1, 2, 3, 4, 5678)}
+
+    async def _find(channel_id, message_id, *, include_terminal=False):
+        return row
+
+    async def _update(target, changes):
+        updates.append(dict(changes))
+        target["values"].update({key: str(value) for key, value in changes.items()})
+
+    async def _resolve(channel_id):
+        return channels.get(channel_id)
+
+    async def _export_header(_loop, _sheet_id, bundle):
+        return SimpleNamespace(filename=f"{bundle.slug}_header.png")
+
+    async def _export_boards(_loop, _sheet_id, bundle):
+        return [SimpleNamespace(filename=f"{bundle.slug}_1.png")]
+
+    monkeypatch.setattr(sheets_core, "_retry_with_backoff", _sync_retry_forbidden)
+    monkeypatch.setattr(leagues_cog, "aload_league_bundles", _async_loader)
+
+    bot = _LeagueApprovalBot()
+    bot.get_cog = lambda _name: None
+    cog = LeaguesCog(bot)
+    monkeypatch.setattr(cog, "_find_approval_row", _find)
+    monkeypatch.setattr(cog, "_update_approval_row", _update)
+    monkeypatch.setattr(cog, "_resolve_channel", _resolve)
+    monkeypatch.setattr(cog, "_export_header_image", _export_header)
+    monkeypatch.setattr(cog, "_export_board_images", _export_boards)
+
+    asyncio.run(cog.on_raw_reaction_add(_LeagueApprovalPayload()))
+
+    assert calls["async_loader"] == 1
+    assert row["values"]["status"] == "posted"
+    assert [update.get("status") for update in updates if "status" in update] == ["posting", "posted"]
+
+
 def test_approval_state_tab_is_loaded_from_leagues_config(monkeypatch):
     import asyncio
     from modules.community.leagues import cog as leagues_cog

--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -47,3 +47,38 @@ def test_merge_onboarding_config_early_merges(monkeypatch, caplog):
 
     messages = [record.getMessage() for record in caplog.records]
     assert any("🧩 Config — merged onboarding tab" in message for message in messages)
+
+
+def test_amerge_onboarding_config_early_uses_async_loader(monkeypatch):
+    import asyncio
+    import shared.config as config
+
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "onboard-sheet-XYZ")
+    fake_config = {"onboarding_tab": "WelcomeQuestions"}
+    calls = {"async": 0, "milestones": 0}
+
+    async def _aload_config(*, force=False):
+        calls["async"] += 1
+        assert force is True
+        return fake_config
+
+    async def _aload_milestones_config_values():
+        calls["milestones"] += 1
+        return "milestone-sheet", {"SHARD_MERCY_TAB": "Mercy"}
+
+    def _sync_loader():
+        raise AssertionError("sync onboarding Config loader must not run in async runtime")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "shared.sheets.onboarding",
+        types.SimpleNamespace(_aload_config=_aload_config, _read_onboarding_config=_sync_loader),
+    )
+    monkeypatch.setattr(config, "_aload_milestones_config_values", _aload_milestones_config_values)
+
+    merged = asyncio.run(config.amerge_onboarding_config_early())
+
+    assert merged == 1
+    assert calls == {"async": 1, "milestones": 1}
+    assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
+    assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"

--- a/tests/shared/test_runtime_startup_retry.py
+++ b/tests/shared/test_runtime_startup_retry.py
@@ -43,7 +43,7 @@ def _patch_runtime_startup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(runtime, "rehydrate_tiers", lambda _bot: None)
     monkeypatch.setattr(runtime, "audit_tiers", lambda _bot, _logger: None)
     monkeypatch.setattr(
-        runtime.shared_config, "merge_onboarding_config_early", lambda: 0
+        runtime.shared_config, "amerge_onboarding_config_early", AsyncMock(return_value=0)
     )
     monkeypatch.setattr(
         "shared.sheets.cache_scheduler.ensure_cache_registration", lambda: None

--- a/tests/test_c1c_ad.py
+++ b/tests/test_c1c_ad.py
@@ -94,9 +94,10 @@ def harness(monkeypatch):
     monkeypatch.setattr(
         c1c_ad.recruitment, "get_recruitment_sheet_id", lambda: "sheet123"
     )
-    monkeypatch.setattr(
-        c1c_ad.sheets_core, "sheets_read", lambda sheet_id, a1_range: rows
-    )
+    async def asheets_read(sheet_id, a1_range, **_kwargs):
+        return rows
+
+    monkeypatch.setattr(c1c_ad.async_core, "asheets_read", asheets_read)
     monkeypatch.setattr(c1c_ad, "get_tab_gid", lambda sheet_id, tab_name: "456")
 
     async def render(*args, **kwargs):
@@ -108,14 +109,14 @@ def harness(monkeypatch):
         def batch_update(self, cells):
             updates.extend(cells)
 
-    monkeypatch.setattr(
-        c1c_ad.sheets_core, "get_worksheet", lambda sheet_id, tab: Worksheet()
-    )
-    monkeypatch.setattr(
-        c1c_ad.sheets_core,
-        "call_with_backoff",
-        lambda func, *args, **kwargs: func(*args, **kwargs),
-    )
+    async def aget_worksheet(sheet_id, tab, **_kwargs):
+        return Worksheet()
+
+    async def acall_with_backoff(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(c1c_ad.async_core, "aget_worksheet", aget_worksheet)
+    monkeypatch.setattr(c1c_ad.async_core, "acall_with_backoff", acall_with_backoff)
     return SimpleNamespace(
         config=config,
         rows=rows,

--- a/tests/test_runtime_async_sheet_boundary.py
+++ b/tests/test_runtime_async_sheet_boundary.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_ROOTS = (ROOT / "modules", ROOT / "cogs", ROOT / "shared")
+
+SYNC_SHEETS_CORE_MODULE = "shared.sheets.core"
+SYNC_CONFIG_MODULE = "shared.config"
+LEAGUES_CONFIG_MODULE = "modules.community.leagues.config"
+ONBOARDING_SHEETS_MODULE = "shared.sheets.onboarding"
+
+FORBIDDEN_SYNC_HELPERS = {
+    f"{SYNC_SHEETS_CORE_MODULE}.fetch_records",
+    f"{SYNC_SHEETS_CORE_MODULE}.fetch_values",
+    f"{SYNC_SHEETS_CORE_MODULE}.get_worksheet",
+    f"{SYNC_SHEETS_CORE_MODULE}.call_with_backoff",
+    f"{SYNC_SHEETS_CORE_MODULE}.read_table",
+    f"{SYNC_SHEETS_CORE_MODULE}.sheets_read",
+    f"{SYNC_SHEETS_CORE_MODULE}._retry_with_backoff",
+    f"{SYNC_CONFIG_MODULE}.merge_onboarding_config_early",
+    f"{SYNC_CONFIG_MODULE}._load_onboarding_config_values",
+    f"{SYNC_CONFIG_MODULE}._load_milestones_config_values",
+    f"{LEAGUES_CONFIG_MODULE}.load_league_bundles",
+    f"{ONBOARDING_SHEETS_MODULE}._read_onboarding_config",
+    "_read_onboarding_config",
+}
+
+ALLOWED_ASYNC_BRIDGES = {
+    "asyncio.to_thread",
+    "shared.sheets.async_core.a_to_thread_with_backoff",
+    "shared.sheets.async_core.acall_with_backoff",
+    "a_to_thread_with_backoff",
+}
+
+APPROVED_BRIDGE_FILES = {
+    Path("shared/sheets/async_core.py"),
+    Path("shared/sheets/async_facade.py"),
+    Path("shared/sheets/async_adapter.py"),
+}
+
+MODULE_ALIAS_TARGETS = {
+    SYNC_SHEETS_CORE_MODULE,
+    SYNC_CONFIG_MODULE,
+    LEAGUES_CONFIG_MODULE,
+    ONBOARDING_SHEETS_MODULE,
+    "shared.sheets.async_core",
+    "asyncio",
+}
+
+DIRECT_IMPORT_MODULES = {
+    SYNC_SHEETS_CORE_MODULE,
+    SYNC_CONFIG_MODULE,
+    LEAGUES_CONFIG_MODULE,
+    ONBOARDING_SHEETS_MODULE,
+    "shared.sheets.async_core",
+}
+
+
+class _RuntimeBoundaryVisitor(ast.NodeVisitor):
+    def __init__(self, *, allow_forbidden_bridges: bool = False) -> None:
+        self.aliases: dict[str, str] = {}
+        self.violations: list[str] = []
+        self._async_depth = 0
+        self.allow_forbidden_bridges = allow_forbidden_bridges
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802 - ast API
+        for alias in node.names:
+            if alias.name in MODULE_ALIAS_TARGETS:
+                self.aliases[alias.asname or alias.name.split(".", 1)[0]] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802 - ast API
+        if node.module is None:
+            return
+        for alias in node.names:
+            local = alias.asname or alias.name
+            if node.module == "shared.sheets" and alias.name == "core":
+                self.aliases[local] = SYNC_SHEETS_CORE_MODULE
+            elif node.module == "shared.sheets" and alias.name == "onboarding":
+                self.aliases[local] = ONBOARDING_SHEETS_MODULE
+            elif node.module == "shared" and alias.name == "config":
+                self.aliases[local] = SYNC_CONFIG_MODULE
+            elif node.module in DIRECT_IMPORT_MODULES:
+                self.aliases[local] = f"{node.module}.{alias.name}"
+            elif f"{node.module}.{alias.name}" in MODULE_ALIAS_TARGETS:
+                self.aliases[local] = f"{node.module}.{alias.name}"
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802 - ast API
+        self._async_depth += 1
+        self.generic_visit(node)
+        self._async_depth -= 1
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - ast API
+        if self._async_depth:
+            bridge_name = self._resolve_name(node.func)
+            bridged_name = self._resolve_name(node.args[0]) if node.args else ""
+            locally_bridged_forbidden = (
+                bridge_name in ALLOWED_ASYNC_BRIDGES
+                and bridged_name in FORBIDDEN_SYNC_HELPERS
+                and not self.allow_forbidden_bridges
+            )
+            if locally_bridged_forbidden:
+                self.violations.append(f"{node.lineno} calls {bridge_name}")
+            elif not self._is_allowed_bridge_call(node):
+                resolved = self._resolve_name(node.func)
+                if resolved in FORBIDDEN_SYNC_HELPERS:
+                    self.violations.append(f"{node.lineno} calls {resolved}")
+        self.generic_visit(node)
+
+    def _is_allowed_bridge_call(self, node: ast.Call) -> bool:
+        if not self.allow_forbidden_bridges:
+            return False
+        bridge_name = self._resolve_name(node.func)
+        if bridge_name not in ALLOWED_ASYNC_BRIDGES:
+            return False
+        if not node.args:
+            return False
+        bridged_name = self._resolve_name(node.args[0])
+        return bridged_name in FORBIDDEN_SYNC_HELPERS
+
+    def _resolve_name(self, node: ast.AST) -> str:
+        raw = self._call_name(node)
+        if not raw:
+            return ""
+        if raw in FORBIDDEN_SYNC_HELPERS or raw in ALLOWED_ASYNC_BRIDGES:
+            return raw
+        if any(raw.startswith(f"{module}.") for module in MODULE_ALIAS_TARGETS):
+            return raw
+        if raw in self.aliases:
+            return self.aliases[raw]
+        first, dot, rest = raw.partition(".")
+        if first in self.aliases:
+            return f"{self.aliases[first]}{dot}{rest}" if dot else self.aliases[first]
+        return raw
+
+    def _call_name(self, node: ast.AST) -> str:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            parent = self._call_name(node.value)
+            return f"{parent}.{node.attr}" if parent else node.attr
+        return ""
+
+
+def _violations_for_source(source: str, *, approved_bridge_file: bool = False) -> list[str]:
+    tree = ast.parse(source)
+    visitor = _RuntimeBoundaryVisitor(allow_forbidden_bridges=approved_bridge_file)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def _violations_for_path(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path.relative_to(ROOT)))
+    visitor = _RuntimeBoundaryVisitor(
+        allow_forbidden_bridges=path.relative_to(ROOT) in APPROVED_BRIDGE_FILES
+    )
+    visitor.visit(tree)
+    return [f"{path.relative_to(ROOT)}:{violation}" for violation in visitor.violations]
+
+
+def test_runtime_async_functions_do_not_directly_call_sync_sheet_config_helpers() -> None:
+    """Live Discord runtime async code must stay on async-safe Sheets/config APIs."""
+
+    violations: list[str] = []
+    for root in RUNTIME_ROOTS:
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            violations.extend(_violations_for_path(path))
+
+    assert violations == []
+
+
+def test_runtime_boundary_catches_sync_core_import_styles() -> None:
+    source = """
+import shared.sheets.core
+import shared.sheets.core as sc
+from shared.sheets import core as sheets_core
+from shared.sheets.core import fetch_records, fetch_values as fv, get_worksheet, call_with_backoff, read_table, _retry_with_backoff
+
+async def bad():
+    shared.sheets.core.fetch_records('s', 't')
+    shared.sheets.core.fetch_values('s', 't')
+    shared.sheets.core.get_worksheet('s', 't')
+    shared.sheets.core.call_with_backoff(lambda: None)
+    shared.sheets.core.read_table(sheet_id='s', tab_name='t')
+    shared.sheets.core._retry_with_backoff(lambda: None)
+    sheets_core.fetch_records('s', 't')
+    sheets_core._retry_with_backoff(lambda: None)
+    sc.fetch_records('s', 't')
+    sc._retry_with_backoff(lambda: None)
+    fetch_records('s', 't')
+    fv('s', 't')
+    get_worksheet('s', 't')
+    call_with_backoff(lambda: None)
+    read_table(sheet_id='s', tab_name='t')
+    _retry_with_backoff(lambda: None)
+"""
+
+    violations = _violations_for_source(source)
+
+    assert len(violations) == 16
+    assert any("shared.sheets.core.fetch_records" in violation for violation in violations)
+    assert any("shared.sheets.core.fetch_values" in violation for violation in violations)
+    assert any("shared.sheets.core.get_worksheet" in violation for violation in violations)
+    assert any("shared.sheets.core.call_with_backoff" in violation for violation in violations)
+    assert any("shared.sheets.core.read_table" in violation for violation in violations)
+    assert any("shared.sheets.core._retry_with_backoff" in violation for violation in violations)
+
+
+def test_runtime_boundary_catches_sync_config_leagues_and_onboarding_helpers() -> None:
+    source = """
+import shared.sheets.onboarding
+from shared.sheets import onboarding as onboarding_sheets
+from shared import config as shared_config
+from shared.config import merge_onboarding_config_early, _load_onboarding_config_values, _load_milestones_config_values
+from modules.community.leagues.config import load_league_bundles
+from shared.sheets.onboarding import _read_onboarding_config
+
+async def bad():
+    _read_onboarding_config('sheet')
+    shared.sheets.onboarding._read_onboarding_config('sheet')
+    onboarding_sheets._read_onboarding_config('sheet')
+    shared_config.merge_onboarding_config_early()
+    merge_onboarding_config_early()
+    _load_onboarding_config_values()
+    _load_milestones_config_values()
+    load_league_bundles('sheet')
+"""
+
+    violations = _violations_for_source(source)
+
+    assert len(violations) == 8
+    assert any("shared.sheets.onboarding._read_onboarding_config" in violation for violation in violations)
+    assert any("shared.config.merge_onboarding_config_early" in violation for violation in violations)
+    assert any("shared.config._load_onboarding_config_values" in violation for violation in violations)
+    assert any("shared.config._load_milestones_config_values" in violation for violation in violations)
+    assert any("modules.community.leagues.config.load_league_bundles" in violation for violation in violations)
+
+
+def test_runtime_boundary_rejects_local_asyncio_to_thread_bridges() -> None:
+    source = """
+import asyncio
+from shared.sheets import core as sheets_core
+
+async def bad():
+    await asyncio.to_thread(sheets_core.fetch_records, 's', 't')
+"""
+
+    violations = _violations_for_source(source)
+
+    assert violations == ["6 calls asyncio.to_thread"]
+
+
+def test_runtime_boundary_allows_approved_centralized_bridge_modules() -> None:
+    source = """
+import asyncio
+from shared.sheets import core as sheets_core
+from shared.sheets import async_core
+
+async def ok():
+    await asyncio.to_thread(sheets_core.fetch_records, 's', 't')
+    await async_core.a_to_thread_with_backoff(sheets_core.get_worksheet, 's', 't')
+"""
+
+    assert _violations_for_source(source, approved_bridge_file=True) == []
+
+
+def test_runtime_boundary_allows_async_safe_runtime_wrappers() -> None:
+    source = """
+from shared.sheets.async_core import afetch_records, afetch_values, aget_worksheet, acall_with_backoff
+from modules.community.leagues.config import aload_league_bundles
+from shared.config import amerge_onboarding_config_early
+
+async def ok():
+    await afetch_records('s', 't')
+    await afetch_values('s', 't')
+    await aget_worksheet('s', 't')
+    await acall_with_backoff(lambda: None)
+    await aload_league_bundles('s')
+    await amerge_onboarding_config_early()
+"""
+
+    assert _violations_for_source(source) == []


### PR DESCRIPTION
### Motivation

- Prevent blocking the bot event loop by replacing synchronous Google Sheets/config access with async-safe boundaries for runtime code.
- Ensure live Discord runtime uses non-blocking Sheet helpers while keeping synchronous helpers for scripts/tests.

### Description

- Added async loader helpers: `shared.config.amerge_onboarding_config_early`, `_aload_onboarding_config_values`, and `_aload_milestones_config_values` to load onboarding/milestones config via async Sheets APIs.
- Introduced async league config functions in `modules.community.leagues.config`: `_aiter_league_rows`, `aload_league_bundles`, and documented sync-only `load_league_bundles` for tooling/tests.
- Replaced sync Sheets calls with async variants in runtime and modules: `modules/common/runtime.py` now calls `amerge_onboarding_config_early`; `modules/community/leagues/cog.py` calls `aload_league_bundles`; `modules/housekeeping/c1c_ad.py` uses `async_core.aget_worksheet`/`acall_with_backoff` and `async_core.asheets_read`.
- Updated tests to use new async APIs and added `tests/test_runtime_async_sheet_boundary.py` which statically enforces that async runtime code does not call blocking Sheets/config helpers.

### Testing

- Updated unit tests were executed including `tests/community/test_leagues_rendering.py`, `tests/config/test_merge_onboarding.py`, `tests/test_c1c_ad.py`, `tests/shared/test_runtime_startup_retry.py`, and the new `tests/test_runtime_async_sheet_boundary.py`.
- All modified and new tests ran locally and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e59fb613883238dc5c4d8ed3ab8ab)