### PR TITLE
Fix async onboarding config preload startup failure

### DIFF
--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from shared.sheets import core
-from shared.sheets.async_core import afetch_values
+from shared.sheets.async_core import afetch_records, afetch_values
 from shared.sheets.cache_service import cache
 
 _CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))

--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -82,3 +82,60 @@ def test_amerge_onboarding_config_early_uses_async_loader(monkeypatch):
     assert calls == {"async": 1, "milestones": 1}
     assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
     assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+
+
+def test_amerge_onboarding_config_early_executes_real_async_sheet_loaders(monkeypatch):
+    import asyncio
+
+    import shared.config as config
+    from shared.sheets import core as sheets_core
+    from shared.sheets import milestones_config
+    from shared.sheets import onboarding as onboarding_sheets
+
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "onboard-sheet-XYZ")
+    monkeypatch.setenv("ONBOARDING_CONFIG_TAB", "OnboardingConfigTab")
+    monkeypatch.setenv("MILESTONES_SHEET_ID", "milestone-sheet-XYZ")
+    monkeypatch.setenv("MILESTONES_CONFIG_TAB", "MilestonesConfigTab")
+    config._CONFIG["MILESTONES_SHEET_ID"] = "milestone-sheet-XYZ"
+
+    onboarding_sheets._CONFIG_CACHE = None
+    onboarding_sheets._CONFIG_CACHE_TS = 0.0
+
+    calls = []
+
+    async def _fake_onboarding_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("onboarding", sheet_id, tab_name))
+        assert sheet_id == "onboard-sheet-XYZ"
+        assert tab_name == "OnboardingConfigTab"
+        return [
+            {"Key": "ONBOARDING_TAB", "Value": "WelcomeQuestions"},
+            {"Key": "WELCOME_TICKETS_TAB", "Value": "WelcomeTickets"},
+        ]
+
+    async def _fake_milestones_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("milestones", sheet_id, tab_name))
+        assert sheet_id == "milestone-sheet-XYZ"
+        assert tab_name == "MilestonesConfigTab"
+        return [
+            {"Key": "SHARD_MERCY_TAB", "Value": "Mercy"},
+            {"Key": "RESET_REMINDER_TAB", "Value": "ResetReminders"},
+        ]
+
+    def _sync_fetch_records(*args, **kwargs):
+        raise AssertionError("sync Sheets fetch_records must not run during async startup preload")
+
+    monkeypatch.setattr(onboarding_sheets, "afetch_records", _fake_onboarding_afetch_records)
+    monkeypatch.setattr(milestones_config.async_core, "afetch_records", _fake_milestones_afetch_records)
+    monkeypatch.setattr(sheets_core, "fetch_records", _sync_fetch_records)
+
+    merged = asyncio.run(config.amerge_onboarding_config_early())
+
+    assert merged == 2
+    assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
+    assert config.cfg.get("WELCOME_TICKETS_TAB") == "WelcomeTickets"
+    assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+    assert config.cfg.get("RESET_REMINDER_TAB") == "ResetReminders"
+    assert calls == [
+        ("onboarding", "onboard-sheet-XYZ", "OnboardingConfigTab"),
+        ("milestones", "milestone-sheet-XYZ", "MilestonesConfigTab"),
+    ]


### PR DESCRIPTION
### Motivation
- Render startup failed during config validation with NameError("name 'afetch_records' is not defined") because the async onboarding config loader referenced the centralized async Sheets wrapper without importing it.
- The existing tests missed the issue because they mocked the onboarding async loader instead of exercising the real async preload path used in production.

### Description
- Import the approved centralized async Sheets wrapper `afetch_records` into `shared/sheets/onboarding.py` so the async `_aload_config` loader can run during startup validation.
- Add a regression test `test_amerge_onboarding_config_early_executes_real_async_sheet_loaders` to `tests/config/test_merge_onboarding.py` that runs `amerge_onboarding_config_early()` through the real async onboarding loader and the Milestones async preload path.
- Guard the test against accidental sync calls by monkeypatching `shared.sheets.core.fetch_records` to raise if invoked, and keep all sheet/tab names and values driven from env or config (no hardcoded fallbacks).

### Testing
- Ran `pytest tests/config/test_merge_onboarding.py tests/test_runtime_async_sheet_boundary.py tests/shared/sheets/test_milestones_config.py` and all tests passed (13 passed, 1 warning).
- The new regression test confirms that `amerge_onboarding_config_early()` completes without `NameError` and that onboarding and Milestones config values are merged into runtime config.
- Runtime async boundary tests continue to pass, proving no sync Sheets helpers are called from the event loop during the async startup preload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e704034a88323bf8bb8cf6740596b)