### PR TITLE
Retry failed unposted league approvals and use async record fetch for onboarding

### DIFF
--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -208,16 +208,46 @@ class LeaguesCog(commands.Cog):
                     extra={"reason": "no_active_approval_row", "channel_id": payload.channel_id, "message_id": payload.message_id},
                 )
                 return
-            status = row["values"].get("status", "").lower()
-            if status != "pending":
+            status = row["values"].get("status", "").strip().lower()
+            posted_at_utc = row["values"].get("posted_at_utc", "").strip()
+            retrying_failed = status == "failed" and not posted_at_utc
+            if status == "posted" or posted_at_utc:
                 log.info(
-                    "league approval reaction ignored",
-                    extra={"reason": "approval_not_pending", "status": status, "message_id": payload.message_id},
+                    "approval_not_retryable",
+                    extra={
+                        "reason": "approval_not_retryable",
+                        "status": status,
+                        "posted_at_utc": posted_at_utc,
+                        "message_id": payload.message_id,
+                    },
                 )
                 return
+            if status not in {"pending", "failed"}:
+                log.info(
+                    "approval_not_retryable",
+                    extra={
+                        "reason": "approval_not_retryable",
+                        "status": status,
+                        "posted_at_utc": posted_at_utc,
+                        "message_id": payload.message_id,
+                    },
+                )
+                return
+            if retrying_failed:
+                self._handled_messages.discard(payload.message_id)
+                log.info(
+                    "approval_retry_from_failed",
+                    extra={
+                        "reason": "approval_retry_from_failed",
+                        "status": status,
+                        "message_id": payload.message_id,
+                        "season_key": row["values"].get("season_key"),
+                        "week_key": row["values"].get("week_key"),
+                    },
+                )
 
             approvers = self._parse_approvers(row["values"].get("approved_by_user_ids", ""))
-            if payload.user_id in approvers:
+            if payload.user_id in approvers and not retrying_failed:
                 log.info("league approval reaction ignored", extra={"reason": "user_already_approved", "message_id": payload.message_id})
                 return
             approvers.add(payload.user_id)

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from shared.sheets import core
-from shared.sheets.async_core import afetch_values
+from shared.sheets.async_core import afetch_records, afetch_values
 from shared.sheets.cache_service import cache
 
 _CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -41,7 +41,7 @@ def test_league_role_mention_prefers_role_id(monkeypatch) -> None:
     assert cog._league_role_mention() == "<@&12345>"
 
 
-def _approval_row(status: str = "pending"):
+def _approval_row(status: str = "pending", *, posted_at_utc: str = "", approved_by_user_ids: str = ""):
     values = {
         "season_key": "2026",
         "week_key": "26",
@@ -49,8 +49,8 @@ def _approval_row(status: str = "pending"):
         "prompt_channel_id": "5678",
         "status": status,
         "required_reactions": "1",
-        "approved_by_user_ids": "",
-        "posted_at_utc": "",
+        "approved_by_user_ids": approved_by_user_ids,
+        "posted_at_utc": posted_at_utc,
         "created_at_utc": "2026-06-24T00:00:00+00:00",
         "updated_at_utc": "2026-06-24T00:00:00+00:00",
         "last_error": "",
@@ -77,9 +77,18 @@ class _LeagueApprovalPayload:
     member = SimpleNamespace(id=1111)
 
 
-async def _run_approval(monkeypatch, *, is_admin: bool, job_result: bool = True, job_error: Exception | None = None):
+async def _run_approval(
+    monkeypatch,
+    *,
+    is_admin: bool,
+    job_result: bool = True,
+    job_error: Exception | None = None,
+    status: str = "pending",
+    posted_at_utc: str = "",
+    approved_by_user_ids: str = "",
+):
     cog = LeaguesCog(_LeagueApprovalBot())
-    row = _approval_row()
+    row = _approval_row(status, posted_at_utc=posted_at_utc, approved_by_user_ids=approved_by_user_ids)
     updates = []
     calls = {"job": 0}
 
@@ -154,6 +163,77 @@ def test_league_approval_marks_failed_and_last_error_on_post_failure(monkeypatch
     assert calls["job"] == 1
     assert statuses == ["posting", "failed"]
     assert "RuntimeError: boom" in row["values"]["last_error"]
+
+
+def test_league_approval_retries_failed_unposted_row(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            job_result=True,
+            status="failed",
+            approved_by_user_ids="1111",
+        )
+    )
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "posted"]
+    assert row["values"]["posted_at_utc"]
+    assert row["values"]["last_error"] == ""
+
+
+def test_league_approval_ignores_failed_row_with_posted_at(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            status="failed",
+            posted_at_utc="2026-06-24T00:00:00+00:00",
+            approved_by_user_ids="1111",
+        )
+    )
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "failed"
+    assert row["values"]["posted_at_utc"] == "2026-06-24T00:00:00+00:00"
+
+
+def test_league_approval_ignores_posted_row(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(monkeypatch, is_admin=True, status="posted", posted_at_utc="2026-06-24T00:00:00+00:00")
+    )
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "posted"
+
+
+def test_league_approval_retry_failure_sets_failed_and_last_error(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            status="failed",
+            approved_by_user_ids="1111",
+            job_error=RuntimeError("retry boom"),
+        )
+    )
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "failed"]
+    assert row["values"]["posted_at_utc"] == ""
+    assert "RuntimeError: retry boom" in row["values"]["last_error"]
 
 
 def test_reaction_approval_runtime_uses_async_league_config_loader(monkeypatch):

--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -82,3 +82,60 @@ def test_amerge_onboarding_config_early_uses_async_loader(monkeypatch):
     assert calls == {"async": 1, "milestones": 1}
     assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
     assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+
+
+def test_amerge_onboarding_config_early_executes_real_async_sheet_loaders(monkeypatch):
+    import asyncio
+
+    import shared.config as config
+    from shared.sheets import core as sheets_core
+    from shared.sheets import milestones_config
+    from shared.sheets import onboarding as onboarding_sheets
+
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "onboard-sheet-XYZ")
+    monkeypatch.setenv("ONBOARDING_CONFIG_TAB", "OnboardingConfigTab")
+    monkeypatch.setenv("MILESTONES_SHEET_ID", "milestone-sheet-XYZ")
+    monkeypatch.setenv("MILESTONES_CONFIG_TAB", "MilestonesConfigTab")
+    config._CONFIG["MILESTONES_SHEET_ID"] = "milestone-sheet-XYZ"
+
+    onboarding_sheets._CONFIG_CACHE = None
+    onboarding_sheets._CONFIG_CACHE_TS = 0.0
+
+    calls = []
+
+    async def _fake_onboarding_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("onboarding", sheet_id, tab_name))
+        assert sheet_id == "onboard-sheet-XYZ"
+        assert tab_name == "OnboardingConfigTab"
+        return [
+            {"Key": "ONBOARDING_TAB", "Value": "WelcomeQuestions"},
+            {"Key": "WELCOME_TICKETS_TAB", "Value": "WelcomeTickets"},
+        ]
+
+    async def _fake_milestones_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("milestones", sheet_id, tab_name))
+        assert sheet_id == "milestone-sheet-XYZ"
+        assert tab_name == "MilestonesConfigTab"
+        return [
+            {"Key": "SHARD_MERCY_TAB", "Value": "Mercy"},
+            {"Key": "RESET_REMINDER_TAB", "Value": "ResetReminders"},
+        ]
+
+    def _sync_fetch_records(*args, **kwargs):
+        raise AssertionError("sync Sheets fetch_records must not run during async startup preload")
+
+    monkeypatch.setattr(onboarding_sheets, "afetch_records", _fake_onboarding_afetch_records)
+    monkeypatch.setattr(milestones_config.async_core, "afetch_records", _fake_milestones_afetch_records)
+    monkeypatch.setattr(sheets_core, "fetch_records", _sync_fetch_records)
+
+    merged = asyncio.run(config.amerge_onboarding_config_early())
+
+    assert merged == 2
+    assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
+    assert config.cfg.get("WELCOME_TICKETS_TAB") == "WelcomeTickets"
+    assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+    assert config.cfg.get("RESET_REMINDER_TAB") == "ResetReminders"
+    assert calls == [
+        ("onboarding", "onboard-sheet-XYZ", "OnboardingConfigTab"),
+        ("milestones", "milestone-sheet-XYZ", "MilestonesConfigTab"),
+    ]


### PR DESCRIPTION
### Motivation
- Allow manual re-approval to retry announcements that previously failed to post but were never actually posted. 
- Harden approval-state checks to avoid re-processing already-posted rows and to log clearer reasons for ignoring reactions. 
- Ensure onboarding config startup uses the asynchronous sheet record fetch API instead of the older value fetch function.

### Description
- Update `LeaguesCog.reaction_add` approval flow to trim and inspect `status` and `posted_at_utc`, permit retries when `status == 'failed'` and `posted_at_utc` is empty, and reject rows that are already `posted` or have a `posted_at_utc` timestamp; also reset `_handled_messages` when retrying a failed unposted row and adjust approver duplicate checks for retries. 
- Add more detailed logging reasons (`approval_not_retryable`, `approval_retry_from_failed`) when ignoring or retrying approval reactions. 
- Extend tests in `tests/community/test_leagues_rendering.py` by parameterizing the approval row helper and expanding `_run_approval` to exercise `status`, `posted_at_utc`, and `approved_by_user_ids` permutations; add tests for retrying failed unposted rows, ignoring failed-but-posted rows, ignoring posted rows, and handling retry failures. 
- Change import in `shared/sheets/onboarding.py` to use `afetch_records` from `shared.sheets.async_core` instead of `afetch_values`. 
- Add an async integration-style unit test `test_amerge_onboarding_config_early_executes_real_async_sheet_loaders` in `tests/config/test_merge_onboarding.py` to verify async loaders are invoked and sync fetchers are not used during async startup preload.

### Testing
- Ran the modified unit tests in `tests/community/test_leagues_rendering.py` which exercise approval retry paths and they passed. 
- Ran the modified and new tests in `tests/config/test_merge_onboarding.py` which validate async onboarding config loading and they passed. 
- No other automated test failures were observed when running the test suite including the new cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e704034a88323bf8bb8cf6740596b)