### PR TITLE
Add async recruitment sheet APIs, improve leagues approval logging/retry, and update callers to async sheet helpers

### DIFF
--- a/modules/community/leagues/cog.py
+++ b/modules/community/leagues/cog.py
@@ -86,19 +86,53 @@ class LeaguesCog(commands.Cog):
     async def _is_valid_approval_admin(self, payload: discord.RawReactionActionEvent) -> bool:
         admin_ids = self._admin_ids()
         if payload.user_id in admin_ids:
+            log.info(
+                "league approval admin gate passed",
+                extra={"gate": "league_admin_ids", "message_id": payload.message_id},
+            )
             return True
 
         member = getattr(payload, "member", None)
+        member_source = "payload" if member is not None else "missing"
         if member is None and payload.guild_id is not None:
             guild = self.bot.get_guild(payload.guild_id)
             if guild is not None:
                 member = guild.get_member(payload.user_id)
+                member_source = "guild_cache" if member is not None else "guild_fetch"
                 if member is None:
                     try:
                         member = await guild.fetch_member(payload.user_id)
                     except Exception:
+                        log.info(
+                            "league approval admin gate failed",
+                            extra={
+                                "reason": "member_fetch_failed",
+                                "configured_user_ids": bool(admin_ids),
+                                "message_id": payload.message_id,
+                            },
+                        )
                         member = None
-        return bool(member is not None and is_admin_member(member))
+        if member is not None and is_admin_member(member):
+            log.info(
+                "league approval admin gate passed",
+                extra={
+                    "gate": "discord_admin",
+                    "member_source": member_source,
+                    "message_id": payload.message_id,
+                },
+            )
+            return True
+        log.info(
+            "league approval admin gate failed",
+            extra={
+                "reason": "not_in_league_admin_ids_or_discord_admin",
+                "configured_user_ids": bool(admin_ids),
+                "member_available": member is not None,
+                "member_source": member_source,
+                "message_id": payload.message_id,
+            },
+        )
+        return False
 
     @staticmethod
     def _is_image_attachment(attachment: discord.Attachment) -> bool:
@@ -208,16 +242,46 @@ class LeaguesCog(commands.Cog):
                     extra={"reason": "no_active_approval_row", "channel_id": payload.channel_id, "message_id": payload.message_id},
                 )
                 return
-            status = row["values"].get("status", "").lower()
-            if status != "pending":
+            status = row["values"].get("status", "").strip().lower()
+            posted_at_utc = row["values"].get("posted_at_utc", "").strip()
+            retrying_failed = status == "failed" and not posted_at_utc
+            if status == "posted" or posted_at_utc:
                 log.info(
-                    "league approval reaction ignored",
-                    extra={"reason": "approval_not_pending", "status": status, "message_id": payload.message_id},
+                    "approval_not_retryable",
+                    extra={
+                        "reason": "approval_not_retryable",
+                        "status": status,
+                        "posted_at_utc": posted_at_utc,
+                        "message_id": payload.message_id,
+                    },
                 )
                 return
+            if status not in {"pending", "failed"}:
+                log.info(
+                    "approval_not_retryable",
+                    extra={
+                        "reason": "approval_not_retryable",
+                        "status": status,
+                        "posted_at_utc": posted_at_utc,
+                        "message_id": payload.message_id,
+                    },
+                )
+                return
+            if retrying_failed:
+                self._handled_messages.discard(payload.message_id)
+                log.info(
+                    "approval_retry_from_failed",
+                    extra={
+                        "reason": "approval_retry_from_failed",
+                        "status": status,
+                        "message_id": payload.message_id,
+                        "season_key": row["values"].get("season_key"),
+                        "week_key": row["values"].get("week_key"),
+                    },
+                )
 
             approvers = self._parse_approvers(row["values"].get("approved_by_user_ids", ""))
-            if payload.user_id in approvers:
+            if payload.user_id in approvers and not retrying_failed:
                 log.info("league approval reaction ignored", extra={"reason": "user_already_approved", "message_id": payload.message_id})
                 return
             approvers.add(payload.user_id)

--- a/modules/housekeeping/c1c_ad.py
+++ b/modules/housekeeping/c1c_ad.py
@@ -281,7 +281,7 @@ def _split_brackets(value: str) -> list[str]:
 
 
 async def _get_reports_tab_name_required() -> str:
-    tab_name = await async_core.a_to_thread_with_backoff(recruitment.get_config_value, "REPORTS_TAB", None)
+    tab_name = await recruitment.get_config_value_async("REPORTS_TAB", None)
     if not str(tab_name or "").strip():
         raise ValueError("reports tab config missing")
     return str(tab_name).strip()

--- a/modules/housekeeping/mirralith_overview.py
+++ b/modules/housekeeping/mirralith_overview.py
@@ -265,8 +265,8 @@ async def run_mirralith_overview_job(bot: discord.Client, trigger: str = "schedu
             failed_labels.append((spec.label, reason))
 
         try:
-            tab_name = recruitment.get_config_value(spec.tab_key, "") or ""
-            range_value = recruitment.get_config_value(spec.range_key, "") or ""
+            tab_name = await recruitment.get_config_value_async(spec.tab_key, "") or ""
+            range_value = await recruitment.get_config_value_async(spec.range_key, "") or ""
         except Exception as exc:
             record_failure("config lookup failed")
             log.warning(

--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -380,6 +380,11 @@ def _resolve_configured_reservation_clan_tag(clan_tag: str) -> str:
     return availability.resolve_configured_clan_tag(clan_tag)
 
 
+async def _aresolve_configured_reservation_clan_tag(clan_tag: str) -> str:
+    """Async resolve of the sheet clan tag through the availability Config clan_tag header."""
+    return await availability.aresolve_configured_clan_tag(clan_tag)
+
+
 def _normalize_tag(tag: str | None) -> str:
     text = "" if tag is None else str(tag).strip().upper()
     return "".join(ch for ch in text if ch.isalnum())
@@ -1124,7 +1129,8 @@ class ReservationCog(commands.Cog):
         fallback_reserved = active_reservations + 1
         fallback_available = max(manual_open - fallback_reserved, 0)
 
-        updated_row = recruitment.get_clan_by_tag(sheet_tag)
+        updated_entry = await recruitment.afind_clan_row(sheet_tag, force=True)
+        updated_row = updated_entry[1] if updated_entry is not None else None
         if updated_row is not None:
             ah_value = _safe_cell(updated_row, 33, fallback_reserved)
             af_value = _safe_cell(updated_row, 31, fallback_available)
@@ -1227,7 +1233,7 @@ class ReservationCog(commands.Cog):
 
         clan_tag = args[1]
         try:
-            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+            sheet_tag = await _aresolve_configured_reservation_clan_tag(clan_tag)
         except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
@@ -1407,7 +1413,7 @@ class ReservationCog(commands.Cog):
 
         clan_tag = args[1]
         try:
-            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+            sheet_tag = await _aresolve_configured_reservation_clan_tag(clan_tag)
         except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",
@@ -1825,7 +1831,7 @@ class ReservationCog(commands.Cog):
         self, ctx: commands.Context, clan_tag: str
     ) -> None:
         try:
-            sheet_tag = _resolve_configured_reservation_clan_tag(clan_tag)
+            sheet_tag = await _aresolve_configured_reservation_clan_tag(clan_tag)
         except ValueError:
             await ctx.reply(
                 f"I don’t know the clan tag `{clan_tag}`. Please check the tag and try again.",

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -259,6 +259,72 @@ def _resolve_availability_headers() -> AvailabilityHeaderResolution:
     )
 
 
+async def _aresolve_availability_headers() -> AvailabilityHeaderResolution:
+    tab_name = await recruitment.get_clans_tab_name_async()
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    header_row = list(await recruitment.aget_clan_header_row(force=True))
+    header_row_index = 3
+
+    configured_headers: dict[str, str] = {}
+    for field in AVAILABILITY_FIELDS:
+        config_key = f"clans_header_{field}"
+        value = await recruitment.get_config_value_async(config_key, None, force=True)
+        if value is None or not str(value).strip():
+            _log_availability_diagnostics(
+                reason="missing_required_config_key",
+                tab_name=tab_name,
+                sheet_id=sheet_id,
+                header_row_index=header_row_index,
+                header_row=header_row,
+                configured_headers=configured_headers,
+                missing_config_key=config_key,
+            )
+            raise ValueError(f"missing required Config key: {config_key}")
+        configured_headers[field] = str(value).strip()
+
+    lookup: dict[str, int] = {}
+    for index, cell in enumerate(header_row):
+        normalized = _normalize_configured_header(cell)
+        if normalized:
+            lookup[normalized] = index
+
+    header_map: dict[str, int] = {}
+    for field, configured_value in configured_headers.items():
+        normalized = _normalize_configured_header(configured_value)
+        if normalized not in lookup:
+            _log_availability_diagnostics(
+                reason="configured_header_not_found",
+                tab_name=tab_name,
+                sheet_id=sheet_id,
+                header_row_index=header_row_index,
+                header_row=header_row,
+                configured_headers=configured_headers,
+                header_map=header_map,
+                configured_header_value=configured_value,
+            )
+            raise ValueError(
+                f"configured bot_info header not found for {field}: {configured_value}"
+            )
+        header_map[field] = lookup[normalized]
+
+    _log_availability_diagnostics(
+        reason="resolved",
+        tab_name=tab_name,
+        sheet_id=sheet_id,
+        header_row_index=header_row_index,
+        header_row=header_row,
+        configured_headers=configured_headers,
+        header_map=header_map,
+    )
+    return AvailabilityHeaderResolution(
+        tab_name=tab_name,
+        sheet_id_masked=_mask_sheet_id(sheet_id),
+        header_row_index=header_row_index,
+        header_row=tuple(str(cell) if cell is not None else "" for cell in header_row),
+        header_map=header_map,
+        configured_headers=configured_headers,
+    )
+
 def _find_availability_clan_row(
     clan_tag: str, headers: AvailabilityHeaderResolution
 ) -> tuple[int, list[str]] | None:
@@ -281,6 +347,42 @@ def _find_availability_clan_row(
         except TypeError:
             return recruitment.find_clan_row(clan_tag)
     return None
+
+
+async def _afind_availability_clan_row(
+    clan_tag: str, headers: AvailabilityHeaderResolution
+) -> tuple[int, list[str]] | None:
+    tag_index = headers.header_map["clan_tag"]
+    normalized_target = _normalize_tag(clan_tag)
+    clan_rows = await recruitment.afetch_clans(force=True)
+    for idx, row in enumerate(clan_rows):
+        tag_value = row[tag_index] if tag_index < len(row) else ""
+        if _normalize_tag(tag_value) == normalized_target:
+            return idx + headers.header_row_index + 1, list(row)
+    return None
+
+
+async def aresolve_configured_clan_tag(clan_tag: str) -> str:
+    """Async resolve of a clan tag from bot_info using Config-provided clan_tag header."""
+
+    headers = await _aresolve_availability_headers()
+    entry = await _afind_availability_clan_row(clan_tag, headers)
+    if entry is None:
+        _log_availability_diagnostics(
+            reason="bot_info_row_not_found",
+            tab_name=headers.tab_name,
+            sheet_id=recruitment.get_recruitment_sheet_id(),
+            header_row_index=headers.header_row_index,
+            header_row=headers.header_row,
+            configured_headers=headers.configured_headers,
+            header_map=headers.header_map,
+            clan_tag=clan_tag,
+        )
+        raise ValueError(f"Unknown clan tag: {clan_tag}")
+    _sheet_row, row = entry
+    tag_index = headers.header_map["clan_tag"]
+    value = row[tag_index] if tag_index < len(row) else ""
+    return (str(value).strip() if value is not None else "") or clan_tag
 
 
 def resolve_configured_clan_tag(clan_tag: str) -> str:
@@ -315,7 +417,7 @@ async def preflight_clan_availability_update(
     | None = None,
 ) -> AvailabilityPreflightPlan:
     """Preflight Config-resolved bot_info availability dependencies before mutating flows."""
-    headers = _resolve_availability_headers()
+    headers = await _aresolve_availability_headers()
     sheet_id = recruitment.get_recruitment_sheet_id()
     try:
         worksheet = await async_core.aget_worksheet(sheet_id, headers.tab_name)
@@ -341,8 +443,10 @@ async def preflight_clan_availability_update(
     if worksheet is None:
         raise ValueError("bot_info worksheet not accessible")
 
-    row_lookup = find_clan_row_fn or _find_availability_clan_row
-    entry = row_lookup(clan_tag, headers)
+    if find_clan_row_fn is None:
+        entry = await _afind_availability_clan_row(clan_tag, headers)
+    else:
+        entry = find_clan_row_fn(clan_tag, headers)
     if entry is None:
         _log_availability_diagnostics(
             reason="bot_info_row_not_found",
@@ -675,7 +779,7 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
             cache_result,
         )
         phase = "post-write verification"
-        refreshed = recruitment.find_clan_row(clan_tag, force=True)
+        refreshed = await recruitment.afind_clan_row(clan_tag, force=True)
         if refreshed is None:
             raise RuntimeError(f"clan cache refresh failed for {clan_tag}")
         _, refreshed_row = refreshed
@@ -926,6 +1030,7 @@ def _normalize_tag(tag: str | None) -> str:
 
 __all__ = [
     "AvailabilityOperationError",
+    "aresolve_configured_clan_tag",
     "adjust_manual_open_spots",
     "is_rate_limited_error",
     "preflight_manual_open_spots_adjustment",

--- a/shared/sheets/feature_refresh.py
+++ b/shared/sheets/feature_refresh.py
@@ -21,7 +21,7 @@ def _missing_config_key(key: str) -> RuntimeError:
 
 def _recruitment_config_tab_loader(config_key: str) -> Loader:
     async def _load() -> list[list[str]]:
-        tab_name = await async_core.a_to_thread_with_backoff(recruitment.get_config_value, config_key, None, force=True)
+        tab_name = await recruitment.get_config_value_async(config_key, None, force=True)
         if not tab_name:
             raise _missing_config_key(config_key)
         try:

--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from shared.sheets import core
-from shared.sheets.async_core import afetch_values
+from shared.sheets.async_core import afetch_records, afetch_values
 from shared.sheets.cache_service import cache
 
 _CACHE_TTL = int(os.getenv("SHEETS_CACHE_TTL_SEC", "900"))

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -582,6 +582,12 @@ def get_clans_tab_name() -> str:
     return _clans_tab()
 
 
+async def get_clans_tab_name_async() -> str:
+    """Async return of the configured clan roster tab name."""
+
+    return await _aclans_tab()
+
+
 def get_reservations_tab_name(default: str = "Reservations") -> str:
     value = _config_lookup("reservations_tab", default) or default
     text = str(value or "").strip()
@@ -701,6 +707,49 @@ def get_clan_header_row(force: bool = False) -> List[str]:
     if force or _CLAN_HEADER_ROW is None or (now - _CLAN_HEADER_TS) >= _CACHE_TTL:
         fetch_clans(force=force)
     return list(_CLAN_HEADER_ROW or [])
+
+
+async def afetch_clans(force: bool = False) -> List[List[str]]:
+    """Async fetch of the recruitment clan matrix from Sheets."""
+
+    global _CLAN_ROWS, _CLAN_ROWS_TS, _CLAN_TAG_INDEX, _CLAN_TAG_INDEX_TS
+    now = time.time()
+    if not force and _CLAN_ROWS and (now - _CLAN_ROWS_TS) < _CACHE_TTL:
+        if _CLAN_TAG_INDEX is None:
+            _CLAN_TAG_INDEX = _build_tag_index(_CLAN_ROWS)
+            _CLAN_TAG_INDEX_TS = _CLAN_ROWS_TS
+        return _CLAN_ROWS
+    return await _load_clans_async()
+
+
+async def aget_clan_header_row(force: bool = False) -> List[str]:
+    """Async return of the cached clan roster header row."""
+
+    global _CLAN_HEADER_ROW, _CLAN_HEADER_TS
+    now = time.time()
+    if force or _CLAN_HEADER_ROW is None or (now - _CLAN_HEADER_TS) >= _CACHE_TTL:
+        await afetch_clans(force=force)
+    return list(_CLAN_HEADER_ROW or [])
+
+
+async def afind_clan_row(
+    clan_tag: str, *, force: bool = False
+) -> tuple[int, List[str]] | None:
+    """Async return of the sheet row number and values for ``clan_tag``."""
+
+    normalized = _normalize_tag(clan_tag)
+    if not normalized:
+        return None
+
+    rows = await afetch_clans(force=force)
+    tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
+    for idx, row in enumerate(rows):
+        if tag_index >= len(row):
+            continue
+        if _normalize_tag(row[tag_index]) == normalized:
+            sheet_row = idx + 4  # Account for the three summary/header rows.
+            return sheet_row, list(row)
+    return None
 
 
 def get_clan_records(force: bool = False) -> List[RecruitmentClanRecord]:

--- a/tests/community/test_leagues_rendering.py
+++ b/tests/community/test_leagues_rendering.py
@@ -41,7 +41,7 @@ def test_league_role_mention_prefers_role_id(monkeypatch) -> None:
     assert cog._league_role_mention() == "<@&12345>"
 
 
-def _approval_row(status: str = "pending"):
+def _approval_row(status: str = "pending", *, posted_at_utc: str = "", approved_by_user_ids: str = ""):
     values = {
         "season_key": "2026",
         "week_key": "26",
@@ -49,8 +49,8 @@ def _approval_row(status: str = "pending"):
         "prompt_channel_id": "5678",
         "status": status,
         "required_reactions": "1",
-        "approved_by_user_ids": "",
-        "posted_at_utc": "",
+        "approved_by_user_ids": approved_by_user_ids,
+        "posted_at_utc": posted_at_utc,
         "created_at_utc": "2026-06-24T00:00:00+00:00",
         "updated_at_utc": "2026-06-24T00:00:00+00:00",
         "last_error": "",
@@ -77,13 +77,26 @@ class _LeagueApprovalPayload:
     member = SimpleNamespace(id=1111)
 
 
-async def _run_approval(monkeypatch, *, is_admin: bool, job_result: bool = True, job_error: Exception | None = None):
+async def _run_approval(
+    monkeypatch,
+    *,
+    is_admin: bool,
+    job_result: bool = True,
+    job_error: Exception | None = None,
+    status: str = "pending",
+    posted_at_utc: str = "",
+    approved_by_user_ids: str = "",
+    league_admin_ids: str | None = None,
+):
     cog = LeaguesCog(_LeagueApprovalBot())
-    row = _approval_row()
+    row = _approval_row(status, posted_at_utc=posted_at_utc, approved_by_user_ids=approved_by_user_ids)
     updates = []
     calls = {"job": 0}
 
-    monkeypatch.delenv("LEAGUE_ADMIN_IDS", raising=False)
+    if league_admin_ids is None:
+        monkeypatch.delenv("LEAGUE_ADMIN_IDS", raising=False)
+    else:
+        monkeypatch.setenv("LEAGUE_ADMIN_IDS", league_admin_ids)
     monkeypatch.setattr("modules.community.leagues.cog.is_admin_member", lambda member: is_admin)
 
     async def _find(channel_id, message_id, *, include_terminal=False):
@@ -122,6 +135,43 @@ def test_league_approval_allows_project_admin_without_league_admin_ids(monkeypat
     assert row["values"]["status"] == "posted"
 
 
+def test_league_approval_allows_configured_league_admin_id(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(monkeypatch, is_admin=False, league_admin_ids="1111")
+    )
+
+    assert calls["job"] == 1
+    assert any(update.get("status") == "posting" for update in updates)
+    assert row["values"]["status"] == "posted"
+
+
+def test_league_approval_rejected_user_logs_admin_gate(monkeypatch, caplog) -> None:
+    import asyncio
+    import logging
+
+    caplog.set_level(logging.INFO, logger="c1c.community.leagues")
+
+    row, updates, calls = asyncio.run(
+        _run_approval(monkeypatch, is_admin=False, league_admin_ids="2222")
+    )
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "pending"
+    assert any(
+        record.getMessage() == "league approval admin gate failed"
+        and getattr(record, "reason", "") == "not_in_league_admin_ids_or_discord_admin"
+        for record in caplog.records
+    )
+    assert any(
+        record.getMessage() == "league approval reaction ignored"
+        and getattr(record, "reason", "") == "user_not_allowed"
+        for record in caplog.records
+    )
+
+
 def test_league_approval_rejects_non_admin_when_not_in_league_admin_ids(monkeypatch) -> None:
     import asyncio
 
@@ -154,6 +204,77 @@ def test_league_approval_marks_failed_and_last_error_on_post_failure(monkeypatch
     assert calls["job"] == 1
     assert statuses == ["posting", "failed"]
     assert "RuntimeError: boom" in row["values"]["last_error"]
+
+
+def test_league_approval_retries_failed_unposted_row(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            job_result=True,
+            status="failed",
+            approved_by_user_ids="1111",
+        )
+    )
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "posted"]
+    assert row["values"]["posted_at_utc"]
+    assert row["values"]["last_error"] == ""
+
+
+def test_league_approval_ignores_failed_row_with_posted_at(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            status="failed",
+            posted_at_utc="2026-06-24T00:00:00+00:00",
+            approved_by_user_ids="1111",
+        )
+    )
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "failed"
+    assert row["values"]["posted_at_utc"] == "2026-06-24T00:00:00+00:00"
+
+
+def test_league_approval_ignores_posted_row(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(monkeypatch, is_admin=True, status="posted", posted_at_utc="2026-06-24T00:00:00+00:00")
+    )
+
+    assert calls["job"] == 0
+    assert updates == []
+    assert row["values"]["status"] == "posted"
+
+
+def test_league_approval_retry_failure_sets_failed_and_last_error(monkeypatch) -> None:
+    import asyncio
+
+    row, updates, calls = asyncio.run(
+        _run_approval(
+            monkeypatch,
+            is_admin=True,
+            status="failed",
+            approved_by_user_ids="1111",
+            job_error=RuntimeError("retry boom"),
+        )
+    )
+
+    statuses = [update.get("status") for update in updates if "status" in update]
+    assert calls["job"] == 1
+    assert statuses == ["posting", "failed"]
+    assert row["values"]["posted_at_utc"] == ""
+    assert "RuntimeError: retry boom" in row["values"]["last_error"]
 
 
 def test_reaction_approval_runtime_uses_async_league_config_loader(monkeypatch):

--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -82,3 +82,60 @@ def test_amerge_onboarding_config_early_uses_async_loader(monkeypatch):
     assert calls == {"async": 1, "milestones": 1}
     assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
     assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+
+
+def test_amerge_onboarding_config_early_executes_real_async_sheet_loaders(monkeypatch):
+    import asyncio
+
+    import shared.config as config
+    from shared.sheets import core as sheets_core
+    from shared.sheets import milestones_config
+    from shared.sheets import onboarding as onboarding_sheets
+
+    monkeypatch.setenv("ONBOARDING_SHEET_ID", "onboard-sheet-XYZ")
+    monkeypatch.setenv("ONBOARDING_CONFIG_TAB", "OnboardingConfigTab")
+    monkeypatch.setenv("MILESTONES_SHEET_ID", "milestone-sheet-XYZ")
+    monkeypatch.setenv("MILESTONES_CONFIG_TAB", "MilestonesConfigTab")
+    config._CONFIG["MILESTONES_SHEET_ID"] = "milestone-sheet-XYZ"
+
+    onboarding_sheets._CONFIG_CACHE = None
+    onboarding_sheets._CONFIG_CACHE_TS = 0.0
+
+    calls = []
+
+    async def _fake_onboarding_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("onboarding", sheet_id, tab_name))
+        assert sheet_id == "onboard-sheet-XYZ"
+        assert tab_name == "OnboardingConfigTab"
+        return [
+            {"Key": "ONBOARDING_TAB", "Value": "WelcomeQuestions"},
+            {"Key": "WELCOME_TICKETS_TAB", "Value": "WelcomeTickets"},
+        ]
+
+    async def _fake_milestones_afetch_records(sheet_id, tab_name, *args, **kwargs):
+        calls.append(("milestones", sheet_id, tab_name))
+        assert sheet_id == "milestone-sheet-XYZ"
+        assert tab_name == "MilestonesConfigTab"
+        return [
+            {"Key": "SHARD_MERCY_TAB", "Value": "Mercy"},
+            {"Key": "RESET_REMINDER_TAB", "Value": "ResetReminders"},
+        ]
+
+    def _sync_fetch_records(*args, **kwargs):
+        raise AssertionError("sync Sheets fetch_records must not run during async startup preload")
+
+    monkeypatch.setattr(onboarding_sheets, "afetch_records", _fake_onboarding_afetch_records)
+    monkeypatch.setattr(milestones_config.async_core, "afetch_records", _fake_milestones_afetch_records)
+    monkeypatch.setattr(sheets_core, "fetch_records", _sync_fetch_records)
+
+    merged = asyncio.run(config.amerge_onboarding_config_early())
+
+    assert merged == 2
+    assert config.cfg.get("ONBOARDING_TAB") == "WelcomeQuestions"
+    assert config.cfg.get("WELCOME_TICKETS_TAB") == "WelcomeTickets"
+    assert config.cfg.get("SHARD_MERCY_TAB") == "Mercy"
+    assert config.cfg.get("RESET_REMINDER_TAB") == "ResetReminders"
+    assert calls == [
+        ("onboarding", "onboard-sheet-XYZ", "OnboardingConfigTab"),
+        ("milestones", "milestone-sheet-XYZ", "MilestonesConfigTab"),
+    ]

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -11,6 +11,9 @@ from modules.placement import reservations as reserve_module
 from shared.sheets import reservations as reservations_sheet
 
 
+_REAL_AVAILABILITY_PREFLIGHT = reserve_module.availability.preflight_clan_availability_update
+
+
 @pytest.fixture(autouse=True)
 def _stub_availability_preflight(monkeypatch):
     header_map = {
@@ -50,7 +53,7 @@ def _stub_availability_preflight(monkeypatch):
             "Headers", (), {"header_map": header_map, "tab_name": "bot_info"}
         )()
 
-    async def fake_preflight(_tag, *, delta=0):
+    async def fake_preflight(_tag, *, delta=0, **_kwargs):
         return Plan()
 
     monkeypatch.setattr(
@@ -61,6 +64,32 @@ def _stub_availability_preflight(monkeypatch):
     monkeypatch.setattr(
         reserve_module, "_resolve_configured_reservation_clan_tag", lambda tag: tag
     )
+
+    async def fake_async_resolve(tag):
+        return tag
+
+    monkeypatch.setattr(
+        reserve_module, "_aresolve_configured_reservation_clan_tag", fake_async_resolve
+    )
+
+
+    async def fake_afind_clan_row(tag, *, force=False):
+        try:
+            row = reserve_module.recruitment.get_clan_by_tag(tag)
+        except Exception:
+            row = None
+        if row is not None:
+            return (10, list(row))
+        try:
+            found = reserve_module.recruitment.find_clan_row(tag)
+        except Exception:
+            return None
+        if found is None:
+            return None
+        row_number, values = found
+        return row_number, list(values)
+
+    monkeypatch.setattr(reserve_module.recruitment, "afind_clan_row", fake_afind_clan_row)
 
 
 class FakeMember:
@@ -278,6 +307,114 @@ def _reservation_ledger(
     rows: list[reservations_sheet.ReservationRow],
 ) -> reservations_sheet.ReservationLedger:
     return reservations_sheet.ReservationLedger(rows=list(rows), status_index=0)
+
+
+def test_reserve_availability_preflight_uses_async_sheets(monkeypatch):
+    header = [""] * 36
+    configured = {
+        "clan_tag": "Clan Tag",
+        "manual_open_spots": "Manual Open Spots",
+        "open_spots": "Open Spots",
+        "inactives": "Inactives",
+        "reservation_count": "Reservation Count",
+        "reservation_summary": "Reservation Summary",
+        "manual_open_spots_seen": "Manual Open Spots Seen",
+    }
+    indexes = {
+        "clan_tag": 2,
+        "manual_open_spots": 4,
+        "open_spots": 31,
+        "inactives": 32,
+        "reservation_count": 33,
+        "reservation_summary": 34,
+        "manual_open_spots_seen": 35,
+    }
+    for key, index in indexes.items():
+        header[index] = configured[key]
+    clan_row = [""] * 36
+    clan_row[2] = "FIT"
+    clan_row[4] = "3"
+    clan_row[31] = "3"
+    clan_row[32] = "0"
+    clan_row[33] = "0"
+    clan_row[34] = ""
+    clan_row[35] = "3"
+
+    class _Worksheet:
+        pass
+
+    async def _config_value(key, default=None, *, force=False):
+        if key == "clans_tab":
+            return "bot_info"
+        prefix = "clans_header_"
+        if key.startswith(prefix):
+            return configured[key.removeprefix(prefix)]
+        return default
+
+    async def _header_row(*, force=False):
+        return list(header)
+
+    async def _clans(*, force=False):
+        return [list(clan_row)]
+
+    async def _aget(sheet_id, tab_name):
+        assert sheet_id == "recruitment-sheet"
+        assert tab_name == "bot_info"
+        return _Worksheet()
+
+    def _sync_forbidden(*_args, **_kwargs):
+        raise AssertionError("sync Sheets/config helper must not run during reserve preflight")
+
+    monkeypatch.setattr(
+        reserve_module.availability,
+        "preflight_clan_availability_update",
+        _REAL_AVAILABILITY_PREFLIGHT,
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "recruitment-sheet"
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_config_value_async", _config_value
+    )
+    monkeypatch.setattr(
+        reserve_module.recruitment,
+        "get_clans_tab_name_async",
+        lambda: asyncio.sleep(0, result="bot_info"),
+    )
+    monkeypatch.setattr(reserve_module.recruitment, "aget_clan_header_row", _header_row)
+    monkeypatch.setattr(reserve_module.recruitment, "afetch_clans", _clans)
+    monkeypatch.setattr(reserve_module.recruitment, "get_config_value", _sync_forbidden)
+    monkeypatch.setattr(reserve_module.recruitment, "get_clan_header_row", _sync_forbidden)
+    monkeypatch.setattr(reserve_module.recruitment, "fetch_clans", _sync_forbidden)
+    monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", _sync_forbidden)
+    monkeypatch.setattr(reserve_module.availability.async_core, "aget_worksheet", _aget)
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "count_active_reservations_for_clan",
+        lambda *_: asyncio.sleep(0, result=0),
+    )
+
+    parent_id = 555
+    recruit = FakeMember(2222, "Recruit")
+    author = FakeMember(1111, "Recruiter")
+    guild = FakeGuild([recruit, author])
+    thread = FakeThread(
+        999, parent_id, name="W1234-Recruit", owner_id=recruit.id, guild=guild
+    )
+    bot = FakeBot([])
+    ctx = FakeContext(bot, guild, thread, author)
+
+    _enable_feature(monkeypatch, True)
+    _setup_parents(monkeypatch, parent_id)
+    _setup_permissions(monkeypatch, recruiter=True)
+
+    cog = _make_cog(bot)
+    asyncio.run(cog.reserve.callback(cog, ctx, "FIT"))
+
+    assert any(
+        "Who do you want to reserve" in (message.content or "")
+        for message in thread.sent
+    )
 
 
 def test_reserve_success(monkeypatch):
@@ -2235,7 +2372,7 @@ def _setup_successful_reserve(
     guild = FakeGuild([recruit])
     thread = FakeThread(thread_id=555, parent_id=parent_id, name=thread_name)
     author = FakeMember(111, "Recruiter")
-    date_message = FakeMessage("2026-06-13", author=author, channel=thread)
+    date_message = FakeMessage("2026-08-13", author=author, channel=thread)
     confirm_message = FakeMessage("yes", author=author, channel=thread)
     bot = FakeBot([date_message, confirm_message])
     ctx = FakeContext(bot, guild=guild, channel=thread, author=author)
@@ -2481,10 +2618,10 @@ def test_reserve_change_flow_cleans_full_completed_chain(monkeypatch):
     guild = FakeGuild([recruit])
     thread = FakeThread(thread_id=555, parent_id=999, name="W0057-ChangeRecruit")
     author = FakeMember(111, "Recruiter")
-    date_message = FakeMessage("2026-06-13", author=author, channel=thread)
+    date_message = FakeMessage("2026-08-13", author=author, channel=thread)
     change_message = FakeMessage("change", author=author, channel=thread)
     change_choice_message = FakeMessage("date", author=author, channel=thread)
-    changed_date_message = FakeMessage("2026-06-14", author=author, channel=thread)
+    changed_date_message = FakeMessage("2026-08-14", author=author, channel=thread)
     confirm_message = FakeMessage("yes", author=author, channel=thread)
     bot = FakeBot(
         [
@@ -2554,7 +2691,7 @@ def test_reserve_change_flow_cleans_full_completed_chain(monkeypatch):
         for message in thread.sent
         if not (message.content or "").startswith("✅ Reserved 1 spot")
     )
-    assert any("2026-06-14" in (message.content or "") for message in thread.sent)
+    assert any("2026-08-14" in (message.content or "") for message in thread.sent)
 
 
 def test_reserve_cleanup_works_for_promo_parent(monkeypatch):

--- a/tests/test_runtime_async_sheet_boundary.py
+++ b/tests/test_runtime_async_sheet_boundary.py
@@ -10,6 +10,7 @@ SYNC_SHEETS_CORE_MODULE = "shared.sheets.core"
 SYNC_CONFIG_MODULE = "shared.config"
 LEAGUES_CONFIG_MODULE = "modules.community.leagues.config"
 ONBOARDING_SHEETS_MODULE = "shared.sheets.onboarding"
+RECRUITMENT_SHEETS_MODULE = "shared.sheets.recruitment"
 
 FORBIDDEN_SYNC_HELPERS = {
     f"{SYNC_SHEETS_CORE_MODULE}.fetch_records",
@@ -24,6 +25,11 @@ FORBIDDEN_SYNC_HELPERS = {
     f"{SYNC_CONFIG_MODULE}._load_milestones_config_values",
     f"{LEAGUES_CONFIG_MODULE}.load_league_bundles",
     f"{ONBOARDING_SHEETS_MODULE}._read_onboarding_config",
+    f"{RECRUITMENT_SHEETS_MODULE}.get_config_value",
+    f"{RECRUITMENT_SHEETS_MODULE}.get_clan_header_row",
+    f"{RECRUITMENT_SHEETS_MODULE}.fetch_clans",
+    f"{RECRUITMENT_SHEETS_MODULE}.find_clan_row",
+    f"{RECRUITMENT_SHEETS_MODULE}.get_clan_by_tag",
     "_read_onboarding_config",
 }
 
@@ -45,6 +51,7 @@ MODULE_ALIAS_TARGETS = {
     SYNC_CONFIG_MODULE,
     LEAGUES_CONFIG_MODULE,
     ONBOARDING_SHEETS_MODULE,
+    RECRUITMENT_SHEETS_MODULE,
     "shared.sheets.async_core",
     "asyncio",
 }
@@ -54,6 +61,7 @@ DIRECT_IMPORT_MODULES = {
     SYNC_CONFIG_MODULE,
     LEAGUES_CONFIG_MODULE,
     ONBOARDING_SHEETS_MODULE,
+    RECRUITMENT_SHEETS_MODULE,
     "shared.sheets.async_core",
 }
 
@@ -80,6 +88,8 @@ class _RuntimeBoundaryVisitor(ast.NodeVisitor):
                 self.aliases[local] = SYNC_SHEETS_CORE_MODULE
             elif node.module == "shared.sheets" and alias.name == "onboarding":
                 self.aliases[local] = ONBOARDING_SHEETS_MODULE
+            elif node.module == "shared.sheets" and alias.name == "recruitment":
+                self.aliases[local] = RECRUITMENT_SHEETS_MODULE
             elif node.module == "shared" and alias.name == "config":
                 self.aliases[local] = SYNC_CONFIG_MODULE
             elif node.module in DIRECT_IMPORT_MODULES:
@@ -219,6 +229,7 @@ from shared import config as shared_config
 from shared.config import merge_onboarding_config_early, _load_onboarding_config_values, _load_milestones_config_values
 from modules.community.leagues.config import load_league_bundles
 from shared.sheets.onboarding import _read_onboarding_config
+from shared.sheets import recruitment
 
 async def bad():
     _read_onboarding_config('sheet')
@@ -229,16 +240,26 @@ async def bad():
     _load_onboarding_config_values()
     _load_milestones_config_values()
     load_league_bundles('sheet')
+    recruitment.fetch_clans(force=True)
+    recruitment.find_clan_row('FIT', force=True)
+    recruitment.get_config_value('clans_tab')
+    recruitment.get_clan_header_row(force=True)
+    recruitment.get_clan_by_tag('FIT')
 """
 
     violations = _violations_for_source(source)
 
-    assert len(violations) == 8
+    assert len(violations) == 13
     assert any("shared.sheets.onboarding._read_onboarding_config" in violation for violation in violations)
     assert any("shared.config.merge_onboarding_config_early" in violation for violation in violations)
     assert any("shared.config._load_onboarding_config_values" in violation for violation in violations)
     assert any("shared.config._load_milestones_config_values" in violation for violation in violations)
     assert any("modules.community.leagues.config.load_league_bundles" in violation for violation in violations)
+    assert any("shared.sheets.recruitment.fetch_clans" in violation for violation in violations)
+    assert any("shared.sheets.recruitment.find_clan_row" in violation for violation in violations)
+    assert any("shared.sheets.recruitment.get_config_value" in violation for violation in violations)
+    assert any("shared.sheets.recruitment.get_clan_header_row" in violation for violation in violations)
+    assert any("shared.sheets.recruitment.get_clan_by_tag" in violation for violation in violations)
 
 
 def test_runtime_boundary_rejects_local_asyncio_to_thread_bridges() -> None:


### PR DESCRIPTION
### Motivation

- Move recruitment/bot_info sheet access and related helpers to async variants so they can be used safely from async runtime without blocking thread bridges.
- Improve admin gate logging and make leagues approval handling more robust around retrying previously failed posts and honoring `posted_at_utc`.
- Replace synchronous Sheets/config lookups in several consumers with the new async helpers to centralize async boundary behavior.

### Description

- Added async recruitment helpers: `recruitment.afetch_clans`, `recruitment.aget_clan_header_row`, `recruitment.afind_clan_row`, and `recruitment.get_clans_tab_name_async`, and exported `aresolve_configured_clan_tag` from `availability` by implementing `_aresolve_availability_headers`, `_afind_availability_clan_row`, and `aresolve_configured_clan_tag`.
- Added `LeaguesCog` admin gate logging in `_is_valid_approval_admin` and extended approval reaction flow to trim/normalize `status` and `posted_at_utc`, support retrying `failed` rows that lack `posted_at_utc`, avoid double-posting, and add richer logs for pass/fail reasons.
- Introduced `_aresolve_configured_reservation_clan_tag` in `reservations.py` and switched callers to await async resolution where appropriate.
- Updated consumers to use async config/sheets lookups including `shared/sheets/feature_refresh.py` loader to call `recruitment.get_config_value_async` and various housekeeping and reservation call sites to use the new async recruitment APIs.
- Updated module imports and runtime boundary checks to recognize `shared.sheets.recruitment` for async boundary analysis.

### Testing

- Ran unit tests in `tests/community/test_leagues_rendering.py` which exercise approval gating, retry and logging behavior, and all added cases passed.
- Ran `tests/placement/test_reserve_command.py` which includes new async preflight and reservation scenarios and they passed locally.
- Ran runtime boundary checks in `tests/test_runtime_async_sheet_boundary.py` and onboarding config async tests in `tests/config/test_merge_onboarding.py` to verify no forbidden sync sheet helpers are used from async code and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e704034a88323bf8bb8cf6740596b)