### PR TITLE
Reduce reservation post-append Sheets reads and add verified recompute + retry

### DIFF
--- a/modules/placement/reservations.py
+++ b/modules/placement/reservations.py
@@ -30,6 +30,7 @@ from shared.config import (
 )
 from shared.cache import telemetry as cache_telemetry
 from shared.logfmt import channel_label
+from shared.sheets import core as sheets_core
 from shared.sheets import recruitment, reservations
 
 log = logging.getLogger(__name__)
@@ -908,9 +909,10 @@ class ReservationCog(commands.Cog):
         manual_open = preflight_plan.numeric_values["manual_open_spots"]
 
         try:
-            active_reservations = await reservations.count_active_reservations_for_clan(
-                sheet_tag
+            active_reservation_rows = (
+                await reservations.get_active_reservations_for_clan(sheet_tag)
             )
+            active_reservations = len(active_reservation_rows)
         except Exception:
             log.exception(
                 "failed to count active reservations",
@@ -1055,44 +1057,30 @@ class ReservationCog(commands.Cog):
             return
 
         source = "reserve"
-        actor = "placement_reservation"
         actor_user = f"{ctx.author} ({getattr(ctx.author, 'id', '-')})"
-        clans_fresh = await _ensure_fresh_clans_for_reservations(
-            actor=actor,
+        reservation_row_ref = f"append:{now.isoformat()} thread:{getattr(ctx.channel, 'id', '')} user:{details.ticket_user_id or ''}"
+        appended_reservation = reservations.ReservationRow(
+            row_number=0,
+            thread_id=str(getattr(ctx.channel, "id", "")),
+            ticket_user_id=details.ticket_user_id,
+            recruiter_id=getattr(ctx.author, "id", None),
             clan_tag=sheet_tag,
-            user=actor_user,
-            source=source,
+            reserved_until=details.reserved_until,
+            created_at=now,
+            status=ACTIVE_STATUS,
+            notes=details.notes,
+            username_snapshot=username_snapshot or "",
+            raw=tuple(str(value) for value in row_values),
         )
-        reservation_row_ref = f"append:{now.isoformat()}"
-        if not clans_fresh:
-            log.warning(
-                "skipped recompute clan availability",
-                extra={
-                    "reason": "fresh_clans_unavailable",
-                    "clan_tag": _normalize_tag(sheet_tag),
-                    "reservation_row": reservation_row_ref,
-                    "thread_id": getattr(ctx.channel, "id", None),
-                    "ticket_user_id": details.ticket_user_id,
-                    "user": actor_user,
-                    "source": source,
-                },
-            )
-            human_log.human(
-                "warning",
-                "⚠️ reservation_partial_success — source=reserve • clan=%s • reservation_row=%s • thread=%s • ticket_user=%s • error_type=FreshClansUnavailable • error=fresh_clans_unavailable • action=rerun recompute/refresh for clan and verify recruiter-facing bot_info open spots"
-                % (
-                    _normalize_tag(sheet_tag),
-                    reservation_row_ref,
-                    getattr(ctx.channel, "id", "-"),
-                    details.ticket_user_id or "-",
-                ),
-            )
-            await ctx.send(
-                "Reservation row was added, but recruiter-facing availability was NOT updated. Admin hint: rerun recompute/refresh for this clan and manually verify bot_info/open spots."
-            )
-            return
+        recompute_rows = [*active_reservation_rows, appended_reservation]
         try:
-            await availability.recompute_clan_availability(sheet_tag, guild=ctx.guild)
+            recompute_result = await sheets_core._retry_with_backoff_async(
+                availability.recompute_clan_availability,
+                sheet_tag,
+                guild=ctx.guild,
+                preflight_plan=preflight_plan,
+                active_reservations=recompute_rows,
+            )
         except Exception as exc:
             error_type = type(exc).__name__
             error_text = str(exc) or repr(exc)
@@ -1126,17 +1114,25 @@ class ReservationCog(commands.Cog):
             )
             return
 
-        fallback_reserved = active_reservations + 1
-        fallback_available = max(manual_open - fallback_reserved, 0)
+        if not getattr(recompute_result, "verified", False):
+            log.error(
+                "reservation recompute finished without verification",
+                extra={
+                    "clan_tag": _normalize_tag(sheet_tag),
+                    "reservation_row": reservation_row_ref,
+                    "thread_id": getattr(ctx.channel, "id", None),
+                    "ticket_user_id": details.ticket_user_id,
+                    "user": actor_user,
+                    "source": source,
+                },
+            )
+            await ctx.send(
+                "Reservation row was added, but recruiter-facing availability was NOT updated. Admin hint: rerun recompute/refresh for this clan and manually verify bot_info/open spots."
+            )
+            return
 
-        updated_entry = await recruitment.afind_clan_row(sheet_tag, force=True)
-        updated_row = updated_entry[1] if updated_entry is not None else None
-        if updated_row is not None:
-            ah_value = _safe_cell(updated_row, 33, fallback_reserved)
-            af_value = _safe_cell(updated_row, 31, fallback_available)
-        else:
-            ah_value = str(fallback_reserved)
-            af_value = str(fallback_available)
+        ah_value = str(recompute_result.reservation_count)
+        af_value = str(recompute_result.available_after_reservations)
 
         await ctx.send(
             (

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -54,6 +54,17 @@ class AvailabilityPreflightPlan:
 
 
 @dataclass(frozen=True, slots=True)
+class AvailabilityRecomputeResult:
+    clan_tag: str
+    sheet_row: int
+    available_after_reservations: int
+    reservation_count: int
+    reservation_summary: str
+    cache_updated: bool
+    verified: bool
+
+
+@dataclass(frozen=True, slots=True)
 class ManualOpenSpotAdjustmentPlan:
     clan_tag: str
     delta: int
@@ -79,7 +90,14 @@ class ManualOpenSpotAdjustmentPlan:
 class AvailabilityOperationError(RuntimeError):
     """Wrap availability sheet failures with the operation phase that failed."""
 
-    def __init__(self, phase: str, clan_tag: str, message: str, *, cause: BaseException | None = None) -> None:
+    def __init__(
+        self,
+        phase: str,
+        clan_tag: str,
+        message: str,
+        *,
+        cause: BaseException | None = None,
+    ) -> None:
         self.phase = phase
         self.clan_tag = clan_tag
         self.cause = cause
@@ -100,9 +118,19 @@ def is_rate_limited_error(exc: BaseException | None) -> bool:
         if response is not None and getattr(response, "status_code", None) == 429:
             return True
         text = f"{type(current).__name__}: {current}".upper()
-        if any(marker in text for marker in ("429", "RESOURCE_EXHAUSTED", "READREQUESTSPERMINUTEPERUSER", "READ REQUESTS PER MINUTE PER USER")):
+        if any(
+            marker in text
+            for marker in (
+                "429",
+                "RESOURCE_EXHAUSTED",
+                "READREQUESTSPERMINUTEPERUSER",
+                "READ REQUESTS PER MINUTE PER USER",
+            )
+        ):
             return True
-        current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        current = getattr(current, "__cause__", None) or getattr(
+            current, "__context__", None
+        )
     return False
 
 
@@ -325,6 +353,7 @@ async def _aresolve_availability_headers() -> AvailabilityHeaderResolution:
         configured_headers=configured_headers,
     )
 
+
 def _find_availability_clan_row(
     clan_tag: str, headers: AvailabilityHeaderResolution
 ) -> tuple[int, list[str]] | None:
@@ -411,10 +440,10 @@ async def preflight_clan_availability_update(
     clan_tag: str,
     *,
     delta: int = 0,
-    find_clan_row_fn: Callable[
-        [str, AvailabilityHeaderResolution], tuple[int, list[str]] | None
-    ]
-    | None = None,
+    find_clan_row_fn: (
+        Callable[[str, AvailabilityHeaderResolution], tuple[int, list[str]] | None]
+        | None
+    ) = None,
 ) -> AvailabilityPreflightPlan:
     """Preflight Config-resolved bot_info availability dependencies before mutating flows."""
     headers = await _aresolve_availability_headers()
@@ -841,7 +870,9 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
             write_range or None,
             extra=extra,
         )
-        if isinstance(exc, AvailabilityOperationError) or (phase == "preflight" and isinstance(exc, ValueError)):
+        if isinstance(exc, AvailabilityOperationError) or (
+            phase == "preflight" and isinstance(exc, ValueError)
+        ):
             raise
         raise AvailabilityOperationError(
             phase,
@@ -856,16 +887,20 @@ async def recompute_clan_availability(
     *,
     guild: reservations.SupportsMemberLookup | None = None,
     resolver: reservations.ResolveUserFn | None = None,
-    find_clan_row_fn: Callable[
-        [str, AvailabilityHeaderResolution], tuple[int, list[str]] | None
-    ]
-    | None = None,
-) -> None:
+    find_clan_row_fn: (
+        Callable[[str, AvailabilityHeaderResolution], tuple[int, list[str]] | None]
+        | None
+    ) = None,
+    preflight_plan: AvailabilityPreflightPlan | None = None,
+    active_reservations: Sequence[reservations.ReservationRow] | None = None,
+) -> AvailabilityRecomputeResult:
     """Recompute Config-resolved bot_info availability for ``clan_tag`` and refresh cache."""
 
-    plan = await preflight_clan_availability_update(
-        clan_tag, delta=0, find_clan_row_fn=find_clan_row_fn
-    )
+    plan = preflight_plan
+    if plan is None:
+        plan = await preflight_clan_availability_update(
+            clan_tag, delta=0, find_clan_row_fn=find_clan_row_fn
+        )
     sheet_row = plan.sheet_row
     row = plan.row
     header_map = plan.headers.header_map
@@ -882,7 +917,10 @@ async def recompute_clan_availability(
     rebase_manual_open_spots = manual_open != seen_manual_open
     base_available = manual_open if rebase_manual_open_spots else current_available
 
-    active_reservations = await reservations.get_active_reservations_for_clan(clan_tag)
+    if active_reservations is None:
+        active_reservations = await reservations.get_active_reservations_for_clan(
+            clan_tag
+        )
     reservation_count = len(active_reservations)
     available_after_reservations = max(base_available - reservation_count, 0)
 
@@ -962,7 +1000,7 @@ async def recompute_clan_availability(
             )
             raise
 
-    recruitment.update_cached_clan_row(sheet_row, updated_row)
+    cache_updated = recruitment.update_cached_clan_row(sheet_row, updated_row)
 
     log.debug(
         "recomputed clan availability",
@@ -977,6 +1015,15 @@ async def recompute_clan_availability(
             "aj_after": manual_open,
             "resolved_header_map": _availability_header_map_columns(header_map),
         },
+    )
+    return AvailabilityRecomputeResult(
+        clan_tag=clan_tag,
+        sheet_row=sheet_row,
+        available_after_reservations=available_after_reservations,
+        reservation_count=reservation_count,
+        reservation_summary=reservation_summary,
+        cache_updated=bool(cache_updated),
+        verified=True,
     )
 
 
@@ -1030,6 +1077,7 @@ def _normalize_tag(tag: str | None) -> str:
 
 __all__ = [
     "AvailabilityOperationError",
+    "AvailabilityRecomputeResult",
     "aresolve_configured_clan_tag",
     "adjust_manual_open_spots",
     "is_rate_limited_error",

--- a/tests/placement/test_reserve_command.py
+++ b/tests/placement/test_reserve_command.py
@@ -10,8 +10,9 @@ import pytest
 from modules.placement import reservations as reserve_module
 from shared.sheets import reservations as reservations_sheet
 
-
-_REAL_AVAILABILITY_PREFLIGHT = reserve_module.availability.preflight_clan_availability_update
+_REAL_AVAILABILITY_PREFLIGHT = (
+    reserve_module.availability.preflight_clan_availability_update
+)
 
 
 @pytest.fixture(autouse=True)
@@ -72,7 +73,6 @@ def _stub_availability_preflight(monkeypatch):
         reserve_module, "_aresolve_configured_reservation_clan_tag", fake_async_resolve
     )
 
-
     async def fake_afind_clan_row(tag, *, force=False):
         try:
             row = reserve_module.recruitment.get_clan_by_tag(tag)
@@ -89,7 +89,18 @@ def _stub_availability_preflight(monkeypatch):
         row_number, values = found
         return row_number, list(values)
 
-    monkeypatch.setattr(reserve_module.recruitment, "afind_clan_row", fake_afind_clan_row)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "afind_clan_row", fake_afind_clan_row
+    )
+
+    async def fake_active_reservations_for_clan(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "get_active_reservations_for_clan",
+        fake_active_reservations_for_clan,
+    )
 
 
 class FakeMember:
@@ -225,6 +236,18 @@ class FakeContext:
 
     async def send(self, content: str, **kwargs):
         return await self.channel.send(content=content, **kwargs)
+
+
+def _verified_recompute_result(tag="#ABC", *, reserved=1, available=2):
+    return reserve_module.availability.AvailabilityRecomputeResult(
+        clan_tag=tag,
+        sheet_row=7,
+        available_after_reservations=available,
+        reservation_count=reserved,
+        reservation_summary="",
+        cache_updated=True,
+        verified=True,
+    )
 
 
 def _enable_feature(monkeypatch, enabled: bool = True) -> None:
@@ -363,7 +386,9 @@ def test_reserve_availability_preflight_uses_async_sheets(monkeypatch):
         return _Worksheet()
 
     def _sync_forbidden(*_args, **_kwargs):
-        raise AssertionError("sync Sheets/config helper must not run during reserve preflight")
+        raise AssertionError(
+            "sync Sheets/config helper must not run during reserve preflight"
+        )
 
     monkeypatch.setattr(
         reserve_module.availability,
@@ -371,7 +396,9 @@ def test_reserve_availability_preflight_uses_async_sheets(monkeypatch):
         _REAL_AVAILABILITY_PREFLIGHT,
     )
     monkeypatch.setattr(
-        reserve_module.recruitment, "get_recruitment_sheet_id", lambda: "recruitment-sheet"
+        reserve_module.recruitment,
+        "get_recruitment_sheet_id",
+        lambda: "recruitment-sheet",
     )
     monkeypatch.setattr(
         reserve_module.recruitment, "get_config_value_async", _config_value
@@ -384,7 +411,9 @@ def test_reserve_availability_preflight_uses_async_sheets(monkeypatch):
     monkeypatch.setattr(reserve_module.recruitment, "aget_clan_header_row", _header_row)
     monkeypatch.setattr(reserve_module.recruitment, "afetch_clans", _clans)
     monkeypatch.setattr(reserve_module.recruitment, "get_config_value", _sync_forbidden)
-    monkeypatch.setattr(reserve_module.recruitment, "get_clan_header_row", _sync_forbidden)
+    monkeypatch.setattr(
+        reserve_module.recruitment, "get_clan_header_row", _sync_forbidden
+    )
     monkeypatch.setattr(reserve_module.recruitment, "fetch_clans", _sync_forbidden)
     monkeypatch.setattr(reserve_module.recruitment, "find_clan_row", _sync_forbidden)
     monkeypatch.setattr(reserve_module.availability.async_core, "aget_worksheet", _aget)
@@ -484,8 +513,9 @@ def test_reserve_success(monkeypatch):
 
     recomputed = {}
 
-    async def fake_recompute(clan_tag, *, guild=None, resolver=None):
+    async def fake_recompute(clan_tag, **_kwargs):
         recomputed["tag"] = clan_tag
+        return _verified_recompute_result(clan_tag, reserved=2, available=1)
 
     monkeypatch.setattr(
         reserve_module.availability, "recompute_clan_availability", fake_recompute
@@ -718,7 +748,7 @@ def test_reserve_accepts_inline_recruit(monkeypatch):
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
-        lambda *args, **kwargs: asyncio.sleep(0),
+        lambda tag, **kwargs: asyncio.sleep(0, result=_verified_recompute_result(tag)),
     )
     monkeypatch.setattr(
         reserve_module,
@@ -928,6 +958,29 @@ def test_reserve_requires_reason(monkeypatch):
         fake_find_active,
     )
 
+    monkeypatch.setattr(
+        reserve_module.reservations,
+        "get_active_reservations_for_clan",
+        lambda *_args, **_kwargs: asyncio.sleep(
+            0,
+            result=[
+                reservations_sheet.ReservationRow(
+                    row_number=2,
+                    thread_id="old",
+                    ticket_user_id=999,
+                    recruiter_id=444,
+                    clan_tag="#DEF",
+                    reserved_until=None,
+                    created_at=None,
+                    status=reserve_module.ACTIVE_STATUS,
+                    notes="",
+                    username_snapshot="Existing",
+                    raw=(),
+                )
+            ],
+        ),
+    )
+
     appended: list[list[str]] = []
 
     async def fake_append(row_values):
@@ -939,7 +992,7 @@ def test_reserve_requires_reason(monkeypatch):
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
-        lambda *args, **kwargs: asyncio.sleep(0),
+        lambda tag, **kwargs: asyncio.sleep(0, result=_verified_recompute_result(tag)),
     )
     monkeypatch.setattr(
         reserve_module,
@@ -2422,7 +2475,7 @@ def _setup_successful_reserve(
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
-        lambda *_args, **_kwargs: asyncio.sleep(0),
+        lambda tag, **_kwargs: asyncio.sleep(0, result=_verified_recompute_result(tag)),
     )
     monkeypatch.setattr(
         reserve_module,
@@ -2669,7 +2722,7 @@ def test_reserve_change_flow_cleans_full_completed_chain(monkeypatch):
     monkeypatch.setattr(
         reserve_module.availability,
         "recompute_clan_availability",
-        lambda *_args, **_kwargs: asyncio.sleep(0),
+        lambda tag, **_kwargs: asyncio.sleep(0, result=_verified_recompute_result(tag)),
     )
     monkeypatch.setattr(
         reserve_module,
@@ -2707,3 +2760,105 @@ def test_reserve_cleanup_works_for_promo_parent(monkeypatch):
     assert date_message.deleted is True
     assert confirm_message.deleted is True
     assert any(name == "Res-M1234-denbotron-C1C5" for name in thread.edited_names)
+
+
+def test_reserve_reuses_preflight_plan_and_rows_without_post_append_reload(monkeypatch):
+    cog, ctx, thread, _messages = _setup_successful_reserve(monkeypatch)
+    calls = {"ensure_fresh": 0, "afind": 0}
+
+    async def forbidden_fresh(**_kwargs):
+        calls["ensure_fresh"] += 1
+        return False
+
+    async def forbidden_afind(*_args, **_kwargs):
+        calls["afind"] += 1
+        raise AssertionError("post-append clan force refresh should not run")
+
+    seen_kwargs = {}
+
+    async def fake_recompute(tag, **kwargs):
+        seen_kwargs.update(kwargs)
+        return _verified_recompute_result(
+            tag, reserved=len(kwargs["active_reservations"]), available=4
+        )
+
+    monkeypatch.setattr(
+        reserve_module, "_ensure_fresh_clans_for_reservations", forbidden_fresh
+    )
+    monkeypatch.setattr(reserve_module.recruitment, "afind_clan_row", forbidden_afind)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", fake_recompute
+    )
+
+    asyncio.run(cog.reserve.callback(cog, ctx, "C1C5", "<@222>"))
+
+    assert calls == {"ensure_fresh": 0, "afind": 0}
+    assert seen_kwargs["preflight_plan"] is not None
+    assert len(seen_kwargs["active_reservations"]) == 1
+    assert any("Effective open spots: `4`" in (m.content or "") for m in thread.sent)
+
+
+def test_reserve_retries_transient_429_after_append(monkeypatch):
+    cog, ctx, thread, _messages = _setup_successful_reserve(monkeypatch)
+    attempts = {"count": 0}
+
+    class QuotaError(RuntimeError):
+        status_code = 429
+
+    async def fake_sleep(_delay, result=None):
+        return result
+
+    async def flaky_recompute(tag, **_kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise QuotaError("429 RESOURCE_EXHAUSTED read requests per minute per user")
+        return _verified_recompute_result(tag, reserved=1, available=4)
+
+    monkeypatch.setattr(reserve_module.sheets_core.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", flaky_recompute
+    )
+
+    asyncio.run(cog.reserve.callback(cog, ctx, "C1C5", "<@222>"))
+
+    assert attempts["count"] == 2
+    assert any((m.content or "").startswith("✅ Reserved 1 spot") for m in thread.sent)
+
+
+def test_reserve_all_recompute_retries_fail_partial_warning(monkeypatch):
+    cog, ctx, thread, _messages = _setup_successful_reserve(monkeypatch)
+    attempts = {"count": 0}
+    runtime_logs: list[tuple[str, str]] = []
+
+    class QuotaError(RuntimeError):
+        status_code = 429
+
+    async def fake_sleep(_delay, result=None):
+        return result
+
+    async def always_quota(*_args, **_kwargs):
+        attempts["count"] += 1
+        raise QuotaError("429 RESOURCE_EXHAUSTED read requests per minute per user")
+
+    monkeypatch.setattr(reserve_module.sheets_core.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        reserve_module.availability, "recompute_clan_availability", always_quota
+    )
+    monkeypatch.setattr(
+        reserve_module.human_log,
+        "human",
+        lambda level, message, **_: runtime_logs.append((level, message)),
+    )
+
+    asyncio.run(cog.reserve.callback(cog, ctx, "C1C5", "<@222>"))
+
+    assert attempts["count"] >= 2
+    assert any(
+        "Reservation row was added, but recruiter-facing availability was NOT updated."
+        in (m.content or "")
+        for m in thread.sent
+    )
+    assert any(
+        "clan=C1C5" in message and "reservation_row=append:" in message
+        for _, message in runtime_logs
+    )


### PR DESCRIPTION
### Motivation
- Reservation flows were causing Google Sheets read-quota 429s after the ledger append due to redundant post-append clan/header/cache reloads, producing partial-success UX.
- The post-append recompute must retry transient quota errors using the centralized async backoff helpers before reporting partial success.
- The user-facing success text must only claim recruiter-facing availability updates when the bot_info write+verification completed successfully.

### Description
- Reuse the preflight availability resolution and in-memory active reservation rows after the append instead of forcing a fresh clan cache reload; the reservation command now constructs an `appended_reservation` and passes `preflight_plan` + `active_reservations` into the recompute call. (`modules/placement/reservations.py`)
- Add `AvailabilityRecomputeResult` and make `recompute_clan_availability` accept `preflight_plan` and `active_reservations`, returning a verified result object containing counts and `verified` state. (`modules/recruitment/availability.py`)
- Wrap the post-append recompute in the centralized async retry/backoff helper so transient 429s are retried before falling back to partial-success handling, and log a detailed `reservation_row_ref` (clan/thread/user) on failure. (`modules/placement/reservations.py` + use of `shared.sheets.core._retry_with_backoff_async`)
- Change the post-append success path to rely on the recompute `verified` flag and to report the exact recruiter-facing counts from the recompute result rather than probing the sheet again. Tests updated/added to assert no post-append force-reload and correct retry/partial-success behavior. (`tests/placement/test_reserve_command.py`)

### Testing
- Ran byte-compile checks with `PYTHONDONTWRITEBYTECODE=1 python -m py_compile modules/placement/reservations.py modules/recruitment/availability.py` and it succeeded. 
- Ran the reservation command test suite with `pytest -q tests/placement/test_reserve_command.py` which passed after the changes; new tests exercise reuse of the preflight plan, retry on transient 429, and exhausted-retry partial-success logging. 
- Verified style/formatting and linting steps used during development and ensured no new hard-coded sheet/tab/header/ID defaults were introduced (diff review and test runs completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9cc7ca908323a8d765fb8a4f6b9a)