### PR TITLE
Paginate and validate Discord embeds for daily recruiter report

### DIFF
--- a/modules/recruitment/reporting/daily_recruiter_update.py
+++ b/modules/recruitment/reporting/daily_recruiter_update.py
@@ -40,6 +40,22 @@ _BOT_REFERENCE: Optional[discord.Client] = None
 _PERSISTENT_VIEW_REGISTERED = False
 _PERSISTENT_VIEW_ATTR = "_c1c_open_spots_pager_registered"
 
+DISCORD_FIELD_VALUE_LIMIT = 1024
+DISCORD_FIELD_NAME_LIMIT = 256
+DISCORD_EMBED_FIELD_LIMIT = 25
+DISCORD_EMBED_TOTAL_LIMIT = 6000
+DISCORD_MESSAGE_EMBED_TOTAL_LIMIT = 6000
+DISCORD_EMBEDS_PER_MESSAGE_LIMIT = 10
+
+
+class DailyReportSectionError(RuntimeError):
+    """Raised when the summary/bracket section cannot be built or sent safely."""
+
+    def __init__(self, section: str, phase: str, message: str) -> None:
+        super().__init__(message)
+        self.section = section
+        self.phase = phase
+
 
 def feature_enabled() -> bool:
     """Return True when the recruitment_reports feature toggle is enabled."""
@@ -358,10 +374,91 @@ def add_fullwidth_field(embed: discord.Embed, *, name: str, value: str) -> None:
     embed.add_field(name=name, value=value, inline=False)
 
 
-def _add_block_divider(embed: discord.Embed) -> None:
-    """Insert the spacer/divider sequence between logical blocks."""
+def _split_text_losslessly(text: str, *, limit: int = DISCORD_FIELD_VALUE_LIMIT) -> List[str]:
+    """Split text into Discord-sized chunks without dropping or rewriting characters."""
 
-    add_fullwidth_field(embed, name="\n", value="\u25AB\u25AA\u25AB\u25AA\u25AB\u25AA\u25AB")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    value = str(text)
+    if not value:
+        return [""]
+    return [value[index : index + limit] for index in range(0, len(value), limit)]
+
+
+def _chunk_lines_for_field(lines: Sequence[str], *, limit: int = DISCORD_FIELD_VALUE_LIMIT) -> List[str]:
+    """Split lines into field values while preserving every report character."""
+
+    chunks: List[str] = []
+    current = ""
+    for raw_line in lines:
+        line = str(raw_line)
+        candidate = line if not current else f"{current}\n{line}"
+        if len(candidate) <= limit:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        if len(line) <= limit:
+            current = line
+            continue
+        chunks.extend(_split_text_losslessly(line, limit=limit))
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _new_report_embed(
+    *,
+    title: str,
+    footer: Optional[str] = None,
+    page: int = 1,
+) -> discord.Embed:
+    embed_title = title if page == 1 else f"{title} (cont. {page})"
+    embed = discord.Embed(title=embed_title, colour=discord.Colour.dark_teal())
+    if footer:
+        embed.set_footer(text=footer)
+    return embed
+
+
+def _append_field_paginated(
+    embeds: List[discord.Embed],
+    *,
+    title: str,
+    footer: Optional[str],
+    field_name: str,
+    lines: Sequence[str],
+    section: str,
+) -> None:
+    """Append full-width fields, opening new embeds whenever Discord limits require it."""
+
+    chunks = _chunk_lines_for_field(lines)
+    if not chunks:
+        return
+    if not embeds:
+        embeds.append(_new_report_embed(title=title, footer=footer))
+    for index, chunk in enumerate(chunks):
+        name = field_name if index == 0 else f"{field_name} (cont.)"
+        if len(name) > DISCORD_FIELD_NAME_LIMIT:
+            raise DailyReportSectionError(
+                section,
+                "pagination",
+                f"field name {field_name!r} exceeds Discord field name limit",
+            )
+        if len(chunk) > DISCORD_FIELD_VALUE_LIMIT:
+            raise DailyReportSectionError(
+                section,
+                "pagination",
+                f"field {field_name!r} could not be split within Discord field value limit",
+            )
+        embed = embeds[-1]
+        if (
+            len(getattr(embed, "fields", [])) >= DISCORD_EMBED_FIELD_LIMIT
+            or len(embed) + len(name) + len(chunk) > DISCORD_EMBED_TOTAL_LIMIT
+        ):
+            embed = _new_report_embed(title=title, footer=footer, page=len(embeds) + 1)
+            embeds.append(embed)
+        add_fullwidth_field(embed, name=name, value=chunk)
 
 
 class ReportSections(NamedTuple):
@@ -544,68 +641,254 @@ def _extract_report_sections(
     )
 
 
-def _build_summary_embed(sections: ReportSections) -> discord.Embed:
-    embed = discord.Embed(
-        title="Summary Open Spots",
-        colour=discord.Colour.dark_teal(),
+def _summary_footer() -> str:
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    return (
+        "last updated "
+        f"{timestamp} • daily snapshot, for most accurate numbers use `!clanmatch`"
     )
 
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
-    embed.set_footer(
-        text=(
-            "last updated "
-            f"{timestamp} • daily snapshot, for most accurate numbers use `!clanmatch`"
-        )
-    )
+
+def _finalize_embeds(embeds: Sequence[discord.Embed]) -> None:
+    for embed in embeds:
+        for field in getattr(embed, "fields", []):
+            try:
+                field.inline = False
+            except Exception:
+                pass
+
+
+def _build_summary_embeds(sections: ReportSections) -> List[discord.Embed]:
+    title = "Summary Open Spots"
+    footer = _summary_footer()
+    embeds = [_new_report_embed(title=title, footer=footer)]
 
     if sections.general_lines:
-        add_fullwidth_field(
-            embed,
-            name="General Overview",
-            value="\n".join(sections.general_lines),
+        _append_field_paginated(
+            embeds,
+            title=title,
+            footer=footer,
+            field_name="General Overview",
+            lines=sections.general_lines,
+            section="summary_bracket",
         )
 
     if sections.general_lines and sections.per_bracket_lines:
-        _add_block_divider(embed)
-
-    if sections.per_bracket_lines:
-        add_fullwidth_field(
-            embed,
-            name="Per Bracket",
-            value="\n".join(sections.per_bracket_lines),
+        _append_field_paginated(
+            embeds,
+            title=title,
+            footer=footer,
+            field_name="\n",
+            lines=["\u25AB\u25AA\u25AB\u25AA\u25AB\u25AA\u25AB"],
+            section="summary_bracket",
         )
 
-    for field in getattr(embed, "fields", []):
-        try:
-            field.inline = False
-        except Exception:
-            pass
+    if sections.per_bracket_lines:
+        _append_field_paginated(
+            embeds,
+            title=title,
+            footer=footer,
+            field_name="Per Bracket",
+            lines=sections.per_bracket_lines,
+            section="summary_bracket",
+        )
 
-    return embed
+    _finalize_embeds(embeds)
+    return embeds
+
+
+def _build_summary_embed(sections: ReportSections) -> discord.Embed:
+    return _build_summary_embeds(sections)[0]
+
+
+def _build_details_embeds(sections: ReportSections) -> List[discord.Embed]:
+    title = "Bracket Details"
+    embeds = [_new_report_embed(title=title, footer=DETAILS_FILTER_FOOTER)]
+    for key, formatted in sections.detail_blocks:
+        _append_field_paginated(
+            embeds,
+            title=title,
+            footer=DETAILS_FILTER_FOOTER,
+            field_name=key.title(),
+            lines=formatted,
+            section="bracket_details",
+        )
+
+    _finalize_embeds(embeds)
+    return embeds
 
 
 def _build_details_embed(sections: ReportSections) -> discord.Embed:
-    embed = discord.Embed(
-        title="Bracket Details",
-        colour=discord.Colour.dark_teal(),
-    )
+    return _build_details_embeds(sections)[0]
 
-    for key, formatted in sections.detail_blocks:
-        add_fullwidth_field(
-            embed,
-            name=key.title(),
-            value="\n".join(formatted),
+
+def _validate_embed_for_send(embed: discord.Embed, *, section: str) -> None:
+    fields = list(getattr(embed, "fields", []))
+    if len(fields) > DISCORD_EMBED_FIELD_LIMIT:
+        raise DailyReportSectionError(
+            section,
+            "validation",
+            f"{section} embed has {len(fields)} fields; Discord limit is {DISCORD_EMBED_FIELD_LIMIT}",
+        )
+    for field in fields:
+        if len(str(getattr(field, "name", ""))) > DISCORD_FIELD_NAME_LIMIT:
+            raise DailyReportSectionError(
+                section,
+                "validation",
+                f"{section} embed field name exceeds Discord field name limit",
+            )
+        if len(str(getattr(field, "value", ""))) > DISCORD_FIELD_VALUE_LIMIT:
+            raise DailyReportSectionError(
+                section,
+                "validation",
+                f"{section} embed field {getattr(field, 'name', '-')!r} exceeds Discord field value limit",
+            )
+    try:
+        embed_len = len(embed)
+    except Exception:
+        embed_len = 0
+    if embed_len > DISCORD_EMBED_TOTAL_LIMIT:
+        raise DailyReportSectionError(
+            section,
+            "validation",
+            f"{section} embed length {embed_len} exceeds Discord limit {DISCORD_EMBED_TOTAL_LIMIT}",
         )
 
-    embed.set_footer(text=DETAILS_FILTER_FOOTER)
 
-    for field in getattr(embed, "fields", []):
+def _validate_embed_message_payload(
+    embeds: Sequence[discord.Embed], *, section: str
+) -> None:
+    if len(embeds) > DISCORD_EMBEDS_PER_MESSAGE_LIMIT:
+        raise DailyReportSectionError(
+            section,
+            "validation",
+            f"{section} message has {len(embeds)} embeds; Discord limit is {DISCORD_EMBEDS_PER_MESSAGE_LIMIT}",
+        )
+    total = 0
+    for embed in embeds:
+        _validate_embed_for_send(embed, section=section)
         try:
-            field.inline = False
+            total += len(embed)
         except Exception:
             pass
+    if total > DISCORD_MESSAGE_EMBED_TOTAL_LIMIT:
+        raise DailyReportSectionError(
+            section,
+            "validation",
+            f"{section} message embed payload length {total} exceeds Discord limit {DISCORD_MESSAGE_EMBED_TOTAL_LIMIT}",
+        )
 
-    return embed
+
+def _group_embeds_for_message_payloads(
+    embeds: Sequence[discord.Embed], *, section: str
+) -> List[List[discord.Embed]]:
+    payloads: List[List[discord.Embed]] = []
+    current: List[discord.Embed] = []
+    current_len = 0
+    for embed in embeds:
+        _validate_embed_for_send(embed, section=section)
+        try:
+            embed_len = len(embed)
+        except Exception:
+            embed_len = 0
+        if embed_len > DISCORD_MESSAGE_EMBED_TOTAL_LIMIT:
+            raise DailyReportSectionError(
+                section,
+                "pagination",
+                f"{section} embed length {embed_len} cannot fit in one Discord message",
+            )
+        if (
+            current
+            and (
+                len(current) >= DISCORD_EMBEDS_PER_MESSAGE_LIMIT
+                or current_len + embed_len > DISCORD_MESSAGE_EMBED_TOTAL_LIMIT
+            )
+        ):
+            _validate_embed_message_payload(current, section=section)
+            payloads.append(current)
+            current = []
+            current_len = 0
+        current.append(embed)
+        current_len += embed_len
+    if current:
+        _validate_embed_message_payload(current, section=section)
+        payloads.append(current)
+    return payloads
+
+
+def _validate_summary_section(
+    sections: ReportSections,
+    summary_embeds: Sequence[discord.Embed],
+    details_embeds: Sequence[discord.Embed],
+) -> None:
+    if not (
+        sections.general_lines
+        or sections.per_bracket_lines
+        or sections.detail_blocks
+    ):
+        raise DailyReportSectionError(
+            "summary_bracket",
+            "build",
+            "summary/bracket builder returned no rows after applying sheet hide rules",
+        )
+    if not summary_embeds:
+        raise DailyReportSectionError(
+            "summary_bracket",
+            "pagination",
+            "summary/bracket pagination produced no summary embeds",
+        )
+    if not details_embeds:
+        raise DailyReportSectionError(
+            "bracket_details",
+            "pagination",
+            "summary/bracket pagination produced no bracket details embeds",
+        )
+    _group_embeds_for_message_payloads(summary_embeds, section="summary_bracket")
+    details_payloads = _group_embeds_for_message_payloads(
+        details_embeds, section="bracket_details"
+    )
+    if len(details_payloads) > 1:
+        raise DailyReportSectionError(
+            "bracket_details",
+            "pagination",
+            "Bracket Details button would require multiple Discord edit payloads",
+        )
+
+
+def _log_summary_section_failure(
+    message: str,
+    exc: BaseException,
+    *,
+    phase: str,
+    context: Optional[ReportFetchContext] = None,
+) -> None:
+    section = getattr(exc, "section", "summary_bracket")
+    failure_phase = getattr(exc, "phase", phase)
+    if context is not None:
+        log.warning(
+            "%s; section=%s phase=%s config_key=%s tab=%r sheet_id_source=%s row_count=%s "
+            "data_source=%s clans_cache=%s error=%s",
+            message,
+            section,
+            failure_phase,
+            context.config_key,
+            context.tab_name,
+            context.sheet_id_source,
+            context.row_count,
+            context.data_source,
+            context.clans_cache_state,
+            _format_error(exc),
+            exc_info=True,
+        )
+        return
+    log.warning(
+        "%s; section=%s phase=%s error=%s",
+        message,
+        section,
+        failure_phase,
+        _format_error(exc),
+        exc_info=True,
+    )
 
 
 async def _load_report_sections() -> ReportSections:
@@ -641,14 +924,22 @@ class OpenSpotsPager(discord.ui.View):
     async def set_summary(self, interaction: discord.Interaction) -> None:
         sections = await self._resolve_sections()
         self._set_page_state("summary")
-        embed = _build_summary_embed(sections)
-        await interaction.response.edit_message(embeds=[embed], view=self)
+        embeds = _build_summary_embeds(sections)
+        payloads = _group_embeds_for_message_payloads(embeds, section="summary_bracket")
+        await interaction.response.edit_message(embeds=payloads[0], view=self)
 
     async def set_details(self, interaction: discord.Interaction) -> None:
         sections = await self._resolve_sections()
         self._set_page_state("details")
-        embed = _build_details_embed(sections)
-        await interaction.response.edit_message(embeds=[embed], view=self)
+        embeds = _build_details_embeds(sections)
+        payloads = _group_embeds_for_message_payloads(embeds, section="bracket_details")
+        if len(payloads) > 1:
+            raise DailyReportSectionError(
+                "bracket_details",
+                "pagination",
+                "Bracket Details button would require multiple Discord edit payloads",
+            )
+        await interaction.response.edit_message(embeds=payloads[0], view=self)
 
     @discord.ui.button(
         label="Summary",
@@ -787,33 +1078,50 @@ async def post_daily_recruiter_update(bot: discord.Client) -> Tuple[bool, str]:
 
     try:
         sections = _extract_report_sections(rows, headers, _REPORT_CONTEXT_CACHE)
-        summary_embed = _build_summary_embed(sections)
+        summary_embeds = _build_summary_embeds(sections)
+        details_embeds = _build_details_embeds(sections)
         pager_view = OpenSpotsPager(sections)
+        _validate_summary_section(sections, summary_embeds, details_embeds)
+        summary_payloads = _group_embeds_for_message_payloads(
+            summary_embeds, section="summary_bracket"
+        )
     except Exception as exc:
         if isinstance(exc, ReportSchemaError):
             _log_report_diagnostics(
-                "failed to build recruiter report: missing Statistics headers",
+                "failed to build daily recruiter report summary/bracket section: missing Statistics headers",
                 context=exc.context,
                 required=exc.required,
                 exc_info=True,
             )
         elif isinstance(exc, ReportFetchError):
             _log_report_diagnostics(
-                "failed to build recruiter report: Statistics fetch/read failure",
+                "failed to build daily recruiter report summary/bracket section: Statistics fetch/read failure",
                 context=exc.context,
                 exc_info=True,
             )
         else:
-            log.warning("failed to build recruiter report", exc_info=True)
+            _log_summary_section_failure(
+                "failed to build daily recruiter report summary/bracket section",
+                exc,
+                phase="build",
+                context=_REPORT_CONTEXT_CACHE,
+            )
         return False, _format_error(exc)
 
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     content = _report_content(today)
 
     try:
-        await channel.send(content=content, embeds=[summary_embed], view=pager_view)
+        await channel.send(content=content, embeds=summary_payloads[0], view=pager_view)
+        for payload in summary_payloads[1:]:
+            await channel.send(content="Summary Open Spots (continued)", embeds=payload)
     except Exception as exc:
-        log.warning("failed to send recruiter report", exc_info=True)
+        _log_summary_section_failure(
+            "Discord rejected daily recruiter report summary/bracket section send",
+            exc,
+            phase="send",
+            context=_REPORT_CONTEXT_CACHE,
+        )
         return False, _format_error(exc)
 
     return True, "-"

--- a/tests/recruitment/test_daily_recruiter_update.py
+++ b/tests/recruitment/test_daily_recruiter_update.py
@@ -34,6 +34,10 @@ def _sample_rows():
     ]
 
 
+def _field_text(embeds):
+    return "\n".join(field.value for embed in embeds for field in embed.fields)
+
+
 def test_build_embeds_from_rows_filters_and_groups():
     rows = _sample_rows()
     headers = dru._headers_map(rows[0])
@@ -362,7 +366,7 @@ def test_post_daily_recruiter_update_sends_pager(monkeypatch):
 
     monkeypatch.setattr(dru, "_fetch_report_rows", fake_fetch)
     monkeypatch.setattr(dru, "get_report_destination_id", lambda: 123)
-    monkeypatch.setattr(dru, "_role_mentions", lambda: ())
+    monkeypatch.setattr(dru, "_role_mentions", lambda: ("<@&1>", "<@&2>"))
     monkeypatch.setattr(dru.discord, "TextChannel", DummyChannel)
 
     ok, error = asyncio.run(dru.post_daily_recruiter_update(bot))
@@ -373,6 +377,366 @@ def test_post_daily_recruiter_update_sends_pager(monkeypatch):
     sent_kwargs = channel.sent[0]
     assert len(sent_kwargs["embeds"]) == 1
     assert isinstance(sent_kwargs["view"], dru.OpenSpotsPager)
+    assert sent_kwargs["content"].startswith("# Update ")
+    assert "<@&1>" in sent_kwargs["content"]
+    assert "<@&2>" in sent_kwargs["content"]
+    assert sent_kwargs["embeds"][0].title == "Summary Open Spots"
+
+
+def test_post_daily_recruiter_update_logs_missing_headers(monkeypatch, caplog):
+    rows = [["bad", "schema"], ["General Overview", ""]]
+    headers = dru._headers_map(rows[0])
+
+    async def fake_fetch():
+        dru._REPORT_CONTEXT_CACHE = dru._report_fetch_context(
+            tab_name="Statistics", rows=rows, data_source="test"
+        )
+        return rows, headers
+
+    class DummyChannel:
+        guild = None
+
+        async def send(self, **kwargs):
+            raise AssertionError("send should not be called")
+
+    bot = MagicMock()
+    bot.get_channel.return_value = DummyChannel()
+    bot.fetch_channel = AsyncMock()
+    bot.wait_until_ready = AsyncMock()
+
+    monkeypatch.setattr(dru, "_fetch_report_rows", fake_fetch)
+    monkeypatch.setattr(dru, "get_report_destination_id", lambda: 123)
+    monkeypatch.setattr(dru.discord, "TextChannel", DummyChannel)
+
+    with caplog.at_level("WARNING", logger="c1c.recruitment.reporting.daily"):
+        ok, error = asyncio.run(dru.post_daily_recruiter_update(bot))
+
+    assert ok is False
+    assert "missing required header" in error
+    assert "summary/bracket section" in caplog.text
+    assert "required=" in caplog.text
+    assert "config_key=REPORTS_TAB" in caplog.text
+
+
+def test_run_full_recruiter_reports_posts_open_tickets_after_summary_failure(monkeypatch):
+    async def fake_report(bot):
+        return False, "summary failed"
+
+    async def fake_audit(bot, *, actor, dry_run):
+        return True, "-"
+
+    async def fake_tickets(bot):
+        return True, "-"
+
+    log_calls = []
+
+    async def fake_log_event(**kwargs):
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(dru, "post_daily_recruiter_update", fake_report)
+    monkeypatch.setattr(dru, "run_role_and_visitor_audit", fake_audit)
+    monkeypatch.setattr(dru, "send_currently_open_tickets_report", fake_tickets)
+    monkeypatch.setattr(dru, "resolve_audit_destination", lambda: (123, "REPORT_RECRUITERS_DEST_ID"))
+    monkeypatch.setattr(dru, "_log_event", fake_log_event)
+
+    results = asyncio.run(dru.run_full_recruiter_reports(MagicMock(), actor="scheduled"))
+
+    assert results["report"] == (False, "summary failed")
+    assert results["open_tickets"] == (True, "-")
+    assert any(call.get("note") == "open-tickets" and call["result"] == "ok" for call in log_calls)
+    assert any(call.get("note") is None and call["result"] == "fail" for call in log_calls)
+
+
+def test_run_full_recruiter_reports_posts_normal_report_and_open_tickets(monkeypatch):
+    async def fake_report(bot):
+        return True, "-"
+
+    async def fake_audit(bot, *, actor, dry_run):
+        return True, "-"
+
+    async def fake_tickets(bot):
+        return True, "-"
+
+    log_calls = []
+
+    async def fake_log_event(**kwargs):
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(dru, "post_daily_recruiter_update", fake_report)
+    monkeypatch.setattr(dru, "run_role_and_visitor_audit", fake_audit)
+    monkeypatch.setattr(dru, "send_currently_open_tickets_report", fake_tickets)
+    monkeypatch.setattr(dru, "resolve_audit_destination", lambda: (123, "REPORT_RECRUITERS_DEST_ID"))
+    monkeypatch.setattr(dru, "_log_event", fake_log_event)
+
+    results = asyncio.run(dru.run_full_recruiter_reports(MagicMock(), actor="scheduled"))
+
+    assert results["report"] == (True, "-")
+    assert results["open_tickets"] == (True, "-")
+    assert any(call.get("note") is None and call["result"] == "ok" for call in log_calls)
+    assert any(call.get("note") == "open-tickets" and call["result"] == "ok" for call in log_calls)
+
+
+def test_summary_embed_splits_long_field_values_without_dropping_lines():
+    rows = _sample_rows()
+    rows[2:2] = [["", "", f"Long Clan {idx}", "1", "0", "0"] for idx in range(40)]
+    headers = dru._headers_map(rows[0])
+
+    sections = dru._extract_report_sections(rows, headers)
+    summary_embeds = dru._build_summary_embeds(sections)
+    details_embeds = dru._build_details_embeds(sections)
+
+    dru._validate_summary_section(sections, summary_embeds, details_embeds)
+    combined = _field_text(summary_embeds)
+    for idx in range(40):
+        assert f"Long Clan {idx}" in combined
+    assert all(
+        len(field.value) <= dru.DISCORD_FIELD_VALUE_LIMIT
+        for embed in summary_embeds
+        for field in embed.fields
+    )
+
+
+def test_details_embed_continues_into_additional_embeds_without_dropping_fields():
+    rows = [
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["General Overview", "", "", "", "", ""],
+        ["", "", "Ops Summary", "3", "1", "0"],
+        ["Bracket Details", "", "", "", "", ""],
+    ]
+    for idx in range(dru.DISCORD_EMBED_FIELD_LIMIT + 5):
+        rows.extend(
+            [
+                ["", f"Bracket {idx}", "", "", "", ""],
+                ["", "", f"Clan {idx}", "1", "0", "0"],
+            ]
+        )
+    headers = dru._headers_map(rows[0])
+
+    sections = dru._extract_report_sections(rows, headers)
+    details_embeds = dru._build_details_embeds(sections)
+
+    assert len(details_embeds) > 1
+    combined = _field_text(details_embeds)
+    for idx in range(dru.DISCORD_EMBED_FIELD_LIMIT + 5):
+        assert f"Clan {idx}" in combined
+    assert all(len(embed.fields) <= dru.DISCORD_EMBED_FIELD_LIMIT for embed in details_embeds)
+
+
+def test_single_extremely_long_line_is_split_without_ellipsis_or_data_loss():
+    long_label = "Clan " + ("A" * (dru.DISCORD_FIELD_VALUE_LIMIT * 2 + 100))
+    sections = dru.ReportSections(
+        general_lines=[f"🔹 **{long_label}:** open 1 | inactives 0 | reserved 0"],
+        per_bracket_lines=[],
+        detail_blocks=[],
+    )
+
+    summary_embeds = dru._build_summary_embeds(sections)
+    combined = _field_text(summary_embeds)
+
+    assert "…" not in combined
+    assert long_label in combined.replace("\n", "")
+    assert all(
+        len(field.value) <= dru.DISCORD_FIELD_VALUE_LIMIT
+        for embed in summary_embeds
+        for field in embed.fields
+    )
+
+
+def test_report_exceeding_embed_total_length_splits_safely():
+    lines = [
+        f"🔹 **Clan {idx:03d}:** open 1 | inactives 0 | reserved 0 " + ("x" * 180)
+        for idx in range(45)
+    ]
+    sections = dru.ReportSections(
+        general_lines=lines,
+        per_bracket_lines=[],
+        detail_blocks=[],
+    )
+
+    summary_embeds = dru._build_summary_embeds(sections)
+
+    assert len(summary_embeds) > 1
+    combined = _field_text(summary_embeds)
+    for idx in range(45):
+        assert f"Clan {idx:03d}" in combined
+    assert all(len(embed) <= dru.DISCORD_EMBED_TOTAL_LIMIT for embed in summary_embeds)
+
+
+def test_summary_exceeding_message_embed_budget_sends_multiple_safe_messages(monkeypatch):
+    rows = _sample_rows()
+    rows[2:2] = [
+        ["", "", f"Long Summary Clan {idx} " + ("x" * 900), "1", "0", "0"]
+        for idx in range(10)
+    ]
+    headers = dru._headers_map(rows[0])
+
+    async def fake_fetch():
+        return rows, headers
+
+    class DummyChannel:
+        def __init__(self):
+            self.sent = []
+            self.guild = None
+
+        async def send(self, **kwargs):
+            self.sent.append(kwargs)
+
+    channel = DummyChannel()
+    bot = MagicMock()
+    bot.get_channel.return_value = channel
+    bot.fetch_channel = AsyncMock()
+    bot.wait_until_ready = AsyncMock()
+
+    monkeypatch.setattr(dru, "_fetch_report_rows", fake_fetch)
+    monkeypatch.setattr(dru, "get_report_destination_id", lambda: 123)
+    monkeypatch.setattr(dru, "_role_mentions", lambda: ("<@&1>",))
+    monkeypatch.setattr(dru.discord, "TextChannel", DummyChannel)
+
+    ok, error = asyncio.run(dru.post_daily_recruiter_update(bot))
+
+    assert ok is True
+    assert error == "-"
+    assert len(channel.sent) > 1
+    assert isinstance(channel.sent[0]["view"], dru.OpenSpotsPager)
+    assert channel.sent[0]["content"].startswith("# Update ")
+    assert "<@&1>" in channel.sent[0]["content"]
+    for sent in channel.sent:
+        assert sum(len(embed) for embed in sent["embeds"]) <= dru.DISCORD_MESSAGE_EMBED_TOTAL_LIMIT
+
+
+def test_summary_more_than_ten_generated_embeds_posts_multiple_safe_messages(monkeypatch):
+    rows = _sample_rows()
+    generated_count = dru.DISCORD_EMBEDS_PER_MESSAGE_LIMIT * 8
+    rows[2:2] = [
+        ["", "", f"Huge Summary Clan {idx:03d} " + ("x" * 900), "1", "0", "0"]
+        for idx in range(generated_count)
+    ]
+    headers = dru._headers_map(rows[0])
+
+    async def fake_fetch():
+        return rows, headers
+
+    class DummyChannel:
+        def __init__(self):
+            self.sent = []
+            self.guild = None
+
+        async def send(self, **kwargs):
+            self.sent.append(kwargs)
+
+    channel = DummyChannel()
+    bot = MagicMock()
+    bot.get_channel.return_value = channel
+    bot.fetch_channel = AsyncMock()
+    bot.wait_until_ready = AsyncMock()
+
+    monkeypatch.setattr(dru, "_fetch_report_rows", fake_fetch)
+    monkeypatch.setattr(dru, "get_report_destination_id", lambda: 123)
+    monkeypatch.setattr(dru, "_role_mentions", lambda: ())
+    monkeypatch.setattr(dru.discord, "TextChannel", DummyChannel)
+
+    ok, error = asyncio.run(dru.post_daily_recruiter_update(bot))
+
+    assert ok is True
+    assert error == "-"
+    total_embeds = sum(len(sent["embeds"]) for sent in channel.sent)
+    assert total_embeds > dru.DISCORD_EMBEDS_PER_MESSAGE_LIMIT
+    combined = "\n".join(
+        field.value
+        for sent in channel.sent
+        for embed in sent["embeds"]
+        for field in embed.fields
+    )
+    for idx in range(generated_count):
+        assert f"Huge Summary Clan {idx:03d}" in combined
+    for sent in channel.sent:
+        assert len(sent["embeds"]) <= dru.DISCORD_EMBEDS_PER_MESSAGE_LIMIT
+        assert sum(len(embed) for embed in sent["embeds"]) <= dru.DISCORD_MESSAGE_EMBED_TOTAL_LIMIT
+
+
+def test_report_too_large_for_details_button_fails_loudly(monkeypatch, caplog):
+    rows = [
+        [
+            "H1_Headline",
+            "H2_Headline",
+            "Key",
+            "open_spots",
+            "inactives",
+            "reserved_spots",
+        ],
+        ["General Overview", "", "", "", "", ""],
+        ["", "", "Ops Summary", "3", "1", "0"],
+        ["Bracket Details", "", "", "", "", ""],
+    ]
+    for idx in range(10):
+        rows.extend(
+            [
+                ["", f"Bracket {idx}", "", "", "", ""],
+                ["", "", f"Clan {idx} " + ("x" * 900), "1", "0", "0"],
+            ]
+        )
+    headers = dru._headers_map(rows[0])
+
+    async def fake_fetch():
+        dru._REPORT_CONTEXT_CACHE = dru._report_fetch_context(
+            tab_name="Statistics", rows=rows, data_source="test"
+        )
+        return rows, headers
+
+    class DummyChannel:
+        guild = None
+
+        async def send(self, **kwargs):
+            raise AssertionError("partial report should not be sent")
+
+    bot = MagicMock()
+    bot.get_channel.return_value = DummyChannel()
+    bot.fetch_channel = AsyncMock()
+    bot.wait_until_ready = AsyncMock()
+
+    monkeypatch.setattr(dru, "_fetch_report_rows", fake_fetch)
+    monkeypatch.setattr(dru, "get_report_destination_id", lambda: 123)
+    monkeypatch.setattr(dru.discord, "TextChannel", DummyChannel)
+
+    with caplog.at_level("WARNING", logger="c1c.recruitment.reporting.daily"):
+        ok, error = asyncio.run(dru.post_daily_recruiter_update(bot))
+
+    assert ok is False
+    assert "Bracket Details button would require multiple Discord edit payloads" in error
+    assert "phase=pagination" in caplog.text
+    assert "row_count=" in caplog.text
+
+
+def test_bracket_details_button_cannot_generate_oversized_edit_payload():
+    sections = dru.ReportSections(
+        general_lines=["🔹 **Ops Summary:** open 3 | inactives 1 | reserved 0"],
+        per_bracket_lines=[],
+        detail_blocks=[
+            (
+                f"Bracket {idx}",
+                [f"🔹 **Clan {idx} " + ("x" * 900) + ":** open 1 | inactives 0 | reserved 0"],
+            )
+            for idx in range(10)
+        ],
+    )
+
+    async def runner():
+        pager = dru.OpenSpotsPager(sections)
+        interaction = MagicMock()
+        interaction.response = AsyncMock()
+        interaction.response.edit_message = AsyncMock()
+        with pytest.raises(dru.DailyReportSectionError):
+            await pager.set_details(interaction)
+        interaction.response.edit_message.assert_not_awaited()
+
+    asyncio.run(runner())
 
 
 def test_parse_utc_time_returns_aware_time():


### PR DESCRIPTION
### Motivation
- Prevent Discord API rejections by enforcing field/embed/message size limits when building daily reports.
- Preserve every report character and avoid data loss by splitting long lines cleanly instead of truncating or adding ellipses.
- Provide clearer validation failures and logging when a report section cannot be safely built or sent.

### Description
- Introduces Discord size limit constants and a new exception `DailyReportSectionError` for section-level failures.
- Adds lossless chunking helpers ` _split_text_losslessly` and `_chunk_lines_for_field` and a paginated field appender `_append_field_paginated` to break large sections into multiple embed fields and embeds. 
- Replaces single-embed builders with paginated builders `_build_summary_embeds` and `_build_details_embeds`, plus helpers `_new_report_embed`, `_finalize_embeds`, `_group_embeds_for_message_payloads`, and validation functions `_validate_embed_for_send` / `_validate_embed_message_payload` / `_validate_summary_section`.
- Updates `OpenSpotsPager` and `post_daily_recruiter_update` to send grouped embed payloads (multiple safe messages when needed) and to fail early with descriptive errors when pagination/validation cannot produce a safe payload; adds `_log_summary_section_failure` for detailed warnings.

### Testing
- Expanded `tests/recruitment/test_daily_recruiter_update.py` with numerous new tests covering pagination, chunking, embed/message limits, error conditions, and the interaction flow (for example `test_post_daily_recruiter_update_sends_pager`, `test_summary_embed_splits_long_field_values_without_dropping_lines`, and `test_report_exceeding_embed_total_length_splits_safely`).
- Ran the updated test suite for the recruitment reporting module (the modified `test_daily_recruiter_update.py`) and all included tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fed7113048323987feb1f83e64fb4)