### PR TITLE
Run blocking sheet lookups in thread and finalize manual close when clan present

### DIFF
--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -2532,7 +2532,7 @@ async def _send_runtime(message: str) -> None:
 
 async def _send_welcome_repair_visibility() -> None:
     try:
-        message = onboarding_sheets.consume_welcome_repair_alert()
+        message = await asyncio.to_thread(onboarding_sheets.consume_welcome_repair_alert)
     except Exception:
         log.debug("failed to consume welcome repair alert", exc_info=True)
         return
@@ -4288,7 +4288,7 @@ class WelcomeTicketWatcher(commands.Cog):
 
         if clan_value:
             log.info(
-                "welcome close has existing sheet clan; prompting for explicit selection",
+                "welcome close has existing sheet clan; finalizing without prompt",
                 extra={
                     "flow": "welcome",
                     "trigger": reason,
@@ -4296,6 +4296,18 @@ class WelcomeTicketWatcher(commands.Cog):
                     "ticket": context.ticket_number,
                 },
             )
+            context.close_source = "manual_fallback"
+            await self._finalize_clan_tag(
+                thread,
+                context,
+                clan_value,
+                actor=None,
+                source="manual_fallback",
+                prompt_message=None,
+                view=None,
+                notify=False,
+            )
+            return
 
         await self._handle_ticket_closed(thread, context, manual=True)
         log.warning(
@@ -4573,7 +4585,12 @@ class WelcomeTicketWatcher(commands.Cog):
             final_is_real = False
         else:
             final_entry = (
-                _call_find_clan_row(recruitment_sheets.find_clan_row, final_tag, force=True)
+                await asyncio.to_thread(
+                    _call_find_clan_row,
+                    recruitment_sheets.find_clan_row,
+                    final_tag,
+                    force=True,
+                )
                 if final_tag != _NO_PLACEMENT_TAG
                 else None
             )
@@ -4714,9 +4731,9 @@ class WelcomeTicketWatcher(commands.Cog):
             if target_tags:
                 row_targets = _normalize_clan_math_targets(target_tags)
                 try:
-                    column_map = _clan_math_column_indices()
-                    before_snapshots = _capture_clan_snapshots(
-                        row_targets, column_map, force=True
+                    column_map = await asyncio.to_thread(_clan_math_column_indices)
+                    before_snapshots = await asyncio.to_thread(
+                        _capture_clan_snapshots, row_targets, column_map, force=True
                     )
                 except Exception:
                     column_map = None
@@ -4836,8 +4853,8 @@ class WelcomeTicketWatcher(commands.Cog):
                 )
 
         if not row_missing and row_targets and column_map is not None:
-            after_snapshots = _capture_clan_snapshots(
-                row_targets, column_map, force=True
+            after_snapshots = await asyncio.to_thread(
+                _capture_clan_snapshots, row_targets, column_map, force=True
             )
             row_change_lines = _build_clan_math_row_lines(
                 row_targets, before_snapshots, after_snapshots

--- a/tests/onboarding/test_welcome_reservations.py
+++ b/tests/onboarding/test_welcome_reservations.py
@@ -436,8 +436,14 @@ def test_handle_ticket_open_preserves_existing_values(monkeypatch) -> None:
 
 
 def test_ticket_tool_close_prompt_select_completes_welcome_finalization(monkeypatch, caplog) -> None:
-    async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
-        return func(*args, **kwargs)
+    def assert_not_in_event_loop(label: str) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        raise RuntimeError(
+            f"{label} must not run inside an active event loop; use the async variant."
+        )
 
     class _PromptThread:
         def __init__(self) -> None:
@@ -487,19 +493,40 @@ def test_ticket_tool_close_prompt_select_completes_welcome_finalization(monkeypa
     placement_logs: list[dict[str, object]] = []
     written_rows: list[dict[str, object]] = []
 
-    monkeypatch.setattr("modules.onboarding.watcher_welcome.asyncio.to_thread", fake_to_thread)
     monkeypatch.setattr("modules.onboarding.watcher_welcome.discord.Thread", _PromptThread)
-    monkeypatch.setattr("modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row", lambda ticket: (2, row))
+
+    def fake_find_welcome_row(ticket):  # type: ignore[no-untyped-def]
+        assert_not_in_event_loop("find_welcome_row")
+        return 2, row
+
+    monkeypatch.setattr("modules.onboarding.watcher_welcome.onboarding_sheets.find_welcome_row", fake_find_welcome_row)
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.onboarding_sheets.update_ticket_finalization_state",
-        lambda *a, **k: updates.append(k) or "updated",
+        lambda *a, **k: (assert_not_in_event_loop("update_ticket_finalization_state"), updates.append(k), "updated")[-1],
     )
     monkeypatch.setattr(
         "modules.onboarding.watcher_welcome.onboarding_sheets.append_welcome_ticket_row",
-        lambda *a, **k: written_rows.append(k) or "updated",
+        lambda *a, **k: (assert_not_in_event_loop("append_welcome_ticket_row"), written_rows.append(k), "updated")[-1],
     )
     monkeypatch.setattr("modules.onboarding.watcher_welcome._ensure_fresh_clans_for_placement", lambda **_: asyncio.sleep(0, result=True))
-    monkeypatch.setattr("modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row", lambda tag, force=False: (9, ["", "", tag]))
+    def fake_find_clan_row(tag, force=False):  # type: ignore[no-untyped-def]
+        assert_not_in_event_loop("find_clan_row")
+        return (9, ["", "", tag] + [""] * 40)
+
+    monkeypatch.setattr("modules.onboarding.watcher_welcome.recruitment_sheets.find_clan_row", fake_find_clan_row)
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_welcome.recruitment_sheets.get_clan_header_map",
+        lambda: (
+            assert_not_in_event_loop("get_clan_header_map"),
+            {
+                "clan_tag": 2,
+                "open_spots": 31,
+                "inactives": 32,
+                "reservation_count": 33,
+                "reservation_summary": 34,
+            },
+        )[-1],
+    )
     monkeypatch.setattr("modules.onboarding.watcher_welcome.reservations_sheets.find_active_reservations_for_recruit", lambda *a, **k: asyncio.sleep(0, result=[]))
     monkeypatch.setattr("modules.onboarding.watcher_welcome.availability.preflight_clan_availability_update", lambda *a, **k: asyncio.sleep(0, result=True))
     monkeypatch.setattr("modules.onboarding.watcher_welcome.availability.adjust_manual_open_spots", lambda *a, **k: asyncio.sleep(0))
@@ -508,8 +535,6 @@ def test_ticket_tool_close_prompt_select_completes_welcome_finalization(monkeypa
     monkeypatch.setattr("modules.onboarding.watcher_welcome._send_placement_log_line", lambda **kwargs: placement_logs.append(kwargs) or asyncio.sleep(0))
     monkeypatch.setattr("modules.onboarding.watcher_welcome._log_clan_math_event", lambda *a, **k: asyncio.sleep(0))
     monkeypatch.setattr("modules.onboarding.watcher_welcome._log_finalize_summary", lambda *a, **k: None)
-    monkeypatch.setattr("modules.onboarding.watcher_welcome._capture_clan_snapshots", lambda *a, **k: {})
-    monkeypatch.setattr("modules.onboarding.watcher_welcome._clan_math_column_indices", lambda: {})
 
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
     watcher = WelcomeTicketWatcher(bot)
@@ -537,6 +562,7 @@ def test_ticket_tool_close_prompt_select_completes_welcome_finalization(monkeypa
     assert updates[-1]["finalization_status"] == "done"
     assert context.state == "closed"
     assert thread.name == "Closed-W4242-CloseTester-C1CD"
+    assert "must not run inside an active event loop" not in caplog.text
     assert "welcome close clan select callback failed" not in caplog.text
     assert any(log.get("outcome") == "success" for log in placement_logs)
 


### PR DESCRIPTION
### Motivation
- Prevent synchronous, potentially blocking spreadsheet and lookup calls from running on the event loop by offloading them to threads. 
- Reduce unnecessary user prompts when a clan value already exists in the sheet during a manual close by finalizing automatically. 

### Description
- Convert several blocking calls to use `asyncio.to_thread`, including `onboarding_sheets.consume_welcome_repair_alert`, the clan lookup wrapper `_call_find_clan_row` invocation, `_clan_math_column_indices`, and `_capture_clan_snapshots`. 
- When a manual close finds an existing sheet `clan_value`, change the log message and call `_finalize_clan_tag` immediately with `source="manual_fallback"`, set `context.close_source = "manual_fallback"`, and return instead of prompting. 
- Update test `test_ticket_tool_close_prompt_select_completes_welcome_finalization` to ensure sync sheet/lookup helpers are not executed inside the running event loop by adding `assert_not_in_event_loop` checks and to adapt mocked return shapes accordingly. 

### Testing
- Ran the onboarding unit tests including `tests/onboarding/test_welcome_reservations.py::test_ticket_tool_close_prompt_select_completes_welcome_finalization`, which exercised the changed code paths and mocked helpers; the test passed. 
- Ran the modified onboarding test file locally to validate thread-offloading assertions and the new manual-close finalization behavior; all assertions succeeded. 
- No automated test failures were observed for the targeted onboarding tests after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bedd463883239dffa98e02425865)