### PR TITLE
Track quota summaries and use cache-aware sheet access for recruitment availability

### DIFF
--- a/cogs/recruitment_open_spots.py
+++ b/cogs/recruitment_open_spots.py
@@ -70,8 +70,19 @@ def _caller_source(ctx: commands.Context) -> str:
 
 def _operation_phase(exc: BaseException) -> str:
     phase = str(getattr(exc, "phase", "") or "").strip().lower().replace("_", "-")
-    if phase in {"preflight", "worksheet-lookup", "worksheet-update", "cache-refresh", "post-write verification", "post-write-verification"}:
-        return "post_write_verification" if phase in {"post-write verification", "post-write-verification"} else phase.replace("-", "_")
+    if phase in {
+        "preflight",
+        "worksheet-lookup",
+        "worksheet-update",
+        "cache-refresh",
+        "post-write verification",
+        "post-write-verification",
+    }:
+        return (
+            "post_write_verification"
+            if phase in {"post-write verification", "post-write-verification"}
+            else phase.replace("-", "_")
+        )
     text = str(exc).lower()
     if "post-write" in text or "cache refresh failed" in text or "verification" in text:
         return "post_write_verification"
@@ -80,6 +91,26 @@ def _operation_phase(exc: BaseException) -> str:
     if "update" in text or "write" in text:
         return "worksheet_update"
     return "preflight"
+
+
+def _log_quota_summary(summary: availability.AvailabilityQuotaSummary | None) -> None:
+    if summary is None:
+        return
+    log.info(
+        "setopenspots quota summary",
+        extra={
+            "command": summary.command,
+            "clan_tag": summary.clan_tag,
+            "operation": summary.operation,
+            "sheet_reads_count": summary.sheet_reads_count,
+            "sheet_writes_count": summary.sheet_writes_count,
+            "cache_hit": summary.cache_hit,
+            "cache_miss": summary.cache_miss,
+            "refreshed_clans_cache": summary.refreshed_clans_cache,
+            "used_cached_header": summary.used_cached_header,
+            "used_cached_row": summary.used_cached_row,
+        },
+    )
 
 
 def _failure_message_for(exc: BaseException) -> str:
@@ -143,22 +174,44 @@ class RecruitmentOpenSpotsCog(commands.Cog):
             return
 
         caller_source = _caller_source(ctx)
+        quota_token = availability.begin_quota_summary(clan_tag_or_name)
         try:
-            old_value, corrected_value, resolved_clan = (
-                await availability.set_manual_open_spots(clan_tag_or_name, new_value)
-            )
-        except ValueError as exc:
-            if _is_ambiguous_clan_error(exc):
-                await ctx.reply(
-                    "That clan input matches multiple clans; please use the clan tag.",
-                    mention_author=False,
+            try:
+                old_value, corrected_value, resolved_clan = (
+                    await availability.set_manual_open_spots(
+                        clan_tag_or_name, new_value
+                    )
                 )
-                return
-            if _is_clan_not_found_error(exc):
-                await ctx.reply(CLAN_NOT_FOUND_MESSAGE, mention_author=False)
-                return
-            phase = _operation_phase(exc)
-            if _is_config_or_preflight_error(exc):
+            except ValueError as exc:
+                if _is_ambiguous_clan_error(exc):
+                    await ctx.reply(
+                        "That clan input matches multiple clans; please use the clan tag.",
+                        mention_author=False,
+                    )
+                    return
+                if _is_clan_not_found_error(exc):
+                    await ctx.reply(CLAN_NOT_FOUND_MESSAGE, mention_author=False)
+                    return
+                phase = _operation_phase(exc)
+                if _is_config_or_preflight_error(exc):
+                    log.error(
+                        "setopenspots failed",
+                        exc_info=True,
+                        extra={
+                            "clan_tag": clan_tag_or_name,
+                            "requested_open_spots": new_value,
+                            "caller_source": caller_source,
+                            "operation_phase": phase,
+                            "exception_type": type(exc).__name__,
+                            "exception_message": str(exc),
+                            "quota_exhausted": availability.is_rate_limited_error(exc),
+                        },
+                    )
+                    await runtime_helpers.send_log_message(
+                        f"⚠️ Open spots correction failed during {phase}: recruitment sheet configuration invalid for {clan_tag_or_name}."
+                    )
+                    await ctx.reply(CONFIG_FAILURE_MESSAGE, mention_author=False)
+                    return
                 log.error(
                     "setopenspots failed",
                     exc_info=True,
@@ -173,50 +226,37 @@ class RecruitmentOpenSpotsCog(commands.Cog):
                     },
                 )
                 await runtime_helpers.send_log_message(
-                    f"⚠️ Open spots correction failed during {phase}: recruitment sheet configuration invalid for {clan_tag_or_name}."
+                    f"⚠️ Open spots correction failed during {phase} for {clan_tag_or_name}: {type(exc).__name__}: {exc}"
                 )
-                await ctx.reply(CONFIG_FAILURE_MESSAGE, mention_author=False)
+                await ctx.reply(_failure_message_for(exc), mention_author=False)
                 return
-            log.error(
-                "setopenspots failed",
-                exc_info=True,
-                extra={
-                    "clan_tag": clan_tag_or_name,
-                    "requested_open_spots": new_value,
-                    "caller_source": caller_source,
-                    "operation_phase": phase,
-                    "exception_type": type(exc).__name__,
-                    "exception_message": str(exc),
-                    "quota_exhausted": availability.is_rate_limited_error(exc),
-                },
-            )
-            await runtime_helpers.send_log_message(
-                f"⚠️ Open spots correction failed during {phase} for {clan_tag_or_name}: {type(exc).__name__}: {exc}"
-            )
-            await ctx.reply(_failure_message_for(exc), mention_author=False)
-            return
-        except Exception as exc:
-            phase = _operation_phase(exc)
-            quota = availability.is_rate_limited_error(exc)
-            log.error(
-                "setopenspots failed",
-                exc_info=True,
-                extra={
-                    "clan_tag": clan_tag_or_name,
-                    "requested_open_spots": new_value,
-                    "caller_source": caller_source,
-                    "operation_phase": phase,
-                    "exception_type": type(exc).__name__,
-                    "exception_message": str(exc),
-                    "quota_exhausted": quota,
-                },
-            )
-            reason = "quota_exhausted" if quota else f"{type(exc).__name__}: {exc}"
-            await runtime_helpers.send_log_message(
-                f"⚠️ Open spots correction failed during {phase} for {clan_tag_or_name}: {reason}"
-            )
-            await ctx.reply(_failure_message_for(exc), mention_author=False)
-            return
+            except Exception as exc:
+                phase = _operation_phase(exc)
+                quota = availability.is_rate_limited_error(exc)
+                log.error(
+                    "setopenspots failed",
+                    exc_info=True,
+                    extra={
+                        "clan_tag": clan_tag_or_name,
+                        "requested_open_spots": new_value,
+                        "caller_source": caller_source,
+                        "operation_phase": phase,
+                        "exception_type": type(exc).__name__,
+                        "exception_message": str(exc),
+                        "quota_exhausted": quota,
+                    },
+                )
+                failure_reason = (
+                    "quota_exhausted" if quota else f"{type(exc).__name__}: {exc}"
+                )
+                await runtime_helpers.send_log_message(
+                    f"⚠️ Open spots correction failed during {phase} for {clan_tag_or_name}: {failure_reason}"
+                )
+                await ctx.reply(_failure_message_for(exc), mention_author=False)
+                return
+        finally:
+            quota_summary = availability.end_quota_summary(quota_token)
+            _log_quota_summary(quota_summary)
 
         actor = _display_name(ctx.author)
         actor_id = getattr(ctx.author, "id", None)

--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextvars
 import logging
 import re
 from dataclasses import dataclass
@@ -31,6 +33,58 @@ NUMERIC_AVAILABILITY_FIELDS = (
     "reservation_count",
     "manual_open_spots_seen",
 )
+
+
+@dataclass(slots=True)
+class AvailabilityQuotaSummary:
+    command: str = "setopenspots"
+    clan_tag: str = ""
+    operation: str = "manual_open_spots_correction"
+    sheet_reads_count: int = 0
+    sheet_writes_count: int = 0
+    cache_hit: bool = False
+    cache_miss: bool = False
+    refreshed_clans_cache: bool = False
+    used_cached_header: bool = False
+    used_cached_row: bool = False
+
+
+_QUOTA_SUMMARY: contextvars.ContextVar[AvailabilityQuotaSummary | None] = (
+    contextvars.ContextVar("availability_quota_summary", default=None)
+)
+
+
+def begin_quota_summary(
+    clan_tag: str, *, operation: str = "manual_open_spots_correction"
+) -> contextvars.Token:
+    return _QUOTA_SUMMARY.set(
+        AvailabilityQuotaSummary(clan_tag=clan_tag, operation=operation)
+    )
+
+
+def end_quota_summary(token: contextvars.Token) -> AvailabilityQuotaSummary | None:
+    summary = _QUOTA_SUMMARY.get()
+    _QUOTA_SUMMARY.reset(token)
+    return summary
+
+
+def current_quota_summary() -> AvailabilityQuotaSummary | None:
+    return _QUOTA_SUMMARY.get()
+
+
+def _quota_note_read(*, refreshed: bool = False) -> None:
+    summary = _QUOTA_SUMMARY.get()
+    if summary is None:
+        return
+    summary.sheet_reads_count += 1
+    if refreshed:
+        summary.refreshed_clans_cache = True
+
+
+def _quota_note_write(count: int = 1) -> None:
+    summary = _QUOTA_SUMMARY.get()
+    if summary is not None:
+        summary.sheet_writes_count += count
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +139,7 @@ class ManualOpenSpotAdjustmentPlan:
     seen_range: str
     combined_range: str | None
     resolved_clan_tag: str
+    preflight_plan: AvailabilityPreflightPlan | None = None
 
 
 class AvailabilityOperationError(RuntimeError):
@@ -219,7 +274,7 @@ def _resolve_availability_headers() -> AvailabilityHeaderResolution:
     header_row_getter = getattr(recruitment, "get_clan_header_row", None)
     if callable(header_row_getter):
         try:
-            header_row = list(header_row_getter(force=True))
+            header_row = list(header_row_getter(force=False))
         except TypeError:
             header_row = list(header_row_getter())
     else:
@@ -288,27 +343,94 @@ def _resolve_availability_headers() -> AvailabilityHeaderResolution:
 
 
 async def _aresolve_availability_headers() -> AvailabilityHeaderResolution:
-    tab_name = await recruitment.get_clans_tab_name_async()
+    async def _load_async_header() -> tuple[str, list[Any], dict[str, str]]:
+        tab = await recruitment.get_clans_tab_name_async()
+        row = list(await recruitment.aget_clan_header_row(force=False))
+        configured: dict[str, str] = {}
+        for field in AVAILABILITY_FIELDS:
+            config_key = f"clans_header_{field}"
+            value = await recruitment.get_config_value_async(
+                config_key, None, force=False
+            )
+            configured[field] = str(value).strip() if value is not None else ""
+        return tab, row, configured
+
+    async def _load_cached_header_with_async_config() -> (
+        tuple[str, list[Any], dict[str, str]]
+    ):
+        tab = await recruitment.get_clans_tab_name_async()
+        try:
+            row = list(recruitment.get_clan_header_row(force=False))
+        except TypeError:
+            row = list(recruitment.get_clan_header_row())
+        configured: dict[str, str] = {}
+        for field in AVAILABILITY_FIELDS:
+            config_key = f"clans_header_{field}"
+            value = await recruitment.get_config_value_async(
+                config_key, None, force=False
+            )
+            configured[field] = str(value).strip() if value is not None else ""
+        return tab, row, configured
+
+    def _load_sync_for_thread() -> tuple[str, list[Any], dict[str, str]]:
+        tab = recruitment.get_clans_tab_name()
+        try:
+            row = list(recruitment.get_clan_header_row(force=False))
+        except TypeError:
+            row = list(recruitment.get_clan_header_row())
+        configured: dict[str, str] = {}
+        for field in AVAILABILITY_FIELDS:
+            config_key = f"clans_header_{field}"
+            try:
+                value = recruitment.get_config_value(config_key, None, force=False)
+            except TypeError:
+                value = recruitment.get_config_value(config_key, None)
+            configured[field] = str(value).strip() if value is not None else ""
+        return tab, row, configured
+
     sheet_id = recruitment.get_recruitment_sheet_id()
-    header_row = list(await recruitment.aget_clan_header_row(force=True))
+    used_cached_header = bool(
+        getattr(recruitment, "clan_header_cache_ready", lambda: False)()
+    )
+    summary = _QUOTA_SUMMARY.get()
+
+    try:
+        if used_cached_header:
+            tab_name, header_row, configured_headers = (
+                await _load_cached_header_with_async_config()
+            )
+        else:
+            tab_name, header_row, configured_headers = await _load_async_header()
+    except Exception:
+        # Compatibility path for callers/tests that only provide sync helpers.
+        # Run it off the event loop so sync Sheets retry/backoff cannot execute
+        # in the Discord event loop.
+        tab_name, header_row, configured_headers = await asyncio.to_thread(
+            _load_sync_for_thread
+        )
+
+    if summary is not None:
+        summary.used_cached_header = used_cached_header
+        if used_cached_header:
+            summary.cache_hit = True
+        else:
+            summary.cache_miss = True
+            _quota_note_read(refreshed=True)
     header_row_index = 3
 
-    configured_headers: dict[str, str] = {}
     for field in AVAILABILITY_FIELDS:
-        config_key = f"clans_header_{field}"
-        value = await recruitment.get_config_value_async(config_key, None, force=True)
-        if value is None or not str(value).strip():
+        if not configured_headers.get(field):
+            config_key = f"clans_header_{field}"
             _log_availability_diagnostics(
                 reason="missing_required_config_key",
                 tab_name=tab_name,
                 sheet_id=sheet_id,
                 header_row_index=header_row_index,
                 header_row=header_row,
-                configured_headers=configured_headers,
+                configured_headers={k: v for k, v in configured_headers.items() if v},
                 missing_config_key=config_key,
             )
             raise ValueError(f"missing required Config key: {config_key}")
-        configured_headers[field] = str(value).strip()
 
     lookup: dict[str, int] = {}
     for index, cell in enumerate(header_row):
@@ -361,7 +483,7 @@ def _find_availability_clan_row(
     normalized_target = _normalize_tag(clan_tag)
     try:
         try:
-            clan_rows = recruitment.fetch_clans(force=True)
+            clan_rows = recruitment.fetch_clans(force=False)
         except TypeError:
             clan_rows = recruitment.fetch_clans()
     except Exception:
@@ -383,12 +505,49 @@ async def _afind_availability_clan_row(
 ) -> tuple[int, list[str]] | None:
     tag_index = headers.header_map["clan_tag"]
     normalized_target = _normalize_tag(clan_tag)
-    clan_rows = await recruitment.afetch_clans(force=True)
+    used_cached_row = bool(getattr(recruitment, "clan_cache_ready", lambda: False)())
+
+    def _sync_find_for_thread() -> tuple[int, list[str]] | None:
+        try:
+            return recruitment.find_clan_row(clan_tag, force=False)
+        except TypeError:
+            return recruitment.find_clan_row(clan_tag)
+
+    if used_cached_row:
+        try:
+            try:
+                clan_rows = recruitment.fetch_clans(force=False)
+            except TypeError:
+                clan_rows = recruitment.fetch_clans()
+        except Exception:
+            clan_rows = []
+    else:
+        try:
+            clan_rows = await recruitment.afetch_clans(force=False)
+        except Exception:
+            clan_rows = []
+
+    summary = _QUOTA_SUMMARY.get()
+    if summary is not None:
+        summary.used_cached_row = used_cached_row
+        if used_cached_row:
+            summary.cache_hit = True
+        else:
+            summary.cache_miss = True
+            if not summary.refreshed_clans_cache:
+                _quota_note_read(refreshed=True)
+
     for idx, row in enumerate(clan_rows):
         tag_value = row[tag_index] if tag_index < len(row) else ""
         if _normalize_tag(tag_value) == normalized_target:
             return idx + headers.header_row_index + 1, list(row)
-    return None
+
+    if used_cached_row:
+        return _sync_find_for_thread()
+
+    # Compatibility fallback for sync-only test doubles/legacy callers, without
+    # running sync Sheets retry/backoff in the event loop.
+    return await asyncio.to_thread(_sync_find_for_thread)
 
 
 async def aresolve_configured_clan_tag(clan_tag: str) -> str:
@@ -604,10 +763,15 @@ def _parse_required_int(
 
 
 async def preflight_manual_open_spots_adjustment(
-    clan_tag: str, delta: int
+    clan_tag: str,
+    delta: int,
+    *,
+    preflight_plan: AvailabilityPreflightPlan | None = None,
 ) -> ManualOpenSpotAdjustmentPlan:
     """Resolve and validate the row, configured headers, parseable cells, and writable worksheet."""
-    plan = await preflight_clan_availability_update(clan_tag, delta=delta)
+    plan = preflight_plan or await preflight_clan_availability_update(
+        clan_tag, delta=delta
+    )
     header_map = plan.headers.header_map
     row = plan.row
     sheet_row = plan.sheet_row
@@ -660,6 +824,7 @@ async def preflight_manual_open_spots_adjustment(
         seen_range=seen_range,
         combined_range=combined_range,
         resolved_clan_tag=resolved_clan_tag,
+        preflight_plan=plan,
     )
 
 
@@ -691,19 +856,35 @@ async def set_manual_open_spots(clan_tag: str, open_spots: int) -> tuple[int, in
 
     old_value = plan.current_available
     delta = open_spots - plan.new_value
-    new_value = await adjust_manual_open_spots(clan_tag, delta)
+    source_preflight_plan = getattr(plan, "preflight_plan", None)
+    try:
+        adjustment_plan = await preflight_manual_open_spots_adjustment(
+            clan_tag, delta, preflight_plan=source_preflight_plan
+        )
+    except TypeError:
+        adjustment_plan = await preflight_manual_open_spots_adjustment(clan_tag, delta)
+    new_value = await adjust_manual_open_spots(
+        clan_tag, delta, adjustment_plan=adjustment_plan
+    )
 
     return old_value, new_value, plan.resolved_clan_tag
 
 
-async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
+async def adjust_manual_open_spots(
+    clan_tag: str,
+    delta: int,
+    *,
+    adjustment_plan: ManualOpenSpotAdjustmentPlan | None = None,
+) -> int:
     """Adjust manual open spots for ``clan_tag`` and return the new value."""
     plan: ManualOpenSpotAdjustmentPlan | None = None
     write_range = ""
     phase = "preflight"
     try:
         log.info("adjust_manual_open_spots:start clan_tag=%s delta=%s", clan_tag, delta)
-        plan = await preflight_manual_open_spots_adjustment(clan_tag, delta)
+        plan = adjustment_plan or await preflight_manual_open_spots_adjustment(
+            clan_tag, delta
+        )
         rebase_manual_open_spots = plan.manual_open != plan.seen_manual_open
         log.info(
             "adjust_manual_open_spots:resolved_row clan_tag=%s sheet_row=%s",
@@ -759,46 +940,72 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
                 [[first_value, second_value]],
                 value_input_option="RAW",
             )
+            _quota_note_write(1)
             log.info(
                 "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
                 clan_tag,
                 update_result,
             )
         else:
-            write_range = plan.open_range
-            log.info(
-                "adjust_manual_open_spots:worksheet_update clan_tag=%s range=%s",
-                clan_tag,
-                write_range,
-            )
-            update_result = await async_core.acall_with_backoff(
-                worksheet.update,
-                write_range,
-                [[str(plan.new_value)]],
-                value_input_option="RAW",
-            )
-            log.info(
-                "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
-                clan_tag,
-                update_result,
-            )
-            write_range = plan.seen_range
-            log.info(
-                "adjust_manual_open_spots:worksheet_update clan_tag=%s range=%s",
-                clan_tag,
-                write_range,
-            )
-            seen_result = await async_core.acall_with_backoff(
-                worksheet.update,
-                write_range,
-                [[str(plan.manual_open)]],
-                value_input_option="RAW",
-            )
-            log.info(
-                "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
-                clan_tag,
-                seen_result,
-            )
+            batch_update = getattr(worksheet, "batch_update", None)
+            if callable(batch_update):
+                write_range = f"{plan.open_range},{plan.seen_range}"
+                log.info(
+                    "adjust_manual_open_spots:worksheet_batch_update clan_tag=%s ranges=%s",
+                    clan_tag,
+                    write_range,
+                )
+                batch_result = await async_core.acall_with_backoff(
+                    batch_update,
+                    [
+                        {"range": plan.open_range, "values": [[str(plan.new_value)]]},
+                        {"range": plan.seen_range, "values": [[str(plan.manual_open)]]},
+                    ],
+                    value_input_option="RAW",
+                )
+                _quota_note_write(1)
+                log.info(
+                    "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
+                    clan_tag,
+                    batch_result,
+                )
+            else:
+                write_range = plan.open_range
+                log.info(
+                    "adjust_manual_open_spots:worksheet_update clan_tag=%s range=%s",
+                    clan_tag,
+                    write_range,
+                )
+                update_result = await async_core.acall_with_backoff(
+                    worksheet.update,
+                    write_range,
+                    [[str(plan.new_value)]],
+                    value_input_option="RAW",
+                )
+                _quota_note_write(1)
+                log.info(
+                    "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
+                    clan_tag,
+                    update_result,
+                )
+                write_range = plan.seen_range
+                log.info(
+                    "adjust_manual_open_spots:worksheet_update clan_tag=%s range=%s",
+                    clan_tag,
+                    write_range,
+                )
+                seen_result = await async_core.acall_with_backoff(
+                    worksheet.update,
+                    write_range,
+                    [[str(plan.manual_open)]],
+                    value_input_option="RAW",
+                )
+                _quota_note_write(1)
+                log.info(
+                    "adjust_manual_open_spots:worksheet_update_result clan_tag=%s result=%r",
+                    clan_tag,
+                    seen_result,
+                )
 
         phase = "cache_refresh"
         cache_result = recruitment.update_cached_clan_row(plan.sheet_row, updated_row)
@@ -806,19 +1013,6 @@ async def adjust_manual_open_spots(clan_tag: str, delta: int) -> int:
             "adjust_manual_open_spots:cache_update_result clan_tag=%s result=%r",
             clan_tag,
             cache_result,
-        )
-        phase = "post-write verification"
-        refreshed = await recruitment.afind_clan_row(clan_tag, force=True)
-        if refreshed is None:
-            raise RuntimeError(f"clan cache refresh failed for {clan_tag}")
-        _, refreshed_row = refreshed
-        refreshed_after = _parse_manual_open_spots(
-            refreshed_row, open_index=plan.open_index
-        )
-        log.info(
-            "adjust_manual_open_spots:af_after_actual clan_tag=%s af_after_actual=%s",
-            clan_tag,
-            refreshed_after,
         )
         log.info(
             "adjusted clan availability",
@@ -972,8 +1166,8 @@ async def recompute_clan_availability(
             reservation_summary,
         ),
     ]
-    for field, write_range, value in writes:
-        try:
+    try:
+        for field, write_range, value in writes:
             log.info(
                 "recompute_clan_availability:worksheet_update clan_tag=%s field=%s range=%s",
                 clan_tag,
@@ -986,19 +1180,14 @@ async def recompute_clan_availability(
                 [[value]],
                 value_input_option="RAW",
             )
-        except Exception:
-            log.exception(
-                "recompute_clan_availability:worksheet_update_exception clan_tag=%s field=%s range=%s",
-                clan_tag,
-                field,
-                write_range,
-                extra={
-                    "clan_tag": _normalize_tag(clan_tag),
-                    "field": field,
-                    "write_range": write_range,
-                },
-            )
-            raise
+            _quota_note_write(1)
+    except Exception:
+        log.exception(
+            "recompute_clan_availability:worksheet_update_exception clan_tag=%s",
+            clan_tag,
+            extra={"clan_tag": _normalize_tag(clan_tag)},
+        )
+        raise
 
     cache_updated = recruitment.update_cached_clan_row(sheet_row, updated_row)
 
@@ -1077,7 +1266,11 @@ def _normalize_tag(tag: str | None) -> str:
 
 __all__ = [
     "AvailabilityOperationError",
+    "AvailabilityQuotaSummary",
     "AvailabilityRecomputeResult",
+    "begin_quota_summary",
+    "current_quota_summary",
+    "end_quota_summary",
     "aresolve_configured_clan_tag",
     "adjust_manual_open_spots",
     "is_rate_limited_error",

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -665,6 +665,25 @@ def _sanitize_clan_rows(
     return cleaned
 
 
+def clan_cache_ready() -> bool:
+    """Return whether clan rows/header are available in the in-memory cache."""
+
+    now = time.time()
+    return bool(
+        _CLAN_ROWS is not None
+        and _CLAN_HEADER_ROW is not None
+        and (now - _CLAN_ROWS_TS) < _CACHE_TTL
+        and (now - _CLAN_HEADER_TS) < _CACHE_TTL
+    )
+
+
+def clan_header_cache_ready() -> bool:
+    """Return whether the clan header row is available in the in-memory cache."""
+
+    now = time.time()
+    return bool(_CLAN_HEADER_ROW is not None and (now - _CLAN_HEADER_TS) < _CACHE_TTL)
+
+
 def fetch_clans(force: bool = False) -> List[List[str]]:
     """Fetch the recruitment clan matrix from Sheets."""
 

--- a/tests/recruitment/test_set_open_spots_command.py
+++ b/tests/recruitment/test_set_open_spots_command.py
@@ -377,9 +377,7 @@ def test_sheet_write_failure_uses_write_message_and_logs_exc_info(monkeypatch, c
     assert "sheet write failed" in ctx.replies[0][0]
     assert logs and "worksheet_update" in logs[0]
     record = next(
-        rec
-        for rec in caplog.records
-        if rec.getMessage() == "setopenspots failed"
+        rec for rec in caplog.records if rec.getMessage() == "setopenspots failed"
     )
     assert record.exc_info is not None
 
@@ -446,7 +444,9 @@ def test_sheet_failure_logs_phase_context_and_exception_details(monkeypatch, cap
         _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4", reason="reason"))
 
     assert "sheet write failed" in ctx.replies[0][0]
-    record = next(rec for rec in caplog.records if rec.getMessage() == "setopenspots failed")
+    record = next(
+        rec for rec in caplog.records if rec.getMessage() == "setopenspots failed"
+    )
     assert record.exc_info is not None
     assert record.clan_tag == "C1CC"
     assert record.requested_open_spots == 4
@@ -497,3 +497,334 @@ def test_post_write_verification_failure_has_distinct_message(monkeypatch):
 
     assert "post-write verification failed" in ctx.replies[0][0]
     assert "sheet write failed" not in ctx.replies[0][0]
+
+
+def test_set_manual_open_spots_reuses_preflight_plan_and_skips_post_write_reread(
+    monkeypatch,
+):
+    from modules.recruitment import availability
+
+    updates = []
+    preflight_calls = []
+
+    class Worksheet:
+        async def update(self, write_range, values, **kwargs):
+            updates.append((write_range, values))
+            return {"ok": True}
+
+    class Headers:
+        tab_name = "configured-tab"
+        header_map = {"clan_tag": 0}
+
+    class Plan:
+        clan_tag = "C1CT"
+        sheet_row = 9
+        row = ("C1CT", "Clan", "6", "", "", "2", "", "6")
+        manual_open_index = 2
+        open_index = 5
+        seen_index = 7
+        manual_open = 6
+        current_available = 2
+        seen_manual_open = 6
+        tab_key = "clans_tab"
+        tab_name = "configured-tab"
+        manual_header_key = "manual_open_spots"
+        manual_header_name = "Manual Open Spots"
+        open_range = "Open9"
+        seen_range = "Seen9"
+        combined_range = None
+        headers = Headers()
+        resolved_clan_tag = "C1CT"
+
+        def __init__(self, delta=0):
+            self.delta = delta
+            self.new_value = self.current_available + delta
+
+    async def fake_preflight(clan, delta, *, preflight_plan=None):
+        preflight_calls.append((clan, delta, preflight_plan is not None))
+        plan = Plan(delta)
+        plan.preflight_plan = preflight_plan or object()
+        return plan
+
+    async def fake_worksheet(_sheet_id, _tab_name):
+        return Worksheet()
+
+    async def fake_backoff(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        availability, "preflight_manual_open_spots_adjustment", fake_preflight
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id"
+    )
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_worksheet)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_backoff)
+    monkeypatch.setattr(
+        availability.recruitment, "update_cached_clan_row", lambda *_args: None
+    )
+
+    async def fail_post_write_reread(*_args, **_kwargs):
+        raise AssertionError("post-write reread should not run")
+
+    monkeypatch.setattr(
+        availability.recruitment, "afind_clan_row", fail_post_write_reread
+    )
+
+    assert _run(availability.set_manual_open_spots("C1CT", 1)) == (2, 1, "C1CT")
+    assert preflight_calls == [("C1CT", 0, False), ("C1CT", -1, True)]
+    assert updates == [("Open9", [["1"]]), ("Seen9", [["6"]])]
+
+
+def test_setopenspots_logs_compact_quota_summary(monkeypatch, caplog):
+    ctx = FakeContext()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+
+    async def fake_set(clan, value):
+        summary = command_module.availability.current_quota_summary()
+        summary.sheet_reads_count = 0
+        summary.sheet_writes_count = 1
+        summary.cache_hit = True
+        summary.used_cached_header = True
+        summary.used_cached_row = True
+        return 2, value, clan
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    with caplog.at_level("INFO", logger=command_module.log.name):
+        _run(cog.setopenspots.callback(cog, ctx, "C1CT", "1", reason="member left"))
+
+    record = next(
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "setopenspots quota summary"
+    )
+    assert record.command == "setopenspots"
+    assert record.clan_tag == "C1CT"
+    assert record.sheet_reads_count == 0
+    assert record.sheet_writes_count == 1
+    assert record.cache_hit is True
+    assert record.used_cached_header is True
+    assert record.used_cached_row is True
+
+
+def _event_loop_sync_guard(*_args, **_kwargs):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+    raise RuntimeError(
+        "_retry_with_backoff must not run inside an active event loop; use the async variant"
+    )
+
+
+def _patch_real_setopenspots_sheet_path(monkeypatch, *, warm_cache):
+    from modules.recruitment import availability
+
+    header = [
+        "Clan Tag",
+        "Manual Open Spots",
+        "Open Spots",
+        "Inactives",
+        "Reservation Count",
+        "Reservation Summary",
+        "Manual Open Spots Seen",
+    ]
+    row = ["C1CT", "6", "2", "0", "0", "", "6"]
+    config = {
+        "clans_header_clan_tag": "Clan Tag",
+        "clans_header_manual_open_spots": "Manual Open Spots",
+        "clans_header_open_spots": "Open Spots",
+        "clans_header_inactives": "Inactives",
+        "clans_header_reservation_count": "Reservation Count",
+        "clans_header_reservation_summary": "Reservation Summary",
+        "clans_header_manual_open_spots_seen": "Manual Open Spots Seen",
+    }
+    updates = []
+    cache_updates = []
+    sync_calls = {"header": 0, "rows": 0}
+
+    class Worksheet:
+        async def update(self, write_range, values, **kwargs):
+            updates.append((write_range, values, kwargs))
+            return {"ok": True}
+
+        async def batch_update(self, data, **kwargs):
+            updates.append(("batch_update", data, kwargs))
+            return {"ok": True}
+
+    async def fake_config_value(key, default=None, *, force=False):
+        return config.get(key, default)
+
+    async def fake_aget_header(*, force=False):
+        if warm_cache:
+            raise AssertionError("warm header path should not call async header loader")
+        return list(header)
+
+    async def fake_afetch_clans(*, force=False):
+        if warm_cache:
+            raise AssertionError("warm clan path should not call async clan loader")
+        return [list(row)]
+
+    def fake_get_header(*, force=False):
+        if not warm_cache:
+            return _event_loop_sync_guard()
+        sync_calls["header"] += 1
+        return list(header)
+
+    def fake_fetch_clans(*, force=False):
+        if not warm_cache:
+            return _event_loop_sync_guard()
+        sync_calls["rows"] += 1
+        return [list(row)]
+
+    async def fake_aget_worksheet(_sheet_id, _tab_name):
+        return Worksheet()
+
+    async def fake_backoff(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+    monkeypatch.setattr(
+        availability.recruitment, "get_recruitment_sheet_id", lambda: "sheet-id"
+    )
+    monkeypatch.setattr(
+        availability.recruitment,
+        "get_clans_tab_name_async",
+        lambda: asyncio.sleep(0, result="configured-tab"),
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_config_value_async", fake_config_value
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "aget_clan_header_row", fake_aget_header
+    )
+    monkeypatch.setattr(availability.recruitment, "afetch_clans", fake_afetch_clans)
+    monkeypatch.setattr(
+        availability.recruitment, "get_clan_header_row", fake_get_header
+    )
+    monkeypatch.setattr(availability.recruitment, "fetch_clans", fake_fetch_clans)
+    monkeypatch.setattr(
+        availability.recruitment, "get_config_value", _event_loop_sync_guard
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "find_clan_row", _event_loop_sync_guard
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_clans_tab_name", _event_loop_sync_guard
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "clan_header_cache_ready", lambda: warm_cache
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "clan_cache_ready", lambda: warm_cache
+    )
+    monkeypatch.setattr(availability.async_core, "aget_worksheet", fake_aget_worksheet)
+    monkeypatch.setattr(availability.async_core, "acall_with_backoff", fake_backoff)
+    monkeypatch.setattr(
+        availability.recruitment,
+        "update_cached_clan_row",
+        lambda sheet_row, values: cache_updates.append((sheet_row, list(values))),
+    )
+    return updates, cache_updates, sync_calls
+
+
+def test_setopenspots_warm_cache_uses_cached_header_and_row_without_sheet_reads(
+    monkeypatch, caplog
+):
+    updates, cache_updates, sync_calls = _patch_real_setopenspots_sheet_path(
+        monkeypatch, warm_cache=True
+    )
+    ctx = FakeContext()
+    cog = RecruitmentOpenSpotsCog(bot=None)
+
+    with caplog.at_level("INFO", logger=command_module.log.name):
+        _run(cog.setopenspots.callback(cog, ctx, "C1CT", "1", reason="member left"))
+
+    summaries = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "setopenspots quota summary"
+    ]
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.cache_hit is True
+    assert summary.cache_miss is False
+    assert summary.used_cached_header is True
+    assert summary.used_cached_row is True
+    assert summary.sheet_reads_count == 0
+    assert summary.sheet_writes_count == 1
+    assert sync_calls == {"header": 1, "rows": 1}
+    assert updates == [
+        (
+            "batch_update",
+            [
+                {"range": "C4", "values": [["1"]]},
+                {"range": "G4", "values": [["6"]]},
+            ],
+            {"value_input_option": "RAW"},
+        )
+    ]
+    assert cache_updates and cache_updates[0][1][2] == "1"
+
+
+def test_setopenspots_cold_cache_uses_async_helpers_not_sync_event_loop_helpers(
+    monkeypatch, caplog
+):
+    updates, cache_updates, sync_calls = _patch_real_setopenspots_sheet_path(
+        monkeypatch, warm_cache=False
+    )
+    ctx = FakeContext()
+    cog = RecruitmentOpenSpotsCog(bot=None)
+
+    with caplog.at_level("INFO", logger=command_module.log.name):
+        _run(cog.setopenspots.callback(cog, ctx, "C1CT", "1", reason="member left"))
+
+    assert "Open spots corrected" in ctx.replies[0][0]
+    summaries = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "setopenspots quota summary"
+    ]
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.cache_hit is False
+    assert summary.cache_miss is True
+    assert summary.used_cached_header is False
+    assert summary.used_cached_row is False
+    assert summary.sheet_reads_count == 1
+    assert summary.sheet_writes_count == 1
+    assert sync_calls == {"header": 0, "rows": 0}
+    assert updates
+    assert cache_updates
+
+
+def test_setopenspots_quota_summary_logged_once_on_failure(monkeypatch, caplog):
+    ctx = FakeContext()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+
+    async def fake_set(_clan, _value):
+        raise command_module.availability.AvailabilityOperationError(
+            "worksheet_update", "C1CT", "boom"
+        )
+
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", fake_set)
+    cog = RecruitmentOpenSpotsCog(bot=None)
+
+    with caplog.at_level("INFO", logger=command_module.log.name):
+        _run(cog.setopenspots.callback(cog, ctx, "C1CT", "1", reason="member left"))
+
+    summaries = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "setopenspots quota summary"
+    ]
+    assert len(summaries) == 1
+    assert "sheet write failed" in ctx.replies[0][0]


### PR DESCRIPTION
### Motivation

- Add instrumentation to track Sheets quota usage for emergency `setopenspots` operations and avoid unnecessary sheet reads when cache is warm.
- Make availability preflight/write flows more robust to mixed sync/async sheet helpers and reuse preflight work to avoid redundant post-write rereads.

### Description

- Introduces `AvailabilityQuotaSummary` and context-var helpers `begin_quota_summary`, `end_quota_summary`, and `current_quota_summary` in `modules.recruitment.availability` to accumulate a compact quota summary for a command. 
- Emits a compact quota log (`setopenspots quota summary`) from `cogs/recruitment_open_spots.py` after `setopenspots` runs (success or failure) and records read/write counts, cache hit/miss and whether cached header/row were used via `_log_quota_summary`.
- Makes header/row resolution cache-aware and tolerant of sync-only helpers by: preferring cached header/row when available, detecting cache hits/misses, using `asyncio.to_thread` fallbacks for sync helpers, and marking quota reads accordingly in `_aresolve_availability_headers` and `_afind_availability_clan_row`.
- Adds lightweight quota accounting calls (`_quota_note_read`, `_quota_note_write`) at relevant read/write points (header/row reads, worksheet updates, batch updates) and adjusts `adjust_manual_open_spots` to use `batch_update` when available.
- Reuses preflight results between `set_manual_open_spots`, `preflight_manual_open_spots_adjustment`, and `adjust_manual_open_spots` by passing `preflight_plan`/`adjustment_plan` to avoid redundant computations and post-write rereads.
- Improves error logging and messaging in `cogs/recruitment_open_spots.py` to better distinguish config/preflight failures, quota failures, and write/verification failures, and to include quota-exhausted context.
- Adds `clan_cache_ready` and `clan_header_cache_ready` helpers in `shared/sheets/recruitment.py` to surface cache readiness to availability logic.
- Updates `__all__` and function signatures to export and accept the new quota and plan parameters.

### Testing

- Ran unit tests in `tests/recruitment/test_set_open_spots_command.py` (including new tests covering quota summaries, warm/cold cache paths, preflight reuse, and failure logging); the tests passed.
- Ran the recruitment availability-related test cases under the test suite (via `pytest tests/recruitment`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510d4763cc8323a2258ae48dbc655e)