### PR TITLE
Fix !finishplacement NONE NONE for abandoned welcome/promo tickets

### DIFF
--- a/modules/onboarding/cmd_finishplacement.py
+++ b/modules/onboarding/cmd_finishplacement.py
@@ -56,7 +56,7 @@ def _upper_tag(value: str | None) -> str:
     return str(value or "").strip().upper()
 
 
-def _is_none_source(value: str | None) -> bool:
+def _is_no_clan_tag(value: str | None) -> bool:
     return _upper_tag(value) in {"", _NO_PLACEMENT_TAG}
 
 
@@ -342,7 +342,7 @@ class FinishPlacementCog(commands.Cog):
     )
     @commands.command(
         name="finishplacement",
-        usage="<source_clan_tag|NONE> <destination_clan_tag>",
+        usage="<source_clan_tag|NONE> <destination_clan_tag|NONE>",
         help="Staff fallback: manually finish a welcome or promo placement in the current ticket thread.",
         brief="Manually finish placement for the current onboarding ticket.",
     )
@@ -369,7 +369,7 @@ class FinishPlacementCog(commands.Cog):
 
         if source_clan_tag is None or destination_clan_tag is None:
             await ctx.reply(
-                "Usage: `!finishplacement <source_clan_tag|NONE> <destination_clan_tag>`",
+                "Usage: `!finishplacement <source_clan_tag|NONE> <destination_clan_tag|NONE>`",
                 mention_author=False,
             )
             return
@@ -409,21 +409,25 @@ class FinishPlacementCog(commands.Cog):
 
         source_tag = _upper_tag(source_clan_tag)
         destination_tag = _upper_tag(destination_clan_tag)
-        if not destination_tag or destination_tag == _NO_PLACEMENT_TAG:
+        if not destination_tag:
             await ctx.reply("Destination clan tag is required.", mention_author=False)
             return
 
-        valid_tags = await self._valid_tags()
-        if destination_tag not in valid_tags or (
-            not _is_none_source(source_tag) and source_tag not in valid_tags
-        ):
-            await ctx.reply(
-                "Unknown clan tag. Please use configured clan tags or `NONE` for source.",
-                mention_author=False,
-            )
-            return
+        tags_to_validate = {
+            tag
+            for tag in (source_tag, destination_tag)
+            if not _is_no_clan_tag(tag)
+        }
+        if tags_to_validate:
+            valid_tags = await self._valid_tags()
+            if any(tag not in valid_tags for tag in tags_to_validate):
+                await ctx.reply(
+                    "Unknown clan tag. Please use configured clan tags or `NONE`.",
+                    mention_author=False,
+                )
+                return
 
-        if flow == "welcome" and not _is_none_source(source_tag):
+        if flow == "welcome" and not _is_no_clan_tag(source_tag):
             log.warning(
                 "finishplacement_wrong_thread_type welcome_source_rejected",
                 extra={
@@ -568,7 +572,7 @@ class FinishPlacementCog(commands.Cog):
         promo_context.ticket_number = context.ticket_id
         promo_context.username = context.username
         promo_context.source_clan_tag = (
-            _NO_PLACEMENT_TAG if _is_none_source(source_tag) else source_tag
+            _NO_PLACEMENT_TAG if _is_no_clan_tag(source_tag) else source_tag
         )
         promo_context.clan_tag = destination_tag
         promo_context.state = "awaiting_destination_clan"

--- a/tests/onboarding/test_finishplacement_command.py
+++ b/tests/onboarding/test_finishplacement_command.py
@@ -9,7 +9,7 @@ import pytest
 
 from modules.onboarding import cmd_finishplacement as fp
 from modules.onboarding.watcher_promo import PromoTicketContext, PromoTicketWatcher
-from modules.onboarding.watcher_welcome import TicketContext, WelcomeTicketWatcher
+from modules.onboarding.watcher_welcome import WelcomeTicketWatcher
 
 
 class DummyThread:
@@ -97,6 +97,92 @@ def test_staff_can_finish_welcome_ticket(monkeypatch):
     assert called_context.username == "player"
     assert watcher._finalize_clan_tag.await_args.args[2] == "C1CD"
     assert ctx.replies[-1][0] == "Placement finalized: **C1CD**."
+
+
+def test_staff_can_finish_welcome_ticket_with_none_destination(monkeypatch):
+    monkeypatch.setattr(
+        fp.onboarding_sheets,
+        "load_clan_tags",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("should not validate NONE as a clan tag")
+        ),
+    )
+    watcher = WelcomeTicketWatcher(SimpleNamespace())
+    watcher._finalize_clan_tag = AsyncMock(
+        side_effect=lambda _thread, context, *_args, **_kwargs: setattr(
+            context, "state", "closed"
+        )
+    )
+    cog = fp.FinishPlacementCog(DummyBot(WelcomeTicketWatcher=watcher))
+    thread = DummyThread(name="W0919-player", parent_id=10)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "NONE")
+    )
+
+    watcher._finalize_clan_tag.assert_awaited_once()
+    assert watcher._finalize_clan_tag.await_args.args[2] == "NONE"
+    assert ctx.replies[-1][0] == "Placement finalized: **NONE**."
+    assert all(
+        "Destination clan tag is required." not in reply[0] for reply in ctx.replies
+    )
+
+
+def test_staff_can_finish_promo_ticket_with_lowercase_none_destination(monkeypatch):
+    monkeypatch.setattr(
+        fp.onboarding_sheets,
+        "load_clan_tags",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("should not validate NONE as a clan tag")
+        ),
+    )
+    watcher = PromoTicketWatcher(SimpleNamespace())
+    watcher._complete_close = AsyncMock(
+        side_effect=lambda _thread, context, *_args, **_kwargs: setattr(
+            context, "state", "closed"
+        )
+    )
+    cog = fp.FinishPlacementCog(DummyBot(PromoTicketWatcher=watcher))
+    thread = DummyThread(name="M0354-player", parent_id=20)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "none", "none")
+    )
+
+    watcher._complete_close.assert_awaited_once()
+    promo_context = watcher._complete_close.await_args.args[1]
+    assert promo_context.source_clan_tag == "NONE"
+    assert promo_context.clan_tag == "NONE"
+    assert watcher._complete_close.await_args.kwargs["previous_final"] == "NONE"
+    assert ctx.replies[-1][0] == "Placement finalized: **NONE** → **NONE**."
+    assert all(
+        "Destination clan tag is required." not in reply[0] for reply in ctx.replies
+    )
+
+
+def test_destination_none_does_not_update_open_spots_or_reservations_in_command(monkeypatch):
+    watcher = PromoTicketWatcher(SimpleNamespace())
+
+    async def fake_complete_close(_thread, context, *_args, **_kwargs):
+        if context.clan_tag != "NONE":
+            raise AssertionError("destination NONE was not preserved for finalizer")
+        context.state = "closed"
+
+    watcher._complete_close = AsyncMock(side_effect=fake_complete_close)
+    cog = fp.FinishPlacementCog(DummyBot(PromoTicketWatcher=watcher))
+    thread = DummyThread(name="M0354-player", parent_id=20)
+    ctx = DummyCtx(thread)
+
+    asyncio.run(
+        fp.FinishPlacementCog.finishplacement.callback(cog, ctx, "NONE", "NONE")
+    )
+
+    watcher._complete_close.assert_awaited_once()
+    promo_context = watcher._complete_close.await_args.args[1]
+    assert promo_context.source_clan_tag == "NONE"
+    assert promo_context.clan_tag == "NONE"
 
 
 def test_staff_can_finish_promo_move_ticket(monkeypatch):

--- a/tests/onboarding/test_promo_close_clan_prompt.py
+++ b/tests/onboarding/test_promo_close_clan_prompt.py
@@ -253,6 +253,69 @@ def test_finalize_never_enters_awaiting_details(monkeypatch):
     assert ctx.state == "closed"
 
 
+def test_promo_close_none_destination_skips_clan_math_and_reservation_updates(monkeypatch):
+    watcher = _setup_watcher(monkeypatch)
+    ctx = _context(
+        state="awaiting_destination_clan", clan_tag="NONE", source_clan_tag="NONE"
+    )
+    ctx.user_id = 4242
+    updates = AsyncMock(
+        side_effect=AssertionError(
+            "destination NONE should not update reservations without a real reservation"
+        )
+    )
+    adjust = AsyncMock(
+        side_effect=AssertionError("destination NONE should not adjust open spots")
+    )
+    recompute = AsyncMock(
+        side_effect=AssertionError("destination NONE should not recompute clans")
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo._ensure_fresh_clans_for_placement",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.recruitment_sheets.find_clan_row",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("destination NONE should not be looked up as a clan")
+        ),
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.reservations_sheets.update_reservation_status",
+        updates,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.availability.adjust_manual_open_spots",
+        adjust,
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.availability.recompute_clan_availability",
+        recompute,
+    )
+    watcher._load_clan_tags = AsyncMock(
+        side_effect=AssertionError("destination NONE should not load clan tags")
+    )
+    thread = DummyThread(10, "closed-R1111-user")
+    thread.edit = AsyncMock()
+
+    asyncio.run(
+        watcher._complete_close(
+            thread,
+            ctx,
+            progression=ctx.progression,
+            clan_name=ctx.clan_name,
+            phase="finishplacement",
+            previous_final="NONE",
+        )
+    )
+
+    assert ctx.state == "closed"
+    assert ctx.clan_tag == "NONE"
+    updates.assert_not_awaited()
+    adjust.assert_not_awaited()
+    recompute.assert_not_awaited()
+
+
 def test_promo_close_with_no_active_reservation_skips_cleanup(monkeypatch, caplog):
     watcher = _setup_watcher(monkeypatch)
     ctx = _context(state="awaiting_clan")


### PR DESCRIPTION
### Motivation
- Admins must be able to finalize welcome or promo tickets when the player has left (no valid source or destination clan), and the existing `!finishplacement NONE NONE` case was rejected for the destination argument.
- The change is scoped to allowing `NONE` as a no-clan sentinel for both source and destination without creating fake clan movement or triggering clan math/reservation updates.

### Description
- Added a shared helper `_is_no_clan_tag` (replaces previous one-sided name) that treats empty or `NONE` (case-insensitive) as the no-clan sentinel and uses it for validation and normalization. (`modules/onboarding/cmd_finishplacement.py`)
- Updated `!finishplacement` usage and argument validation so a destination of `NONE` is accepted and only non-`NONE` tags are validated against configured clan tags. (`usage` string and validation logic in `finishplacement` command)
- Kept welcome ticket rules unchanged (welcome still only allows `NONE` as source) and preserved promo behavior by passing `NONE` through to the promo finalizer as the no-placement sentinel instead of treating it as a real clan tag. (`promo` path now sets `promo_context.clan_tag` to `NONE` without performing clan lookups)
- Added focused tests asserting `!finishplacement NONE NONE` and `none none` succeed and that destination `NONE` does not trigger clan validation, reservation updates, or open-spot adjustments. (tests updated/added in `tests/onboarding/test_finishplacement_command.py` and `tests/onboarding/test_promo_close_clan_prompt.py`)

### Testing
- Ran the formatter/linter check: `python -m ruff check modules/onboarding/cmd_finishplacement.py tests/onboarding/test_finishplacement_command.py tests/onboarding/test_promo_close_clan_prompt.py` and it passed.
- Ran focused test runs: `pytest -q tests/onboarding/test_finishplacement_command.py tests/onboarding/test_welcome_reservations.py tests/onboarding/test_promo_close_clan_prompt.py` and these targeted tests passed.
- Performed additional focused unit runs during development (individual test invocations for the new cases) and they passed; a full `pytest -q` run was attempted but produced unrelated failures outside the scope of this change and was not used as acceptance for this narrowly-scoped fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5228dc42548323be00f390ffc85a74)