### PR TITLE
Use async reports tab lookup and introduce default reports tab name in daily recruiter reporting

### DIFF
--- a/modules/recruitment/reporting/daily_recruiter_update.py
+++ b/modules/recruitment/reporting/daily_recruiter_update.py
@@ -19,7 +19,7 @@ from shared.config import (
 from shared.logfmt import LogTemplates, channel_label, guild_label, human_reason, user_label
 from shared.sheets.recruitment import (
     afetch_reports_tab,
-    get_reports_tab_name,
+    get_reports_tab_name_async,
 )
 from modules.recruitment.reporting.destinations import get_report_destination_id
 from modules.recruitment.reporting.open_ticket_report import (
@@ -35,6 +35,8 @@ UTC = timezone.utc
 DETAILS_FILTER_FOOTER = (
     "Clans with 0 openings, 0 inactives, and 0 reserved seats are hidden here."
 )
+
+DEFAULT_REPORTS_TAB_NAME = "Statistics"
 
 _BOT_REFERENCE: Optional[discord.Client] = None
 _PERSISTENT_VIEW_REGISTERED = False
@@ -333,7 +335,7 @@ def _require_report_headers(
         if _resolve_index(headers, name) is None
     ]
     if missing:
-        ctx = context or _report_fetch_context(tab_name=get_reports_tab_name("Statistics"))
+        ctx = context or _report_fetch_context(tab_name=DEFAULT_REPORTS_TAB_NAME)
         raise ReportSchemaError(
             f"Statistics report missing required header(s): {', '.join(missing)}",
             required=_REPORT_REQUIRED_HEADERS,
@@ -471,11 +473,11 @@ async def _fetch_report_rows() -> Tuple[List[List[str]], HeadersMap]:
     sheet_id = get_recruitment_sheet_id().strip()
     if not sheet_id:
         context = _report_fetch_context(
-            tab_name=get_reports_tab_name("Statistics"),
+            tab_name=DEFAULT_REPORTS_TAB_NAME,
             underlying_exception_type="RuntimeError",
         )
         raise ReportFetchError("RECRUITMENT_SHEET_ID is not configured", context=context)
-    tab_name = get_reports_tab_name("Statistics")
+    tab_name = await get_reports_tab_name_async(DEFAULT_REPORTS_TAB_NAME)
     try:
         rows = await afetch_reports_tab(tab_name)
     except asyncio.TimeoutError as exc:
@@ -561,7 +563,7 @@ def _extract_report_sections(
     rows: Sequence[Sequence[str]], headers: HeadersMap, context: Optional[ReportFetchContext] = None
 ) -> ReportSections:
     if not rows:
-        ctx = context or _report_fetch_context(tab_name=get_reports_tab_name("Statistics"), rows=rows)
+        ctx = context or _report_fetch_context(tab_name=DEFAULT_REPORTS_TAB_NAME, rows=rows)
         raise ReportFetchError(
             "Recruiter report skipped because the Statistics sheet returned no rows.",
             context=ctx,
@@ -966,7 +968,7 @@ def _build_embeds_from_rows(
     rows: Sequence[Sequence[str]], headers: HeadersMap
 ) -> Tuple[discord.Embed, discord.Embed]:
     context = _report_fetch_context(
-        tab_name="Statistics",
+        tab_name=DEFAULT_REPORTS_TAB_NAME,
         rows=rows,
         data_source="test" if rows else "direct",
     )

--- a/tests/recruitment/test_daily_recruiter_update.py
+++ b/tests/recruitment/test_daily_recruiter_update.py
@@ -156,7 +156,7 @@ def test_statistics_header_normalization_accepts_existing_sheet_headers():
     sections = dru._extract_report_sections(
         rows,
         headers,
-        dru._report_fetch_context(tab_name="Statistics", rows=rows, data_source="test"),
+        dru._report_fetch_context(tab_name=dru.DEFAULT_REPORTS_TAB_NAME, rows=rows, data_source="test"),
     )
 
     assert sections.general_lines
@@ -166,7 +166,7 @@ def test_statistics_header_normalization_accepts_existing_sheet_headers():
 def test_missing_headers_include_diagnostics():
     rows = [["not", "the", "schema"], ["General Overview"]]
     headers = dru._headers_map(rows[0])
-    context = dru._report_fetch_context(tab_name="Statistics", rows=rows, data_source="test")
+    context = dru._report_fetch_context(tab_name=dru.DEFAULT_REPORTS_TAB_NAME, rows=rows, data_source="test")
 
     with pytest.raises(dru.ReportSchemaError) as exc_info:
         dru._extract_report_sections(rows, headers, context)
@@ -175,7 +175,7 @@ def test_missing_headers_include_diagnostics():
     assert exc.required == dru._REPORT_REQUIRED_HEADERS
     assert exc.actual_first_row == tuple(rows[0])
     assert exc.context.config_key == "REPORTS_TAB"
-    assert exc.context.tab_name == "Statistics"
+    assert exc.context.tab_name == dru.DEFAULT_REPORTS_TAB_NAME
     assert exc.context.row_count == 2
 
 
@@ -190,7 +190,7 @@ def test_fetch_timeout_uses_cached_valid_rows(monkeypatch):
     monkeypatch.setattr(dru, "_REPORT_HEADERS_CACHE", headers)
     monkeypatch.setattr(dru, "_REPORT_CONTEXT_CACHE", None)
     monkeypatch.setattr(dru, "get_recruitment_sheet_id", lambda: "sheet-id")
-    monkeypatch.setattr(dru, "get_reports_tab_name", lambda default="Statistics": "Statistics")
+    monkeypatch.setattr(dru, "get_reports_tab_name_async", AsyncMock(return_value=dru.DEFAULT_REPORTS_TAB_NAME))
     monkeypatch.setattr(dru, "afetch_reports_tab", timeout_fetch)
 
     fetched_rows, fetched_headers = asyncio.run(dru._fetch_report_rows())
@@ -210,7 +210,7 @@ def test_fetch_timeout_without_cache_returns_actionable_error(monkeypatch):
     monkeypatch.setattr(dru, "_REPORT_HEADERS_CACHE", {})
     monkeypatch.setattr(dru, "_REPORT_CONTEXT_CACHE", None)
     monkeypatch.setattr(dru, "get_recruitment_sheet_id", lambda: "sheet-id")
-    monkeypatch.setattr(dru, "get_reports_tab_name", lambda default="Statistics": "Statistics")
+    monkeypatch.setattr(dru, "get_reports_tab_name_async", AsyncMock(return_value=dru.DEFAULT_REPORTS_TAB_NAME))
     monkeypatch.setattr(dru, "afetch_reports_tab", timeout_fetch)
 
     with pytest.raises(dru.ReportFetchError) as exc_info:
@@ -219,6 +219,32 @@ def test_fetch_timeout_without_cache_returns_actionable_error(monkeypatch):
     assert "Google Sheets/cache fetch timed out" in str(exc_info.value)
     assert exc_info.value.context.underlying_exception_type == "TimeoutError"
 
+
+def test_fetch_report_rows_uses_async_reports_tab_lookup_in_async_context(monkeypatch):
+    rows = _sample_rows()
+
+    async def fake_fetch(tab_name):
+        assert tab_name == "Configured Stats"
+        return rows
+
+    def forbidden_sync_reports_tab(*_args, **_kwargs):
+        raise AssertionError("sync report tab lookup must not be used from async report path")
+
+    monkeypatch.setattr(dru, "_REPORT_ROWS_CACHE", None)
+    monkeypatch.setattr(dru, "_REPORT_HEADERS_CACHE", {})
+    monkeypatch.setattr(dru, "_REPORT_CONTEXT_CACHE", None)
+    monkeypatch.setattr(dru, "get_recruitment_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(dru, "get_reports_tab_name", forbidden_sync_reports_tab, raising=False)
+    monkeypatch.setattr(dru, "get_reports_tab_name_async", AsyncMock(return_value="Configured Stats"))
+    monkeypatch.setattr(dru, "afetch_reports_tab", fake_fetch)
+
+    fetched_rows, fetched_headers = asyncio.run(dru._fetch_report_rows())
+
+    assert fetched_rows == rows
+    assert fetched_headers == dru._headers_map(rows[0])
+    dru.get_reports_tab_name_async.assert_awaited_once_with(dru.DEFAULT_REPORTS_TAB_NAME)
+    assert dru._REPORT_CONTEXT_CACHE is not None
+    assert dru._REPORT_CONTEXT_CACHE.tab_name == "Configured Stats"
 
 def test_bracket_details_keep_each_mixed_non_zero_case():
     rows = [
@@ -389,7 +415,7 @@ def test_post_daily_recruiter_update_logs_missing_headers(monkeypatch, caplog):
 
     async def fake_fetch():
         dru._REPORT_CONTEXT_CACHE = dru._report_fetch_context(
-            tab_name="Statistics", rows=rows, data_source="test"
+            tab_name=dru.DEFAULT_REPORTS_TAB_NAME, rows=rows, data_source="test"
         )
         return rows, headers
 
@@ -686,7 +712,7 @@ def test_report_too_large_for_details_button_fails_loudly(monkeypatch, caplog):
 
     async def fake_fetch():
         dru._REPORT_CONTEXT_CACHE = dru._report_fetch_context(
-            tab_name="Statistics", rows=rows, data_source="test"
+            tab_name=dru.DEFAULT_REPORTS_TAB_NAME, rows=rows, data_source="test"
         )
         return rows, headers
 


### PR DESCRIPTION
### Motivation

- Make the recruitment reporting path use the asynchronous reports-tab lookup to avoid calling a sync helper from async code and centralize the default tab name.

### Description

- Add `DEFAULT_REPORTS_TAB_NAME = "Statistics"` and replace hardcoded literal occurrences of `"Statistics"` with the constant.
- Replace synchronous calls to `get_reports_tab_name` with the asynchronous `get_reports_tab_name_async` and `await` its result in `_fetch_report_rows` and related call sites.
- Update header-missing diagnostics and report-context creation to use `DEFAULT_REPORTS_TAB_NAME` for consistent tab-name reporting.
- Update unit tests to use `DEFAULT_REPORTS_TAB_NAME`, switch test monkeypatches to `get_reports_tab_name_async`, and add `test_fetch_report_rows_uses_async_reports_tab_lookup_in_async_context` which asserts the async lookup is used.

### Testing

- Ran `pytest tests/recruitment/test_daily_recruiter_update.py` and the modified test file passed, including the new `test_fetch_report_rows_uses_async_reports_tab_lookup_in_async_context` test.
- Existing recruitment reporting unit tests covering header normalization, fetch-timeout handling, and embed generation were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a528fb9239883239663093173ef5f39)