### PR TITLE
Reduce onboarding sheet resolver log noise

### DIFF
--- a/shared/sheets/onboarding.py
+++ b/shared/sheets/onboarding.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
+from shared.config import get_onboarding_sheet_id
 from shared.sheets import core
 from shared.sheets.async_core import afetch_records, afetch_values
 from shared.sheets.cache_service import cache
@@ -25,6 +26,7 @@ _CLAN_TAG_TS: float = 0.0
 _WELCOME_REPAIR_LAST_RUN: float = 0.0
 _WELCOME_REPAIR_ALERT_LAST_TS: float = 0.0
 _WELCOME_REPAIR_ALERT_PENDING: str | None = None
+_LAST_INFO_LOGGED_SHEET_ID: str | None = None
 
 
 log = logging.getLogger(__name__)
@@ -180,15 +182,23 @@ _CURRENT_TICKET_CUTOFF = datetime(2026, 4, 1, tzinfo=timezone.utc)
 
 
 def _sheet_id() -> str:
-    """Resolve the onboarding sheet id – no legacy fallbacks."""
+    """Resolve the onboarding sheet id from runtime Config – no legacy fallbacks."""
 
-    sheet_id = os.getenv("ONBOARDING_SHEET_ID", "").strip()
+    global _LAST_INFO_LOGGED_SHEET_ID
+
+    sheet_id = get_onboarding_sheet_id().strip()
     if not sheet_id:
         raise RuntimeError("ONBOARDING_SHEET_ID not set")
-    # Log tail only, never the full id
+    # Log tail only, never the full id. Repeated resolver calls are expected
+    # during ticket finalization, so keep a single INFO breadcrumb per resolved
+    # id and move repeated resolver traces to DEBUG.
     tail = sheet_id[-6:] if len(sheet_id) >= 6 else sheet_id
     redacted = f"…{tail}" if len(sheet_id) > len(tail) else tail
-    log.info("📄 Onboarding sheet resolved • id_tail=%s", redacted)
+    if _LAST_INFO_LOGGED_SHEET_ID != sheet_id:
+        log.info("📄 Onboarding sheet resolved • id_tail=%s", redacted)
+        _LAST_INFO_LOGGED_SHEET_ID = sheet_id
+    else:
+        log.debug("📄 Onboarding sheet resolved • id_tail=%s", redacted)
     return sheet_id
 
 

--- a/tests/onboarding/test_onboarding_sheet_id_required.py
+++ b/tests/onboarding/test_onboarding_sheet_id_required.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from shared.sheets import onboarding
 
 
-def test_sheet_id_requires_explicit_env(monkeypatch: "pytest.MonkeyPatch") -> None:
-    """_sheet_id should raise when ONBOARDING_SHEET_ID is missing."""
+def test_sheet_id_requires_explicit_config(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """_sheet_id should raise when ONBOARDING_SHEET_ID is missing from Config."""
 
-    monkeypatch.delenv("ONBOARDING_SHEET_ID", raising=False)
+    monkeypatch.setattr(onboarding, "get_onboarding_sheet_id", lambda: "")
 
     with pytest.raises(RuntimeError) as excinfo:
         onboarding._sheet_id()
@@ -19,8 +21,30 @@ def test_sheet_id_requires_explicit_env(monkeypatch: "pytest.MonkeyPatch") -> No
 
 
 def test_sheet_id_returns_value_when_present(monkeypatch: "pytest.MonkeyPatch") -> None:
-    monkeypatch.setenv("ONBOARDING_SHEET_ID", "abc123")
+    monkeypatch.setattr(onboarding, "get_onboarding_sheet_id", lambda: "abc123")
+    monkeypatch.setattr(onboarding, "_LAST_INFO_LOGGED_SHEET_ID", None)
 
     assert onboarding._sheet_id() == "abc123"
-    # Reset for other tests to avoid residue
-    monkeypatch.delenv("ONBOARDING_SHEET_ID", raising=False)
+
+
+def test_sheet_id_does_not_emit_repeated_info_logs(
+    monkeypatch: "pytest.MonkeyPatch", caplog: "pytest.LogCaptureFixture"
+) -> None:
+    monkeypatch.setattr(onboarding, "get_onboarding_sheet_id", lambda: "sheet-abc123")
+    monkeypatch.setattr(onboarding, "_LAST_INFO_LOGGED_SHEET_ID", None)
+
+    with caplog.at_level(logging.DEBUG, logger=onboarding.log.name):
+        assert onboarding._sheet_id() == "sheet-abc123"
+        assert onboarding._sheet_id() == "sheet-abc123"
+        assert onboarding._sheet_id() == "sheet-abc123"
+
+    resolved = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("📄 Onboarding sheet resolved")
+    ]
+    assert [record.levelno for record in resolved] == [
+        logging.INFO,
+        logging.DEBUG,
+        logging.DEBUG,
+    ]


### PR DESCRIPTION
### Motivation

- Calls to the onboarding sheet resolver were emitting repeated INFO-level "📄 Onboarding sheet resolved" lines during command finalization flows, creating log spam during `!finishplacement` runs.
- The resolver used the environment directly and logged on every call instead of using the runtime `Config` and reducing noisy resolver breadcrumbs.

### Description

- Switch onboarding resolver to use runtime Config via `get_onboarding_sheet_id()` instead of reading `os.getenv("ONBOARDING_SHEET_ID")` directly in `_sheet_id()` (`shared/sheets/onboarding.py`).
- Add a module-level `_LAST_INFO_LOGGED_SHEET_ID` cache and emit a single `INFO` breadcrumb when a new sheet id is resolved, demoting subsequent resolver messages for the same id to `DEBUG` to avoid repeated INFO spam.
- Preserve loud failure behavior when the onboarding sheet id is missing by continuing to raise `RuntimeError("ONBOARDING_SHEET_ID not set")` and keep error logging intact.
- Add and update unit tests in `tests/onboarding/test_onboarding_sheet_id_required.py` to assert missing-config behavior, correct resolution via `get_onboarding_sheet_id()`, and that repeated calls produce one `INFO` then `DEBUG` log records.

### Testing

- Ran `python -m pytest tests/onboarding/test_onboarding_sheet_id_required.py tests/onboarding/test_finishplacement_command.py` and all tests passed (`13 passed`).
- Ran static checks with `ruff` and fixed formatting with `black`, and `ruff` reported no issues for the changed files.
- Verified the new resolver logging behavior with a unit test that captures logs and asserts one `INFO` followed by `DEBUG` records for repeated `_sheet_id()` calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b204eb3c8323b44f224d124020f2)