### PR TITLE
Fix promo finishplacement open spot reconciliation

### DIFF
--- a/modules/onboarding/watcher_promo.py
+++ b/modules/onboarding/watcher_promo.py
@@ -1395,10 +1395,20 @@ class PromoTicketWatcher(commands.Cog):
                 )
 
         logging_channel_result = "skip"
-        reservation_status = "released" if cleanup.reservation_row is not None and cleanup.ok else ("failed" if not cleanup.ok else "none")
-        clan_update_status = "done" if cleanup.ok else "partial"
-        finalization_status = "done" if cleanup.ok else "partial"
-        finalization_note = "finalized by close handler" if cleanup.ok else (cleanup.reason or "reservation/clan update partially failed")
+        reservation_ok = getattr(cleanup, "reservation_ok", cleanup.ok)
+        clan_update_ok = getattr(cleanup, "clan_update_ok", cleanup.ok)
+        reservation_status = (
+            "released"
+            if cleanup.reservation_row is not None and reservation_ok
+            else ("failed" if not reservation_ok else "none")
+        )
+        clan_update_status = "done" if clan_update_ok else "partial"
+        finalization_status = "done" if clan_update_ok else "partial"
+        finalization_note = (
+            "finalized by close handler"
+            if clan_update_ok
+            else (cleanup.reason or "clan open spot reconciliation partially failed")
+        )
         try:
             await asyncio.to_thread(onboarding_sheets.update_ticket_finalization_state, "promo", ticket=ticket_id_final, thread_id=getattr(thread, "id", None), finalization_status=finalization_status, reservation_status=reservation_status, clan_update_status=clan_update_status, finalization_note=finalization_note)
             _promo_log_transition("success" if finalization_status == "done" else "failure", thread=thread, context=context, metadata_row_number=(found_state[0] if found_state else None), status_after="closed", finalization_status_after=finalization_status, reason=finalization_note)

--- a/modules/onboarding/watcher_welcome.py
+++ b/modules/onboarding/watcher_welcome.py
@@ -1948,6 +1948,8 @@ class ReservationCleanupResult:
     skipped: bool
     reason: str | None
     decision_line: str
+    reservation_ok: bool = True
+    clan_update_ok: bool = True
     source_clan_lookup_key: str = ""
     source_clan_row_found: bool = False
     source_clan_row_number: int | None = None
@@ -2001,25 +2003,23 @@ async def cleanup_reservation_for_ticket_close(
     recomputed_tags: List[str] = []
     reason: str | None = None
     ok = True
+    reservation_ok = True
+    clan_update_ok = True
+    reservation_lookup_failed = False
 
     try:
         matches = await find_active_reservations(
             user_id, user_label
         )
     except Exception:
+        matches = []
+        reservation_lookup_failed = True
+        reservation_ok = False
+        ok = False
         reason = "reservation_lookup_failed"
         event_log.exception(
-            "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • result=skip • reason=%s",
+            "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • reservation=lookup_failed • result=failed • reason=%s • open_spot_reconcile=continue",
             normalized_scope, ticket, user_label or "-", user_id or "-", normalized_final or "-", reason,
-        )
-        decision_line = (
-            "decision: "
-            f"final_tag={normalized_final or '-'} • previous_final={normalized_previous or '-'} • "
-            "reservation=lookup_failed • consume_open_spot=False • final_is_real=False • "
-            "decision_result=skipped_open_delta • skip_reason=reservation_lookup_failed"
-        )
-        return ReservationCleanupResult(
-            None, "lookup_failed", None, None, False, False, {}, {}, [], [], True, False, True, reason, decision_line
         )
 
     if matches:
@@ -2079,7 +2079,7 @@ async def cleanup_reservation_for_ticket_close(
             normalized_scope, ticket, user_label or "-", user_id or "-", normalized_final or "-", reason,
         )
         return ReservationCleanupResult(
-            None, "none", None, None, False, False, {}, {}, [], [], False, False, True, reason, decision_line
+            None, "none", None, None, False, False, {}, {}, [], [], False, False, True, reason, decision_line, True, False
         )
 
     try:
@@ -2090,6 +2090,9 @@ async def cleanup_reservation_for_ticket_close(
         )
         final_is_real = final_entry is not None
     except Exception:
+        reason = "final_clan_lookup_failed"
+        ok = False
+        clan_update_ok = False
         event_log.exception(
             "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • result=partial • reason=final_clan_lookup_failed",
             normalized_scope, ticket, user_label or "-", user_id or "-", normalized_final or "-",
@@ -2127,6 +2130,9 @@ async def cleanup_reservation_for_ticket_close(
                 source_clan_not_real_reason = "source_clan_row_not_found"
         except Exception:
             source_clan_not_real_reason = "source_clan_lookup_exception"
+            reason = "source_clan_lookup_failed"
+            ok = False
+            clan_update_ok = False
             event_log.exception(
                 "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • source_clan_tag=%s • result=partial • reason=source_clan_lookup_failed",
                 normalized_scope, ticket, user_label or "-", user_id or "-", normalized_previous or "-",
@@ -2195,6 +2201,7 @@ async def cleanup_reservation_for_ticket_close(
             )
         except Exception:
             ok = False
+            reservation_ok = False
             reason = "reservation_status_update_failed"
             event_log.exception(
                 "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • reservation=row%s • old_status=%s • new_status=%s • result=partial • reason=%s",
@@ -2207,6 +2214,7 @@ async def cleanup_reservation_for_ticket_close(
             applied_open_deltas[tag] = applied_open_deltas.get(tag, 0) + delta
         except Exception:
             ok = False
+            clan_update_ok = False
             reason = f"adjust_manual_open_spots_failed:{tag}:{delta}"
             event_log.exception(
                 "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • affected_clan=%s • delta=%s • result=partial • reason=adjust_manual_open_spots_failed",
@@ -2219,6 +2227,7 @@ async def cleanup_reservation_for_ticket_close(
             recomputed_tags.append(tag)
         except Exception:
             ok = False
+            clan_update_ok = False
             reason = f"recompute_clan_availability_failed:{tag}"
             event_log.exception(
                 "reservation_cleanup — scope=%s • ticket=%s • user=%s • user_id=%s • clan_tag=%s • affected_clan=%s • result=partial • reason=recompute_clan_availability_failed • missing_tag=%s • lookup_path=%s",
@@ -2242,6 +2251,7 @@ async def cleanup_reservation_for_ticket_close(
         open_deltas=applied_open_deltas,
     )
     if decision.open_deltas and not applied_open_deltas:
+        clan_update_ok = False
         failed_bits = ", ".join(
             f"{tag}:{delta:+d}" for tag, delta in sorted(decision.open_deltas.items())
         )
@@ -2260,7 +2270,7 @@ async def cleanup_reservation_for_ticket_close(
         user_label or "-",
         user_id or "-",
         normalized_final or "-",
-        f"row{reservation_row.row_number}" if reservation_row is not None else "none",
+        "lookup_failed" if reservation_lookup_failed else (f"row{reservation_row.row_number}" if reservation_row is not None else "none"),
         old_status or "-",
         new_status or "-",
         f"recomputed:{','.join(recomputed_tags) if recomputed_tags else 'none'}",
@@ -2285,6 +2295,8 @@ async def cleanup_reservation_for_ticket_close(
         False,
         reason,
         decision_line,
+        reservation_ok,
+        clan_update_ok,
         source_clan_lookup_key,
         source_clan_row_found,
         source_clan_row_number,

--- a/tests/onboarding/test_promo_open_spot_reconciliation.py
+++ b/tests/onboarding/test_promo_open_spot_reconciliation.py
@@ -1,0 +1,198 @@
+import asyncio
+
+import pytest
+
+from modules.onboarding.watcher_welcome import cleanup_reservation_for_ticket_close
+
+
+async def _fresh(**_kwargs):
+    return True
+
+
+async def _noop_recompute(*_args, **_kwargs):
+    return None
+
+
+async def _noop_update(*_args, **_kwargs):
+    return None
+
+
+def _clan_lookup(tags):
+    def find(tag, force=False):
+        normalized = str(tag).strip().upper()
+        if normalized not in tags:
+            return None
+        return (tags.index(normalized) + 2, ["", "", normalized, "", "2"])
+
+    return find
+
+
+def test_promo_finishplacement_no_reservation_still_reconciles_open_spots():
+    deltas = []
+
+    async def no_reservations(*_args, **_kwargs):
+        return []
+
+    async def adjust(tag, delta):
+        deltas.append((tag, delta))
+        return 1
+
+    result = asyncio.run(
+        cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="L0061",
+            user="Player",
+            user_id=1001,
+            final_tag="C1C0",
+            previous_final="C1CT",
+            require_source_for_open_spot_math=True,
+            require_active_reservation=False,
+            ensure_fresh_fn=_fresh,
+            find_active_reservations_fn=no_reservations,
+            find_clan_row_fn=_clan_lookup(["C1CT", "C1C0"]),
+            update_reservation_status_fn=_noop_update,
+            adjust_manual_open_spots_fn=adjust,
+            recompute_clan_availability_fn=_noop_recompute,
+        )
+    )
+
+    assert sorted(deltas) == [("C1C0", -1), ("C1CT", 1)]
+    assert result.reservation_label == "none"
+    assert result.reservation_ok is True
+    assert result.clan_update_ok is True
+    assert result.applied_open_deltas == {"C1CT": 1, "C1C0": -1}
+
+
+def test_promo_finishplacement_reservation_lookup_failure_does_not_poison_clan_update():
+    deltas = []
+
+    async def lookup_fails(*_args, **_kwargs):
+        raise RuntimeError("sheets unavailable")
+
+    async def adjust(tag, delta):
+        deltas.append((tag, delta))
+        return 1
+
+    result = asyncio.run(
+        cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="L0061",
+            user="Player",
+            user_id=1001,
+            final_tag="C1C0",
+            previous_final="C1CT",
+            require_source_for_open_spot_math=True,
+            require_active_reservation=False,
+            ensure_fresh_fn=_fresh,
+            find_active_reservations_fn=lookup_fails,
+            find_clan_row_fn=_clan_lookup(["C1CT", "C1C0"]),
+            update_reservation_status_fn=_noop_update,
+            adjust_manual_open_spots_fn=adjust,
+            recompute_clan_availability_fn=_noop_recompute,
+        )
+    )
+
+    assert sorted(deltas) == [("C1C0", -1), ("C1CT", 1)]
+    assert result.reservation_label == "none"
+    assert result.reservation_ok is False
+    assert result.clan_update_ok is True
+
+
+def test_promo_finishplacement_final_clan_lookup_failure_marks_clan_partial():
+    async def no_reservations(*_args, **_kwargs):
+        return []
+
+    def find(tag, force=False):
+        normalized = str(tag).strip().upper()
+        if normalized == "C1C0":
+            raise RuntimeError("lookup failed")
+        if normalized == "C1CT":
+            return (2, ["", "", normalized, "", "2"])
+        return None
+
+    result = asyncio.run(
+        cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="L0061",
+            user="Player",
+            user_id=1001,
+            final_tag="C1C0",
+            previous_final="C1CT",
+            require_source_for_open_spot_math=True,
+            require_active_reservation=False,
+            ensure_fresh_fn=_fresh,
+            find_active_reservations_fn=no_reservations,
+            find_clan_row_fn=find,
+            update_reservation_status_fn=_noop_update,
+            adjust_manual_open_spots_fn=_noop_update,
+            recompute_clan_availability_fn=_noop_recompute,
+        )
+    )
+
+    assert result.clan_update_ok is False
+    assert result.reason == "final_clan_lookup_failed"
+
+
+def test_promo_finishplacement_open_spot_write_failure_marks_clan_partial():
+    async def no_reservations(*_args, **_kwargs):
+        return []
+
+    async def adjust(tag, delta):
+        raise RuntimeError(f"cannot write {tag} {delta}")
+
+    result = asyncio.run(
+        cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="L0061",
+            user="Player",
+            user_id=1001,
+            final_tag="C1C0",
+            previous_final="C1CT",
+            require_source_for_open_spot_math=True,
+            require_active_reservation=False,
+            ensure_fresh_fn=_fresh,
+            find_active_reservations_fn=no_reservations,
+            find_clan_row_fn=_clan_lookup(["C1CT", "C1C0"]),
+            update_reservation_status_fn=_noop_update,
+            adjust_manual_open_spots_fn=adjust,
+            recompute_clan_availability_fn=_noop_recompute,
+        )
+    )
+
+    assert result.clan_update_ok is False
+    assert result.applied_open_deltas == {}
+    assert result.reason.startswith("adjust_manual_open_spots_failed:")
+
+
+def test_promo_finishplacement_same_source_destination_has_no_open_spot_delta():
+    deltas = []
+
+    async def no_reservations(*_args, **_kwargs):
+        return []
+
+    async def adjust(tag, delta):
+        deltas.append((tag, delta))
+        return 1
+
+    result = asyncio.run(
+        cleanup_reservation_for_ticket_close(
+            scope="promo",
+            ticket="L0061",
+            user="Player",
+            user_id=1001,
+            final_tag="C1C0",
+            previous_final="C1C0",
+            require_source_for_open_spot_math=True,
+            require_active_reservation=False,
+            ensure_fresh_fn=_fresh,
+            find_active_reservations_fn=no_reservations,
+            find_clan_row_fn=_clan_lookup(["C1C0"]),
+            update_reservation_status_fn=_noop_update,
+            adjust_manual_open_spots_fn=adjust,
+            recompute_clan_availability_fn=_noop_recompute,
+        )
+    )
+
+    assert deltas == []
+    assert result.clan_update_ok is True
+    assert result.applied_open_deltas == {}


### PR DESCRIPTION
### Motivation
- Promo/move ticket flows were skipping clan open spot reconciliation when reservation lookup failed, which incorrectly prevented mandatory open-spot corrections. 
- Reservation health must be reported independently from clan reconciliation so reservation failures don’t poison open-spot math.

### Description
- Decoupled reservation and clan reconciliation results by adding `reservation_ok` and `clan_update_ok` to `ReservationCleanupResult` and tracking reservation lookup/update vs clan lookup/write/recompute independently. 
- Modified `cleanup_reservation_for_ticket_close` to continue open-spot calculation and writes when reservations are missing or reservation lookup fails, while marking `reservation_ok` false on reservation lookup/status errors and `clan_update_ok` false only on clan lookup/write/recompute failures. 
- Updated promo finalization logic to derive `reservation_status` from the reservation outcome and `clan_update_status`/`finalization_status` from clan reconciliation outcome (uses `getattr` fallback for older result objects). 
- Added regression tests `tests/onboarding/test_promo_open_spot_reconciliation.py` that cover: no reservation, reservation lookup failure, final clan lookup failure, open-spot write failure, and same-source/destination no-op behavior.

### Testing
- `python -m py_compile modules/onboarding/watcher_welcome.py modules/onboarding/watcher_promo.py` — succeeded. 
- `pytest -q tests/onboarding/test_promo_open_spot_reconciliation.py` — succeeded (new regression suite). 
- `pytest -q tests/onboarding/test_promo_open_spot_reconciliation.py tests/onboarding/test_promo_watcher.py tests/onboarding/test_finishplacement_command.py` — succeeded (targeted onboarding promo/finishplacement suites). 
- Running the entire `tests/onboarding` suite surfaced unrelated environment/fixture issues in this container (missing async sheet fakes and onboarding config), so the broad suite was not used to gate this change; targeted regressions above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b3b1c49c8323b042638e04de2861)