### PR TITLE
Add achievements housekeeping module and admin commands to publish/refresh images

### DIFF
--- a/cogs/housekeeping_achievements.py
+++ b/cogs/housekeeping_achievements.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.housekeeping.achievements import (
+    AchievementsConfigError,
+    publish_achievements,
+    refresh_achievements,
+)
+
+log = logging.getLogger("c1c.housekeeping.achievements.cog")
+
+
+class AchievementsCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational", section="utilities", access_tier="admin"
+    )
+    @commands.group(
+        name="achievements",
+        invoke_without_command=True,
+        help="Publish or refresh the configured achievements images.",
+        brief="Publish or refresh achievements images.",
+    )
+    @admin_only()
+    async def achievements_group(self, ctx: commands.Context) -> None:
+        if ctx.invoked_subcommand is None:
+            await ctx.send('Use "!achievements publish" or "!achievements refresh".')
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational", section="utilities", access_tier="admin"
+    )
+    @achievements_group.command(name="publish")
+    @admin_only()
+    async def achievements_publish(self, ctx: commands.Context) -> None:
+        try:
+            result = await publish_achievements(self.bot)
+        except AchievementsConfigError as exc:
+            await ctx.send(f"Achievements publish failed: {exc}")
+            return
+        except Exception:
+            log.exception("Achievements publish failed")
+            await ctx.send(
+                "Achievements publish failed. Please check the bot logs for details."
+            )
+            return
+        await ctx.send(result.message)
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational", section="utilities", access_tier="admin"
+    )
+    @achievements_group.command(name="refresh")
+    @admin_only()
+    async def achievements_refresh(self, ctx: commands.Context) -> None:
+        try:
+            result = await refresh_achievements(self.bot)
+        except AchievementsConfigError as exc:
+            await ctx.send(f"Achievements refresh failed: {exc}")
+            return
+        except Exception:
+            log.exception("Achievements refresh failed")
+            await ctx.send(
+                "Achievements refresh failed. Please check the bot logs for details."
+            )
+            return
+        await ctx.send(result.message)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AchievementsCog(bot))

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1215,6 +1215,7 @@ class Runtime:
         from c1c_coreops import cog as coreops_cog
         from cogs import app_admin
         from cogs import housekeeping_mirralith
+        from cogs import housekeeping_achievements
         from cogs import housekeeping_c1c_ad
         from cogs import recruitment_clan_ads
         from modules.housekeeping import cleanup as housekeeping_cleanup_commands
@@ -1253,6 +1254,9 @@ class Runtime:
             log.info("modules: mirralith_overview enabled")
         else:
             log.info("modules: mirralith_overview disabled")
+
+        await housekeeping_achievements.setup(self.bot)
+        log.info("modules: achievements command registered")
 
         await housekeeping_c1c_ad.setup(self.bot)
         log.info("modules: c1c_ad command registered")

--- a/modules/housekeeping/__init__.py
+++ b/modules/housekeeping/__init__.py
@@ -4,5 +4,6 @@ __all__ = [
     "cleanup",
     "keepalive",
     "mirralith_overview",
+    "achievements",
     "role_audit",
 ]

--- a/modules/housekeeping/achievements.py
+++ b/modules/housekeeping/achievements.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import io
+import logging
+from dataclasses import dataclass
+import discord
+
+from shared.sheets import async_core, recruitment
+from shared.sheets.export_utils import ImageExportError, export_pdf_as_png, get_tab_gid
+
+log = logging.getLogger("c1c.housekeeping.achievements")
+
+REQUIRED_CONFIG_KEYS: tuple[str, ...] = (
+    "achievement_tab",
+    "achievement_range",
+    "achievement_champion_range",
+    "achievement_post_channel_id",
+    "achievement_post_message_id",
+)
+
+RANGE_CONFIG_KEYS: tuple[tuple[str, str], ...] = (
+    ("achievement_range", "achievements.png"),
+    ("achievement_champion_range", "achievement_champions.png"),
+)
+
+
+@dataclass(frozen=True)
+class AchievementsConfig:
+    tab: str
+    achievement_range: str
+    champion_range: str
+    channel_id: int
+    message_id: int | None
+
+
+@dataclass(frozen=True)
+class AchievementsResult:
+    status: str
+    message: str
+    message_id: int | None = None
+
+
+class AchievementsConfigError(RuntimeError):
+    pass
+
+
+def _column_label(index: int) -> str:
+    label = ""
+    value = index
+    while value > 0:
+        value, rem = divmod(value - 1, 26)
+        label = chr(ord("A") + rem) + label
+    return label
+
+
+def _normalize_key(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def _header_map(header: list[object]) -> dict[str, int]:
+    return {
+        _normalize_key(value): index
+        for index, value in enumerate(header)
+        if _normalize_key(value)
+    }
+
+
+async def _read_config_entries() -> tuple[dict[str, tuple[str, int, int]], str, str]:
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    tab_name = recruitment.get_config_tab_name()
+    matrix = await async_core.afetch_values(sheet_id, tab_name)
+    if not matrix:
+        raise AchievementsConfigError("Recruitment Config worksheet is empty.")
+    headers = _header_map(list(matrix[0]))
+    if "key" not in headers:
+        raise AchievementsConfigError(
+            "Recruitment Config worksheet missing Key column."
+        )
+    key_col = headers["key"]
+    value_col = headers.get("value", key_col + 1)
+    entries: dict[str, tuple[str, int, int]] = {}
+    for row_index, row in enumerate(matrix[1:], start=2):
+        key = _normalize_key(row[key_col] if key_col < len(row) else "")
+        if not key:
+            continue
+        raw_value = row[value_col] if value_col < len(row) else ""
+        entries[key] = (str(raw_value or "").strip(), row_index, value_col + 1)
+    return entries, sheet_id, tab_name
+
+
+async def _write_config_value(key: str, value: str) -> None:
+    entries, sheet_id, tab_name = await _read_config_entries()
+    normalized = _normalize_key(key)
+    if normalized not in entries:
+        raise AchievementsConfigError(
+            f"Missing required Config key {key}; create a blank row before publishing."
+        )
+    _, row_index, value_col = entries[normalized]
+    worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
+    target = f"{_column_label(value_col)}{row_index}"
+    await async_core.acall_with_backoff(
+        worksheet.update,
+        target,
+        [[value]],
+        value_input_option="RAW",
+    )
+
+
+async def resolve_config(*, require_message_id: bool) -> AchievementsConfig:
+    entries, _, _ = await _read_config_entries()
+    missing_keys = [key for key in REQUIRED_CONFIG_KEYS if key not in entries]
+    if missing_keys:
+        raise AchievementsConfigError(
+            "Missing required Config key(s): " + ", ".join(missing_keys)
+        )
+    values = {key: entries[key][0] for key in REQUIRED_CONFIG_KEYS}
+    blank = [
+        key
+        for key, value in values.items()
+        if not value and key != "achievement_post_message_id"
+    ]
+    if blank:
+        raise AchievementsConfigError(
+            "Blank required Config key(s): " + ", ".join(blank)
+        )
+    try:
+        channel_id = int(values["achievement_post_channel_id"])
+    except ValueError as exc:
+        raise AchievementsConfigError(
+            "Config key achievement_post_channel_id must be a Discord snowflake ID."
+        ) from exc
+    message_id: int | None = None
+    if values["achievement_post_message_id"]:
+        try:
+            message_id = int(values["achievement_post_message_id"])
+        except ValueError as exc:
+            raise AchievementsConfigError(
+                "Config key achievement_post_message_id is invalid. Run !achievements publish."
+            ) from exc
+    elif require_message_id:
+        raise AchievementsConfigError(
+            "achievement_post_message_id is missing. Run !achievements publish."
+        )
+    return AchievementsConfig(
+        tab=values["achievement_tab"],
+        achievement_range=values["achievement_range"],
+        champion_range=values["achievement_champion_range"],
+        channel_id=channel_id,
+        message_id=message_id,
+    )
+
+
+async def resolve_message_target(
+    bot: discord.Client, channel_id: int
+) -> discord.abc.Messageable | None:
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(channel_id)  # type: ignore[attr-defined]
+        except Exception:
+            return None
+    return (
+        channel
+        if hasattr(channel, "send") or hasattr(channel, "fetch_message")
+        else None
+    )
+
+
+async def render_achievement_files(config: AchievementsConfig) -> list[discord.File]:
+    sheet_id = recruitment.get_recruitment_sheet_id()
+    loop = asyncio.get_running_loop()
+    gid = await loop.run_in_executor(None, get_tab_gid, sheet_id, config.tab)
+    if gid is None:
+        raise AchievementsConfigError(
+            f"Configured achievement_tab {config.tab!r} could not be resolved."
+        )
+
+    files: list[discord.File] = []
+    ranges = {
+        "achievement_range": config.achievement_range,
+        "achievement_champion_range": config.champion_range,
+    }
+    for key, filename in RANGE_CONFIG_KEYS:
+        cell_range = ranges[key]
+        if ":" not in cell_range:
+            raise AchievementsConfigError(
+                f"Config key {key} must be an A1 range like A1:Z99."
+            )
+        try:
+            png = await export_pdf_as_png(
+                sheet_id,
+                gid,
+                cell_range,
+                log_context={"label": key, "tab": config.tab, "range": cell_range},
+                fit_range_to_one_page=True,
+                fail_on_multi_page=True,
+                crop_to_content=True,
+            )
+        except ImageExportError as exc:
+            raise AchievementsConfigError(str(exc)) from exc
+        if not png:
+            raise AchievementsConfigError(
+                f"Failed to render {key} as a one-page image."
+            )
+        files.append(discord.File(io.BytesIO(png), filename=filename))
+    return files
+
+
+def build_message_content() -> str:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return f"# Achievements\n-# Last updated {stamp}"
+
+
+async def publish_achievements(bot: discord.Client) -> AchievementsResult:
+    config = await resolve_config(require_message_id=False)
+    channel = await resolve_message_target(bot, config.channel_id)
+    if channel is None or not hasattr(channel, "send"):
+        return AchievementsResult(
+            "error",
+            "Configured achievement_post_channel_id is not a messageable channel/thread.",
+        )
+    files = await render_achievement_files(config)
+    message = await channel.send(content=build_message_content(), files=files)  # type: ignore[attr-defined]
+    try:
+        await _write_config_value("achievement_post_message_id", str(message.id))
+    except Exception as exc:
+        log.exception(
+            "achievement message posted but Config writeback failed",
+            extra={"message_id": message.id},
+        )
+        return AchievementsResult(
+            "error",
+            f"Posted achievements message {message.id}, but failed to write achievement_post_message_id: {exc}",
+            message_id=message.id,
+        )
+    return AchievementsResult(
+        "success",
+        f"Published achievements message {message.id}.",
+        message_id=message.id,
+    )
+
+
+async def refresh_achievements(bot: discord.Client) -> AchievementsResult:
+    config = await resolve_config(require_message_id=True)
+    channel = await resolve_message_target(bot, config.channel_id)
+    if channel is None or not hasattr(channel, "fetch_message"):
+        return AchievementsResult(
+            "error",
+            "Configured achievement_post_channel_id is not fetchable. Run !achievements publish.",
+        )
+    try:
+        message = await channel.fetch_message(config.message_id)  # type: ignore[attr-defined,arg-type]
+    except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+        return AchievementsResult(
+            "error",
+            "achievement_post_message_id is missing, invalid, or no longer exists. Run !achievements publish.",
+        )
+    files = await render_achievement_files(config)
+    await message.edit(content=build_message_content(), attachments=files)
+    return AchievementsResult(
+        "success",
+        f"Refreshed achievements message {config.message_id}.",
+        config.message_id,
+    )
+
+
+__all__ = [
+    "AchievementsConfig",
+    "AchievementsConfigError",
+    "AchievementsResult",
+    "publish_achievements",
+    "refresh_achievements",
+    "render_achievement_files",
+    "resolve_config",
+]

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,0 +1,189 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.housekeeping_achievements import AchievementsCog
+from modules.housekeeping import achievements
+
+
+class DummyMessage:
+    def __init__(self, message_id):
+        self.id = message_id
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent = []
+        self.messages = {55: DummyMessage(55)}
+
+    async def send(self, **kwargs):
+        msg = DummyMessage(100 + len(self.sent))
+        self.sent.append(kwargs)
+        self.messages[msg.id] = msg
+        return msg
+
+    async def fetch_message(self, message_id):
+        if message_id not in self.messages:
+            import discord
+
+            raise discord.NotFound(
+                SimpleNamespace(status=404, reason="missing"), "missing"
+            )
+        return self.messages[message_id]
+
+
+class DummyBot:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get_channel(self, channel_id):
+        return self.channel if channel_id == 123 else None
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    config = {
+        "achievement_tab": "Achievements",
+        "achievement_range": "A1:H20",
+        "achievement_champion_range": "J1:Q20",
+        "achievement_post_channel_id": "123",
+        "achievement_post_message_id": "55",
+    }
+    writes = []
+    channel = DummyChannel()
+
+    monkeypatch.setattr(
+        achievements.recruitment, "get_recruitment_sheet_id", lambda: "sheet123"
+    )
+    monkeypatch.setattr(
+        achievements.recruitment, "get_config_tab_name", lambda: "Config"
+    )
+
+    async def afetch_values(sheet_id, tab_name):
+        assert sheet_id == "sheet123"
+        assert tab_name == "Config"
+        return [["Key", "Value"], *[[key, value] for key, value in config.items()]]
+
+    monkeypatch.setattr(achievements.async_core, "afetch_values", afetch_values)
+    monkeypatch.setattr(achievements, "get_tab_gid", lambda sheet_id, tab_name: "999")
+
+    async def render(*args, **kwargs):
+        return b"png"
+
+    monkeypatch.setattr(achievements, "export_pdf_as_png", render)
+
+    class Worksheet:
+        def update(self, target, values, **kwargs):
+            writes.append((target, values, kwargs))
+
+    async def aget_worksheet(sheet_id, tab_name):
+        assert sheet_id == "sheet123"
+        assert tab_name == "Config"
+        return Worksheet()
+
+    async def acall_with_backoff(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(achievements.async_core, "aget_worksheet", aget_worksheet)
+    monkeypatch.setattr(
+        achievements.async_core, "acall_with_backoff", acall_with_backoff
+    )
+    return SimpleNamespace(
+        config=config, writes=writes, channel=channel, bot=DummyBot(channel)
+    )
+
+
+def test_publish_writes_achievement_post_message_id(harness):
+    result = asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert result.status == "success"
+    assert result.message_id == 100
+    assert harness.writes == [("B6", [["100"]], {"value_input_option": "RAW"})]
+    assert len(harness.channel.sent) == 1
+    assert len(harness.channel.sent[0]["files"]) == 2
+
+
+def test_publish_requires_existing_message_id_config_row(harness):
+    del harness.config["achievement_post_message_id"]
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert "achievement_post_message_id" in str(exc.value)
+    assert harness.channel.sent == []
+    assert harness.writes == []
+
+
+def test_refresh_edits_configured_message_and_does_not_send(harness):
+    result = asyncio.run(achievements.refresh_achievements(harness.bot))
+
+    assert result.status == "success"
+    assert harness.channel.sent == []
+    assert len(harness.channel.messages[55].edits) == 1
+    assert len(harness.channel.messages[55].edits[0]["attachments"]) == 2
+
+
+def test_refresh_missing_message_id_tells_admin_to_publish(harness):
+    harness.config["achievement_post_message_id"] = ""
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.refresh_achievements(harness.bot))
+
+    assert "Run !achievements publish" in str(exc.value)
+    assert harness.channel.sent == []
+
+
+def test_refresh_invalid_existing_message_does_not_send(harness):
+    harness.config["achievement_post_message_id"] = "999"
+
+    result = asyncio.run(achievements.refresh_achievements(harness.bot))
+
+    assert result.status == "error"
+    assert "Run !achievements publish" in result.message
+    assert harness.channel.sent == []
+
+
+def test_render_uses_one_page_export_options(monkeypatch, harness):
+    calls = []
+
+    async def render(*args, **kwargs):
+        calls.append((args, kwargs))
+        return b"png"
+
+    monkeypatch.setattr(achievements, "export_pdf_as_png", render)
+    config = asyncio.run(achievements.resolve_config(require_message_id=True))
+
+    files = asyncio.run(achievements.render_achievement_files(config))
+
+    assert len(files) == 2
+    assert [call[1]["fit_range_to_one_page"] for call in calls] == [True, True]
+    assert [call[1]["fail_on_multi_page"] for call in calls] == [True, True]
+
+
+def test_multi_page_export_fails_clearly(monkeypatch, harness):
+    async def render(*args, **kwargs):
+        raise achievements.ImageExportError("image export produced multiple pages")
+
+    monkeypatch.setattr(achievements, "export_pdf_as_png", render)
+    config = asyncio.run(achievements.resolve_config(require_message_id=True))
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.render_achievement_files(config))
+
+    assert "image export produced multiple pages" in str(exc.value)
+
+
+def test_achievements_commands_are_admin_gated():
+    commands = [
+        AchievementsCog.achievements_group,
+        AchievementsCog.achievements_publish,
+        AchievementsCog.achievements_refresh,
+    ]
+    for command in commands:
+        checks = getattr(command, "checks", [])
+        assert checks, f"{command} has no command checks"


### PR DESCRIPTION
### Motivation
- Provide admins a way to render achievements from the recruitment sheet as images and post or refresh a pinned achievements message in Discord. 
- Store and manage the target post info in the recruitment Config worksheet so the bot can update the same message without creating duplicates.
- Centralize image export logic and config validation to ensure clear errors when sheet/range/config are misconfigured.

### Description
- Add `modules/housekeeping/achievements.py` implementing `AchievementsConfig`, `AchievementsResult`, `resolve_config`, `render_achievement_files`, `publish_achievements`, `refresh_achievements`, and `AchievementsConfigError`, using `shared.sheets.export_utils.export_pdf_as_png` to produce PNGs from an A1 range and writing back `achievement_post_message_id` to the Config sheet. 
- Add `cogs/housekeeping_achievements.py` introducing an admin-only command group `!achievements` with `publish` and `refresh` subcommands that call the new module functions and surface user-friendly errors. 
- Register the new cog at startup by updating `modules/common/runtime.py` to `await housekeeping_achievements.setup(self.bot)` and export the module from `modules/housekeeping/__init__.py`. 
- Add unit tests in `tests/test_achievements.py` that cover publish writeback, refresh behavior, error cases, and that the cog commands have checks.

### Testing
- Ran the new unit tests in `tests/test_achievements.py` via `pytest` which exercise `publish_achievements`, `refresh_achievements`, `render_achievement_files`, and config error handling, and they passed. 
- Verified that the cog is registered at startup by invoking the runtime `load_extensions` path that now awaits `housekeeping_achievements.setup`, and no startup errors occurred during local validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540f10d430832390ed0c2c74c787f8)