### PR TITLE
Support publishing and tracking two achievement messages/files

### DIFF
--- a/modules/housekeeping/achievements.py
+++ b/modules/housekeeping/achievements.py
@@ -17,12 +17,17 @@ REQUIRED_CONFIG_KEYS: tuple[str, ...] = (
     "achievement_range",
     "achievement_champion_range",
     "achievement_post_channel_id",
-    "achievement_post_message_id",
+    "achievement_post_message_id_1",
+    "achievement_post_message_id_2",
 )
 
-RANGE_CONFIG_KEYS: tuple[tuple[str, str], ...] = (
-    ("achievement_range", "achievements.png"),
-    ("achievement_champion_range", "achievement_champions.png"),
+RANGE_CONFIG_KEYS: tuple[tuple[str, str, str], ...] = (
+    ("achievement_range", "achievements.png", "achievement_post_message_id_1"),
+    (
+        "achievement_champion_range",
+        "achievement_champions.png",
+        "achievement_post_message_id_2",
+    ),
 )
 
 
@@ -32,14 +37,14 @@ class AchievementsConfig:
     achievement_range: str
     champion_range: str
     channel_id: int
-    message_id: int | None
+    message_ids: tuple[int | None, int | None]
 
 
 @dataclass(frozen=True)
 class AchievementsResult:
     status: str
     message: str
-    message_id: int | None = None
+    message_ids: tuple[int, ...] = ()
 
 
 class AchievementsConfigError(RuntimeError):
@@ -116,10 +121,9 @@ async def resolve_config(*, require_message_id: bool) -> AchievementsConfig:
             "Missing required Config key(s): " + ", ".join(missing_keys)
         )
     values = {key: entries[key][0] for key in REQUIRED_CONFIG_KEYS}
+    message_id_keys = {"achievement_post_message_id_1", "achievement_post_message_id_2"}
     blank = [
-        key
-        for key, value in values.items()
-        if not value and key != "achievement_post_message_id"
+        key for key, value in values.items() if not value and key not in message_id_keys
     ]
     if blank:
         raise AchievementsConfigError(
@@ -131,24 +135,29 @@ async def resolve_config(*, require_message_id: bool) -> AchievementsConfig:
         raise AchievementsConfigError(
             "Config key achievement_post_channel_id must be a Discord snowflake ID."
         ) from exc
-    message_id: int | None = None
-    if values["achievement_post_message_id"]:
-        try:
-            message_id = int(values["achievement_post_message_id"])
-        except ValueError as exc:
+
+    message_ids: list[int | None] = []
+    for key in ("achievement_post_message_id_1", "achievement_post_message_id_2"):
+        value = values[key]
+        if value:
+            try:
+                message_ids.append(int(value))
+            except ValueError as exc:
+                raise AchievementsConfigError(
+                    f"Config key {key} is invalid. Run !achievements publish."
+                ) from exc
+        elif require_message_id:
             raise AchievementsConfigError(
-                "Config key achievement_post_message_id is invalid. Run !achievements publish."
-            ) from exc
-    elif require_message_id:
-        raise AchievementsConfigError(
-            "achievement_post_message_id is missing. Run !achievements publish."
-        )
+                f"{key} is missing. Run !achievements publish."
+            )
+        else:
+            message_ids.append(None)
     return AchievementsConfig(
         tab=values["achievement_tab"],
         achievement_range=values["achievement_range"],
         champion_range=values["achievement_champion_range"],
         channel_id=channel_id,
-        message_id=message_id,
+        message_ids=(message_ids[0], message_ids[1]),
     )
 
 
@@ -182,7 +191,7 @@ async def render_achievement_files(config: AchievementsConfig) -> list[discord.F
         "achievement_range": config.achievement_range,
         "achievement_champion_range": config.champion_range,
     }
-    for key, filename in RANGE_CONFIG_KEYS:
+    for key, filename, _message_id_key in RANGE_CONFIG_KEYS:
         cell_range = ranges[key]
         if ":" not in cell_range:
             raise AchievementsConfigError(
@@ -222,23 +231,32 @@ async def publish_achievements(bot: discord.Client) -> AchievementsResult:
             "Configured achievement_post_channel_id is not a messageable channel/thread.",
         )
     files = await render_achievement_files(config)
-    message = await channel.send(content=build_message_content(), files=files)  # type: ignore[attr-defined]
+    messages = []
+    for file in files:
+        messages.append(
+            await channel.send(content=build_message_content(), files=[file])  # type: ignore[attr-defined]
+        )
     try:
-        await _write_config_value("achievement_post_message_id", str(message.id))
+        for message, (_range_key, _filename, message_id_key) in zip(
+            messages, RANGE_CONFIG_KEYS, strict=True
+        ):
+            await _write_config_value(message_id_key, str(message.id))
     except Exception as exc:
+        ids = tuple(message.id for message in messages)
         log.exception(
-            "achievement message posted but Config writeback failed",
-            extra={"message_id": message.id},
+            "achievement messages posted but Config writeback failed",
+            extra={"message_ids": ids},
         )
         return AchievementsResult(
             "error",
-            f"Posted achievements message {message.id}, but failed to write achievement_post_message_id: {exc}",
-            message_id=message.id,
+            f"Posted achievements messages {', '.join(str(i) for i in ids)}, but failed to write Config message IDs: {exc}",
+            message_ids=ids,
         )
+    ids = tuple(message.id for message in messages)
     return AchievementsResult(
         "success",
-        f"Published achievements message {message.id}.",
-        message_id=message.id,
+        f"Published achievements messages {ids[0]} and {ids[1]}.",
+        message_ids=ids,
     )
 
 
@@ -250,19 +268,25 @@ async def refresh_achievements(bot: discord.Client) -> AchievementsResult:
             "error",
             "Configured achievement_post_channel_id is not fetchable. Run !achievements publish.",
         )
-    try:
-        message = await channel.fetch_message(config.message_id)  # type: ignore[attr-defined,arg-type]
-    except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-        return AchievementsResult(
-            "error",
-            "achievement_post_message_id is missing, invalid, or no longer exists. Run !achievements publish.",
-        )
+    messages = []
+    for message_id, (_range_key, _filename, message_id_key) in zip(
+        config.message_ids, RANGE_CONFIG_KEYS, strict=True
+    ):
+        try:
+            messages.append(await channel.fetch_message(message_id))  # type: ignore[attr-defined,arg-type]
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return AchievementsResult(
+                "error",
+                f"{message_id_key} is missing, invalid, deleted, or not fetchable. Run !achievements publish.",
+            )
     files = await render_achievement_files(config)
-    await message.edit(content=build_message_content(), attachments=files)
+    for message, file in zip(messages, files, strict=True):
+        await message.edit(content=build_message_content(), attachments=[file])
+    ids = tuple(message.id for message in messages)
     return AchievementsResult(
         "success",
-        f"Refreshed achievements message {config.message_id}.",
-        config.message_id,
+        f"Refreshed achievements messages {ids[0]} and {ids[1]}.",
+        ids,
     )
 
 

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -19,7 +19,7 @@ class DummyMessage:
 class DummyChannel:
     def __init__(self):
         self.sent = []
-        self.messages = {55: DummyMessage(55)}
+        self.messages = {55: DummyMessage(55), 56: DummyMessage(56)}
 
     async def send(self, **kwargs):
         msg = DummyMessage(100 + len(self.sent))
@@ -52,7 +52,8 @@ def harness(monkeypatch):
         "achievement_range": "A1:H20",
         "achievement_champion_range": "J1:Q20",
         "achievement_post_channel_id": "123",
-        "achievement_post_message_id": "55",
+        "achievement_post_message_id_1": "55",
+        "achievement_post_message_id_2": "56",
     }
     writes = []
     channel = DummyChannel()
@@ -98,38 +99,47 @@ def harness(monkeypatch):
     )
 
 
-def test_publish_writes_achievement_post_message_id(harness):
+def test_publish_writes_achievement_post_message_ids(harness):
     result = asyncio.run(achievements.publish_achievements(harness.bot))
 
     assert result.status == "success"
-    assert result.message_id == 100
-    assert harness.writes == [("B6", [["100"]], {"value_input_option": "RAW"})]
-    assert len(harness.channel.sent) == 1
-    assert len(harness.channel.sent[0]["files"]) == 2
+    assert result.message_ids == (100, 101)
+    assert harness.writes == [
+        ("B6", [["100"]], {"value_input_option": "RAW"}),
+        ("B7", [["101"]], {"value_input_option": "RAW"}),
+    ]
+    assert len(harness.channel.sent) == 2
+    assert len(harness.channel.sent[0]["files"]) == 1
+    assert len(harness.channel.sent[1]["files"]) == 1
 
 
-def test_publish_requires_existing_message_id_config_row(harness):
-    del harness.config["achievement_post_message_id"]
+def test_publish_requires_existing_message_id_config_rows(harness):
+    del harness.config["achievement_post_message_id_2"]
 
     with pytest.raises(achievements.AchievementsConfigError) as exc:
         asyncio.run(achievements.publish_achievements(harness.bot))
 
-    assert "achievement_post_message_id" in str(exc.value)
+    assert "achievement_post_message_id_2" in str(exc.value)
     assert harness.channel.sent == []
     assert harness.writes == []
 
 
-def test_refresh_edits_configured_message_and_does_not_send(harness):
+def test_refresh_edits_configured_messages_and_does_not_send(harness):
     result = asyncio.run(achievements.refresh_achievements(harness.bot))
 
     assert result.status == "success"
+    assert result.message_ids == (55, 56)
     assert harness.channel.sent == []
     assert len(harness.channel.messages[55].edits) == 1
-    assert len(harness.channel.messages[55].edits[0]["attachments"]) == 2
+    assert len(harness.channel.messages[56].edits) == 1
+    assert len(harness.channel.messages[55].edits[0]["attachments"]) == 1
+    assert len(harness.channel.messages[56].edits[0]["attachments"]) == 1
+    assert "files" not in harness.channel.messages[55].edits[0]
+    assert "files" not in harness.channel.messages[56].edits[0]
 
 
 def test_refresh_missing_message_id_tells_admin_to_publish(harness):
-    harness.config["achievement_post_message_id"] = ""
+    harness.config["achievement_post_message_id_1"] = ""
 
     with pytest.raises(achievements.AchievementsConfigError) as exc:
         asyncio.run(achievements.refresh_achievements(harness.bot))
@@ -139,7 +149,7 @@ def test_refresh_missing_message_id_tells_admin_to_publish(harness):
 
 
 def test_refresh_invalid_existing_message_does_not_send(harness):
-    harness.config["achievement_post_message_id"] = "999"
+    harness.config["achievement_post_message_id_2"] = "999"
 
     result = asyncio.run(achievements.refresh_achievements(harness.bot))
 


### PR DESCRIPTION
### Motivation
- Separate achievement and champion ranges should be posted as individual Discord messages and tracked independently in the configuration.
- The single `achievement_post_message_id` slot was insufficient for storing two message targets and for editing each message later on.
- Config writeback and refresh logic must be updated to handle two message IDs safely and report errors clearly.

### Description
- Replaced single config key `achievement_post_message_id` with `achievement_post_message_id_1` and `achievement_post_message_id_2`, and updated `REQUIRED_CONFIG_KEYS` accordingly.
- Converted `RANGE_CONFIG_KEYS` to include the associated message config key and updated loops to iterate `(range, filename, message_id_key)` tuples.
- Updated `AchievementsConfig` to store `message_ids: tuple[int|None, int|None]` and `AchievementsResult` to return `message_ids` instead of a single `message_id`.
- `resolve_config` now parses and validates two message ID config entries, honoring `require_message_id` for each; `publish_achievements` sends one Discord message per rendered file and writes back both config message IDs; `refresh_achievements` fetches and edits both configured messages with their corresponding files.
- Updated tests in `tests/test_achievements.py` to expect two sent messages, two config writebacks, and two edited messages.

### Testing
- Ran `pytest tests/test_achievements.py` which exercises `publish_achievements`, `refresh_achievements`, `resolve_config`, and `render_achievement_files`, and the updated tests passed.
- Ran the test module with the patched `achievements` mocks and the publish/refresh flows succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5414bc682483238f6b291199bf713a)