### PR TITLE
Support dynamic Config-driven achievements publishing

### DIFF
--- a/modules/housekeeping/achievements.py
+++ b/modules/housekeeping/achievements.py
@@ -12,32 +12,31 @@ from shared.sheets.export_utils import ImageExportError, export_pdf_as_png, get_
 
 log = logging.getLogger("c1c.housekeeping.achievements")
 
-REQUIRED_CONFIG_KEYS: tuple[str, ...] = (
+BASE_CONFIG_KEYS: tuple[str, ...] = (
     "achievement_tab",
-    "achievement_range",
-    "achievement_champion_range",
     "achievement_post_channel_id",
-    "achievement_post_message_id_1",
-    "achievement_post_message_id_2",
+    "achievement_range_count",
 )
 
-RANGE_CONFIG_KEYS: tuple[tuple[str, str, str], ...] = (
-    ("achievement_range", "achievements.png", "achievement_post_message_id_1"),
-    (
-        "achievement_champion_range",
-        "achievement_champions.png",
-        "achievement_post_message_id_2",
-    ),
-)
+
+@dataclass(frozen=True)
+class AchievementRangeConfig:
+    index: int
+    range_key: str
+    message_id_key: str
+    cell_range: str
+    message_id: int | None
 
 
 @dataclass(frozen=True)
 class AchievementsConfig:
     tab: str
-    achievement_range: str
-    champion_range: str
     channel_id: int
-    message_ids: tuple[int | None, int | None]
+    ranges: tuple[AchievementRangeConfig, ...]
+
+    @property
+    def message_ids(self) -> tuple[int | None, ...]:
+        return tuple(item.message_id for item in self.ranges)
 
 
 @dataclass(frozen=True)
@@ -113,52 +112,83 @@ async def _write_config_value(key: str, value: str) -> None:
     )
 
 
+def _require_config_key(entries: dict[str, tuple[str, int, int]], key: str) -> str:
+    if key not in entries:
+        raise AchievementsConfigError(f"Missing required Config key(s): {key}")
+    return entries[key][0]
+
+
 async def resolve_config(*, require_message_id: bool) -> AchievementsConfig:
     entries, _, _ = await _read_config_entries()
-    missing_keys = [key for key in REQUIRED_CONFIG_KEYS if key not in entries]
+    missing_keys = [key for key in BASE_CONFIG_KEYS if key not in entries]
     if missing_keys:
         raise AchievementsConfigError(
             "Missing required Config key(s): " + ", ".join(missing_keys)
         )
-    values = {key: entries[key][0] for key in REQUIRED_CONFIG_KEYS}
-    message_id_keys = {"achievement_post_message_id_1", "achievement_post_message_id_2"}
-    blank = [
-        key for key, value in values.items() if not value and key not in message_id_keys
+
+    tab = entries["achievement_tab"][0]
+    channel_value = entries["achievement_post_channel_id"][0]
+    count_value = entries["achievement_range_count"][0]
+    blank_base = [
+        key
+        for key, value in (
+            ("achievement_tab", tab),
+            ("achievement_post_channel_id", channel_value),
+            ("achievement_range_count", count_value),
+        )
+        if not value
     ]
-    if blank:
+    if blank_base:
         raise AchievementsConfigError(
-            "Blank required Config key(s): " + ", ".join(blank)
+            "Blank required Config key(s): " + ", ".join(blank_base)
         )
     try:
-        channel_id = int(values["achievement_post_channel_id"])
+        channel_id = int(channel_value)
     except ValueError as exc:
         raise AchievementsConfigError(
             "Config key achievement_post_channel_id must be a Discord snowflake ID."
         ) from exc
+    try:
+        range_count = int(count_value)
+    except ValueError as exc:
+        raise AchievementsConfigError(
+            "Config key achievement_range_count must be a positive integer."
+        ) from exc
+    if range_count <= 0:
+        raise AchievementsConfigError(
+            "Config key achievement_range_count must be a positive integer."
+        )
 
-    message_ids: list[int | None] = []
-    for key in ("achievement_post_message_id_1", "achievement_post_message_id_2"):
-        value = values[key]
-        if value:
+    ranges: list[AchievementRangeConfig] = []
+    for index in range(1, range_count + 1):
+        range_key = f"achievement_range_{index}"
+        message_id_key = f"achievement_post_message_id_{index}"
+        cell_range = _require_config_key(entries, range_key)
+        message_value = _require_config_key(entries, message_id_key)
+        if not cell_range:
+            raise AchievementsConfigError(f"Config key {range_key} must not be blank.")
+        message_id: int | None = None
+        if message_value:
             try:
-                message_ids.append(int(value))
+                message_id = int(message_value)
             except ValueError as exc:
                 raise AchievementsConfigError(
-                    f"Config key {key} is invalid. Run !achievements publish."
+                    f"Config key {message_id_key} is invalid. Run !achievements publish."
                 ) from exc
         elif require_message_id:
             raise AchievementsConfigError(
-                f"{key} is missing. Run !achievements publish."
+                f"{message_id_key} is missing. Run !achievements publish."
             )
-        else:
-            message_ids.append(None)
-    return AchievementsConfig(
-        tab=values["achievement_tab"],
-        achievement_range=values["achievement_range"],
-        champion_range=values["achievement_champion_range"],
-        channel_id=channel_id,
-        message_ids=(message_ids[0], message_ids[1]),
-    )
+        ranges.append(
+            AchievementRangeConfig(
+                index=index,
+                range_key=range_key,
+                message_id_key=message_id_key,
+                cell_range=cell_range,
+                message_id=message_id,
+            )
+        )
+    return AchievementsConfig(tab=tab, channel_id=channel_id, ranges=tuple(ranges))
 
 
 async def resolve_message_target(
@@ -187,22 +217,21 @@ async def render_achievement_files(config: AchievementsConfig) -> list[discord.F
         )
 
     files: list[discord.File] = []
-    ranges = {
-        "achievement_range": config.achievement_range,
-        "achievement_champion_range": config.champion_range,
-    }
-    for key, filename, _message_id_key in RANGE_CONFIG_KEYS:
-        cell_range = ranges[key]
-        if ":" not in cell_range:
+    for item in config.ranges:
+        if ":" not in item.cell_range:
             raise AchievementsConfigError(
-                f"Config key {key} must be an A1 range like A1:Z99."
+                f"Config key {item.range_key} must be an A1 range like A1:Z99."
             )
         try:
             png = await export_pdf_as_png(
                 sheet_id,
                 gid,
-                cell_range,
-                log_context={"label": key, "tab": config.tab, "range": cell_range},
+                item.cell_range,
+                log_context={
+                    "label": item.range_key,
+                    "tab": config.tab,
+                    "range": item.cell_range,
+                },
                 fit_range_to_one_page=True,
                 fail_on_multi_page=True,
                 crop_to_content=True,
@@ -211,13 +240,17 @@ async def render_achievement_files(config: AchievementsConfig) -> list[discord.F
             raise AchievementsConfigError(str(exc)) from exc
         if not png:
             raise AchievementsConfigError(
-                f"Failed to render {key} as a one-page image."
+                f"Failed to render {item.range_key} as a one-page image."
             )
-        files.append(discord.File(io.BytesIO(png), filename=filename))
+        files.append(
+            discord.File(io.BytesIO(png), filename=f"achievements_{item.index}.png")
+        )
     return files
 
 
-def build_message_content() -> str:
+def build_message_content(index: int) -> str:
+    if index != 1:
+        return ""
     stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     return f"# Achievements\n-# Last updated {stamp}"
 
@@ -232,15 +265,16 @@ async def publish_achievements(bot: discord.Client) -> AchievementsResult:
         )
     files = await render_achievement_files(config)
     messages = []
-    for file in files:
+    for item, file in zip(config.ranges, files, strict=True):
         messages.append(
-            await channel.send(content=build_message_content(), files=[file])  # type: ignore[attr-defined]
+            await channel.send(content=build_message_content(item.index), files=[file])  # type: ignore[attr-defined]
         )
     try:
-        for message, (_range_key, _filename, message_id_key) in zip(
-            messages, RANGE_CONFIG_KEYS, strict=True
-        ):
-            await _write_config_value(message_id_key, str(message.id))
+        for message, item in zip(messages, config.ranges, strict=True):
+            try:
+                await _write_config_value(item.message_id_key, str(message.id))
+            except Exception as exc:
+                raise AchievementsConfigError(f"{item.message_id_key}: {exc}") from exc
     except Exception as exc:
         ids = tuple(message.id for message in messages)
         log.exception(
@@ -255,7 +289,7 @@ async def publish_achievements(bot: discord.Client) -> AchievementsResult:
     ids = tuple(message.id for message in messages)
     return AchievementsResult(
         "success",
-        f"Published achievements messages {ids[0]} and {ids[1]}.",
+        f"Published achievements messages {', '.join(str(i) for i in ids)}.",
         message_ids=ids,
     )
 
@@ -269,28 +303,29 @@ async def refresh_achievements(bot: discord.Client) -> AchievementsResult:
             "Configured achievement_post_channel_id is not fetchable. Run !achievements publish.",
         )
     messages = []
-    for message_id, (_range_key, _filename, message_id_key) in zip(
-        config.message_ids, RANGE_CONFIG_KEYS, strict=True
-    ):
+    for item in config.ranges:
         try:
-            messages.append(await channel.fetch_message(message_id))  # type: ignore[attr-defined,arg-type]
+            messages.append(await channel.fetch_message(item.message_id))  # type: ignore[attr-defined,arg-type]
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
             return AchievementsResult(
                 "error",
-                f"{message_id_key} is missing, invalid, deleted, or not fetchable. Run !achievements publish.",
+                f"{item.message_id_key} is missing, invalid, deleted, or not fetchable. Run !achievements publish.",
             )
     files = await render_achievement_files(config)
-    for message, file in zip(messages, files, strict=True):
-        await message.edit(content=build_message_content(), attachments=[file])
+    for item, message, file in zip(config.ranges, messages, files, strict=True):
+        await message.edit(
+            content=build_message_content(item.index), attachments=[file]
+        )
     ids = tuple(message.id for message in messages)
     return AchievementsResult(
         "success",
-        f"Refreshed achievements messages {ids[0]} and {ids[1]}.",
+        f"Refreshed achievements messages {', '.join(str(i) for i in ids)}.",
         ids,
     )
 
 
 __all__ = [
+    "AchievementRangeConfig",
     "AchievementsConfig",
     "AchievementsConfigError",
     "AchievementsResult",

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -19,7 +19,11 @@ class DummyMessage:
 class DummyChannel:
     def __init__(self):
         self.sent = []
-        self.messages = {55: DummyMessage(55), 56: DummyMessage(56)}
+        self.messages = {
+            55: DummyMessage(55),
+            56: DummyMessage(56),
+            57: DummyMessage(57),
+        }
 
     async def send(self, **kwargs):
         msg = DummyMessage(100 + len(self.sent))
@@ -49,11 +53,14 @@ class DummyBot:
 def harness(monkeypatch):
     config = {
         "achievement_tab": "Achievements",
-        "achievement_range": "A1:H20",
-        "achievement_champion_range": "J1:Q20",
         "achievement_post_channel_id": "123",
+        "achievement_range_count": "3",
+        "achievement_range_1": "A1:H20",
+        "achievement_range_2": "A22:H40",
+        "achievement_range_3": "A42:H60",
         "achievement_post_message_id_1": "55",
         "achievement_post_message_id_2": "56",
+        "achievement_post_message_id_3": "57",
     }
     writes = []
     channel = DummyChannel()
@@ -99,18 +106,37 @@ def harness(monkeypatch):
     )
 
 
-def test_publish_writes_achievement_post_message_ids(harness):
+def test_publish_sends_configured_messages_and_writes_ids(harness):
     result = asyncio.run(achievements.publish_achievements(harness.bot))
 
     assert result.status == "success"
-    assert result.message_ids == (100, 101)
+    assert result.message_ids == (100, 101, 102)
     assert harness.writes == [
-        ("B6", [["100"]], {"value_input_option": "RAW"}),
-        ("B7", [["101"]], {"value_input_option": "RAW"}),
+        ("B8", [["100"]], {"value_input_option": "RAW"}),
+        ("B9", [["101"]], {"value_input_option": "RAW"}),
+        ("B10", [["102"]], {"value_input_option": "RAW"}),
     ]
-    assert len(harness.channel.sent) == 2
-    assert len(harness.channel.sent[0]["files"]) == 1
-    assert len(harness.channel.sent[1]["files"]) == 1
+    assert len(harness.channel.sent) == 3
+    assert [len(sent["files"]) for sent in harness.channel.sent] == [1, 1, 1]
+    assert harness.channel.sent[0]["files"][0].filename == "achievements_1.png"
+    assert harness.channel.sent[1]["files"][0].filename == "achievements_2.png"
+    assert harness.channel.sent[2]["files"][0].filename == "achievements_3.png"
+    assert harness.channel.sent[0]["content"].startswith(
+        "# Achievements\n-# Last updated "
+    )
+    assert harness.channel.sent[1]["content"] == ""
+    assert harness.channel.sent[2]["content"] == ""
+
+
+def test_publish_allows_blank_message_ids_when_rows_exist(harness):
+    harness.config["achievement_post_message_id_1"] = ""
+    harness.config["achievement_post_message_id_2"] = ""
+    harness.config["achievement_post_message_id_3"] = ""
+
+    result = asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert result.status == "success"
+    assert result.message_ids == (100, 101, 102)
 
 
 def test_publish_requires_existing_message_id_config_rows(harness):
@@ -124,27 +150,63 @@ def test_publish_requires_existing_message_id_config_rows(harness):
     assert harness.writes == []
 
 
+def test_missing_range_key_fails_clearly(harness):
+    del harness.config["achievement_range_2"]
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert "achievement_range_2" in str(exc.value)
+    assert harness.channel.sent == []
+
+
+def test_blank_range_key_fails_clearly(harness):
+    harness.config["achievement_range_2"] = ""
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert "achievement_range_2" in str(exc.value)
+    assert "must not be blank" in str(exc.value)
+
+
 def test_refresh_edits_configured_messages_and_does_not_send(harness):
     result = asyncio.run(achievements.refresh_achievements(harness.bot))
 
     assert result.status == "success"
-    assert result.message_ids == (55, 56)
+    assert result.message_ids == (55, 56, 57)
     assert harness.channel.sent == []
-    assert len(harness.channel.messages[55].edits) == 1
-    assert len(harness.channel.messages[56].edits) == 1
-    assert len(harness.channel.messages[55].edits[0]["attachments"]) == 1
-    assert len(harness.channel.messages[56].edits[0]["attachments"]) == 1
-    assert "files" not in harness.channel.messages[55].edits[0]
-    assert "files" not in harness.channel.messages[56].edits[0]
+    for message_id in (55, 56, 57):
+        assert len(harness.channel.messages[message_id].edits) == 1
+        edit = harness.channel.messages[message_id].edits[0]
+        assert len(edit["attachments"]) == 1
+        assert "files" not in edit
+    assert (
+        harness.channel.messages[55]
+        .edits[0]["content"]
+        .startswith("# Achievements\n-# Last updated ")
+    )
+    assert harness.channel.messages[56].edits[0]["content"] == ""
+    assert harness.channel.messages[57].edits[0]["content"] == ""
 
 
-def test_refresh_missing_message_id_tells_admin_to_publish(harness):
+def test_refresh_blank_message_id_tells_admin_to_publish(harness):
     harness.config["achievement_post_message_id_1"] = ""
 
     with pytest.raises(achievements.AchievementsConfigError) as exc:
         asyncio.run(achievements.refresh_achievements(harness.bot))
 
     assert "Run !achievements publish" in str(exc.value)
+    assert harness.channel.sent == []
+
+
+def test_refresh_missing_message_id_config_row_fails_clearly(harness):
+    del harness.config["achievement_post_message_id_3"]
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.refresh_achievements(harness.bot))
+
+    assert "achievement_post_message_id_3" in str(exc.value)
     assert harness.channel.sent == []
 
 
@@ -156,6 +218,15 @@ def test_refresh_invalid_existing_message_does_not_send(harness):
     assert result.status == "error"
     assert "Run !achievements publish" in result.message
     assert harness.channel.sent == []
+
+
+def test_range_count_must_be_positive_integer(harness):
+    harness.config["achievement_range_count"] = "0"
+
+    with pytest.raises(achievements.AchievementsConfigError) as exc:
+        asyncio.run(achievements.publish_achievements(harness.bot))
+
+    assert "achievement_range_count must be a positive integer" in str(exc.value)
 
 
 def test_render_uses_one_page_export_options(monkeypatch, harness):
@@ -170,9 +241,10 @@ def test_render_uses_one_page_export_options(monkeypatch, harness):
 
     files = asyncio.run(achievements.render_achievement_files(config))
 
-    assert len(files) == 2
-    assert [call[1]["fit_range_to_one_page"] for call in calls] == [True, True]
-    assert [call[1]["fail_on_multi_page"] for call in calls] == [True, True]
+    assert len(files) == 3
+    assert [call[1]["fit_range_to_one_page"] for call in calls] == [True, True, True]
+    assert [call[1]["fail_on_multi_page"] for call in calls] == [True, True, True]
+    assert [call[1]["crop_to_content"] for call in calls] == [True, True, True]
 
 
 def test_multi_page_export_fails_clearly(monkeypatch, harness):


### PR DESCRIPTION
### Motivation
- Allow the achievements feature to be driven entirely by sheet Config so the number and ranges of achievement images are not hardcoded. 
- Replace brittle fixed keys/assumptions (two ranges, hardcoded message IDs and range names) with a contiguous, Config-controlled set of ranges. 
- Reduce message clutter by showing the Achievements title and last-updated timestamp only on the first posted/updated message.

### Description
- Reworked Config parsing to require `achievement_range_count` and to read contiguous `achievement_range_<n>` and `achievement_post_message_id_<n>` rows for `n` in `1..N`, with explicit validation for missing, blank, or invalid entries. 
- Rendering now iterates configured ranges in numeric order, preserves the existing export options (`fit_range_to_one_page=True`, `fail_on_multi_page=True`, `crop_to_content=True`), and uses deterministic filenames `achievements_<index>.png`. 
- `publish_achievements` posts exactly one message per configured range (in numeric order) and writes each created message ID back to the corresponding `achievement_post_message_id_<n>` Config key, while `refresh_achievements` fetches and edits the configured messages in place and never posts new messages. 
- Message content behavior changed so only the first message contains `# Achievements
-# Last updated YYYY-MM-DD HH:MM UTC` and all subsequent messages have empty content; this applies to both publish and refresh flows.

### Testing
- Ran the updated unit tests with `pytest -q tests/test_achievements.py` and they passed. 
- Tests added/updated to cover at least 3 configured ranges, publish writeback of message IDs, refresh editing without posting, first-message-only content behavior, blank vs missing message ID validation, missing/blank range validation, and one-page export option enforcement. 
- No changes were made to gateway intents, OAuth scopes, permissions, or sheet ID environment variables as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541a68adb08323ba03ba68bcdb5e44)