### PR TITLE
Add Achievement Collector module and cog with scheduler, docs, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ docs/ops/.env.example
 - `ONBOARDING_SHEET_ID`
 - `REMINDER_SHEET_ID`
 - `MILESTONES_SHEET_ID`
+- `ACHIEVEMENTS_SHEET_ID`
 - *(other sheet IDs live in env.example — keep doc updates in sync with env.example when adding new sheets)*
 
 **Logging / Telemetry (ENV var names — exact):**
@@ -66,7 +67,7 @@ docs/ops/.env.example
 - `GSPREAD_CREDENTIALS`
 
 **Access**
-- Read/Write: recruitment/config/milestones/reminders (sheet IDs above)
+- Read/Write: recruitment/config/milestones/reminders and read achievement definitions (sheet IDs above)
 - Principle: No hard-coded tab names; resolve tab names and IDs from your Sheet Config tabs.
 
 ---

--- a/cogs/housekeeping_achievement_collector.py
+++ b/cogs/housekeeping_achievement_collector.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.housekeeping.achievement_collector import (
+    AchievementCollectorError,
+    AchievementCollectorScheduler,
+    LeaderboardCache,
+    build_leaderboard,
+    effective_limit,
+    leaderboard_embed,
+    rank_embed,
+    resolve_config,
+    resolve_messageable,
+)
+
+log = logging.getLogger("c1c.housekeeping.achievement_collector.cog")
+_ALLOWED_NONE = discord.AllowedMentions.none()
+
+
+def _error_embed(message: str) -> discord.Embed:
+    return discord.Embed(title="Achievement Collector", description=message, colour=discord.Colour.red())
+
+
+class AchievementCollectorCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._cache: LeaderboardCache | None = None
+        self._scheduler = AchievementCollectorScheduler(self)
+
+    async def cog_load(self) -> None:
+        self._scheduler.start()
+
+    async def cog_unload(self) -> None:
+        self._scheduler.cancel()
+
+    async def cog_command_error(self, ctx: commands.Context, error: Exception) -> None:
+        if isinstance(error, commands.BadArgument):
+            await ctx.send(embed=_error_embed("Limit must be a positive integer."), allowed_mentions=_ALLOWED_NONE)
+            return
+        raise error
+
+    async def _get_or_build_cache(self, guild: discord.Guild) -> LeaderboardCache:
+        if self._cache is not None and self._cache.guild_id == guild.id:
+            return self._cache
+        config = await resolve_config()
+        self._cache = await build_leaderboard(guild, config)
+        return self._cache
+
+    async def _rebuild(self, guild: discord.Guild) -> tuple[object, LeaderboardCache]:
+        config = await resolve_config()
+        cache = await build_leaderboard(guild, config)
+        self._cache = cache
+        return config, cache
+
+    async def publish_scheduled(self, config=None) -> None:
+        guilds = list(getattr(self.bot, "guilds", []) or [])
+        if not guilds:
+            log.warning("achievement collector scheduled post skipped; no guilds")
+            return
+        guild = guilds[0]
+        if config is None:
+            config = await resolve_config()
+        cache = await build_leaderboard(guild, config)
+        self._cache = cache
+        channel = await resolve_messageable(self.bot, config.channel_id)
+        if channel is None:
+            raise AchievementCollectorError("Invalid achievement_collector_channel_id.")
+        await channel.send(embed=leaderboard_embed(cache, config.default_limit), allowed_mentions=_ALLOWED_NONE)
+
+    @tier("public")
+    @help_metadata(function_group="community", section="achievements", access_tier="public")
+    @commands.group(name="achievementcollector", invoke_without_command=True, help="Achievement Collector leaderboard.")
+    async def achievementcollector_group(self, ctx: commands.Context) -> None:
+        if ctx.invoked_subcommand is None:
+            await ctx.send(embed=_error_embed('Use "!achievementcollector preview", "publish", or "rank".'), allowed_mentions=_ALLOWED_NONE)
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="achievements", access_tier="admin")
+    @achievementcollector_group.command(name="preview")
+    @admin_only()
+    async def preview(self, ctx: commands.Context, limit: int | None = None) -> None:
+        if ctx.guild is None:
+            await ctx.send(embed=_error_embed("This command can only be used in a server."), allowed_mentions=_ALLOWED_NONE)
+            return
+        try:
+            config, cache = await self._rebuild(ctx.guild)
+            resolved_limit = effective_limit(limit, config)  # type: ignore[arg-type]
+        except AchievementCollectorError as exc:
+            await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
+            return
+        except Exception:
+            log.exception("achievement collector preview failed")
+            await ctx.send(embed=_error_embed("Achievement Collector preview failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
+            return
+        await ctx.send(embed=leaderboard_embed(cache, resolved_limit, preview=True), allowed_mentions=_ALLOWED_NONE)
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="achievements", access_tier="admin")
+    @achievementcollector_group.command(name="publish")
+    @admin_only()
+    async def publish(self, ctx: commands.Context, limit: int | None = None) -> None:
+        if ctx.guild is None:
+            await ctx.send(embed=_error_embed("This command can only be used in a server."), allowed_mentions=_ALLOWED_NONE)
+            return
+        try:
+            config, cache = await self._rebuild(ctx.guild)
+            resolved_limit = effective_limit(limit, config)  # type: ignore[arg-type]
+            channel = await resolve_messageable(self.bot, config.channel_id)  # type: ignore[attr-defined]
+            if channel is None:
+                raise AchievementCollectorError("Invalid achievement_collector_channel_id.")
+            await channel.send(embed=leaderboard_embed(cache, resolved_limit), allowed_mentions=_ALLOWED_NONE)
+        except AchievementCollectorError as exc:
+            await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
+            return
+        except Exception:
+            log.exception("achievement collector publish failed")
+            await ctx.send(embed=_error_embed("Achievement Collector publish failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
+            return
+        await ctx.send(embed=discord.Embed(title="Achievement Collector", description="Published Achievement Collectors leaderboard.", colour=discord.Colour.green()), allowed_mentions=_ALLOWED_NONE)
+
+    @tier("public")
+    @help_metadata(function_group="community", section="achievements", access_tier="public")
+    @achievementcollector_group.command(name="rank")
+    async def rank(self, ctx: commands.Context, member: discord.Member | None = None) -> None:
+        if ctx.guild is None:
+            await ctx.send(embed=_error_embed("This command can only be used in a server."), allowed_mentions=_ALLOWED_NONE)
+            return
+        target = member or ctx.author
+        try:
+            cache = await self._get_or_build_cache(ctx.guild)
+        except AchievementCollectorError as exc:
+            await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
+            return
+        except Exception:
+            log.exception("achievement collector rank failed")
+            await ctx.send(embed=_error_embed("Achievement Collector rank failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
+            return
+        await ctx.send(embed=rank_embed(target, cache), allowed_mentions=_ALLOWED_NONE)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AchievementCollectorCog(bot))

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -55,6 +55,9 @@ REMINDER_SHEET_ID=
 # Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific).
 MILESTONES_SHEET_ID=
 
+# Google Sheet ID for achievement definitions used by Achievement Collector roles.
+ACHIEVEMENTS_SHEET_ID=
+
 # Worksheet name containing recruitment config (default: Config).
 RECRUITMENT_CONFIG_TAB=
 

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -61,6 +61,7 @@ Missing any **Required** key causes the bot to exit with an error at startup. If
 | `ONBOARDING_SHEET_ID` | string | — | Google Sheet ID for onboarding trackers. |
 | `REMINDER_SHEET_ID` | string | — | Google Sheet ID for reminders (service-specific). |
 | `MILESTONES_SHEET_ID` | string | — | Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific). |
+| `ACHIEVEMENTS_SHEET_ID` | string | — | Google Sheet ID for achievement definitions used by the Achievement Collector role source. |
 | `MILESTONES_CONFIG_TAB` | string | required | Deployment checklist: set `MILESTONES_CONFIG_TAB=Config` in Render for prod before deploy if it is not already configured. |
 | `RECRUITMENT_CONFIG_TAB` | string | `Config` | Worksheet name containing recruitment config. |
 | `ONBOARDING_CONFIG_TAB` | string | `Config` | Worksheet name containing onboarding config. |
@@ -123,6 +124,19 @@ sync modules remain available for non-async scripts and cache warmers.
 | `LEAGUE_ADMIN_IDS` | csv | — | Discord user IDs allowed to confirm Wednesday reminders via 👍 and to trigger manual posts. |
 | `LEAGUES_REMINDER_MONDAY_UTC` | HH:MM | `13:00` | UTC time for the Monday reminder asking admins to update the Leagues sheet. |
 | `LEAGUES_REMINDER_WEDNESDAY_UTC` | HH:MM | `13:00` | UTC time for the Wednesday reminder + reaction check that triggers posting. |
+
+
+### Achievement Collector Config keys
+
+The Achievement Collector reads its role definitions from `ACHIEVEMENTS_SHEET_ID`, but these scheduling and display keys live in the existing Woadkeeper Config sheet:
+
+- `achievement_collector_channel_id` — Discord channel/thread ID for published and scheduled leaderboard posts.
+- `achievement_collector_default_limit` — default number of leaderboard rows when no command limit is supplied.
+- `achievement_collector_max_limit` — maximum allowed leaderboard rows; command limits are capped to this value.
+- `achievement_collector_min_count` — minimum counted active achievement roles required to appear on the leaderboard.
+- `achievement_collector_schedule_rrule` — iCalendar RRULE syntax used to compute monthly scheduled posts.
+- `achievement_collector_schedule_time_utc` — `HH:MM` UTC time applied to scheduled posts.
+- `achievement_collector_roles_tab` — tab name in the achievement definitions sheet containing dynamic `role_id` and `Active` headers.
 
 ### Runtime flags
 | Key | Type | Default | Notes |

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1216,6 +1216,7 @@ class Runtime:
         from cogs import app_admin
         from cogs import housekeeping_mirralith
         from cogs import housekeeping_achievements
+        from cogs import housekeeping_achievement_collector
         from cogs import housekeeping_c1c_ad
         from cogs import recruitment_clan_ads
         from modules.housekeeping import cleanup as housekeeping_cleanup_commands
@@ -1257,6 +1258,9 @@ class Runtime:
 
         await housekeeping_achievements.setup(self.bot)
         log.info("modules: achievements command registered")
+
+        await housekeeping_achievement_collector.setup(self.bot)
+        log.info("modules: achievement_collector command registered")
 
         await housekeeping_c1c_ad.setup(self.bot)
         log.info("modules: c1c_ad command registered")

--- a/modules/housekeeping/achievement_collector.py
+++ b/modules/housekeeping/achievement_collector.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import discord
+from modules.common.embeds import get_embed_colour
+from shared.sheets import async_core, recruitment
+
+log = logging.getLogger("c1c.housekeeping.achievement_collector")
+
+CONFIG_KEYS: tuple[str, ...] = (
+    "achievement_collector_channel_id",
+    "achievement_collector_default_limit",
+    "achievement_collector_max_limit",
+    "achievement_collector_min_count",
+    "achievement_collector_schedule_rrule",
+    "achievement_collector_schedule_time_utc",
+    "achievement_collector_roles_tab",
+)
+LEADERBOARD_INTRO = "The shiny badges have been counted. Some of you are getting alarmingly shiny:"
+RANK_FOOTER = "Want to snoop on another rank? Use !achievementcollector rank @member"
+PREVIEW_FOOTER = "Preview only. Use !achievementcollector publish to send this to the configured channel."
+
+
+class AchievementCollectorError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AchievementCollectorConfig:
+    channel_id: int
+    default_limit: int
+    max_limit: int
+    min_count: int
+    schedule_rrule: str
+    schedule_time_utc: str
+    roles_tab: str
+
+
+@dataclass(frozen=True, slots=True)
+class LeaderboardEntry:
+    member_id: int
+    mention: str
+    display_name: str
+    count: int
+    rank: int
+
+
+@dataclass(frozen=True, slots=True)
+class LeaderboardCache:
+    guild_id: int
+    built_at: dt.datetime
+    entries: tuple[LeaderboardEntry, ...]
+    counts: Mapping[int, int]
+
+
+def _normalize_header(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def _cell(row: list[Any], idx: int) -> str:
+    if idx < 0 or idx >= len(row):
+        return ""
+    return str(row[idx] or "").strip()
+
+
+async def _config_value(key: str) -> str:
+    value = await recruitment.get_config_value_async(key)
+    if value is None or not str(value).strip():
+        raise AchievementCollectorError(f"Missing required Config key(s): {key}")
+    return str(value).strip()
+
+
+def _parse_int(value: str, key: str, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise AchievementCollectorError(f"Config key {key} must be an integer.") from exc
+    if parsed < minimum:
+        raise AchievementCollectorError(f"Config key {key} must be >= {minimum}.")
+    return parsed
+
+
+async def resolve_config() -> AchievementCollectorConfig:
+    values = {key: await _config_value(key) for key in CONFIG_KEYS}
+    channel_id = _parse_int(values["achievement_collector_channel_id"], "achievement_collector_channel_id", minimum=1)
+    default_limit = _parse_int(values["achievement_collector_default_limit"], "achievement_collector_default_limit", minimum=1)
+    max_limit = _parse_int(values["achievement_collector_max_limit"], "achievement_collector_max_limit", minimum=1)
+    min_count = _parse_int(values["achievement_collector_min_count"], "achievement_collector_min_count", minimum=0)
+    if default_limit > max_limit:
+        raise AchievementCollectorError("Config key achievement_collector_default_limit must not exceed achievement_collector_max_limit.")
+    parse_schedule(values["achievement_collector_schedule_rrule"], values["achievement_collector_schedule_time_utc"])
+    return AchievementCollectorConfig(channel_id, default_limit, max_limit, min_count, values["achievement_collector_schedule_rrule"], values["achievement_collector_schedule_time_utc"], values["achievement_collector_roles_tab"])
+
+
+def parse_schedule(rrule_text: str, time_utc: str, *, now: dt.datetime | None = None) -> dt.datetime:
+    try:
+        hour_text, minute_text = str(time_utc).strip().split(":", 1)
+        hour, minute = int(hour_text), int(minute_text)
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError
+    except ValueError as exc:
+        raise AchievementCollectorError("Config key achievement_collector_schedule_time_utc must use HH:MM UTC format.") from exc
+    base = (now or dt.datetime.now(dt.timezone.utc)).astimezone(dt.timezone.utc)
+    dtstart = base.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    try:
+        rule_text = str(rrule_text).strip()
+        if rule_text.upper().startswith("RRULE:"):
+            rule_text = rule_text.split(":", 1)[1]
+        parts = dict(part.split("=", 1) for part in rule_text.split(";") if part)
+    except ValueError as exc:
+        raise AchievementCollectorError("Config key achievement_collector_schedule_rrule must be valid iCalendar RRULE syntax.") from exc
+    freq = parts.get("FREQ", "").upper()
+    if freq not in {"MONTHLY", "WEEKLY", "DAILY"}:
+        raise AchievementCollectorError("Config key achievement_collector_schedule_rrule must be valid iCalendar RRULE syntax.")
+
+    def candidate_for(month_offset: int = 0, day: int | None = None) -> dt.datetime:
+        year = base.year + ((base.month - 1 + month_offset) // 12)
+        month = ((base.month - 1 + month_offset) % 12) + 1
+        use_day = day if day is not None else base.day
+        return dt.datetime(year, month, use_day, hour, minute, tzinfo=dt.timezone.utc)
+
+    if freq == "DAILY":
+        cand = dtstart
+        return cand if cand >= base else cand + dt.timedelta(days=1)
+    if freq == "WEEKLY":
+        byday = parts.get("BYDAY", "").upper()
+        weekdays = {"MO": 0, "TU": 1, "WE": 2, "TH": 3, "FR": 4, "SA": 5, "SU": 6}
+        wanted = weekdays.get(byday, base.weekday()) if byday else base.weekday()
+        days = (wanted - base.weekday()) % 7
+        cand = base.replace(hour=hour, minute=minute, second=0, microsecond=0) + dt.timedelta(days=days)
+        return cand if cand >= base else cand + dt.timedelta(days=7)
+    # MONTHLY supports the deployed rule
+    # FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1 (first Monday of the month) plus
+    # BYMONTHDAY for simpler monthly day-of-month schedules.
+    weekdays = {"MO": 0, "TU": 1, "WE": 2, "TH": 3, "FR": 4, "SA": 5, "SU": 6}
+
+    def monthly_byday_candidate(month_offset: int, weekday: int, setpos: int) -> dt.datetime:
+        year = base.year + ((base.month - 1 + month_offset) // 12)
+        month = ((base.month - 1 + month_offset) % 12) + 1
+        first = dt.datetime(year, month, 1, hour, minute, tzinfo=dt.timezone.utc)
+        if setpos > 0:
+            delta_days = (weekday - first.weekday()) % 7
+            day = 1 + delta_days + ((setpos - 1) * 7)
+        else:
+            if month == 12:
+                next_month = dt.datetime(year + 1, 1, 1, hour, minute, tzinfo=dt.timezone.utc)
+            else:
+                next_month = dt.datetime(year, month + 1, 1, hour, minute, tzinfo=dt.timezone.utc)
+            last = next_month - dt.timedelta(days=1)
+            delta_days = (last.weekday() - weekday) % 7
+            day = last.day - delta_days + ((setpos + 1) * 7)
+        return dt.datetime(year, month, day, hour, minute, tzinfo=dt.timezone.utc)
+
+    try:
+        if "BYDAY" in parts:
+            byday = parts["BYDAY"].upper()
+            if "," in byday or byday not in weekdays:
+                raise ValueError
+            setpos = int(parts.get("BYSETPOS", "1"))
+            if setpos == 0:
+                raise ValueError
+            for offset in range(0, 24):
+                try:
+                    cand = monthly_byday_candidate(offset, weekdays[byday], setpos)
+                except ValueError:
+                    continue
+                if cand >= base:
+                    return cand
+        else:
+            day = int(parts.get("BYMONTHDAY", "1"))
+            if not 1 <= day <= 31:
+                raise ValueError
+            for offset in range(0, 24):
+                try:
+                    cand = candidate_for(offset, day)
+                except ValueError:
+                    continue
+                if cand >= base:
+                    return cand
+    except ValueError as exc:
+        raise AchievementCollectorError("Config key achievement_collector_schedule_rrule must be valid iCalendar RRULE syntax.") from exc
+    raise AchievementCollectorError("Config key achievement_collector_schedule_rrule produced no future runs.")
+
+
+def effective_limit(raw_limit: int | None, config: AchievementCollectorConfig) -> int:
+    if raw_limit is None:
+        return config.default_limit
+    if raw_limit <= 0:
+        raise AchievementCollectorError("Limit must be a positive integer.")
+    return min(raw_limit, config.max_limit)
+
+
+async def load_active_role_ids(config: AchievementCollectorConfig) -> set[int]:
+    sheet_id = os.getenv("ACHIEVEMENTS_SHEET_ID", "").strip()
+    if not sheet_id:
+        raise AchievementCollectorError("Missing ACHIEVEMENTS_SHEET_ID.")
+    matrix = await async_core.afetch_values(sheet_id, config.roles_tab)
+    if not matrix:
+        raise AchievementCollectorError("Achievement roles worksheet is empty.")
+    headers = {_normalize_header(value): idx for idx, value in enumerate(matrix[0]) if _normalize_header(value)}
+    missing = [name for name in ("role_id", "active") if name not in headers]
+    if missing:
+        raise AchievementCollectorError("Achievement roles worksheet missing required header(s): " + ", ".join("Active" if m == "active" else m for m in missing))
+    role_col = headers["role_id"]
+    active_col = headers["active"]
+    role_ids: set[int] = set()
+    for row in matrix[1:]:
+        role_value = _cell(row, role_col)
+        if not role_value:
+            continue
+        if _cell(row, active_col).lower() != "true":
+            continue
+        try:
+            role_ids.add(int(role_value))
+        except ValueError:
+            log.warning("achievement collector stale/invalid role_id ignored", extra={"role_id": role_value})
+    return role_ids
+
+
+async def build_leaderboard(guild: discord.Guild, config: AchievementCollectorConfig) -> LeaderboardCache:
+    active_role_ids = await load_active_role_ids(config)
+    existing_role_ids: set[int] = set()
+    for role_id in active_role_ids:
+        if guild.get_role(role_id) is None:
+            log.warning("achievement collector stale/deleted role ignored", extra={"guild_id": guild.id, "role_id": role_id})
+            continue
+        existing_role_ids.add(role_id)
+
+    rows: list[tuple[str, int, str, int]] = []
+    counts: dict[int, int] = {}
+    for member in getattr(guild, "members", []) or []:
+        if getattr(member, "bot", False):
+            continue
+        count = sum(1 for role in getattr(member, "roles", []) if getattr(role, "id", None) in existing_role_ids)
+        counts[int(member.id)] = count
+        if count >= config.min_count:
+            rows.append((str(getattr(member, "display_name", "")), int(member.id), str(member.mention), count))
+    rows.sort(key=lambda row: (-row[3], row[0].lower()))
+    entries = tuple(LeaderboardEntry(member_id, mention, display_name, count, idx) for idx, (display_name, member_id, mention, count) in enumerate(rows, start=1))
+    return LeaderboardCache(guild.id, dt.datetime.now(dt.timezone.utc), entries, counts)
+
+
+def _achievements_word(count: int) -> str:
+    return "achievement" if count == 1 else "achievements"
+
+
+def leaderboard_embed(cache: LeaderboardCache, limit: int, *, preview: bool = False) -> discord.Embed:
+    title = "Achievement Collectors Preview" if preview else "Achievement Collectors"
+    if not cache.entries:
+        embed = discord.Embed(title="Achievement Collectors", description="No achievement collectors found yet. Suspiciously unshiny.", colour=get_embed_colour("community"))
+        embed.set_footer(text=RANK_FOOTER)
+        return embed
+    lines = [LEADERBOARD_INTRO, ""]
+    for entry in cache.entries[:limit]:
+        lines.append(f"{entry.rank}. {entry.mention} - {entry.count} {_achievements_word(entry.count)}")
+    embed = discord.Embed(title=title, description="\n".join(lines), colour=get_embed_colour("community"))
+    embed.set_footer(text=PREVIEW_FOOTER if preview else RANK_FOOTER)
+    return embed
+
+
+def rank_embed(member: discord.Member, cache: LeaderboardCache) -> discord.Embed:
+    entry = next((item for item in cache.entries if item.member_id == member.id), None)
+    count = int(cache.counts.get(member.id, 0))
+    mention = member.mention
+    if count == 0:
+        desc = f"{mention} has no counted achievements yet. Tragic. Fixable. Go collect shiny things."
+    elif count == 1:
+        desc = f"{mention} has 1 achievement. The collection has begun. Someone hide the shiny things."
+    elif entry is None:
+        desc = f"{mention} has {count} achievements. The hoard is growing, but not enough to make the board yet."
+    elif entry.rank == 1:
+        desc = f"{mention} is sitting at rank #1 with {count} achievements. Disgustingly shiny. Respectfully."
+    elif entry.rank in (2, 3):
+        desc = f"{mention} has {count} achievements and is rank #{entry.rank}. Dangerously shiny behaviour."
+    elif 4 <= entry.rank <= 10:
+        desc = f"{mention} is rank #{entry.rank} with {count} achievements. Not the throne, but definitely in the shiny danger zone."
+    else:
+        desc = f"{mention} has {count} achievements and is rank #{entry.rank}. The hoard is growing. Slowly. Suspiciously."
+    embed = discord.Embed(title="Achievement Collector Rank", description=desc, colour=get_embed_colour("community"))
+    embed.set_footer(text=RANK_FOOTER)
+    return embed
+
+
+async def resolve_messageable(bot: discord.Client, channel_id: int) -> Any | None:
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(channel_id)  # type: ignore[attr-defined]
+        except Exception:
+            return None
+    return channel if hasattr(channel, "send") else None
+
+
+class AchievementCollectorScheduler:
+    def __init__(self, cog: Any) -> None:
+        self.cog = cog
+        self.task: asyncio.Task[None] | None = None
+        self.last_post_key: str | None = None
+
+    def start(self) -> None:
+        if self.task is None or self.task.done():
+            self.task = asyncio.create_task(self._run(), name="achievement_collector_scheduler")
+
+    def cancel(self) -> None:
+        if self.task is not None:
+            self.task.cancel()
+
+    async def _run(self) -> None:
+        await self.cog.bot.wait_until_ready()
+        while not self.cog.bot.is_closed():
+            try:
+                config = await resolve_config()
+                next_run = parse_schedule(config.schedule_rrule, config.schedule_time_utc)
+                await asyncio.sleep(max(0.0, (next_run - dt.datetime.now(dt.timezone.utc)).total_seconds()))
+                post_key = next_run.strftime("%Y-%m-%dT%H:%MZ")
+                if post_key != self.last_post_key:
+                    self.last_post_key = post_key
+                    await self.cog.publish_scheduled(config)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("achievement collector scheduler failed; retrying after backoff")
+                await asyncio.sleep(3600)
+
+
+__all__ = [
+    "AchievementCollectorConfig", "AchievementCollectorError", "LeaderboardCache", "LeaderboardEntry",
+    "build_leaderboard", "effective_limit", "leaderboard_embed", "load_active_role_ids", "parse_schedule",
+    "rank_embed", "resolve_config", "resolve_messageable", "AchievementCollectorScheduler",
+]

--- a/tests/cogs/test_achievement_collector.py
+++ b/tests/cogs/test_achievement_collector.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.housekeeping_achievement_collector import AchievementCollectorCog
+from modules.housekeeping import achievement_collector as ac
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class Role:
+    def __init__(self, id): self.id = id
+
+class Member:
+    def __init__(self, id, name, roles=(), bot=False):
+        self.id = id; self.display_name = name; self.roles = list(roles); self.bot = bot; self.mention = f"<@{id}>"
+
+class Guild:
+    id = 123
+    def __init__(self, roles, members):
+        self._roles = {r.id: r for r in roles}; self.members = members
+    def get_role(self, rid): return self._roles.get(rid)
+
+class Channel:
+    def __init__(self): self.sent=[]
+    async def send(self, **kwargs): self.sent.append(kwargs); return SimpleNamespace(id=42)
+
+class Ctx:
+    def __init__(self, guild, author, channel): self.guild=guild; self.author=author; self.channel=channel; self.sent=[]
+    async def send(self, **kwargs): self.sent.append(kwargs); return SimpleNamespace(id=99)
+
+
+def cfg(**overrides):
+    base = dict(channel_id=555, default_limit=5, max_limit=10, min_count=1, schedule_rrule="FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1", schedule_time_utc="09:30", roles_tab="Roles")
+    base.update(overrides)
+    return ac.AchievementCollectorConfig(**base)
+
+
+def test_missing_achievements_sheet_id_fails(monkeypatch):
+    monkeypatch.delenv("ACHIEVEMENTS_SHEET_ID", raising=False)
+    with pytest.raises(ac.AchievementCollectorError, match="Missing ACHIEVEMENTS_SHEET_ID"):
+        run(ac.load_active_role_ids(cfg()))
+
+
+def test_missing_config_key_fails(monkeypatch):
+    async def fake(key): return None if key == "achievement_collector_roles_tab" else "1"
+    monkeypatch.setattr(ac.recruitment, "get_config_value_async", fake)
+    with pytest.raises(ac.AchievementCollectorError, match="achievement_collector_roles_tab"):
+        run(ac.resolve_config())
+
+
+@pytest.mark.parametrize("key,value", [
+    ("achievement_collector_default_limit", "x"),
+    ("achievement_collector_max_limit", "x"),
+    ("achievement_collector_min_count", "x"),
+])
+def test_invalid_integer_config_fails(monkeypatch, key, value):
+    values = {
+        "achievement_collector_channel_id":"1", "achievement_collector_default_limit":"5", "achievement_collector_max_limit":"10", "achievement_collector_min_count":"1",
+        "achievement_collector_schedule_rrule":"FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1", "achievement_collector_schedule_time_utc":"09:30", "achievement_collector_roles_tab":"Roles",
+    }
+    values[key] = value
+    async def fake(k): return values[k]
+    monkeypatch.setattr(ac.recruitment, "get_config_value_async", fake)
+    with pytest.raises(ac.AchievementCollectorError, match=key): run(ac.resolve_config())
+
+
+def test_dynamic_headers_active_true_blank_and_inactive_ignored(monkeypatch):
+    monkeypatch.setenv("ACHIEVEMENTS_SHEET_ID", "sheet")
+    async def fake_values(sheet_id, tab):
+        return [["Other", "Active", "role_id"], ["", "TRUE", "101"], ["", "true", "102"], ["", "False", "103"], ["", "TRUE", ""], ["", "yes", "104"]]
+    monkeypatch.setattr(ac.async_core, "afetch_values", fake_values)
+    assert run(ac.load_active_role_ids(cfg())) == {101, 102}
+
+
+def test_missing_headers_fail(monkeypatch):
+    monkeypatch.setenv("ACHIEVEMENTS_SHEET_ID", "sheet")
+    async def fake_values(sheet_id, tab): return [["role_id", "Enabled"]]
+    monkeypatch.setattr(ac.async_core, "afetch_values", fake_values)
+    with pytest.raises(ac.AchievementCollectorError, match="Active"):
+        run(ac.load_active_role_ids(cfg()))
+
+
+def test_stale_roles_bots_min_count_and_sorting(monkeypatch):
+    async def fake_roles(config): return {1, 2, 999}
+    monkeypatch.setattr(ac, "load_active_role_ids", fake_roles)
+    r1, r2, stale = Role(1), Role(2), Role(999)
+    guild = Guild([r1, r2], [Member(1,"Zed",[r1,r2]), Member(2,"Amy",[r1,r2]), Member(3,"Low",[r1]), Member(4,"Bot",[r1,r2], bot=True), Member(5,"Stale",[stale])])
+    cache = run(ac.build_leaderboard(guild, cfg(min_count=2)))
+    assert [(e.display_name, e.count, e.rank) for e in cache.entries] == [("Amy",2,1),("Zed",2,2)]
+    assert 4 not in cache.counts
+
+
+def test_effective_limit_default_override_cap_and_invalid():
+    c = cfg(default_limit=7, max_limit=10)
+    assert ac.effective_limit(None, c) == 7
+    assert ac.effective_limit(3, c) == 3
+    assert ac.effective_limit(99, c) == 10
+    with pytest.raises(ac.AchievementCollectorError): ac.effective_limit(0, c)
+
+
+def test_leaderboard_and_rank_embeds_and_allowed_copy_branches():
+    entries = tuple(ac.LeaderboardEntry(i, f"<@{i}>", f"U{i:02}", count, i) for i, count in enumerate([11,10,9,8,7,6,5,4,3,2,2], start=1))
+    entries = entries + (ac.LeaderboardEntry(20, "<@20>", "One", 1, 12),)
+    counts = {e.member_id:e.count for e in entries} | {21:0}
+    cache = ac.LeaderboardCache(1, dt.datetime.now(dt.timezone.utc), entries, counts)
+    emb = ac.leaderboard_embed(cache, 2)
+    assert emb.title == "Achievement Collectors" and emb.description.startswith(ac.LEADERBOARD_INTRO)
+    assert "1. <@1> - 11 achievements" in emb.description
+    assert ac.rank_embed(Member(1,"",[]), cache).description == "<@1> is sitting at rank #1 with 11 achievements. Disgustingly shiny. Respectfully."
+    assert "Dangerously shiny" in ac.rank_embed(Member(2,"",[]), cache).description
+    assert "shiny danger zone" in ac.rank_embed(Member(4,"",[]), cache).description
+    assert "hoard is growing" in ac.rank_embed(Member(11,"",[]), cache).description
+    assert "collection has begun" in ac.rank_embed(Member(20,"",[]), cache).description
+    assert "no counted achievements" in ac.rank_embed(Member(21,"",[]), cache).description
+
+
+
+def test_rank_embed_handles_count_above_one_below_min_count_without_rank():
+    cache = ac.LeaderboardCache(
+        1,
+        dt.datetime.now(dt.timezone.utc),
+        (),
+        {30: 2},
+    )
+
+    embed = ac.rank_embed(Member(30, "BelowMin", []), cache)
+
+    assert embed.description == "<@30> has 2 achievements. The hoard is growing, but not enough to make the board yet."
+
+def test_empty_leaderboard_embed():
+    cache = ac.LeaderboardCache(1, dt.datetime.now(dt.timezone.utc), (), {})
+    emb = ac.leaderboard_embed(cache, 10)
+    assert emb.title == "Achievement Collectors"
+    assert emb.description == "No achievement collectors found yet. Suspiciously unshiny."
+
+
+def test_scheduler_config_parses_first_monday_before_due_time():
+    nxt = ac.parse_schedule(
+        "FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1",
+        "09:30",
+        now=dt.datetime(2026, 2, 1, 12, 0, tzinfo=dt.timezone.utc),
+    )
+    assert nxt == dt.datetime(2026, 2, 2, 9, 30, tzinfo=dt.timezone.utc)
+
+
+def test_scheduler_config_parses_first_monday_after_due_time():
+    nxt = ac.parse_schedule(
+        "FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1",
+        "09:30",
+        now=dt.datetime(2026, 2, 2, 9, 31, tzinfo=dt.timezone.utc),
+    )
+    assert nxt == dt.datetime(2026, 3, 2, 9, 30, tzinfo=dt.timezone.utc)
+
+
+def test_scheduler_config_invalid_rrule_and_time_fail():
+    with pytest.raises(ac.AchievementCollectorError): ac.parse_schedule("not rrule", "09:30")
+    with pytest.raises(ac.AchievementCollectorError): ac.parse_schedule("FREQ=MONTHLY", "25:99")
+
+
+def test_preview_publish_rank_routing_embeds_allowed_mentions_and_cache(monkeypatch):
+    r=Role(1); guild=Guild([r],[Member(1,"A",[r]), Member(2,"B",[])])
+    current=Channel(); publish_ch=Channel(); bot=SimpleNamespace(get_channel=lambda cid: publish_ch, fetch_channel=None, wait_until_ready=lambda: None, is_closed=lambda: True)
+    cog = AchievementCollectorCog(bot)
+    cog._scheduler.start = lambda: None
+    async def fake_config(): return cfg(channel_id=555, default_limit=5, max_limit=5, min_count=1)
+    builds = {"n":0}
+    async def fake_build(g, c):
+        builds["n"] += 1
+        return ac.LeaderboardCache(g.id, dt.datetime.now(dt.timezone.utc), (ac.LeaderboardEntry(1,"<@1>","A",1,1),), {1:1,2:0})
+    monkeypatch.setattr("cogs.housekeeping_achievement_collector.resolve_config", fake_config)
+    monkeypatch.setattr("cogs.housekeeping_achievement_collector.build_leaderboard", fake_build)
+    ctx=Ctx(guild,guild.members[0],current)
+    run(cog.preview.callback(cog, ctx, None))
+    assert ctx.sent[-1]["embed"].title == "Achievement Collectors Preview"
+    assert str(ctx.sent[-1]["allowed_mentions"]) == str(ac.discord.AllowedMentions.none())
+    run(cog.publish.callback(cog, ctx, 99))
+    assert publish_ch.sent[-1]["embed"].title == "Achievement Collectors"
+    run(cog.rank.callback(cog, ctx, None))
+    run(cog.rank.callback(cog, ctx, guild.members[1]))
+    assert "<@1>" in ctx.sent[-2]["embed"].description
+    assert "<@2>" in ctx.sent[-1]["embed"].description
+    assert builds["n"] == 2  # preview + publish; rank reused publish cache
+
+
+def test_command_access_gates():
+    assert any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.preview.checks)
+    assert any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.publish.checks)
+    assert not any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.rank.checks)


### PR DESCRIPTION
### Motivation
- Introduce an Achievement Collector feature that posts and previews leaderboards of members holding configured achievement roles and supports scheduled posts.
- Provide configuration and operational integration with existing Sheets-driven runtime and scheduling infrastructure.

### Description
- Add a new housekeeping module `modules/housekeeping/achievement_collector.py` implementing config resolution, sheet-driven role loading, leaderboard building, RRULE schedule parsing, message routing, and an async scheduler (`AchievementCollectorScheduler`).
- Add a new Cog `cogs/housekeeping_achievement_collector.py` exposing the `!achievementcollector` command group with `preview`, `publish`, and `rank` subcommands and integrating with the scheduler and existing RBAC/metadata decorators.
- Wire the cog into the bot startup by registering it in `modules/common/runtime.py` so the cog is loaded and its scheduler started on boot.
- Update operational docs and env examples to add the `ACHIEVEMENTS_SHEET_ID` env var and document new config keys used by the Achievement Collector in `docs/ops/.env.example`, `docs/ops/Config.md`, and `AGENTS.md`.
- Add comprehensive unit tests in `tests/cogs/test_achievement_collector.py` covering config parsing, sheet header parsing, leaderboard construction, embeds, schedule parsing, routing, and access checks.

### Testing
- Added unit tests in `tests/cogs/test_achievement_collector.py` that exercise config resolution, `load_active_role_ids`, `build_leaderboard`, `parse_schedule`, embed rendering, command behavior, and scheduler logic.
- Executed the new test suite with `pytest` for the added tests and confirmed the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ad657ea08323b3a4b4719277374a)