### PR TITLE
Fix achievement collector command failure reporting

### DIFF
--- a/cogs/housekeeping_achievement_collector.py
+++ b/cogs/housekeeping_achievement_collector.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 
 import discord
 from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
+from modules.common import runtime as runtime_helpers
 from modules.housekeeping.achievement_collector import (
     AchievementCollectorError,
     AchievementCollectorScheduler,
@@ -21,6 +24,24 @@ from modules.housekeeping.achievement_collector import (
 
 log = logging.getLogger("c1c.housekeeping.achievement_collector.cog")
 _ALLOWED_NONE = discord.AllowedMentions.none()
+
+
+_SENSITIVE_EXCEPTION_DETAIL_RE = re.compile(r"\b(sheet contents?|message content|credentials?|token)\s*:", re.IGNORECASE)
+
+
+def _short_exception_message(exc: BaseException) -> str:
+    message = " ".join(str(exc).split()) or "-"
+    sheet_id = os.getenv("ACHIEVEMENTS_SHEET_ID")
+    if sheet_id:
+        message = message.replace(sheet_id, "[redacted_sheet_id]")
+    sensitive_match = _SENSITIVE_EXCEPTION_DETAIL_RE.search(message)
+    if sensitive_match:
+        message = message[: sensitive_match.start()].rstrip(" -:;•") or "[redacted]"
+    return message[:180]
+
+
+def _context_id(obj: object, attr: str) -> int | None:
+    return getattr(getattr(obj, attr, None), "id", None)
 
 
 def _error_embed(message: str) -> discord.Embed:
@@ -44,6 +65,46 @@ class AchievementCollectorCog(commands.Cog):
             await ctx.send(embed=_error_embed("Limit must be a positive integer."), allowed_mentions=_ALLOWED_NONE)
             return
         raise error
+
+    async def _report_collector_failure(
+        self,
+        ctx: commands.Context,
+        command_name: str,
+        exc: BaseException,
+        *,
+        limit: int | None = None,
+        target_member: discord.Member | None = None,
+    ) -> None:
+        log.exception(
+            "achievement collector %s failed",
+            command_name,
+            extra={
+                "achievement_collector_command": command_name,
+                "guild_id": _context_id(ctx, "guild"),
+                "channel_id": _context_id(ctx, "channel"),
+                "actor_id": _context_id(ctx, "author"),
+                "provided_limit": limit,
+                "target_member_id": getattr(target_member, "id", None),
+                "exception_type": type(exc).__name__,
+            },
+        )
+        fields = [
+            "feature=achievement collector",
+            f"command={command_name}",
+            f"guild_id={_context_id(ctx, 'guild')}",
+            f"channel_id={_context_id(ctx, 'channel')}",
+            f"actor_id={_context_id(ctx, 'author')}",
+            f"exception_type={type(exc).__name__}",
+            f"exception={_short_exception_message(exc)}",
+        ]
+        if limit is not None:
+            fields.append(f"limit={limit}")
+        if target_member is not None:
+            fields.append(f"target_member_id={getattr(target_member, 'id', None)}")
+        try:
+            await runtime_helpers.send_log_message("❌ " + " • ".join(fields))
+        except Exception:
+            log.warning("failed to send achievement collector ops failure report", exc_info=True)
 
     async def _get_or_build_cache(self, guild: discord.Guild) -> LeaderboardCache:
         if self._cache is not None and self._cache.guild_id == guild.id:
@@ -92,10 +153,11 @@ class AchievementCollectorCog(commands.Cog):
             config, cache = await self._rebuild(ctx.guild)
             resolved_limit = effective_limit(limit, config)  # type: ignore[arg-type]
         except AchievementCollectorError as exc:
+            await self._report_collector_failure(ctx, "preview", exc, limit=limit)
             await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
             return
-        except Exception:
-            log.exception("achievement collector preview failed")
+        except Exception as exc:
+            await self._report_collector_failure(ctx, "preview", exc, limit=limit)
             await ctx.send(embed=_error_embed("Achievement Collector preview failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
             return
         await ctx.send(embed=leaderboard_embed(cache, resolved_limit, preview=True), allowed_mentions=_ALLOWED_NONE)
@@ -116,10 +178,11 @@ class AchievementCollectorCog(commands.Cog):
                 raise AchievementCollectorError("Invalid achievement_collector_channel_id.")
             await channel.send(embed=leaderboard_embed(cache, resolved_limit), allowed_mentions=_ALLOWED_NONE)
         except AchievementCollectorError as exc:
+            await self._report_collector_failure(ctx, "publish", exc, limit=limit)
             await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
             return
-        except Exception:
-            log.exception("achievement collector publish failed")
+        except Exception as exc:
+            await self._report_collector_failure(ctx, "publish", exc, limit=limit)
             await ctx.send(embed=_error_embed("Achievement Collector publish failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
             return
         await ctx.send(embed=discord.Embed(title="Achievement Collector", description="Published Achievement Collectors leaderboard.", colour=discord.Colour.green()), allowed_mentions=_ALLOWED_NONE)
@@ -135,10 +198,11 @@ class AchievementCollectorCog(commands.Cog):
         try:
             cache = await self._get_or_build_cache(ctx.guild)
         except AchievementCollectorError as exc:
+            await self._report_collector_failure(ctx, "rank", exc, target_member=member)
             await ctx.send(embed=_error_embed(str(exc)), allowed_mentions=_ALLOWED_NONE)
             return
-        except Exception:
-            log.exception("achievement collector rank failed")
+        except Exception as exc:
+            await self._report_collector_failure(ctx, "rank", exc, target_member=member)
             await ctx.send(embed=_error_embed("Achievement Collector rank failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
             return
         await ctx.send(embed=rank_embed(target, cache), allowed_mentions=_ALLOWED_NONE)

--- a/tests/cogs/test_achievement_collector.py
+++ b/tests/cogs/test_achievement_collector.py
@@ -194,3 +194,63 @@ def test_command_access_gates():
     assert any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.preview.checks)
     assert any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.publish.checks)
     assert not any(getattr(chk, "__qualname__", "").endswith("admin_only.<locals>.predicate") for chk in AchievementCollectorCog.rank.checks)
+
+@pytest.mark.parametrize("command_name,limit,target_member_id", [
+    ("preview", 7, None),
+    ("publish", 8, None),
+    ("rank", None, 2),
+])
+def test_collector_unexpected_exception_logs_traceback_and_ops_notification(monkeypatch, caplog, command_name, limit, target_member_id):
+    monkeypatch.setenv("ACHIEVEMENTS_SHEET_ID", "secret-sheet-id")
+    r = Role(1)
+    guild = Guild([r], [Member(1, "Actor", [r]), Member(2, "Target", [])])
+    guild.id = 456
+    current = Channel()
+    current.id = 789
+    bot = SimpleNamespace(get_channel=lambda cid: None, fetch_channel=None, wait_until_ready=lambda: None, is_closed=lambda: True)
+    cog = AchievementCollectorCog(bot)
+    ops_logs = []
+
+    async def fake_send_log_message(message):
+        ops_logs.append(message)
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("boom secret-sheet-id sheet contents: shiny row message content: !achievementcollector preview")
+
+    monkeypatch.setattr("cogs.housekeeping_achievement_collector.runtime_helpers.send_log_message", fake_send_log_message)
+    if command_name in {"preview", "publish"}:
+        monkeypatch.setattr(cog, "_rebuild", boom)
+    else:
+        monkeypatch.setattr(cog, "_get_or_build_cache", boom)
+
+    ctx = Ctx(guild, guild.members[0], current)
+    ctx.author.id = 1234
+    target = guild.members[1] if target_member_id is not None else None
+
+    with caplog.at_level("ERROR", logger="c1c.housekeeping.achievement_collector.cog"):
+        if command_name == "preview":
+            run(cog.preview.callback(cog, ctx, limit))
+        elif command_name == "publish":
+            run(cog.publish.callback(cog, ctx, limit))
+        else:
+            run(cog.rank.callback(cog, ctx, target))
+
+    record = next(rec for rec in caplog.records if rec.message == f"achievement collector {command_name} failed")
+    assert record.exc_info is not None
+    assert record.exc_info[0] is RuntimeError
+    assert ctx.sent[-1]["embed"].title == "Achievement Collector"
+    assert ops_logs
+    ops_message = ops_logs[-1]
+    assert "feature=achievement collector" in ops_message
+    assert f"command={command_name}" in ops_message
+    assert "guild_id=456" in ops_message
+    assert "channel_id=789" in ops_message
+    assert "actor_id=1234" in ops_message
+    assert "exception_type=RuntimeError" in ops_message
+    if limit is not None:
+        assert f"limit={limit}" in ops_message
+    if target_member_id is not None:
+        assert f"target_member_id={target_member_id}" in ops_message
+    assert "secret-sheet-id" not in ops_message
+    assert "shiny row" not in ops_message
+    assert "!achievementcollector preview" not in ops_message


### PR DESCRIPTION
### Motivation
- Achievement collector admin commands (`preview`, `publish`, `rank`) failed in prod without useful diagnostics because caught exceptions were not preserved in structured logs and no ops/log channel notification was sent.
- The goal is to make failures visible to ops while avoiding leaking sensitive sheet or message details.

### Description
- Add a shared reporter `_report_collector_failure` in `cogs/housekeeping_achievement_collector.py` that calls `log.exception(...)` with `extra` context and sends a concise ops notification via `modules.common.runtime.send_log_message`.
- Implement `_short_exception_message` to redact `ACHIEVEMENTS_SHEET_ID` and trim/remove sensitive details (matching `sheet contents`, `message content`, `credentials`, `token`) and truncate the text for ops messages.
- Route exception handlers in `preview`, `publish`, and `rank` to use `_report_collector_failure` for both `AchievementCollectorError` and unexpected exceptions while preserving the existing user-facing embedded failure responses.
- Add focused tests in `tests/cogs/test_achievement_collector.py` that assert traceback is retained in app logs, ops notifications include `feature`, `command`, `guild_id`, `channel_id`, `actor_id`, `exception_type` and optional `limit`/`target_member_id`, and that sensitive values/contents are excluded from ops messages.

### Testing
- Ran `pytest -q tests/cogs/test_achievement_collector.py` and the suite passed, including the new `test_collector_unexpected_exception_logs_traceback_and_ops_notification` cases.
- New tests validate both log traceback presence (`log.exception(...)`) and ops/log channel notification content and sanitization, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54c41df11083238b163648705f8dbb)