### PR TITLE
Gracefully handle panel refresh failures after saving traditional prep and add tests

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -1120,7 +1120,51 @@ class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
             await _send_ephemeral(interaction, "Couldn’t save champion preparation right now. Try again in a moment.")
             return
         self.panel_view.prep = prep
-        await _edit_traditional_prep_message(interaction, view=self.panel_view)
+        try:
+            await _edit_traditional_prep_message(interaction, view=self.panel_view)
+        except Exception as exc:
+            log.exception(
+                "fusion traditional prep post-save panel refresh failed",
+                extra={
+                    "fusion_id": self.panel_view.target.fusion_id,
+                    "user_id": self.panel_view.user_id,
+                    "response_done_after_failure": interaction.response.is_done(),
+                },
+                exc_info=True,
+            )
+            try:
+                await fusion_logs.send_ops_alert(
+                    component="traditional_prep",
+                    summary="post_save_refresh_failed",
+                    dedupe_key=f"fusion:traditional_prep:refresh:{self.panel_view.target.fusion_id}",
+                    error=exc,
+                    fields={"fusion_id": self.panel_view.target.fusion_id, "save_success": True},
+                )
+            except Exception:
+                log.exception(
+                    "fusion traditional prep post-save ops alert failed",
+                    extra={
+                        "fusion_id": self.panel_view.target.fusion_id,
+                        "user_id": self.panel_view.user_id,
+                        "save_success": True,
+                    },
+                    exc_info=True,
+                )
+            try:
+                await _send_ephemeral(
+                    interaction,
+                    "Champion preparation was saved, but I couldn’t refresh the panel. Reopen My Progress to see the latest values.",
+                )
+            except Exception:
+                log.exception(
+                    "fusion traditional prep post-save fallback notification failed",
+                    extra={
+                        "fusion_id": self.panel_view.target.fusion_id,
+                        "user_id": self.panel_view.user_id,
+                        "response_done_after_notification_failure": interaction.response.is_done(),
+                    },
+                    exc_info=True,
+                )
 
 async def _edit_traditional_prep_message(interaction: discord.Interaction, *, view: "TraditionalPrepPanelView") -> None:
     context = fusion_logs.interaction_context(interaction, custom_id=_FUSION_TRAD_PREP_UPDATE_CUSTOM_ID)
@@ -1130,15 +1174,15 @@ async def _edit_traditional_prep_message(interaction: discord.Interaction, *, vi
         "response_done_before_send": interaction.response.is_done(),
     })
     log.info("fusion traditional prep panel edit path selected", extra=context)
-    await _safe_defer_progress_interaction(interaction)
+    embed = view.build_embed()
+    if not interaction.response.is_done():
+        await interaction.response.edit_message(embed=embed, view=view)
+        return
     edit_original = getattr(interaction, "edit_original_response", None)
     if callable(edit_original):
-        await edit_original(embed=view.build_embed(), view=view)
+        await edit_original(embed=embed, view=view)
         return
-    if not interaction.response.is_done():
-        await interaction.response.edit_message(embed=view.build_embed(), view=view)
-        return
-    await interaction.followup.send(embed=view.build_embed(), view=view, ephemeral=True)
+    await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
 
 class FusionProgressPanelView(discord.ui.View):

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -808,14 +808,167 @@ def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
 
         await modal.on_submit(interaction)
 
-        interaction.response.defer.assert_awaited_once_with(thinking=False)
-        interaction.edit_original_response.assert_awaited_once()
-        interaction.response.edit_message.assert_not_awaited()
+        interaction.response.defer.assert_not_awaited()
+        interaction.response.edit_message.assert_awaited_once()
+        interaction.edit_original_response.assert_not_awaited()
         interaction.followup.send.assert_not_awaited()
         assert panel.prep.epics_ascended == 4
 
     asyncio.run(_run())
 
+
+def test_traditional_prep_modal_save_acknowledges_when_panel_refresh_fails(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        interaction.response.edit_message.side_effect = RuntimeError("edit failed")
+        target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+        events = [_event_row("e1", reward_type="rare", reward_amount=16)]
+        progress_by_event = {"e1": "done"}
+        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id), rares_owned=16)
+        panel = opt_in_view.TraditionalPrepPanelView(
+            user_id=member.id,
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            prep=prep,
+        )
+        modal = opt_in_view._TraditionalPrepModal(view=panel)
+        for item, value in (
+            (modal.rares_level_40, "16"),
+            (modal.rares_ascended, "16"),
+            (modal.epics_fused, "4"),
+            (modal.epics_level_50, "4"),
+            (modal.epics_ascended, "4"),
+        ):
+            item._value = value
+
+        saved = fusion_sheets.FusionTraditionalUserProgressRow(
+            fusion_id="f-1",
+            user_id=str(member.id),
+            rares_owned=16,
+            rares_level_40=16,
+            rares_ascended=16,
+            epics_fused=4,
+            epics_level_50=4,
+            epics_ascended=4,
+            target_ready=True,
+        )
+        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
+        monkeypatch.setattr(opt_in_view.fusion_logs, "send_ops_alert", AsyncMock())
+
+        await modal.on_submit(interaction)
+
+        interaction.response.edit_message.assert_awaited_once()
+        interaction.response.send_message.assert_awaited_once()
+        message = interaction.response.send_message.await_args.args[0]
+        assert "was saved" in message
+        assert panel.prep.epics_ascended == 4
+
+    asyncio.run(_run())
+
+
+def test_traditional_prep_modal_save_still_notifies_when_refresh_and_ops_alert_fail(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        interaction.response.edit_message.side_effect = RuntimeError("edit failed")
+        target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+        events = [_event_row("e1", reward_type="rare", reward_amount=16)]
+        progress_by_event = {"e1": "done"}
+        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id), rares_owned=16)
+        panel = opt_in_view.TraditionalPrepPanelView(
+            user_id=member.id,
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            prep=prep,
+        )
+        modal = opt_in_view._TraditionalPrepModal(view=panel)
+        for item, value in (
+            (modal.rares_level_40, "16"),
+            (modal.rares_ascended, "16"),
+            (modal.epics_fused, "4"),
+            (modal.epics_level_50, "4"),
+            (modal.epics_ascended, "4"),
+        ):
+            item._value = value
+
+        saved = fusion_sheets.FusionTraditionalUserProgressRow(
+            fusion_id="f-1",
+            user_id=str(member.id),
+            rares_owned=16,
+            rares_level_40=16,
+            rares_ascended=16,
+            epics_fused=4,
+            epics_level_50=4,
+            epics_ascended=4,
+            target_ready=True,
+        )
+        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
+        monkeypatch.setattr(opt_in_view.fusion_logs, "send_ops_alert", AsyncMock(side_effect=RuntimeError("alert failed")))
+
+        await modal.on_submit(interaction)
+
+        interaction.response.edit_message.assert_awaited_once()
+        interaction.response.send_message.assert_awaited_once()
+        message = interaction.response.send_message.await_args.args[0]
+        assert "was saved" in message
+        assert panel.prep.epics_ascended == 4
+
+    asyncio.run(_run())
+
+def test_traditional_prep_modal_save_does_not_raise_when_refresh_and_fallback_notification_fail(monkeypatch):
+    async def _run() -> None:
+        member = _Member(role=None)
+        guild = _Guild(role=None, member=member)
+        interaction = _interaction(guild, member)
+        interaction.response.edit_message.side_effect = RuntimeError("edit failed")
+        interaction.response.send_message.side_effect = RuntimeError("notification failed")
+        target = _fusion_row(opt_in_role_id=777, fusion_type="traditional")
+        events = [_event_row("e1", reward_type="rare", reward_amount=16)]
+        progress_by_event = {"e1": "done"}
+        prep = fusion_sheets.FusionTraditionalUserProgressRow(fusion_id="f-1", user_id=str(member.id), rares_owned=16)
+        panel = opt_in_view.TraditionalPrepPanelView(
+            user_id=member.id,
+            target=target,
+            events=events,
+            progress_by_event=progress_by_event,
+            prep=prep,
+        )
+        modal = opt_in_view._TraditionalPrepModal(view=panel)
+        for item, value in (
+            (modal.rares_level_40, "16"),
+            (modal.rares_ascended, "16"),
+            (modal.epics_fused, "4"),
+            (modal.epics_level_50, "4"),
+            (modal.epics_ascended, "4"),
+        ):
+            item._value = value
+
+        saved = fusion_sheets.FusionTraditionalUserProgressRow(
+            fusion_id="f-1",
+            user_id=str(member.id),
+            rares_owned=16,
+            rares_level_40=16,
+            rares_ascended=16,
+            epics_fused=4,
+            epics_level_50=4,
+            epics_ascended=4,
+            target_ready=True,
+        )
+        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
+        monkeypatch.setattr(opt_in_view.fusion_logs, "send_ops_alert", AsyncMock())
+
+        await modal.on_submit(interaction)
+
+        interaction.response.edit_message.assert_awaited_once()
+        interaction.response.send_message.assert_awaited_once()
+        assert panel.prep.epics_ascended == 4
+
+    asyncio.run(_run())
 
 def _button_by_label(view, label: str):
     for child in view.children:


### PR DESCRIPTION
### Motivation
- Prevent unhandled exceptions when the UI refresh after saving a traditional champion-prep record fails and ensure the user is informed that their save succeeded. 
- Record an operational alert when the post-save refresh fails so operators can investigate without impacting the user experience. 
- Simplify and make message edit logic more robust by consolidating embed creation and choosing the appropriate edit/send path based on `interaction.response.is_done()`.

### Description
- Wrap the post-save call to `_edit_traditional_prep_message` in a `try/except` block and log detailed context when the refresh fails. 
- Send an ops alert via `fusion_logs.send_ops_alert` on post-save refresh failures and guard that call with its own `try/except` to avoid cascading failures. 
- Provide a user-facing fallback ephemeral notification when the panel couldn’t be refreshed and guard that notification with `try/except` as well. 
- Refactor `_edit_traditional_prep_message` to build the embed once and prefer `interaction.response.edit_message` when `response.is_done()` is false, otherwise use `edit_original_response` or a followup. 
- Update tests in `tests/community/test_fusion_opt_in_view.py` to reflect the changed edit flow and to add new tests that assert correct behavior when refresh, ops alert, and fallback notification fail.

### Testing
- Ran the unit tests in `tests/community/test_fusion_opt_in_view.py`, including the updated `test_traditional_prep_modal_save_edits_original_panel` and three new tests for refresh/error paths, and they all passed. 
- Verified the existing save flow still updates `panel.prep` and exercises the message-editing code path. 
- Confirmed new failure scenarios exercise logging, ops alerting, and the fallback ephemeral notification without raising exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54b9c0992883238a769f6a39b81c7f)