### PR TITLE
Compute required epics for traditional fusion, validate counts, update UI and sheet header aliases

### DIFF
--- a/modules/community/fusion/opt_in_view.py
+++ b/modules/community/fusion/opt_in_view.py
@@ -69,9 +69,20 @@ def _is_traditional_fusion(target: fusion_sheets.FusionRow) -> bool:
     return str(target.fusion_type or "").strip().casefold() == "traditional"
 
 
+def _required_traditional_epics(needed_total: int) -> int:
+    """Return the final Epic count needed for a traditional fusion target."""
+
+    return min(4, max(0, (max(0, int(needed_total)) + 3) // 4))
+
+
+def _traditional_target_ready(*, epics_ascended: int, required_epics: int) -> bool:
+    return max(0, int(epics_ascended)) >= max(0, int(required_epics))
+
+
 def _validate_traditional_prep_counts(
     *,
     needed_total: int,
+    required_epics: int,
     rares_acquired: int,
     rares_level_40: int,
     rares_ascended: int,
@@ -90,8 +101,8 @@ def _validate_traditional_prep_counts(
         return "All champion preparation counts must be non-negative integers."
     if rares_level_40 > needed_total or rares_ascended > needed_total:
         return f"Rare prep counts cannot be higher than {needed_total}."
-    if epics_fused > 4 or epics_level_50 > 4 or epics_ascended > 4:
-        return "Epic prep counts cannot be higher than 4."
+    if epics_fused > required_epics or epics_level_50 > required_epics or epics_ascended > required_epics:
+        return f"Epic prep counts cannot be higher than {required_epics}."
     if rares_level_40 > rares_acquired:
         return "Rares level 40 cannot be higher than Rares acquired from event rewards."
     if rares_ascended > rares_level_40:
@@ -123,8 +134,9 @@ def _build_traditional_prep_embed(
     )
     needed_total = rare_progress.required
     rares_still_needed = rare_progress.to_go
-    ready = prep.target_ready
-    missing = "Nothing, the target champion is ready to fuse." if ready else f"{max(0, 4 - prep.epics_ascended)} fully ascended Epics"
+    required_epics = _required_traditional_epics(needed_total)
+    missing_epics = max(0, required_epics - prep.epics_ascended)
+    ready = _traditional_target_ready(epics_ascended=prep.epics_ascended, required_epics=required_epics)
     embed = discord.Embed(
         title=f"Champion Preparation: {target.champion or target.fusion_name}",
         description="Traditional fusion prep tracker.",
@@ -140,8 +152,11 @@ def _build_traditional_prep_embed(
         inline=False,
     )
     embed.add_field(name="Rare Prep", value=f"Rares level 40: {prep.rares_level_40} / {needed_total}\nRares fully ascended: {prep.rares_ascended} / {needed_total}", inline=False)
-    embed.add_field(name="Epic Prep", value=f"Epics fused: {prep.epics_fused} / 4\nEpics level 50: {prep.epics_level_50} / 4\nEpics fully ascended: {prep.epics_ascended} / 4", inline=False)
-    embed.add_field(name="Final Fusion", value=f"Ready to fuse {target.champion or target.fusion_name}: {'Yes' if ready else 'No'}\nMissing: {missing}", inline=False)
+    embed.add_field(name="Epic Prep", value=f"Epics fused: {prep.epics_fused} / {required_epics}\nEpics level 50: {prep.epics_level_50} / {required_epics}\nEpics fully ascended: {prep.epics_ascended} / {required_epics}", inline=False)
+    final_fusion_lines = [f"Ready to fuse {target.champion or target.fusion_name}: {'Yes' if ready else 'No'}"]
+    if missing_epics > 0:
+        final_fusion_lines.append(f"Missing: {missing_epics} fully ascended Epics")
+    embed.add_field(name="Final Fusion", value="\n".join(final_fusion_lines), inline=False)
     return embed
 
 def _supports_partial_fragments(event: fusion_sheets.FusionEventRow | None, *, status: str | None) -> bool:
@@ -1095,7 +1110,6 @@ class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
         except ValueError:
             await _send_ephemeral(interaction, "Champion preparation counts must be whole numbers.")
             return
-        needed_total = max(0, int(self.panel_view.target.needed))
         rare_progress = calculate_traditional_rare_progress(
             target=self.panel_view.target,
             events=self.panel_view.events,
@@ -1107,13 +1121,15 @@ class _TraditionalPrepModal(discord.ui.Modal, title="Champion Preparation"):
             ).display_status_by_event,
             partial_by_event=self.panel_view.partial_by_event,
         )
+        needed_total = rare_progress.required
         rares_acquired = rare_progress.acquired
-        error = _validate_traditional_prep_counts(needed_total=needed_total, rares_acquired=rares_acquired, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4])
+        required_epics = _required_traditional_epics(needed_total)
+        error = _validate_traditional_prep_counts(needed_total=needed_total, required_epics=required_epics, rares_acquired=rares_acquired, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4])
         if error:
             await _send_ephemeral(interaction, error)
             return
         try:
-            prep = await fusion_sheets.upsert_user_traditional_progress(self.panel_view.target.fusion_id, str(self.panel_view.user_id), rares_owned=self.panel_view.prep.rares_owned, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4], target_ready=self.panel_view.prep.target_ready, updated_at=dt.datetime.now(dt.timezone.utc))
+            prep = await fusion_sheets.upsert_user_traditional_progress(self.panel_view.target.fusion_id, str(self.panel_view.user_id), rares_owned=self.panel_view.prep.rares_owned, rares_level_40=values[0], rares_ascended=values[1], epics_fused=values[2], epics_level_50=values[3], epics_ascended=values[4], target_ready=_traditional_target_ready(epics_ascended=values[4], required_epics=required_epics), updated_at=dt.datetime.now(dt.timezone.utc))
         except Exception as exc:
             log.exception("fusion traditional prep save failed", extra={"fusion_id": self.panel_view.target.fusion_id, "user_id": self.panel_view.user_id})
             await fusion_logs.send_ops_alert(component="traditional_prep", summary="save_failed", dedupe_key=f"fusion:traditional_prep:save:{self.panel_view.target.fusion_id}", error=exc, fields={"fusion_id": self.panel_view.target.fusion_id})

--- a/shared/sheets/fusion.py
+++ b/shared/sheets/fusion.py
@@ -45,15 +45,15 @@ _FUSION_REMINDER_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "sent_at_utc": ("sent_at_utc",),
 }
 _FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
-    "fusion_id": ("fusion_id",),
-    "user_id": ("user_id",),
-    "rares_owned": ("rares_owned",),
-    "rares_level_40": ("rares_level_40",),
-    "rares_ascended": ("rares_ascended",),
-    "epics_fused": ("epics_fused",),
-    "epics_level_50": ("epics_level_50",),
-    "epics_ascended": ("epics_ascended",),
-    "target_ready": ("target_ready",),
+    "fusion_id": ("fusion_id", "fusion id", "fusion"),
+    "user_id": ("user_id", "user id", "user"),
+    "rares_owned": ("rares_owned", "rares owned"),
+    "rares_level_40": ("rares_level_40", "rares level 40", "rare level 40"),
+    "rares_ascended": ("rares_ascended", "rares fully ascended", "rare fully ascended"),
+    "epics_fused": ("epics_fused", "epics fused", "epic fused"),
+    "epics_level_50": ("epics_level_50", "epics level 50", "epic level 50"),
+    "epics_ascended": ("epics_ascended", "epics fully ascended", "epic fully ascended"),
+    "target_ready": ("target_ready", "target ready", "ready to fuse"),
     "updated_at_utc": ("updated_at_utc", "updated at utc", "updatedat", "updated_at"),
 }
 _FUSION_PROGRESS_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {

--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock
 
 from modules.community.fusion import opt_in_view
 from modules.community.fusion.progress_share import build_share_snapshot
-from modules.community.fusion.traditional_progress import calculate_traditional_rare_progress
+from modules.community.fusion.traditional_progress import TraditionalRareProgress, calculate_traditional_rare_progress
 from shared.sheets import fusion as fusion_sheets
 
 
@@ -714,6 +714,7 @@ def test_non_traditional_my_progress_uses_followup_when_interaction_already_ackn
 def test_traditional_prep_validation_blocks_impossible_counts():
     message = opt_in_view._validate_traditional_prep_counts(
         needed_total=16,
+        required_epics=4,
         rares_acquired=8,
         rares_level_40=8,
         rares_ascended=4,
@@ -804,7 +805,13 @@ def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
             epics_ascended=4,
             target_ready=True,
         )
-        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", AsyncMock(return_value=saved))
+        upsert = AsyncMock(return_value=saved)
+        monkeypatch.setattr(fusion_sheets, "upsert_user_traditional_progress", upsert)
+        monkeypatch.setattr(
+            opt_in_view,
+            "calculate_traditional_rare_progress",
+            lambda **_kwargs: TraditionalRareProgress(required=16, available_sources=16, acquired=16, skipped=0, missed=0, to_go=0),
+        )
 
         await modal.on_submit(interaction)
 
@@ -812,6 +819,7 @@ def test_traditional_prep_modal_save_edits_original_panel(monkeypatch):
         interaction.response.edit_message.assert_awaited_once()
         interaction.edit_original_response.assert_not_awaited()
         interaction.followup.send.assert_not_awaited()
+        assert upsert.await_args.kwargs["target_ready"] is True
         assert panel.prep.epics_ascended == 4
 
     asyncio.run(_run())
@@ -1195,6 +1203,21 @@ def test_traditional_prep_embed_separates_manual_inventory_from_event_acquired()
 
 
 
+def test_traditional_prep_embed_recalculates_ready_and_omits_zero_missing():
+    target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), champion="Haggibah the Nestmaid", needed=16, available=16, reward_type="rares")
+    prep = fusion_sheets.FusionTraditionalUserProgressRow(
+        fusion_id="f-1", user_id="42", rares_owned=16, rares_level_40=16, rares_ascended=16, epics_fused=4, epics_level_50=4, epics_ascended=4, target_ready=False
+    )
+
+    embed = opt_in_view._build_traditional_prep_embed(
+        target=target, events=[_event_row("rare", reward_type="rare", reward_amount=16.0)], progress_by_event={"rare": "done"}, prep=prep
+    )
+
+    final_field = next(field for field in embed.fields if field.name == "Final Fusion")
+    assert "Ready to fuse Haggibah the Nestmaid: Yes" in final_field.value
+    assert "Missing:" not in final_field.value
+
+
 def test_traditional_rare_progress_counts_effectively_missed_events():
     target = replace(_fusion_row(opt_in_role_id=777, fusion_type="traditional"), needed=16, available=17, reward_type="rares")
     now = dt.datetime(2026, 7, 4, tzinfo=dt.timezone.utc)
@@ -1264,6 +1287,7 @@ def test_traditional_rare_progress_in_progress_without_partial_counts_zero():
 def test_traditional_prep_validation_uses_event_acquired_rares():
     assert opt_in_view._validate_traditional_prep_counts(
         needed_total=16,
+        required_epics=4,
         rares_acquired=max(0, 4),
         rares_level_40=2,
         rares_ascended=0,
@@ -1273,6 +1297,7 @@ def test_traditional_prep_validation_uses_event_acquired_rares():
     ) is None
     assert opt_in_view._validate_traditional_prep_counts(
         needed_total=16,
+        required_epics=4,
         rares_acquired=max(0, 0),
         rares_level_40=2,
         rares_ascended=0,

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -501,6 +501,27 @@ def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.Monk
     assert row.target_ready is True
 
 
+def test_traditional_progress_resolves_human_readable_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _resolve_tab_name(_key: str) -> str:
+        return "fusion_traditional_user_prog"
+
+    async def _afetch_values(_sheet_id: str, _tab_name: str):
+        return [
+            ["User ID", "Fusion ID", "Epics fully ascended", "Rares owned", "Rares level 40", "Rares fully ascended", "Epics fused", "Epics level 50", "Target ready", "Updated At UTC"],
+            ["42", "f-1", "4", "16", "16", "16", "4", "4", "TRUE", "2026-07-01T00:00:00+00:00"],
+        ]
+
+    monkeypatch.setattr(fusion, "_resolve_tab_name", _resolve_tab_name)
+    monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
+
+    row = asyncio.run(fusion.get_user_traditional_progress("f-1", "42"))
+
+    assert row.rares_level_40 == 16
+    assert row.epics_ascended == 4
+    assert row.target_ready is True
+
+
 def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     worksheet = AsyncMock()
 


### PR DESCRIPTION
### Motivation
- Properly compute how many Epics are required for a traditional fusion from the rare requirement and use that to determine readiness and validation limits.
- Ensure the prep UI and save flow recalculate readiness instead of relying on stale stored `target_ready` flags.
- Make sheet import tolerant of human-readable column headers for traditional progress to improve robustness when spreadsheets use different headings.

### Description
- Add `_required_traditional_epics(required_total)` and `_traditional_target_ready(...)` helpers and change `_validate_traditional_prep_counts` to accept `required_epics` and enforce epic upper bounds based on that value instead of a fixed 4.
- Rework `_build_traditional_prep_embed` to compute `required_epics` from `calculate_traditional_rare_progress`, display epic counts using that computed total, recompute `ready` dynamically, and omit the "Missing" line when nothing is missing.
- Update `_TraditionalPrepModal.on_submit` to derive `needed_total` from `calculate_traditional_rare_progress`, compute `required_epics` for validation, and pass a computed `target_ready` into `upsert_user_traditional_progress` on save.
- Expand `_FUSION_TRADITIONAL_PROGRESS_COLUMN_ALIASES` in `shared/sheets/fusion.py` to include human-readable header aliases so `get_user_traditional_progress` and upsert operations resolve various header formats.
- Update and add unit tests to cover validation logic, embed rendering, modal save behavior, and header resolution for traditional progress data.

### Testing
- Ran the modified unit tests in `tests/community/test_fusion_opt_in_view.py` and `tests/shared/sheets/test_fusion.py`, including new cases for human-readable headers and embed readiness logic, and they passed.
- Tests that validate the modal save behavior confirm `target_ready` is computed and sent to `upsert_user_traditional_progress` successfully.
- Tests for `_validate_traditional_prep_counts` and `_build_traditional_prep_embed` confirm the epic limits, missing-epics messaging, and recalculated "Ready to fuse" state behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54cbaf3d7883238380115ac3d63856)