### PR TITLE
Improve achievement collector failure diagnostics

### DIFF
--- a/cogs/housekeeping_achievement_collector.py
+++ b/cogs/housekeeping_achievement_collector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import traceback
 
 import discord
 from discord.ext import commands
@@ -48,6 +49,52 @@ def _error_embed(message: str) -> discord.Embed:
     return discord.Embed(title="Achievement Collector", description=message, colour=discord.Colour.red())
 
 
+def _traceback_file_label(filename: str) -> str:
+    try:
+        return os.path.relpath(filename)
+    except ValueError:
+        return filename
+
+
+def _exception_traceback_metadata(exc: BaseException) -> dict[str, object]:
+    frames = traceback.extract_tb(exc.__traceback__)
+    if not frames:
+        return {
+            "exception_origin_file": None,
+            "exception_origin_line": None,
+            "exception_origin_function": None,
+            "exception_trace_frames": [],
+        }
+
+    recent_frames = frames[-8:]
+    trace_frames = [
+        {
+            "file": _traceback_file_label(frame.filename),
+            "line": frame.lineno,
+            "function": frame.name,
+        }
+        for frame in recent_frames
+    ]
+    origin = trace_frames[-1]
+    return {
+        "exception_origin_file": origin["file"],
+        "exception_origin_line": origin["line"],
+        "exception_origin_function": origin["function"],
+        "exception_trace_frames": trace_frames,
+    }
+
+
+def _exception_origin_marker(traceback_metadata: dict[str, object]) -> str | None:
+    origin_file = traceback_metadata.get("exception_origin_file")
+    origin_line = traceback_metadata.get("exception_origin_line")
+    origin_function = traceback_metadata.get("exception_origin_function")
+    if not origin_file or not origin_line:
+        return None
+    if origin_function:
+        return f"{origin_file}:{origin_line} {origin_function}"
+    return f"{origin_file}:{origin_line}"
+
+
 class AchievementCollectorCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -75,6 +122,7 @@ class AchievementCollectorCog(commands.Cog):
         limit: int | None = None,
         target_member: discord.Member | None = None,
     ) -> None:
+        traceback_metadata = _exception_traceback_metadata(exc)
         log.error(
             "achievement collector %s failed",
             command_name,
@@ -87,6 +135,7 @@ class AchievementCollectorCog(commands.Cog):
                 "provided_limit": limit,
                 "target_member_id": getattr(target_member, "id", None),
                 "exception_type": type(exc).__name__,
+                **traceback_metadata,
             },
         )
         fields = [
@@ -98,6 +147,9 @@ class AchievementCollectorCog(commands.Cog):
             f"exception_type={type(exc).__name__}",
             f"exception={_short_exception_message(exc)}",
         ]
+        origin_marker = _exception_origin_marker(traceback_metadata)
+        if origin_marker:
+            fields.append(f"origin={origin_marker}")
         if limit is not None:
             fields.append(f"limit={limit}")
         if target_member is not None:

--- a/tests/cogs/test_achievement_collector.py
+++ b/tests/cogs/test_achievement_collector.py
@@ -231,14 +231,22 @@ def test_report_collector_failure_logs_passed_permission_error_explicit_exc_info
     assert kwargs["exc_info"][0] is PermissionError
     assert kwargs["exc_info"][1] is passed_exc
     assert kwargs["exc_info"][2] is passed_exc.__traceback__
-    assert kwargs["extra"] == {
-        "achievement_collector_command": "preview",
-        "guild_id": 456,
-        "channel_id": 789,
-        "actor_id": 1234,
-        "provided_limit": 25,
-        "target_member_id": None,
-        "exception_type": "PermissionError",
+    extra = kwargs["extra"]
+    assert extra["achievement_collector_command"] == "preview"
+    assert extra["guild_id"] == 456
+    assert extra["channel_id"] == 789
+    assert extra["actor_id"] == 1234
+    assert extra["provided_limit"] == 25
+    assert extra["target_member_id"] is None
+    assert extra["exception_type"] == "PermissionError"
+    assert extra["exception_origin_file"].endswith("tests/cogs/test_achievement_collector.py")
+    assert isinstance(extra["exception_origin_line"], int)
+    assert extra["exception_origin_function"] == "_raise_permission_error_with_traceback"
+    assert extra["exception_trace_frames"]
+    assert extra["exception_trace_frames"][-1] == {
+        "file": extra["exception_origin_file"],
+        "line": extra["exception_origin_line"],
+        "function": "_raise_permission_error_with_traceback",
     }
     assert ops_logs
     ops_message = ops_logs[-1]
@@ -246,6 +254,8 @@ def test_report_collector_failure_logs_passed_permission_error_explicit_exc_info
     assert "command=preview" in ops_message
     assert "exception_type=PermissionError" in ops_message
     assert "exception=-" in ops_message
+    assert "origin=tests/cogs/test_achievement_collector.py:" in ops_message
+    assert "_raise_permission_error_with_traceback" in ops_message
     assert "secret-sheet-id" not in ops_message
     assert "ACHIEVEMENTS_SHEET_ID" not in ops_message
     assert "sheet contents" not in ops_message
@@ -303,6 +313,8 @@ def test_collector_permission_error_empty_message_ops_notification_and_embed(mon
     assert f"command={command_name}" in ops_message
     assert "exception_type=PermissionError" in ops_message
     assert "exception=-" in ops_message
+    assert "origin=tests/cogs/test_achievement_collector.py:" in ops_message
+    assert " boom" in ops_message
     assert "secret-sheet-id" not in ops_message
     assert "ACHIEVEMENTS_SHEET_ID" not in ops_message
     assert "sheet contents" not in ops_message
@@ -353,6 +365,10 @@ def test_collector_unexpected_exception_logs_traceback_and_ops_notification(monk
     record = next(rec for rec in caplog.records if rec.message == f"achievement collector {command_name} failed")
     assert record.exc_info is not None
     assert record.exc_info[0] is RuntimeError
+    assert record.exception_origin_file.endswith("tests/cogs/test_achievement_collector.py")
+    assert isinstance(record.exception_origin_line, int)
+    assert record.exception_origin_function == "boom"
+    assert record.exception_trace_frames[-1]["function"] == "boom"
     assert ctx.sent[-1]["embed"].title == "Achievement Collector"
     assert ops_logs
     ops_message = ops_logs[-1]
@@ -362,6 +378,8 @@ def test_collector_unexpected_exception_logs_traceback_and_ops_notification(monk
     assert "channel_id=789" in ops_message
     assert "actor_id=1234" in ops_message
     assert "exception_type=RuntimeError" in ops_message
+    assert "origin=tests/cogs/test_achievement_collector.py:" in ops_message
+    assert " boom" in ops_message
     if limit is not None:
         assert f"limit={limit}" in ops_message
     if target_member_id is not None:


### PR DESCRIPTION
### Motivation
- Structured logging in production was dropping traceback fields (e.g. `trace`/`exc_text`) even when `exc_info` was provided, so PermissionError origins were not visible in app logs and ops notifications lacked a compact source marker.
- We need reliable, metadata-only origin information (file, line, function, recent frames) for achievement collector failures without exposing secrets, sheet contents, message content, or locals.

### Description
- Add `traceback`-based helpers (`_exception_traceback_metadata`, `_traceback_file_label`, `_exception_origin_marker`) to extract origin file, line, function and up to the last 8 traceback frames (metadata-only) from the passed exception. (cogs/housekeeping_achievement_collector.py)
- Preserve the explicit `exc_info=(type(exc), exc, exc.__traceback__)` call and inject the derived traceback metadata into the structured log `extra` payload so origin fields persist even when global formatters drop `exc_text`/`trace`.
- Add a compact metadata-only `origin=<file>:<line> <function>` marker to the ops/log Discord notification while keeping the existing sanitized exception message and redaction rules. (cogs/housekeeping_achievement_collector.py)
- Extend and update focused unit tests to assert the presence and correctness of `exception_origin_file`, `exception_origin_line`, `exception_origin_function`, `exception_trace_frames`, and the `origin=` marker in ops/log messages, while preserving redaction and embed behavior. (tests/cogs/test_achievement_collector.py)

### Testing
- Ran `pytest tests/cogs/test_achievement_collector.py -q` and all tests in that file passed. 
- Ran `ruff check cogs/housekeeping_achievement_collector.py` and linting for the modified cog passed. 
- Ran `pytest -q --maxfail=1` which failed in an unrelated test (`tests/community/shard_tracker/test_data.py::test_get_config_prefers_env_channel_id`) due to an existing `MilestonesSheetIdUnavailable` setup issue outside the scope of this change. 
- The changes are committed on the working branch and the PR was created with these modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54cd26244c83238989a3ec9702576f)