### PR TITLE
Require RAID_ROLE_ID for Achievement Collector eligibility

### DIFF
--- a/cogs/housekeeping_achievement_collector.py
+++ b/cogs/housekeeping_achievement_collector.py
@@ -18,8 +18,11 @@ from modules.housekeeping.achievement_collector import (
     build_leaderboard,
     effective_limit,
     leaderboard_embed,
+    member_has_role,
+    non_raid_rank_embed,
     rank_embed,
     resolve_config,
+    resolve_raid_role_id,
     resolve_messageable,
 )
 
@@ -249,6 +252,7 @@ class AchievementCollectorCog(commands.Cog):
             return
         target = member or ctx.author
         try:
+            raid_role_id = resolve_raid_role_id(ctx.guild)
             cache = await self._get_or_build_cache(ctx.guild)
         except AchievementCollectorError as exc:
             await self._report_collector_failure(ctx, "rank", exc, target_member=member)
@@ -257,6 +261,9 @@ class AchievementCollectorCog(commands.Cog):
         except Exception as exc:
             await self._report_collector_failure(ctx, "rank", exc, target_member=member)
             await ctx.send(embed=_error_embed("Achievement Collector rank failed. Check the bot logs."), allowed_mentions=_ALLOWED_NONE)
+            return
+        if not member_has_role(target, raid_role_id):
+            await ctx.send(embed=non_raid_rank_embed(target), allowed_mentions=_ALLOWED_NONE)
             return
         await ctx.send(embed=rank_embed(target, cache), allowed_mentions=_ALLOWED_NONE)
 

--- a/modules/housekeeping/achievement_collector.py
+++ b/modules/housekeeping/achievement_collector.py
@@ -25,6 +25,8 @@ CONFIG_KEYS: tuple[str, ...] = (
 LEADERBOARD_INTRO = "The shiny badges have been counted. Some of you are getting alarmingly shiny:"
 RANK_FOOTER = "Want to snoop on another rank? Use !achievementcollector rank @member"
 PREVIEW_FOOTER = "Preview only. Use !achievementcollector publish to send this to the configured channel."
+NON_RAID_RANK_COPY = "{mention} is not on the collector board right now. No raid badge, no shiny leaderboard nonsense."
+
 
 
 class AchievementCollectorError(RuntimeError):
@@ -196,6 +198,25 @@ def effective_limit(raw_limit: int | None, config: AchievementCollectorConfig) -
     return min(raw_limit, config.max_limit)
 
 
+def resolve_raid_role_id(guild: discord.Guild) -> int:
+    raw_role_id = os.getenv("RAID_ROLE_ID", "").strip()
+    if not raw_role_id:
+        raise AchievementCollectorError("Missing RAID_ROLE_ID; Achievement Collector requires the active clan raid role.")
+    try:
+        role_id = int(raw_role_id)
+    except ValueError as exc:
+        raise AchievementCollectorError("RAID_ROLE_ID must be a valid Discord role ID integer.") from exc
+    if role_id <= 0:
+        raise AchievementCollectorError("RAID_ROLE_ID must be a valid Discord role ID integer.")
+    if guild.get_role(role_id) is None:
+        raise AchievementCollectorError("RAID_ROLE_ID could not be resolved in this guild.")
+    return role_id
+
+
+def member_has_role(member: discord.Member, role_id: int) -> bool:
+    return any(getattr(role, "id", None) == role_id for role in getattr(member, "roles", []) or [])
+
+
 async def load_active_role_ids(config: AchievementCollectorConfig) -> set[int]:
     sheet_id = os.getenv("ACHIEVEMENTS_SHEET_ID", "").strip()
     if not sheet_id:
@@ -224,6 +245,7 @@ async def load_active_role_ids(config: AchievementCollectorConfig) -> set[int]:
 
 
 async def build_leaderboard(guild: discord.Guild, config: AchievementCollectorConfig) -> LeaderboardCache:
+    raid_role_id = resolve_raid_role_id(guild)
     active_role_ids = await load_active_role_ids(config)
     existing_role_ids: set[int] = set()
     for role_id in active_role_ids:
@@ -236,6 +258,8 @@ async def build_leaderboard(guild: discord.Guild, config: AchievementCollectorCo
     counts: dict[int, int] = {}
     for member in getattr(guild, "members", []) or []:
         if getattr(member, "bot", False):
+            continue
+        if not member_has_role(member, raid_role_id):
             continue
         count = sum(1 for role in getattr(member, "roles", []) if getattr(role, "id", None) in existing_role_ids)
         counts[int(member.id)] = count
@@ -261,6 +285,12 @@ def leaderboard_embed(cache: LeaderboardCache, limit: int, *, preview: bool = Fa
         lines.append(f"{entry.rank}. {entry.mention} - {entry.count} {_achievements_word(entry.count)}")
     embed = discord.Embed(title=title, description="\n".join(lines), colour=get_embed_colour("community"))
     embed.set_footer(text=PREVIEW_FOOTER if preview else RANK_FOOTER)
+    return embed
+
+
+def non_raid_rank_embed(member: discord.Member) -> discord.Embed:
+    embed = discord.Embed(title="Achievement Collector Rank", description=NON_RAID_RANK_COPY.format(mention=member.mention), colour=get_embed_colour("community"))
+    embed.set_footer(text=RANK_FOOTER)
     return embed
 
 
@@ -330,7 +360,9 @@ class AchievementCollectorScheduler:
 
 
 __all__ = [
-    "AchievementCollectorConfig", "AchievementCollectorError", "LeaderboardCache", "LeaderboardEntry",
-    "build_leaderboard", "effective_limit", "leaderboard_embed", "load_active_role_ids", "parse_schedule",
-    "rank_embed", "resolve_config", "resolve_messageable", "AchievementCollectorScheduler",
+    "AchievementCollectorConfig", "AchievementCollectorError", "AchievementCollectorScheduler",
+    "LeaderboardCache", "LeaderboardEntry", "NON_RAID_RANK_COPY", "build_leaderboard",
+    "effective_limit", "leaderboard_embed", "load_active_role_ids", "member_has_role",
+    "non_raid_rank_embed", "parse_schedule", "rank_embed", "resolve_config",
+    "resolve_messageable", "resolve_raid_role_id",
 ]

--- a/tests/cogs/test_achievement_collector.py
+++ b/tests/cogs/test_achievement_collector.py
@@ -92,8 +92,9 @@ def test_missing_headers_fail(monkeypatch):
 def test_stale_roles_bots_min_count_and_sorting(monkeypatch):
     async def fake_roles(config): return {1, 2, 999}
     monkeypatch.setattr(ac, "load_active_role_ids", fake_roles)
-    r1, r2, stale = Role(1), Role(2), Role(999)
-    guild = Guild([r1, r2], [Member(1,"Zed",[r1,r2]), Member(2,"Amy",[r1,r2]), Member(3,"Low",[r1]), Member(4,"Bot",[r1,r2], bot=True), Member(5,"Stale",[stale])])
+    raid, r1, r2, stale = Role(10), Role(1), Role(2), Role(999)
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
+    guild = Guild([raid, r1, r2], [Member(1,"Zed",[raid,r1,r2]), Member(2,"Amy",[raid,r1,r2]), Member(3,"Low",[raid,r1]), Member(4,"Bot",[raid,r1,r2], bot=True), Member(5,"Stale",[raid,stale])])
     cache = run(ac.build_leaderboard(guild, cfg(min_count=2)))
     assert [(e.display_name, e.count, e.rank) for e in cache.entries] == [("Amy",2,1),("Zed",2,2)]
     assert 4 not in cache.counts
@@ -167,7 +168,8 @@ def test_scheduler_config_invalid_rrule_and_time_fail():
 
 
 def test_preview_publish_rank_routing_embeds_allowed_mentions_and_cache(monkeypatch):
-    r=Role(1); guild=Guild([r],[Member(1,"A",[r]), Member(2,"B",[])])
+    raid=Role(10); r=Role(1); guild=Guild([raid,r],[Member(1,"A",[raid,r]), Member(2,"B",[raid])])
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
     current=Channel(); publish_ch=Channel(); bot=SimpleNamespace(get_channel=lambda cid: publish_ch, fetch_channel=None, wait_until_ready=lambda: None, is_closed=lambda: True)
     cog = AchievementCollectorCog(bot)
     cog._scheduler.start = lambda: None
@@ -271,7 +273,9 @@ def test_report_collector_failure_logs_passed_permission_error_explicit_exc_info
 ])
 def test_collector_permission_error_empty_message_ops_notification_and_embed(monkeypatch, command_name, limit, target_member_id):
     monkeypatch.setenv("ACHIEVEMENTS_SHEET_ID", "secret-sheet-id")
-    guild = Guild([], [Member(1, "Actor", []), Member(2, "Target", [])])
+    raid = Role(10)
+    guild = Guild([raid], [Member(1, "Actor", [raid]), Member(2, "Target", [raid])])
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
     guild.id = 456
     channel = Channel()
     channel.id = 789
@@ -329,8 +333,10 @@ def test_collector_permission_error_empty_message_ops_notification_and_embed(mon
 ])
 def test_collector_unexpected_exception_logs_traceback_and_ops_notification(monkeypatch, caplog, command_name, limit, target_member_id):
     monkeypatch.setenv("ACHIEVEMENTS_SHEET_ID", "secret-sheet-id")
+    raid = Role(10)
     r = Role(1)
-    guild = Guild([r], [Member(1, "Actor", [r]), Member(2, "Target", [])])
+    guild = Guild([raid, r], [Member(1, "Actor", [raid, r]), Member(2, "Target", [raid])])
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
     guild.id = 456
     current = Channel()
     current.id = 789
@@ -387,3 +393,110 @@ def test_collector_unexpected_exception_logs_traceback_and_ops_notification(monk
     assert "secret-sheet-id" not in ops_message
     assert "shiny row" not in ops_message
     assert "!achievementcollector preview" not in ops_message
+
+
+def test_raid_role_eligibility_filters_members_bots_and_min_count(monkeypatch):
+    async def fake_roles(config): return {1, 2}
+    monkeypatch.setattr(ac, "load_active_role_ids", fake_roles)
+    raid, ach1, ach2 = Role(10), Role(1), Role(2)
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
+    guild = Guild(
+        [raid, ach1, ach2],
+        [
+            Member(1, "Included", [raid, ach1, ach2]),
+            Member(2, "NoRaid", [ach1, ach2]),
+            Member(3, "Bot", [raid, ach1, ach2], bot=True),
+            Member(4, "BelowMin", [raid, ach1]),
+        ],
+    )
+
+    cache = run(ac.build_leaderboard(guild, cfg(min_count=2)))
+
+    assert [(entry.member_id, entry.display_name, entry.count) for entry in cache.entries] == [(1, "Included", 2)]
+    assert cache.counts == {1: 2, 4: 1}
+
+
+def test_rank_member_without_raid_role_returns_non_raid_copy(monkeypatch):
+    raid, ach = Role(10), Role(1)
+    guild = Guild([raid, ach], [Member(1, "Actor", [raid, ach]), Member(2, "NoRaid", [ach])])
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
+    ctx = Ctx(guild, guild.members[0], Channel())
+    cog = AchievementCollectorCog(SimpleNamespace())
+
+    async def fake_cache(_guild):
+        return ac.LeaderboardCache(_guild.id, dt.datetime.now(dt.timezone.utc), (), {})
+
+    monkeypatch.setattr(cog, "_get_or_build_cache", fake_cache)
+
+    run(cog.rank.callback(cog, ctx, guild.members[1]))
+
+    assert ctx.sent[-1]["embed"].description == "<@2> is not on the collector board right now. No raid badge, no shiny leaderboard nonsense."
+
+
+def test_preview_and_publish_leaderboards_only_contain_raid_members(monkeypatch):
+    async def fake_roles(config): return {1}
+    monkeypatch.setattr(ac, "load_active_role_ids", fake_roles)
+    raid, ach = Role(10), Role(1)
+    monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
+    guild = Guild([raid, ach], [Member(1, "Raid", [raid, ach]), Member(2, "NoRaid", [ach])])
+    current, publish_ch = Channel(), Channel()
+    bot = SimpleNamespace(get_channel=lambda cid: publish_ch, fetch_channel=None, wait_until_ready=lambda: None, is_closed=lambda: True)
+    cog = AchievementCollectorCog(bot)
+
+    async def fake_config(): return cfg(channel_id=555, default_limit=5, max_limit=5, min_count=1)
+
+    monkeypatch.setattr("cogs.housekeeping_achievement_collector.resolve_config", fake_config)
+    ctx = Ctx(guild, guild.members[0], current)
+
+    run(cog.preview.callback(cog, ctx, None))
+    run(cog.publish.callback(cog, ctx, None))
+
+    assert "<@1>" in ctx.sent[0]["embed"].description
+    assert "<@2>" not in ctx.sent[0]["embed"].description
+    assert "<@1>" in publish_ch.sent[-1]["embed"].description
+    assert "<@2>" not in publish_ch.sent[-1]["embed"].description
+
+
+@pytest.mark.parametrize(
+    "env_value,roles,message",
+    [
+        (None, [Role(10)], "Missing RAID_ROLE_ID"),
+        ("not-a-role", [Role(10)], "RAID_ROLE_ID must be a valid Discord role ID integer"),
+        ("10", [], "RAID_ROLE_ID could not be resolved in this guild"),
+    ],
+)
+def test_raid_role_id_validation_fails_clearly(monkeypatch, env_value, roles, message):
+    if env_value is None:
+        monkeypatch.delenv("RAID_ROLE_ID", raising=False)
+    else:
+        monkeypatch.setenv("RAID_ROLE_ID", env_value)
+    guild = Guild(roles, [])
+
+    with pytest.raises(ac.AchievementCollectorError, match=message):
+        ac.resolve_raid_role_id(guild)
+
+
+def test_missing_raid_role_id_command_reports_ops_without_sheet_read(monkeypatch):
+    monkeypatch.delenv("RAID_ROLE_ID", raising=False)
+    sheet_reads = {"n": 0}
+    ops_logs = []
+    ach = Role(1)
+    guild = Guild([ach], [Member(1, "Actor", [ach])])
+    ctx = Ctx(guild, guild.members[0], Channel())
+    cog = AchievementCollectorCog(SimpleNamespace())
+
+    async def fake_roles(_config):
+        sheet_reads["n"] += 1
+        return {ach.id}
+
+    async def fake_send_log_message(message):
+        ops_logs.append(message)
+
+    monkeypatch.setattr(ac, "load_active_role_ids", fake_roles)
+    monkeypatch.setattr("cogs.housekeeping_achievement_collector.runtime_helpers.send_log_message", fake_send_log_message)
+
+    run(cog.rank.callback(cog, ctx, None))
+
+    assert sheet_reads["n"] == 0
+    assert ctx.sent[-1]["embed"].description.startswith("Missing RAID_ROLE_ID")
+    assert ops_logs and "feature=achievement collector" in ops_logs[-1]


### PR DESCRIPTION
### Motivation
- Ensure the Achievement Collector leaderboard only includes active clan members by requiring the configured `RAID_ROLE_ID` Discord role for eligibility. 
- Provide clear failures and operator reporting when `RAID_ROLE_ID` is missing, invalid, or not resolvable in a guild. 
- Keep existing behavior for achievement role sourcing, counting, scheduling, cache semantics, and public rank visibility while excluding non-raid members from the collector board.

### Description
- Added `resolve_raid_role_id(guild)` to validate and resolve the existing `RAID_ROLE_ID` env var and fail with clear `AchievementCollectorError` messages when missing, invalid, or not found in the guild.  
- Added `member_has_role(member, role_id)` helper and `non_raid_rank_embed` copy using the requested message for non-raid members.  
- Updated `build_leaderboard` to call `resolve_raid_role_id` first, then exclude bots and members who do not have the raid role before counting achievement roles and applying `achievement_collector_min_count`.  
- Updated the `!achievementcollector rank` command to validate `RAID_ROLE_ID` and return the non-raid embed for targets without the raid role while preserving public rank behavior for raid members.  
- Exported the new helpers in `__all__` and added focused unit tests covering inclusion/exclusion, bot exclusion, min-count, preview/publish filtering, rank copy for non-raid members, raid-role validation failures, ops reporting, and ensuring no extra sheet reads are performed for the raid-role check.

### Testing
- Ran the focused unit test suite with `python -m pytest -q tests/cogs/test_achievement_collector.py`, which passed.  
- Added tests: `test_raid_role_eligibility_filters_members_bots_and_min_count`, `test_rank_member_without_raid_role_returns_non_raid_copy`, `test_preview_and_publish_leaderboards_only_contain_raid_members`, `test_raid_role_id_validation_fails_clearly`, and `test_missing_raid_role_id_command_reports_ops_without_sheet_read`, all of which exercised the new behavior and succeeded.  
- Also ran `git diff --check` as a pre-commit verification step with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551c6fb7588323a7fc49aaea7532cd)