### PR TITLE
Add Wandering Souls investigation command, config, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ docs/ops/.env.example
 
 **RBAC / Access Lists**
 - Permissions UI blacklists: `PERMS_BLACKLIST_CHANNEL_IDS`, `PERMS_BLACKLIST_CATEGORY_IDS` — **IDs only**; numeric; comma-separated if needed.
+- Wandering Souls diagnostics use `WANDERING_SOULS_ROLE_ID` and `WANDERING_SOULS_EXCLUDE_ROLE_ID` to identify included/excluded roles.
 - `GUILD_IDS` env var exists for allowed guilds.
 
 **Deploy / Runtime**

--- a/cogs/housekeeping_wandering_souls.py
+++ b/cogs/housekeeping_wandering_souls.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.housekeeping import wandering_souls as ws
+
+log = logging.getLogger("c1c.housekeeping.wandering_souls.cog")
+
+MEMBER_LOAD_ERROR = "The investigation could not safely run because the full member list could not be loaded."
+
+
+class WanderingSoulsCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @commands.group(
+        name="wanderingsouls",
+        invoke_without_command=True,
+        help="Admin diagnostics for Wandering Souls members.",
+        brief="Investigate Wandering Souls members.",
+    )
+    @commands.guild_only()
+    @admin_only()
+    async def wandering_souls_group(self, ctx: commands.Context) -> None:
+        if ctx.invoked_subcommand is None:
+            await ctx.send(embed=ws.build_diagnostics_embed())
+
+    @tier("admin")
+    @help_metadata(function_group="operational", section="utilities", access_tier="admin")
+    @wandering_souls_group.command(name="investigate")
+    @commands.guild_only()
+    @admin_only()
+    async def investigate(self, ctx: commands.Context) -> None:
+        guild = ctx.guild
+        if guild is None:
+            await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+            return
+        if not getattr(guild, "chunked", False):
+            try:
+                await guild.chunk(cache=True)
+            except Exception:
+                log.exception("wandering souls investigation failed to chunk guild members")
+                await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+                return
+        if getattr(guild, "members", None) is None:
+            await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+            return
+
+        wandering_role, exclude_role, error = ws.resolve_investigation_roles(guild)
+        if error:
+            await ctx.send(embed=ws.build_error_embed(error))
+            return
+        result = ws.collect_wandering_souls(guild, int(wandering_role.id), int(exclude_role.id))
+        for embed in ws.build_investigation_embeds(result):
+            await ctx.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(WanderingSoulsCog(bot))

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -101,6 +101,8 @@ RECRUITER_ROLE_IDS=
 RAID_ROLE_ID=
 # Wandering Souls role for members without clan tags.
 WANDERING_SOULS_ROLE_ID=
+# Role excluded from Wandering Souls investigation results.
+WANDERING_SOULS_EXCLUDE_ROLE_ID=
 # Visitor role used during welcome ticketing.
 VISITOR_ROLE_ID=
 # Comma-separated list of all clan-tag role IDs.

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1217,6 +1217,7 @@ class Runtime:
         from cogs import housekeeping_mirralith
         from cogs import housekeeping_achievements
         from cogs import housekeeping_achievement_collector
+        from cogs import housekeeping_wandering_souls
         from cogs import housekeeping_c1c_ad
         from cogs import recruitment_clan_ads
         from modules.housekeeping import cleanup as housekeeping_cleanup_commands
@@ -1261,6 +1262,9 @@ class Runtime:
 
         await housekeeping_achievement_collector.setup(self.bot)
         log.info("modules: achievement_collector command registered")
+
+        await housekeeping_wandering_souls.setup(self.bot)
+        log.info("modules: wandering_souls command registered")
 
         await housekeeping_c1c_ad.setup(self.bot)
         log.info("modules: c1c_ad command registered")

--- a/modules/housekeeping/wandering_souls.py
+++ b/modules/housekeeping/wandering_souls.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any
+
+import discord
+
+from shared import config
+from shared.theme import colors
+
+ACTIVITY_FOOTER = "Last activity and message count are based on tracked bot-visible activity only."
+UNKNOWN = "unknown"
+MAX_EMBED_DESCRIPTION = 3900
+
+
+@dataclass(frozen=True)
+class InvestigationEntry:
+    member: Any
+    last_activity: dt.datetime | None = None
+    message_count: int | None = None
+
+
+@dataclass(frozen=True)
+class InvestigationResult:
+    total_wandering: int
+    excluded: int
+    entries: tuple[InvestigationEntry, ...]
+
+
+def _role_ids(member: Any) -> set[int]:
+    return {int(role.id) for role in getattr(member, "roles", ()) if getattr(role, "id", None) is not None}
+
+
+def _resolve_required_role(guild: Any, env_name: str, role_id: int | None) -> tuple[Any | None, str | None]:
+    if role_id is None:
+        return None, f"Missing or invalid {env_name}. Set it to a numeric Discord role ID."
+    role = guild.get_role(role_id) if guild is not None else None
+    if role is None:
+        return None, f"Configured {env_name}={role_id} was not found in this guild."
+    return role, None
+
+
+def resolve_investigation_roles(guild: Any) -> tuple[Any | None, Any | None, str | None]:
+    wandering_role, error = _resolve_required_role(
+        guild, "WANDERING_SOULS_ROLE_ID", config.get_wandering_souls_role_id()
+    )
+    if error:
+        return None, None, error
+    exclude_role, error = _resolve_required_role(
+        guild,
+        "WANDERING_SOULS_EXCLUDE_ROLE_ID",
+        config.get_wandering_souls_exclude_role_id(),
+    )
+    if error:
+        return None, None, error
+    return wandering_role, exclude_role, None
+
+
+def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id: int) -> InvestigationResult:
+    wandering: list[Any] = []
+    entries: list[InvestigationEntry] = []
+    excluded = 0
+    for member in getattr(guild, "members", ()):
+        ids = _role_ids(member)
+        if wandering_role_id not in ids:
+            continue
+        wandering.append(member)
+        if exclude_role_id in ids:
+            excluded += 1
+            continue
+        entries.append(InvestigationEntry(member=member))
+    entries.sort(key=lambda entry: (entry.last_activity is None, entry.last_activity or dt.datetime.max.replace(tzinfo=dt.timezone.utc), getattr(entry.member, "display_name", "")))
+    return InvestigationResult(total_wandering=len(wandering), excluded=excluded, entries=tuple(entries))
+
+
+def _format_date(value: Any) -> str:
+    if value is None:
+        return UNKNOWN
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=dt.timezone.utc)
+        return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return str(value)
+
+
+def _entry_block(entry: InvestigationEntry) -> str:
+    member = entry.member
+    display_name = getattr(member, "display_name", None) or getattr(member, "name", None) or str(getattr(member, "id", "unknown"))
+    joined = _format_date(getattr(member, "joined_at", None))
+    activity = _format_date(entry.last_activity)
+    messages = UNKNOWN if entry.message_count is None else str(entry.message_count)
+    return f"Player: {display_name}\nJoined: {joined}\nLast activity: {activity}\nMessages: {messages}"
+
+
+def build_investigation_embeds(result: InvestigationResult) -> list[discord.Embed]:
+    summary = (
+        f"Total members with Wandering Souls role: {result.total_wandering}\n"
+        f"Excluded members count: {result.excluded}\n"
+        f"Final listed members count: {len(result.entries)}"
+    )
+    embeds: list[discord.Embed] = []
+    current = summary
+    page_entries = 0
+    for entry in result.entries:
+        block = "\n\n" + _entry_block(entry)
+        if page_entries and len(current) + len(block) > MAX_EMBED_DESCRIPTION:
+            embed = discord.Embed(title="Wandering Souls Investigation", description=current, colour=colors.admin)
+            embed.set_footer(text=ACTIVITY_FOOTER)
+            embeds.append(embed)
+            current = summary + block
+            page_entries = 1
+        else:
+            current += block
+            page_entries += 1
+    embed = discord.Embed(title="Wandering Souls Investigation", description=current, colour=colors.admin)
+    embed.set_footer(text=ACTIVITY_FOOTER)
+    embeds.append(embed)
+    for index, embed in enumerate(embeds, start=1):
+        if len(embeds) > 1:
+            embed.title = f"Wandering Souls Investigation ({index}/{len(embeds)})"
+    return embeds
+
+
+def build_diagnostics_embed() -> discord.Embed:
+    return discord.Embed(
+        title="Wandering Souls Diagnostics",
+        description="Use `!wanderingsouls investigate` to list current Wandering Souls members.",
+        colour=colors.admin,
+    )
+
+
+def build_error_embed(message: str) -> discord.Embed:
+    return discord.Embed(
+        title="Wandering Souls Investigation Error",
+        description=message,
+        colour=discord.Colour.red(),
+    )

--- a/shared/config.py
+++ b/shared/config.py
@@ -53,6 +53,7 @@ __all__ = [
     "get_clan_role_ids",
     "get_raid_role_id",
     "get_wandering_souls_role_id",
+    "get_wandering_souls_exclude_role_id",
     "get_visitor_role_id",
     "get_recruitment_coordinator_role_ids",
     "get_guardian_knight_role_ids",
@@ -538,6 +539,7 @@ def _load_config() -> Dict[str, object]:
         "CLAN_ROLE_IDS": _int_set(os.getenv("CLAN_ROLE_IDS")),
         "RAID_ROLE_ID": _first_int(os.getenv("RAID_ROLE_ID")),
         "WANDERING_SOULS_ROLE_ID": _first_int(os.getenv("WANDERING_SOULS_ROLE_ID")),
+        "WANDERING_SOULS_EXCLUDE_ROLE_ID": _first_int(os.getenv("WANDERING_SOULS_EXCLUDE_ROLE_ID")),
         "VISITOR_ROLE_ID": _first_int(os.getenv("VISITOR_ROLE_ID")),
         "LEAD_ROLE_IDS": _int_set(os.getenv("LEAD_ROLE_IDS")),
         "CLAN_LEAD_IDS": _int_set(os.getenv("CLAN_LEAD_IDS")),
@@ -1004,6 +1006,10 @@ def get_raid_role_id() -> Optional[int]:
 
 def get_wandering_souls_role_id() -> Optional[int]:
     return _optional_id("WANDERING_SOULS_ROLE_ID")
+
+
+def get_wandering_souls_exclude_role_id() -> Optional[int]:
+    return _optional_id("WANDERING_SOULS_EXCLUDE_ROLE_ID")
 
 
 def get_visitor_role_id() -> Optional[int]:

--- a/tests/modules/housekeeping/test_wandering_souls.py
+++ b/tests/modules/housekeeping/test_wandering_souls.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+from cogs.housekeeping_wandering_souls import WanderingSoulsCog
+from modules.housekeeping import wandering_souls as ws
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class Role:
+    def __init__(self, role_id):
+        self.id = role_id
+
+
+class Member:
+    def __init__(self, member_id, name, roles=(), joined_at=None):
+        self.id = member_id
+        self.display_name = name
+        self.roles = list(roles)
+        self.joined_at = joined_at
+        self.mention = f"<@{member_id}>"
+
+    async def add_roles(self, *args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("read-only command must not mutate roles")
+
+    async def remove_roles(self, *args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("read-only command must not mutate roles")
+
+
+class Guild:
+    def __init__(self, roles, members, *, chunked=True, chunk_error=None):
+        self._roles = {role.id: role for role in roles}
+        self.members = list(members)
+        self.chunked = chunked
+        self.chunk_error = chunk_error
+        self.chunk_calls = []
+
+    def get_role(self, role_id):
+        return self._roles.get(role_id)
+
+    async def chunk(self, *, cache=False):
+        self.chunk_calls.append({"cache": cache})
+        if self.chunk_error is not None:
+            raise self.chunk_error
+        self.chunked = True
+        return self.members
+
+
+class Ctx:
+    def __init__(self, guild):
+        self.guild = guild
+        self.invoked_subcommand = None
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return SimpleNamespace(id=len(self.sent))
+
+
+def test_missing_wandering_souls_role_id_returns_admin_error(monkeypatch):
+    exclude = Role(20)
+    guild = Guild([exclude], [])
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: None)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: exclude.id)
+
+    _wandering, _exclude, error = ws.resolve_investigation_roles(guild)
+
+    assert error == "Missing or invalid WANDERING_SOULS_ROLE_ID. Set it to a numeric Discord role ID."
+    assert ws.build_error_embed(error).title == "Wandering Souls Investigation Error"
+
+
+def test_missing_wandering_souls_exclude_role_id_returns_admin_error(monkeypatch):
+    wandering = Role(10)
+    guild = Guild([wandering], [])
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: wandering.id)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: None)
+
+    _wandering, _exclude, error = ws.resolve_investigation_roles(guild)
+
+    assert error == "Missing or invalid WANDERING_SOULS_EXCLUDE_ROLE_ID. Set it to a numeric Discord role ID."
+    assert "WANDERING_SOULS_EXCLUDE_ROLE_ID" in ws.build_error_embed(error).description
+
+
+def test_members_with_wandering_souls_role_are_included():
+    wandering = Role(10)
+    exclude = Role(20)
+    member = Member(1, "Included", [wandering])
+    guild = Guild([wandering, exclude], [member, Member(2, "Other", [])])
+
+    result = ws.collect_wandering_souls(guild, wandering.id, exclude.id)
+
+    assert result.total_wandering == 1
+    assert [entry.member.display_name for entry in result.entries] == ["Included"]
+
+
+def test_members_with_both_wandering_souls_and_exclusion_role_are_excluded():
+    wandering = Role(10)
+    exclude = Role(20)
+    guild = Guild([wandering, exclude], [Member(1, "Excluded", [wandering, exclude]), Member(2, "Included", [wandering])])
+
+    result = ws.collect_wandering_souls(guild, wandering.id, exclude.id)
+
+    assert result.total_wandering == 2
+    assert result.excluded == 1
+    assert [entry.member.display_name for entry in result.entries] == ["Included"]
+
+
+def test_bare_wandering_souls_group_response_is_embed():
+    ctx = Ctx(Guild([], []))
+    cog = WanderingSoulsCog(SimpleNamespace())
+
+    run(cog.wandering_souls_group.callback(cog, ctx))
+
+    assert ctx.sent
+    embed = ctx.sent[0]["embed"]
+    assert embed.title == "Wandering Souls Diagnostics"
+    assert embed.description == "Use `!wanderingsouls investigate` to list current Wandering Souls members."
+
+
+def test_command_chunks_guild_before_collecting_when_cache_is_incomplete(monkeypatch):
+    wandering = Role(10)
+    exclude = Role(20)
+    guild = Guild([wandering, exclude], [Member(1, "Included", [wandering])], chunked=False)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: wandering.id)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: exclude.id)
+    ctx = Ctx(guild)
+    cog = WanderingSoulsCog(SimpleNamespace())
+
+    run(cog.investigate.callback(cog, ctx))
+
+    assert guild.chunk_calls == [{"cache": True}]
+    assert ctx.sent[0]["embed"].title == "Wandering Souls Investigation"
+    assert "Player: Included" in ctx.sent[0]["embed"].description
+
+
+def test_command_returns_error_embed_when_chunking_fails(monkeypatch):
+    wandering = Role(10)
+    exclude = Role(20)
+    guild = Guild([wandering, exclude], [Member(1, "Partial", [wandering])], chunked=False, chunk_error=RuntimeError("discord unavailable"))
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: wandering.id)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: exclude.id)
+    ctx = Ctx(guild)
+    cog = WanderingSoulsCog(SimpleNamespace())
+
+    run(cog.investigate.callback(cog, ctx))
+
+    assert guild.chunk_calls == [{"cache": True}]
+    assert len(ctx.sent) == 1
+    embed = ctx.sent[0]["embed"]
+    assert embed.title == "Wandering Souls Investigation Error"
+    assert "full member list could not be loaded" in embed.description
+    assert "Partial" not in embed.description
+
+
+def test_command_is_read_only_and_does_not_call_role_mutation_methods(monkeypatch):
+    wandering = Role(10)
+    exclude = Role(20)
+    guild = Guild([wandering, exclude], [Member(1, "Included", [wandering])])
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: wandering.id)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: exclude.id)
+    ctx = Ctx(guild)
+    cog = WanderingSoulsCog(SimpleNamespace())
+
+    run(cog.investigate.callback(cog, ctx))
+
+    assert ctx.sent
+    assert ctx.sent[0]["embed"].title == "Wandering Souls Investigation"
+
+
+def test_long_results_are_paginated_safely():
+    entries = tuple(ws.InvestigationEntry(Member(i, f"Member {i:03} with a fairly long display name", [])) for i in range(120))
+    result = ws.InvestigationResult(total_wandering=120, excluded=0, entries=entries)
+
+    embeds = ws.build_investigation_embeds(result)
+
+    assert len(embeds) > 1
+    assert all(len(embed.description) <= ws.MAX_EMBED_DESCRIPTION for embed in embeds)
+    assert embeds[0].title.startswith("Wandering Souls Investigation (1/")
+
+
+def test_unknown_activity_and_message_stats_are_rendered_honestly():
+    joined = dt.datetime(2026, 1, 2, 3, 4, tzinfo=dt.timezone.utc)
+    result = ws.InvestigationResult(total_wandering=1, excluded=0, entries=(ws.InvestigationEntry(Member(1, "Mystery", [], joined)),))
+
+    embed = ws.build_investigation_embeds(result)[0]
+
+    assert "Last activity: unknown" in embed.description
+    assert "Messages: unknown" in embed.description
+    assert embed.footer.text == ws.ACTIVITY_FOOTER


### PR DESCRIPTION
### Motivation
- Provide an admin-only diagnostic to inspect members assigned the Wandering Souls role and allow excluding specific roles from results.

### Description
- Add `modules/housekeeping/wandering_souls.py` implementing investigation logic, result formatting, and embed builders for paginated output.
- Add `cogs/housekeeping_wandering_souls.py` to expose `!wanderingsouls` and `!wanderingsouls investigate` admin commands and wire chunking/error handling.
- Register the cog in the bot startup by importing and calling `housekeeping_wandering_souls.setup` from `modules/common/runtime.py`.
- Add configuration support in `shared/config.py` (`WANDERING_SOULS_EXCLUDE_ROLE_ID` and `get_wandering_souls_exclude_role_id`) and document the env var in `docs/ops/.env.example` and `AGENTS.md`.
- Add unit tests in `tests/modules/housekeeping/test_wandering_souls.py` covering role resolution, collection, pagination, error handling, and read-only behavior.

### Testing
- Ran `pytest tests/modules/housekeeping/test_wandering_souls.py` and the new unit tests passed successfully.
- Existing startup flow was exercised to ensure the new cog is registered without errors during runtime initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551e6c931083239fe7397e88591e5c)