### PR TITLE
Improve Wandering Souls investigation output

### DIFF
--- a/cogs/housekeeping_wandering_souls.py
+++ b/cogs/housekeeping_wandering_souls.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import discord
 from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
@@ -36,7 +37,12 @@ class WanderingSoulsCog(commands.Cog):
     @wandering_souls_group.command(name="investigate")
     @commands.guild_only()
     @admin_only()
-    async def investigate(self, ctx: commands.Context) -> None:
+    async def investigate(self, ctx: commands.Context, days: str | None = None) -> None:
+        scan_days, parse_error = ws.parse_scan_days(days)
+        if parse_error:
+            await ctx.send(embed=ws.build_error_embed(parse_error))
+            return
+
         guild = ctx.guild
         if guild is None:
             await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
@@ -56,9 +62,11 @@ class WanderingSoulsCog(commands.Cog):
         if error:
             await ctx.send(embed=ws.build_error_embed(error))
             return
-        result = ws.collect_wandering_souls(guild, int(wandering_role.id), int(exclude_role.id))
+        result = ws.collect_wandering_souls(guild, int(wandering_role.id), int(exclude_role.id), scan_days=int(scan_days))
+        result = await ws.scan_recent_messages(guild, result)
+        allowed_mentions = discord.AllowedMentions.none()
         for embed in ws.build_investigation_embeds(result):
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, allowed_mentions=allowed_mentions)
 
 
 async def setup(bot: commands.Bot):

--- a/modules/housekeeping/wandering_souls.py
+++ b/modules/housekeeping/wandering_souls.py
@@ -9,16 +9,20 @@ import discord
 from shared import config
 from shared.theme import colors
 
-ACTIVITY_FOOTER = "Last activity and message count are based on tracked bot-visible activity only."
+ACTIVITY_FOOTER = "Message stats are based on bot-visible channel history scanned for this command."
 UNKNOWN = "unknown"
 MAX_EMBED_DESCRIPTION = 3900
+DEFAULT_SCAN_DAYS = 90
+MIN_SCAN_DAYS = 1
+MAX_SCAN_DAYS = 180
 
 
 @dataclass(frozen=True)
 class InvestigationEntry:
     member: Any
-    last_activity: dt.datetime | None = None
-    message_count: int | None = None
+    last_message_at: dt.datetime | None = None
+    scanned_message_count: int = 0
+    last_message_channel: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -26,6 +30,18 @@ class InvestigationResult:
     total_wandering: int
     excluded: int
     entries: tuple[InvestigationEntry, ...]
+    scan_days: int = DEFAULT_SCAN_DAYS
+    scan_warning_count: int = 0
+
+
+def parse_scan_days(value: str | None) -> tuple[int | None, str | None]:
+    if value is None:
+        return DEFAULT_SCAN_DAYS, None
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return None, "Accepted syntax: `!wanderingsouls investigate` or `!wanderingsouls investigate <days>` where `<days>` is a whole number from 1 to 180."
+    return max(MIN_SCAN_DAYS, min(MAX_SCAN_DAYS, days)), None
 
 
 def _role_ids(member: Any) -> set[int]:
@@ -57,7 +73,7 @@ def resolve_investigation_roles(guild: Any) -> tuple[Any | None, Any | None, str
     return wandering_role, exclude_role, None
 
 
-def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id: int) -> InvestigationResult:
+def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id: int, *, scan_days: int = DEFAULT_SCAN_DAYS) -> InvestigationResult:
     wandering: list[Any] = []
     entries: list[InvestigationEntry] = []
     excluded = 0
@@ -70,13 +86,75 @@ def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id:
             excluded += 1
             continue
         entries.append(InvestigationEntry(member=member))
-    entries.sort(key=lambda entry: (entry.last_activity is None, entry.last_activity or dt.datetime.max.replace(tzinfo=dt.timezone.utc), getattr(entry.member, "display_name", "")))
-    return InvestigationResult(total_wandering=len(wandering), excluded=excluded, entries=tuple(entries))
+    entries = _sort_entries(entries)
+    return InvestigationResult(total_wandering=len(wandering), excluded=excluded, entries=tuple(entries), scan_days=scan_days)
 
 
-def _format_date(value: Any) -> str:
+def _sort_entries(entries: list[InvestigationEntry]) -> list[InvestigationEntry]:
+    return sorted(
+        entries,
+        key=lambda entry: (
+            entry.last_message_at is None,
+            entry.last_message_at or dt.datetime.max.replace(tzinfo=dt.timezone.utc),
+            getattr(entry.member, "joined_at", None) or dt.datetime.max.replace(tzinfo=dt.timezone.utc),
+            (getattr(entry.member, "display_name", None) or "").casefold(),
+        ),
+    )
+
+
+def _scan_channels(guild: Any) -> list[Any]:
+    channels = list(getattr(guild, "text_channels", ()) or ())
+    channels.extend(getattr(guild, "threads", ()) or ())
+    return channels
+
+
+async def scan_recent_messages(guild: Any, result: InvestigationResult, *, now: dt.datetime | None = None) -> InvestigationResult:
+    if now is None:
+        now = dt.datetime.now(dt.timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.timezone.utc)
+    cutoff = now - dt.timedelta(days=result.scan_days)
+    candidate_ids = {int(getattr(entry.member, "id")) for entry in result.entries}
+    stats: dict[int, dict[str, Any]] = {member_id: {"count": 0, "last_at": None, "channel": None} for member_id in candidate_ids}
+    warnings = 0
+    for channel in _scan_channels(guild):
+        history = getattr(channel, "history", None)
+        if history is None:
+            continue
+        try:
+            async for message in history(limit=None, after=cutoff, oldest_first=False):
+                created_at = getattr(message, "created_at", None)
+                if isinstance(created_at, dt.datetime):
+                    if created_at.tzinfo is None:
+                        created_at = created_at.replace(tzinfo=dt.timezone.utc)
+                    if created_at < cutoff:
+                        break
+                author_id = getattr(getattr(message, "author", None), "id", None)
+                if author_id not in candidate_ids:
+                    continue
+                item = stats[int(author_id)]
+                item["count"] += 1
+                if created_at is not None and (item["last_at"] is None or created_at > item["last_at"]):
+                    item["last_at"] = created_at
+                    item["channel"] = channel
+        except (discord.Forbidden, discord.NotFound, discord.HTTPException):
+            warnings += 1
+            continue
+    entries = [
+        InvestigationEntry(
+            member=entry.member,
+            last_message_at=stats[int(getattr(entry.member, "id"))]["last_at"],
+            scanned_message_count=stats[int(getattr(entry.member, "id"))]["count"],
+            last_message_channel=stats[int(getattr(entry.member, "id"))]["channel"],
+        )
+        for entry in result.entries
+    ]
+    return InvestigationResult(result.total_wandering, result.excluded, tuple(_sort_entries(entries)), result.scan_days, warnings)
+
+
+def _format_date(value: Any, *, none_text: str = UNKNOWN) -> str:
     if value is None:
-        return UNKNOWN
+        return none_text
     if isinstance(value, dt.datetime):
         if value.tzinfo is None:
             value = value.replace(tzinfo=dt.timezone.utc)
@@ -84,21 +162,38 @@ def _format_date(value: Any) -> str:
     return str(value)
 
 
+def _channel_reference(channel: Any | None) -> str:
+    if channel is None:
+        return UNKNOWN
+    return getattr(channel, "mention", None) or getattr(channel, "name", None) or UNKNOWN
+
+
 def _entry_block(entry: InvestigationEntry) -> str:
     member = entry.member
-    display_name = getattr(member, "display_name", None) or getattr(member, "name", None) or str(getattr(member, "id", "unknown"))
+    member_id = getattr(member, "id", "unknown")
+    display_name = getattr(member, "display_name", None) or getattr(member, "name", None) or str(member_id)
     joined = _format_date(getattr(member, "joined_at", None))
-    activity = _format_date(entry.last_activity)
-    messages = UNKNOWN if entry.message_count is None else str(entry.message_count)
-    return f"Player: {display_name}\nJoined: {joined}\nLast activity: {activity}\nMessages: {messages}"
+    last_message = _format_date(entry.last_message_at, none_text="none found in scan window")
+    return (
+        f"Profile: <@{member_id}>\n"
+        f"Name: {display_name}\n"
+        f"ID: {member_id}\n"
+        f"Joined: {joined}\n"
+        f"Last message: {last_message}\n"
+        f"Messages in scan window: {entry.scanned_message_count}\n"
+        f"Last seen channel: {_channel_reference(entry.last_message_channel)}"
+    )
 
 
 def build_investigation_embeds(result: InvestigationResult) -> list[discord.Embed]:
     summary = (
         f"Total members with Wandering Souls role: {result.total_wandering}\n"
         f"Excluded members count: {result.excluded}\n"
-        f"Final listed members count: {len(result.entries)}"
+        f"Final listed members count: {len(result.entries)}\n"
+        f"Message scan window: last {result.scan_days} days"
     )
+    if result.scan_warning_count:
+        summary += f"\nScan warning count: {result.scan_warning_count} channel(s) could not be read"
     embeds: list[discord.Embed] = []
     current = summary
     page_entries = 0

--- a/tests/modules/housekeeping/test_wandering_souls.py
+++ b/tests/modules/housekeeping/test_wandering_souls.py
@@ -135,7 +135,7 @@ def test_command_chunks_guild_before_collecting_when_cache_is_incomplete(monkeyp
 
     assert guild.chunk_calls == [{"cache": True}]
     assert ctx.sent[0]["embed"].title == "Wandering Souls Investigation"
-    assert "Player: Included" in ctx.sent[0]["embed"].description
+    assert "Name: Included" in ctx.sent[0]["embed"].description
 
 
 def test_command_returns_error_embed_when_chunking_fails(monkeypatch):
@@ -183,12 +183,135 @@ def test_long_results_are_paginated_safely():
     assert embeds[0].title.startswith("Wandering Souls Investigation (1/")
 
 
-def test_unknown_activity_and_message_stats_are_rendered_honestly():
+def test_unknown_message_stats_are_rendered_honestly():
     joined = dt.datetime(2026, 1, 2, 3, 4, tzinfo=dt.timezone.utc)
     result = ws.InvestigationResult(total_wandering=1, excluded=0, entries=(ws.InvestigationEntry(Member(1, "Mystery", [], joined)),))
 
     embed = ws.build_investigation_embeds(result)[0]
 
-    assert "Last activity: unknown" in embed.description
-    assert "Messages: unknown" in embed.description
+    assert "Last activity" not in embed.description
+    assert "Last message: none found in scan window" in embed.description
+    assert "Messages in scan window: 0" in embed.description
     assert embed.footer.text == ws.ACTIVITY_FOOTER
+
+class Message:
+    def __init__(self, author_id, created_at):
+        self.author = SimpleNamespace(id=author_id)
+        self.created_at = created_at
+
+
+class Channel:
+    def __init__(self, channel_id, name, messages=(), error=None):
+        self.id = channel_id
+        self.name = name
+        self.mention = f"<#{channel_id}>"
+        self.messages = list(messages)
+        self.error = error
+        self.calls = []
+
+    async def _history(self, *, limit=None, after=None, oldest_first=False):
+        self.calls.append({"limit": limit, "after": after, "oldest_first": oldest_first})
+        if self.error is not None:
+            raise self.error
+        for message in self.messages:
+            yield message
+
+    def history(self, *, limit=None, after=None, oldest_first=False):
+        return self._history(limit=limit, after=after, oldest_first=oldest_first)
+
+
+def test_default_scan_window_is_90_days():
+    assert ws.parse_scan_days(None) == (90, None)
+    result = ws.collect_wandering_souls(Guild([Role(10), Role(20)], [Member(1, "A", [Role(10)])]), 10, 20)
+    assert result.scan_days == 90
+
+
+def test_invalid_day_argument_returns_embed_error():
+    days, error = ws.parse_scan_days("soon")
+    embed = ws.build_error_embed(error)
+
+    assert days is None
+    assert embed.title == "Wandering Souls Investigation Error"
+    assert "!wanderingsouls investigate <days>" in embed.description
+
+
+def test_day_argument_is_clamped_to_max_180():
+    assert ws.parse_scan_days("999") == (180, None)
+
+
+def test_entries_include_profile_mention_and_id_and_last_message_wording():
+    result = ws.InvestigationResult(total_wandering=1, excluded=0, entries=(ws.InvestigationEntry(Member(123, "Mystery", [])),))
+    description = ws.build_investigation_embeds(result)[0].description
+
+    assert "Profile: <@123>" in description
+    assert "ID: 123" in description
+    assert "Last activity" not in description
+    assert "Last message:" in description
+    assert "Messages in scan window:" in description
+
+
+def test_only_final_candidate_member_ids_are_counted():
+    now = dt.datetime(2026, 7, 13, tzinfo=dt.timezone.utc)
+    wandering = Role(10)
+    exclude = Role(20)
+    included = Member(1, "Included", [wandering])
+    other = Member(2, "Other", [])
+    guild = Guild([wandering, exclude], [included, other])
+    channel = Channel(100, "general", [Message(1, now), Message(2, now)])
+    guild.text_channels = [channel]
+
+    result = ws.collect_wandering_souls(guild, wandering.id, exclude.id)
+    scanned = run(ws.scan_recent_messages(guild, result, now=now))
+
+    assert len(scanned.entries) == 1
+    assert scanned.entries[0].member.id == 1
+    assert scanned.entries[0].scanned_message_count == 1
+
+
+def test_excluded_role_members_are_not_scanned_or_counted():
+    now = dt.datetime(2026, 7, 13, tzinfo=dt.timezone.utc)
+    wandering = Role(10)
+    exclude = Role(20)
+    included = Member(1, "Included", [wandering])
+    excluded = Member(2, "Excluded", [wandering, exclude])
+    guild = Guild([wandering, exclude], [included, excluded])
+    channel = Channel(100, "general", [Message(1, now), Message(2, now)])
+    guild.text_channels = [channel]
+
+    result = ws.collect_wandering_souls(guild, wandering.id, exclude.id)
+    scanned = run(ws.scan_recent_messages(guild, result, now=now))
+
+    assert scanned.excluded == 1
+    assert [entry.member.id for entry in scanned.entries] == [1]
+    assert scanned.entries[0].scanned_message_count == 1
+
+
+def test_forbidden_channel_history_is_skipped_and_reported(monkeypatch):
+    now = dt.datetime(2026, 7, 13, tzinfo=dt.timezone.utc)
+    monkeypatch.setattr(ws.discord, "Forbidden", RuntimeError)
+    guild = Guild([Role(10), Role(20)], [Member(1, "Included", [Role(10)])])
+    guild.text_channels = [Channel(100, "private", error=RuntimeError("no access"))]
+    result = ws.collect_wandering_souls(guild, 10, 20)
+
+    scanned = run(ws.scan_recent_messages(guild, result, now=now))
+    description = ws.build_investigation_embeds(scanned)[0].description
+
+    assert scanned.scan_warning_count == 1
+    assert "Scan warning count: 1 channel(s) could not be read" in description
+
+
+def test_scan_populates_last_message_count_and_channel():
+    now = dt.datetime(2026, 7, 13, 12, tzinfo=dt.timezone.utc)
+    older = now - dt.timedelta(days=2)
+    member = Member(1, "Included", [Role(10)])
+    guild = Guild([Role(10), Role(20)], [member])
+    channel = Channel(100, "general", [Message(1, older), Message(1, now)])
+    guild.text_channels = [channel]
+
+    result = ws.collect_wandering_souls(guild, 10, 20, scan_days=90)
+    scanned = run(ws.scan_recent_messages(guild, result, now=now))
+    description = ws.build_investigation_embeds(scanned)[0].description
+
+    assert "Last message: 2026-07-13 12:00 UTC" in description
+    assert "Messages in scan window: 2" in description
+    assert "Last seen channel: <#100>" in description


### PR DESCRIPTION
### Motivation
- The existing investigation only showed display names and honest but unhelpful “Last activity: unknown” / “Messages: unknown”, which made it hard for admins to open profiles or get actionable context.
- The goal was to produce clickable/identifiable member entries and optionally surface bounded recent message history for final candidates so admins can triage without running unbounded scans.
- The change must remain read-only, admin-only, preserve role resolution from env vars (`WANDERING_SOULS_ROLE_ID`, `WANDERING_SOULS_EXCLUDE_ROLE_ID`), preserve guild chunking behavior, and avoid touching sheets, roles, scheduled collectors, or intents/permissions.

### Description
- Add optional `!wanderingsouls investigate <days>` parsing with a default of `90` days, syntax validation, and clamping to the safe range `1..180` via `parse_scan_days()` in `modules/housekeeping/wandering_souls.py` and an updated cog signature to accept `days` in `cogs/housekeeping_wandering_souls.py`.
- Collect only final Wandering Souls candidates (excluding members with the exclusion role) and perform a bounded scan of bot-visible text/forum/thread channels for messages newer than now - `<days>`, skipping channels without history and counting read failures as scan warnings in `scan_recent_messages()`.
- Replace ambiguous wording with explicit per-member fields in embeds: `Profile: <@USER_ID>`, `Name: <display name>`, `ID: <USER_ID>`, `Joined: <YYYY-MM-DD HH:MM UTC or unknown>`, `Last message: <timestamp or none found in scan window>`, `Messages in scan window: <count>`, and `Last seen channel: <#CHANNEL_ID> or unknown`, and add a summary (total, excluded, listed, message scan window, scan warning count) on every page; allowed mentions are disabled when sending to avoid pings.
- Preserve operational guardrails: command remains admin-only and read-only, role resolution still uses `WANDERING_SOULS_ROLE_ID` and `WANDERING_SOULS_EXCLUDE_ROLE_ID`, no sheets are written, no roles are mutated, and there are no changes to gateway intents, OAuth scopes, permissions, access lists, or sheet IDs.

### Testing
- Ran `pytest tests/modules/housekeeping/test_wandering_souls.py` and the updated Wandering Souls unit tests passed.
- Per-file compile check with `python -m py_compile` on the modified files passed.
- Full test run (`pytest -q --maxfail=1`) stopped on an unrelated existing shard-tracker test due to a missing milestones sheet ID in test environment (`MilestonesSheetIdUnavailable`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55268a480c8323bdfa8bbbe4dc516b)