### PR TITLE
Hotfix: require explicit scan window for Wandering Souls investigate and add per-guild scan lock

### DIFF
--- a/cogs/housekeeping_wandering_souls.py
+++ b/cogs/housekeeping_wandering_souls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
@@ -17,6 +18,15 @@ MEMBER_LOAD_ERROR = "The investigation could not safely run because the full mem
 class WanderingSoulsCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        self._scan_locks: dict[int, asyncio.Lock] = {}
+
+    def _scan_lock_for(self, guild: discord.Guild) -> asyncio.Lock:
+        guild_id = int(getattr(guild, "id", id(guild)))
+        lock = self._scan_locks.get(guild_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._scan_locks[guild_id] = lock
+        return lock
 
     @tier("admin")
     @help_metadata(function_group="operational", section="utilities", access_tier="admin")
@@ -47,26 +57,34 @@ class WanderingSoulsCog(commands.Cog):
         if guild is None:
             await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
             return
-        if not getattr(guild, "chunked", False):
-            try:
-                await guild.chunk(cache=True)
-            except Exception:
-                log.exception("wandering souls investigation failed to chunk guild members")
-                await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
-                return
-        if getattr(guild, "members", None) is None:
-            await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+
+        lock = self._scan_lock_for(guild)
+        if lock.locked():
+            await ctx.send(embed=ws.build_error_embed(ws.SCAN_ALREADY_RUNNING_ERROR))
             return
 
-        wandering_role, exclude_role, error = ws.resolve_investigation_roles(guild)
-        if error:
-            await ctx.send(embed=ws.build_error_embed(error))
-            return
-        result = ws.collect_wandering_souls(guild, int(wandering_role.id), int(exclude_role.id), scan_days=int(scan_days))
-        result = await ws.scan_recent_messages(guild, result)
-        allowed_mentions = discord.AllowedMentions.none()
-        for embed in ws.build_investigation_embeds(result):
-            await ctx.send(embed=embed, allowed_mentions=allowed_mentions)
+        async with lock:
+            await ctx.send(embed=ws.build_ack_embed(int(scan_days)))
+            if not getattr(guild, "chunked", False):
+                try:
+                    await guild.chunk(cache=True)
+                except Exception:
+                    log.exception("wandering souls investigation failed to chunk guild members")
+                    await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+                    return
+            if getattr(guild, "members", None) is None:
+                await ctx.send(embed=ws.build_error_embed(MEMBER_LOAD_ERROR))
+                return
+
+            wandering_role, exclude_role, error = ws.resolve_investigation_roles(guild)
+            if error:
+                await ctx.send(embed=ws.build_error_embed(error))
+                return
+            result = ws.collect_wandering_souls(guild, int(wandering_role.id), int(exclude_role.id), scan_days=int(scan_days))
+            result = await ws.scan_recent_messages(guild, result)
+            allowed_mentions = discord.AllowedMentions.none()
+            for embed in ws.build_investigation_embeds(result):
+                await ctx.send(embed=embed, allowed_mentions=allowed_mentions)
 
 
 async def setup(bot: commands.Bot):

--- a/modules/housekeeping/wandering_souls.py
+++ b/modules/housekeeping/wandering_souls.py
@@ -12,7 +12,6 @@ from shared.theme import colors
 ACTIVITY_FOOTER = "Message stats are based on bot-visible channel history scanned for this command."
 UNKNOWN = "unknown"
 MAX_EMBED_DESCRIPTION = 3900
-DEFAULT_SCAN_DAYS = 90
 MIN_SCAN_DAYS = 1
 MAX_SCAN_DAYS = 180
 
@@ -30,17 +29,22 @@ class InvestigationResult:
     total_wandering: int
     excluded: int
     entries: tuple[InvestigationEntry, ...]
-    scan_days: int = DEFAULT_SCAN_DAYS
+    scan_days: int = MIN_SCAN_DAYS
     scan_warning_count: int = 0
+
+
+MISSING_SCAN_WINDOW_ERROR = "Missing scan window.\nUse: !wanderingsouls investigate 30\nAllowed range: 1-180 days."
+INVALID_SCAN_WINDOW_ERROR = "Invalid scan window.\nUse: !wanderingsouls investigate 30\nAllowed range: 1-180 days."
+SCAN_ALREADY_RUNNING_ERROR = "A Wandering Souls investigation scan is already running. Wait for it to finish before starting another."
 
 
 def parse_scan_days(value: str | None) -> tuple[int | None, str | None]:
     if value is None:
-        return DEFAULT_SCAN_DAYS, None
+        return None, MISSING_SCAN_WINDOW_ERROR
     try:
         days = int(value)
     except (TypeError, ValueError):
-        return None, "Accepted syntax: `!wanderingsouls investigate` or `!wanderingsouls investigate <days>` where `<days>` is a whole number from 1 to 180."
+        return None, INVALID_SCAN_WINDOW_ERROR
     return max(MIN_SCAN_DAYS, min(MAX_SCAN_DAYS, days)), None
 
 
@@ -73,7 +77,7 @@ def resolve_investigation_roles(guild: Any) -> tuple[Any | None, Any | None, str
     return wandering_role, exclude_role, None
 
 
-def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id: int, *, scan_days: int = DEFAULT_SCAN_DAYS) -> InvestigationResult:
+def collect_wandering_souls(guild: Any, wandering_role_id: int, exclude_role_id: int, *, scan_days: int = MIN_SCAN_DAYS) -> InvestigationResult:
     wandering: list[Any] = []
     entries: list[InvestigationEntry] = []
     excluded = 0
@@ -220,7 +224,15 @@ def build_investigation_embeds(result: InvestigationResult) -> list[discord.Embe
 def build_diagnostics_embed() -> discord.Embed:
     return discord.Embed(
         title="Wandering Souls Diagnostics",
-        description="Use `!wanderingsouls investigate` to list current Wandering Souls members.",
+        description="Use `!wanderingsouls investigate <days>` to scan Wandering Souls message activity.",
+        colour=colors.admin,
+    )
+
+
+def build_ack_embed(scan_days: int) -> discord.Embed:
+    return discord.Embed(
+        title="Wandering Souls Investigation",
+        description=f"Scanning Wandering Souls activity for the last {scan_days} days…",
         colour=colors.admin,
     )
 

--- a/tests/modules/housekeeping/test_wandering_souls.py
+++ b/tests/modules/housekeeping/test_wandering_souls.py
@@ -119,7 +119,7 @@ def test_bare_wandering_souls_group_response_is_embed():
     assert ctx.sent
     embed = ctx.sent[0]["embed"]
     assert embed.title == "Wandering Souls Diagnostics"
-    assert embed.description == "Use `!wanderingsouls investigate` to list current Wandering Souls members."
+    assert embed.description == "Use `!wanderingsouls investigate <days>` to scan Wandering Souls message activity."
 
 
 def test_command_chunks_guild_before_collecting_when_cache_is_incomplete(monkeypatch):
@@ -131,11 +131,12 @@ def test_command_chunks_guild_before_collecting_when_cache_is_incomplete(monkeyp
     ctx = Ctx(guild)
     cog = WanderingSoulsCog(SimpleNamespace())
 
-    run(cog.investigate.callback(cog, ctx))
+    run(cog.investigate.callback(cog, ctx, "30"))
 
     assert guild.chunk_calls == [{"cache": True}]
     assert ctx.sent[0]["embed"].title == "Wandering Souls Investigation"
-    assert "Name: Included" in ctx.sent[0]["embed"].description
+    assert ctx.sent[0]["embed"].description == "Scanning Wandering Souls activity for the last 30 days…"
+    assert "Name: Included" in ctx.sent[1]["embed"].description
 
 
 def test_command_returns_error_embed_when_chunking_fails(monkeypatch):
@@ -147,11 +148,12 @@ def test_command_returns_error_embed_when_chunking_fails(monkeypatch):
     ctx = Ctx(guild)
     cog = WanderingSoulsCog(SimpleNamespace())
 
-    run(cog.investigate.callback(cog, ctx))
+    run(cog.investigate.callback(cog, ctx, "30"))
 
     assert guild.chunk_calls == [{"cache": True}]
-    assert len(ctx.sent) == 1
-    embed = ctx.sent[0]["embed"]
+    assert len(ctx.sent) == 2
+    assert ctx.sent[0]["embed"].description == "Scanning Wandering Souls activity for the last 30 days…"
+    embed = ctx.sent[1]["embed"]
     assert embed.title == "Wandering Souls Investigation Error"
     assert "full member list could not be loaded" in embed.description
     assert "Partial" not in embed.description
@@ -166,7 +168,7 @@ def test_command_is_read_only_and_does_not_call_role_mutation_methods(monkeypatc
     ctx = Ctx(guild)
     cog = WanderingSoulsCog(SimpleNamespace())
 
-    run(cog.investigate.callback(cog, ctx))
+    run(cog.investigate.callback(cog, ctx, "30"))
 
     assert ctx.sent
     assert ctx.sent[0]["embed"].title == "Wandering Souls Investigation"
@@ -220,10 +222,13 @@ class Channel:
         return self._history(limit=limit, after=after, oldest_first=oldest_first)
 
 
-def test_default_scan_window_is_90_days():
-    assert ws.parse_scan_days(None) == (90, None)
-    result = ws.collect_wandering_souls(Guild([Role(10), Role(20)], [Member(1, "A", [Role(10)])]), 10, 20)
-    assert result.scan_days == 90
+def test_missing_scan_window_returns_embed_error():
+    days, error = ws.parse_scan_days(None)
+    embed = ws.build_error_embed(error)
+
+    assert days is None
+    assert embed.title == "Wandering Souls Investigation Error"
+    assert embed.description == "Missing scan window.\nUse: !wanderingsouls investigate 30\nAllowed range: 1-180 days."
 
 
 def test_invalid_day_argument_returns_embed_error():
@@ -232,7 +237,7 @@ def test_invalid_day_argument_returns_embed_error():
 
     assert days is None
     assert embed.title == "Wandering Souls Investigation Error"
-    assert "!wanderingsouls investigate <days>" in embed.description
+    assert "Use: !wanderingsouls investigate 30" in embed.description
 
 
 def test_day_argument_is_clamped_to_max_180():
@@ -315,3 +320,50 @@ def test_scan_populates_last_message_count_and_channel():
     assert "Last message: 2026-07-13 12:00 UTC" in description
     assert "Messages in scan window: 2" in description
     assert "Last seen channel: <#100>" in description
+
+
+def test_bare_investigate_returns_missing_window_without_collecting_or_scanning(monkeypatch):
+    guild = Guild([Role(10), Role(20)], [Member(1, "Included", [Role(10)])])
+    ctx = Ctx(guild)
+    cog = WanderingSoulsCog(SimpleNamespace())
+    monkeypatch.setattr(ws, "collect_wandering_souls", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not collect")))
+    monkeypatch.setattr(ws, "scan_recent_messages", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not scan")))
+
+    run(cog.investigate.callback(cog, ctx))
+
+    assert len(ctx.sent) == 1
+    embed = ctx.sent[0]["embed"]
+    assert embed.title == "Wandering Souls Investigation Error"
+    assert embed.description == "Missing scan window.\nUse: !wanderingsouls investigate 30\nAllowed range: 1-180 days."
+
+
+def test_command_rejects_concurrent_scans(monkeypatch):
+    wandering = Role(10)
+    exclude = Role(20)
+    guild = Guild([wandering, exclude], [Member(1, "Included", [wandering])])
+    monkeypatch.setattr(ws.config, "get_wandering_souls_role_id", lambda: wandering.id)
+    monkeypatch.setattr(ws.config, "get_wandering_souls_exclude_role_id", lambda: exclude.id)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_scan(guild, result):
+        started.set()
+        await release.wait()
+        return result
+
+    monkeypatch.setattr(ws, "scan_recent_messages", slow_scan)
+    cog = WanderingSoulsCog(SimpleNamespace())
+    first = Ctx(guild)
+    second = Ctx(guild)
+
+    async def exercise():
+        first_task = asyncio.create_task(cog.investigate.callback(cog, first, "30"))
+        await started.wait()
+        await cog.investigate.callback(cog, second, "30")
+        release.set()
+        await first_task
+
+    run(exercise())
+
+    assert second.sent[0]["embed"].title == "Wandering Souls Investigation Error"
+    assert second.sent[0]["embed"].description == ws.SCAN_ALREADY_RUNNING_ERROR


### PR DESCRIPTION
### Motivation
- The `!wanderingsouls investigate` command previously started a silent default 90-day message-history scan which could produce role-only reports that are useless; the scan window must be explicit and acknowledged. 
- Prevent stacking expensive concurrent scans and ensure admins are explicitly requesting a read-only activity scan with a bounded window.

### Description
- Require an explicit scan window by changing `parse_scan_days` to return an error when `days` is omitted and by removing the old 90-day default; scan values are clamped to `1-180` days and invalid/non-numeric input returns a clear admin-facing error embed (`MISSING_SCAN_WINDOW_ERROR`, `INVALID_SCAN_WINDOW_ERROR`). (files: `modules/housekeeping/wandering_souls.py`)
- Add an immediate acknowledgement embed `build_ack_embed(scan_days)` sent before scanning: `Scanning Wandering Souls activity for the last <days> days…`. (file: `modules/housekeeping/wandering_souls.py`)
- Add a per-guild asyncio lock in the cog so repeated scans do not stack and concurrent requests are rejected with an admin-facing embed (`SCAN_ALREADY_RUNNING_ERROR`). (file: `cogs/housekeeping_wandering_souls.py`)
- Move chunking/member-load logic inside the scan lock and preserve read-only behavior and existing include/exclude role filtering and report fields (profile mention, name, ID, joined, last message, messages in window, last seen channel); no role mutations, no sheet writes, and no other behavior changes. (files: `cogs/housekeeping_wandering_souls.py`, `modules/housekeeping/wandering_souls.py`)
- Update and add unit tests to assert the new behaviors (missing window error, no collection/scan for bare command, ack before scanning, concurrent-scan rejection, invalid days handling, clamping to 1-180). (file: `tests/modules/housekeeping/test_wandering_souls.py`)
- Guardrails: no changes to Discord intents, OAuth scopes, permissions, access lists, sheet IDs, scheduled collectors, achievements, or any role mutation logic.

### Testing
- Ran `pytest -q tests/modules/housekeeping/test_wandering_souls.py` and the test suite passed. 
- Tests were updated/added to cover: missing scan window returns the admin error embed, bare command does not collect or scan members, `!wanderingsouls investigate 30` sends acknowledgement then produces the report, concurrent scans are rejected, invalid day arguments produce an error, and days are clamped to `1-180`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55313a20648323b648db44a0d64920)