### PR TITLE
Use async Google Sheets helpers in runtime code; add async tab-name helpers and guardrail tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ docs/ops/.env.example
 **Feature Toggles / Config (from Sheets, not ENV)**
 - Feature toggles must be served from your sheet config tabs (per contract). Do **not** move runtime toggles to ENV unless you explicitly add them to `env.example` and document the reason.
 
+**Async runtime Sheets rule**
+- Discord commands, listeners, views, modals, scheduler jobs, and async startup/on_ready code must never call synchronous Google Sheets helpers. Use async helpers only (`afetch_records`, `afetch_values`, `asheets_read`, `acall_with_backoff`, `get_config_value_async`, and async tab/header helpers). If no async helper exists, add one instead of calling the sync helper.
+
 **Gateway Intents / Permissions (operational guidance)**
 - Maintain minimum necessary intents in both portal and code. Any change to intents or OAuth scopes must be:
   1. Listed here,

--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -352,7 +352,7 @@ class AppAdmin(commands.Cog):
             )
             return
 
-        tab_name = recruitment_sheet.get_role_map_tab_name()
+        tab_name = await recruitment_sheet.get_role_map_tab_name_async()
         try:
             entries = await cluster_role_map.fetch_role_map_rows(tab_name=tab_name)
         except cluster_role_map.RoleMapLoadError as exc:

--- a/modules/ops/cluster_role_map.py
+++ b/modules/ops/cluster_role_map.py
@@ -149,7 +149,9 @@ async def fetch_role_map_rows(tab_name: str | None = None) -> List[RoleMapRow]:
     if not sheet_id:
         raise RoleMapLoadError("Recruitment sheet ID is missing")
 
-    rolemap_tab = _normalize_text(tab_name) or recruitment.get_role_map_tab_name()
+    rolemap_tab = (
+        _normalize_text(tab_name) or await recruitment.get_role_map_tab_name_async()
+    )
     if not rolemap_tab:
         raise RoleMapLoadError("Role map tab name missing")
 

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -72,7 +72,7 @@ from shared.sheets.async_core import (
     acall_with_backoff,
     afetch_records,
 )
-from shared.sheets.recruitment import get_config_value_async, get_reports_tab_name
+from shared.sheets.recruitment import get_config_value_async, get_reports_tab_name_async
 import shared.sheets.core as sheets_core
 from modules.common.config_sheets import SHEET_TARGETS, SheetTarget
 
@@ -2569,7 +2569,7 @@ class CoreOpsCog(commands.Cog):
 
         if target.sheet_id_key == "RECRUITMENT_SHEET_ID":
             reports_config = discovery.tab_map.get("REPORTS_TAB")
-            reports_default = get_reports_tab_name("Statistics")
+            reports_default = await get_reports_tab_name_async("Statistics")
             reports_tab = (reports_config or reports_default or "").strip()
             if reports_tab:
                 normalized_reports = reports_tab.lower()

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -594,10 +594,24 @@ def get_reservations_tab_name(default: str = "Reservations") -> str:
     return text or default
 
 
+async def get_reservations_tab_name_async(default: str = "Reservations") -> str:
+    value = await _aconfig_lookup("reservations_tab", default) or default
+    text = str(value or "").strip()
+    return text or default
+
+
 def get_role_map_tab_name(default: str = "WhoWeAre") -> str:
     """Return the configured role map worksheet name."""
 
     value = _config_lookup("rolemap_tab", default) or default
+    text = str(value or "").strip()
+    return text or default
+
+
+async def get_role_map_tab_name_async(default: str = "WhoWeAre") -> str:
+    """Async return of the configured role map worksheet name."""
+
+    value = await _aconfig_lookup("rolemap_tab", default) or default
     text = str(value or "").strip()
     return text or default
 

--- a/shared/sheets/reservations.py
+++ b/shared/sheets/reservations.py
@@ -103,7 +103,7 @@ async def append_reservation_row(row_values: Sequence[Any]) -> None:
 
     recruitment.ensure_service_account_credentials()
     sheet_id = recruitment.get_recruitment_sheet_id()
-    tab_name = recruitment.get_reservations_tab_name()
+    tab_name = await recruitment.get_reservations_tab_name_async()
     worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
     payload = [str(value) if value is not None else "" for value in row_values]
     await async_core.acall_with_backoff(
@@ -122,7 +122,7 @@ async def load_reservation_ledger() -> ReservationLedger:
 
     header = [_normalize_schema_cell(cell) for cell in matrix[0]]
     if header != RESERVATIONS_HEADERS:
-        tab_name = recruitment.get_reservations_tab_name()
+        tab_name = await recruitment.get_reservations_tab_name_async()
         log.error(
             "reservations header mismatch",
             extra={
@@ -322,7 +322,7 @@ async def update_reservation_status(
 
     recruitment.ensure_service_account_credentials()
     sheet_id = recruitment.get_recruitment_sheet_id()
-    tab_name = recruitment.get_reservations_tab_name()
+    tab_name = await recruitment.get_reservations_tab_name_async()
     worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
 
     cell = f"{_column_label(column_index)}{row_number}"
@@ -342,7 +342,7 @@ async def update_reservation_expiry(row_number: int, reserved_until: dt.date) ->
 
     recruitment.ensure_service_account_credentials()
     sheet_id = recruitment.get_recruitment_sheet_id()
-    tab_name = recruitment.get_reservations_tab_name()
+    tab_name = await recruitment.get_reservations_tab_name_async()
     worksheet = await async_core.aget_worksheet(sheet_id, tab_name)
 
     cell = f"{_column_label(RESERVED_UNTIL_COL)}{row_number}"
@@ -357,7 +357,7 @@ async def update_reservation_expiry(row_number: int, reserved_until: dt.date) ->
 async def _fetch_reservations_matrix() -> List[List[str]]:
     recruitment.ensure_service_account_credentials()
     sheet_id = recruitment.get_recruitment_sheet_id()
-    tab_name = recruitment.get_reservations_tab_name()
+    tab_name = await recruitment.get_reservations_tab_name_async()
     return await async_core.afetch_values(sheet_id, tab_name)
 
 

--- a/tests/cogs/test_app_admin.py
+++ b/tests/cogs/test_app_admin.py
@@ -230,7 +230,7 @@ def test_whoweare_command_reports_sheet_errors(monkeypatch):
         ctx.reply = AsyncMock()
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def raise_error(*_args, **_kwargs):
             raise cluster_role_map.RoleMapLoadError("sheet offline")
@@ -290,7 +290,7 @@ def test_whoweare_command_cleans_old_map_messages(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -353,7 +353,7 @@ def test_whoweare_command_posts_multi_message_map(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -433,7 +433,7 @@ def test_whoweare_command_marks_unassigned_with_blue_diamond(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -490,7 +490,7 @@ def test_whoweare_command_handles_empty_categories(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -542,7 +542,7 @@ def test_whoweare_command_logs_channel_fallback(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -611,7 +611,7 @@ def test_whoweare_command_falls_back_for_non_messageable_channel(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -681,7 +681,7 @@ def test_whoweare_command_falls_back_for_foreign_channel(monkeypatch):
         monkeypatch.setattr(runtime_helpers.discord, "TextChannel", FakeChannel)
 
         monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
-        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", lambda: "WhoWeAre")
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name_async", AsyncMock(return_value="WhoWeAre"))
 
         async def fake_fetch(*_args, **_kwargs):
             return []
@@ -798,3 +798,35 @@ def test_build_role_map_render_hides_real_empty_role_without_fallback_members():
     assert render.unassigned_roles == 1
     assert render.missing_roles == 0
     assert render.empty_roles == 1
+
+
+def test_whoweare_does_not_call_sync_sheets_lookup_in_event_loop(monkeypatch):
+    async def _run() -> None:
+        bot = object()
+        cog = AppAdmin(bot)
+        ctx = SimpleNamespace(guild=SimpleNamespace(name="Guild"), reply=AsyncMock())
+
+        monkeypatch.setattr(feature_flags, "is_enabled", lambda key: True)
+
+        def fail_sync_lookup(*_args, **_kwargs):
+            raise AssertionError("sync role map tab lookup must not run in !whoweare")
+
+        monkeypatch.setattr(recruitment_sheet, "get_role_map_tab_name", fail_sync_lookup)
+        monkeypatch.setattr(
+            recruitment_sheet,
+            "get_role_map_tab_name_async",
+            AsyncMock(return_value="WhoWeAre"),
+        )
+
+        async def raise_error(*_args, **_kwargs):
+            raise cluster_role_map.RoleMapLoadError("stop after async lookup")
+
+        monkeypatch.setattr(cluster_role_map, "fetch_role_map_rows", raise_error)
+        monkeypatch.setattr(runtime_helpers, "send_log_message", AsyncMock())
+
+        await cog.whoweare.callback(cog, ctx)
+
+        recruitment_sheet.get_role_map_tab_name_async.assert_awaited_once_with()
+        ctx.reply.assert_awaited_once()
+
+    asyncio.run(_run())

--- a/tests/guardrails/test_async_sheets_guardrail.py
+++ b/tests/guardrails/test_async_sheets_guardrail.py
@@ -1,0 +1,179 @@
+"""Guardrail against synchronous Google Sheets helpers in async runtime code."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_ROOTS = ["cogs", "modules", "shared", "packages/c1c-coreops/src"]
+FORBIDDEN_HELPERS = {
+    "fetch_records",
+    "fetch_values",
+    "sheets_read",
+    "read_table",
+    "call_with_backoff",
+    "_retry_with_backoff",
+    "get_config_value",
+    "_config_lookup",
+    "_load_config",
+    "get_clans_tab_name",
+    "get_role_map_tab_name",
+    "get_reports_tab_name",
+    "get_reservations_tab_name",
+}
+FORBIDDEN_MODULES = {
+    "shared.sheets.core",
+    "shared.sheets.recruitment",
+}
+ASYNC_FACADE_MODULES = {
+    "shared.sheets.async_facade",
+}
+SAFE_ASYNC_CALL_ALLOWLIST = {
+    # Compatibility fallback runs sync helpers off-loop via asyncio.to_thread.
+    ("modules/recruitment/availability.py", "_aresolve_availability_headers", "get_clans_tab_name"),
+    ("modules/recruitment/availability.py", "_aresolve_availability_headers", "get_config_value"),
+}
+
+
+@dataclass(frozen=True)
+class ImportAliases:
+    async_facade_modules: frozenset[str]
+    forbidden_modules: frozenset[str]
+    forbidden_functions: dict[str, str]
+
+
+def _runtime_files() -> list[Path]:
+    files: list[Path] = []
+    for root in RUNTIME_ROOTS:
+        base = ROOT / root
+        if base.exists():
+            files.extend(p for p in base.rglob("*.py") if "__pycache__" not in p.parts)
+    return sorted(files)
+
+
+def _join_module(base: str | None, name: str) -> str:
+    return f"{base}.{name}" if base else name
+
+
+def _import_aliases(tree: ast.Module) -> ImportAliases:
+    async_facade_modules: set[str] = set()
+    forbidden_modules: set[str] = set()
+    forbidden_functions: dict[str, str] = {}
+
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local_name = alias.asname or alias.name.split(".", 1)[0]
+                if alias.name in ASYNC_FACADE_MODULES:
+                    async_facade_modules.add(local_name)
+                elif alias.name in FORBIDDEN_MODULES:
+                    forbidden_modules.add(local_name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local_name = alias.asname or alias.name
+                imported_module = _join_module(module, alias.name)
+                if imported_module in ASYNC_FACADE_MODULES:
+                    async_facade_modules.add(local_name)
+                elif imported_module in FORBIDDEN_MODULES:
+                    forbidden_modules.add(local_name)
+                elif module in FORBIDDEN_MODULES and alias.name in FORBIDDEN_HELPERS:
+                    forbidden_functions[local_name] = alias.name
+    return ImportAliases(
+        async_facade_modules=frozenset(async_facade_modules),
+        forbidden_modules=frozenset(forbidden_modules),
+        forbidden_functions=forbidden_functions,
+    )
+
+
+def _forbidden_call_name(call: ast.Call, aliases: ImportAliases) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return aliases.forbidden_functions.get(func.id)
+    if isinstance(func, ast.Attribute) and func.attr in FORBIDDEN_HELPERS:
+        if isinstance(func.value, ast.Name):
+            module_name = func.value.id
+            if module_name in aliases.async_facade_modules:
+                return None
+            if module_name in aliases.forbidden_modules:
+                return func.attr
+        return func.attr
+    return None
+
+
+def test_async_runtime_does_not_call_sync_sheets_helpers() -> None:
+    failures: list[str] = []
+    for path in _runtime_files():
+        rel = path.relative_to(ROOT).as_posix()
+        tree = ast.parse(path.read_text(), filename=rel)
+        aliases = _import_aliases(tree)
+        for fn in [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)]:
+            for call in [n for n in ast.walk(fn) if isinstance(n, ast.Call)]:
+                name = _forbidden_call_name(call, aliases)
+                if name is None:
+                    continue
+                if (rel, fn.name, name) in SAFE_ASYNC_CALL_ALLOWLIST:
+                    continue
+                failures.append(
+                    f"{rel}:{call.lineno} in async {fn.name}() calls sync "
+                    f"{name}(); use the async Sheets helper instead"
+                )
+    assert not failures, (
+        "Synchronous Google Sheets helpers are forbidden in async "
+        "Discord/runtime paths:\n" + "\n".join(failures)
+    )
+
+
+def test_guardrail_detects_forbidden_import_alias_inside_async_function() -> None:
+    tree = ast.parse(
+        "from shared.sheets.core import fetch_records as sheet_fetch_records\n"
+        "async def command():\n"
+        "    return sheet_fetch_records('sheet', 'tab')\n"
+    )
+    aliases = _import_aliases(tree)
+    command = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+    call = next(n for n in ast.walk(command) if isinstance(n, ast.Call))
+
+    assert _forbidden_call_name(call, aliases) == "fetch_records"
+
+
+def test_async_facade_alias_is_the_only_allowed_sheets_alias() -> None:
+    async_tree = ast.parse(
+        "from shared.sheets import async_facade as sheets\n"
+        "async def command():\n"
+        "    return await sheets.fetch_records('sheet', 'tab')\n"
+    )
+    core_tree = ast.parse(
+        "import shared.sheets.core as sheets\n"
+        "async def command():\n"
+        "    return sheets.fetch_records('sheet', 'tab')\n"
+    )
+
+    async_aliases = _import_aliases(async_tree)
+    core_aliases = _import_aliases(core_tree)
+    async_call = next(n for n in ast.walk(async_tree) if isinstance(n, ast.Call))
+    core_call = next(n for n in ast.walk(core_tree) if isinstance(n, ast.Call))
+
+    assert _forbidden_call_name(async_call, async_aliases) is None
+    assert _forbidden_call_name(core_call, core_aliases) == "fetch_records"
+
+
+def test_whoweare_regression_uses_async_role_map_tab_lookup() -> None:
+    path = ROOT / "cogs/app_admin.py"
+    tree = ast.parse(path.read_text(), filename="cogs/app_admin.py")
+    whoweare = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "whoweare"
+    )
+    called = {
+        call.func.attr
+        for call in ast.walk(whoweare)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+    }
+    assert "get_role_map_tab_name" not in called
+    assert "get_role_map_tab_name_async" in called

--- a/tests/shared/sheets/test_recruitment_async_tab_names.py
+++ b/tests/shared/sheets/test_recruitment_async_tab_names.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from shared.sheets import recruitment
+
+
+def test_async_role_map_tab_name_uses_async_config(monkeypatch):
+    calls = []
+
+    async def fake_afetch_records(sheet_id, tab):
+        calls.append((sheet_id, tab))
+        return [{"Key": "rolemap_tab", "Value": "ConfiguredWho"}]
+
+    monkeypatch.setenv("RECRUITMENT_SHEET_ID", "sheet-id")
+    monkeypatch.setattr(recruitment, "afetch_records", fake_afetch_records)
+    recruitment._CONFIG_CACHE = {}
+    recruitment._CONFIG_CACHE_TS = 0
+
+    assert asyncio.run(recruitment.get_role_map_tab_name_async()) == "ConfiguredWho"
+    assert calls == [("sheet-id", "Config")]
+
+
+def test_async_reservations_tab_name_uses_async_config(monkeypatch):
+    async def fake_afetch_records(sheet_id, tab):
+        return [{"Key": "reservations_tab", "Value": "ConfiguredReservations"}]
+
+    monkeypatch.setenv("RECRUITMENT_SHEET_ID", "sheet-id")
+    monkeypatch.setattr(recruitment, "afetch_records", fake_afetch_records)
+    recruitment._CONFIG_CACHE = {}
+    recruitment._CONFIG_CACHE_TS = 0
+
+    assert asyncio.run(recruitment.get_reservations_tab_name_async()) == "ConfiguredReservations"


### PR DESCRIPTION
### Motivation

- Prevent blocking the event loop by forbidding synchronous Google Sheets helpers from async runtime code and document the rule. 
- Migrate lookup helpers for sheet tab names to async facades so runtime commands/listeners/schedulers use non-blocking calls. 
- Add an automated guardrail to detect regressions where sync sheet helpers are called from async functions.

### Description

- Documented the new "Async runtime Sheets rule" in `AGENTS.md`. 
- Added async tab-name helper functions to `shared/sheets/recruitment.py`: `get_role_map_tab_name_async` and `get_reservations_tab_name_async`, and ensured `get_reports_tab_name_async` is present/used. 
- Replaced synchronous tab-name lookups with their async counterparts in runtime code: `cogs/app_admin.whoweare`, `modules/ops/cluster_role_map.fetch_role_map_rows`, `packages/c1c-coreops/src/c1c_coreops/cog.py`, and `shared/sheets/reservations.py`. 
- Added an AST-based guardrail test `tests/guardrails/test_async_sheets_guardrail.py` that scans async functions for forbidden synchronous Sheets helpers and enforces use of async facades. 
- Updated and added unit tests to reflect the async helpers and to assert the runtime command doesn’t call sync helpers, including `tests/cogs/test_app_admin.py` and `tests/shared/sheets/test_recruitment_async_tab_names.py`.

### Testing

- Ran the updated unit tests for recruitment tab lookups (`tests/shared/sheets/test_recruitment_async_tab_names.py`), which passed. 
- Ran the new guardrail test (`tests/guardrails/test_async_sheets_guardrail.py`) to detect forbidden sync calls in async functions, which passed. 
- Ran the modified `tests/cogs/test_app_admin.py` suite to validate `whoweare` behavior and the regression test, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55eee1c1408323bb622659aa8cc387)