### PR TITLE
Improve global interaction exception diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@ import datetime as dt
 import logging
 import os
 import signal
+import sys
 import time
+import traceback
 from typing import Optional
 
 import discord
@@ -48,6 +50,117 @@ logging.basicConfig(
 log = logging.getLogger("c1c.app")
 
 LOG_MESSAGE_CONTENT_MAX_LEN = 200
+
+
+def _traceback_file_label(filename: str) -> str:
+    try:
+        return os.path.relpath(filename)
+    except ValueError:
+        return filename
+
+
+def _exception_traceback_metadata(exc: BaseException) -> dict[str, object]:
+    frames = traceback.extract_tb(exc.__traceback__)
+    if not frames:
+        return {
+            "exception_origin_file": None,
+            "exception_origin_line": None,
+            "exception_origin_function": None,
+            "exception_trace_frames": [],
+        }
+
+    trace_frames = [
+        {
+            "file": _traceback_file_label(frame.filename),
+            "line": frame.lineno,
+            "function": frame.name,
+        }
+        for frame in frames[-8:]
+    ]
+    origin = trace_frames[-1]
+    return {
+        "exception_origin_file": origin["file"],
+        "exception_origin_line": origin["line"],
+        "exception_origin_function": origin["function"],
+        "exception_trace_frames": trace_frames,
+    }
+
+
+def _exception_origin_marker(traceback_metadata: dict[str, object]) -> str:
+    origin_file = traceback_metadata.get("exception_origin_file") or "-"
+    origin_line = traceback_metadata.get("exception_origin_line") or "-"
+    origin_function = traceback_metadata.get("exception_origin_function") or "-"
+    return f"{origin_file}:{origin_line} {origin_function}"
+
+
+def _safe_id(obj: object | None) -> int | None:
+    return getattr(obj, "id", None)
+
+
+def _first_present(*values: object) -> object | None:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _find_custom_id(payload: object) -> object | None:
+    if not isinstance(payload, dict):
+        return None
+    custom_id = payload.get("custom_id")
+    if custom_id is not None:
+        return custom_id
+    for key in ("components", "children"):
+        components = payload.get(key)
+        if isinstance(components, list):
+            for component in components:
+                found = _find_custom_id(component)
+                if found is not None:
+                    return found
+    return None
+
+
+def _interaction_diagnostics(interaction: object | None) -> dict[str, object]:
+    data = getattr(interaction, "data", None)
+    command = getattr(interaction, "command", None)
+    guild = getattr(interaction, "guild", None)
+    channel = getattr(interaction, "channel", None)
+    user = getattr(interaction, "user", None)
+    message = getattr(interaction, "message", None)
+    interaction_type = getattr(getattr(interaction, "type", None), "name", None) or str(getattr(interaction, "type", "-"))
+    return {
+        "interaction_type": interaction_type,
+        "interaction_id": _safe_id(interaction),
+        "interaction_user_id": _safe_id(user),
+        "guild_id": _safe_id(guild) or getattr(interaction, "guild_id", None),
+        "channel_id": _safe_id(channel) or getattr(interaction, "channel_id", None),
+        "message_id": _safe_id(message),
+        "command_name": _first_present(
+            getattr(command, "qualified_name", None),
+            getattr(command, "name", None),
+            data.get("name") if isinstance(data, dict) else None,
+        ),
+        "custom_id": _find_custom_id(data),
+        "component_type": data.get("component_type") if isinstance(data, dict) else None,
+    }
+
+
+async def _send_interaction_error_ops_message(metadata: dict[str, object]) -> None:
+    runtime_obj = globals().get("runtime")
+    if runtime_obj is None:
+        return
+    try:
+        await runtime_obj.send_log_message(
+            "⚠️ Interaction error — "
+            f"type={metadata.get('interaction_type') or '-'} "
+            f"custom_id={metadata.get('custom_id') or '-'} "
+            f"user={metadata.get('interaction_user_id') or '-'} "
+            f"channel={metadata.get('channel_id') or '-'} "
+            f"origin={_exception_origin_marker(metadata)} "
+            f"exception={metadata.get('exception_type') or '-'}"
+        )
+    except Exception:
+        log.warning("failed to send interaction error to log channel", exc_info=True)
 
 INTENTS = discord.Intents.default()
 INTENTS.message_content = True
@@ -439,7 +552,25 @@ async def on_resumed():
 
 @bot.event
 async def on_error(event: str, *_args, **_kwargs) -> None:
-    log.exception("Unhandled exception in %s", event)
+    exc_type, exc, tb = sys.exc_info()
+    if exc is None:
+        log.exception("Unhandled exception in %s", event)
+        return
+
+    traceback_metadata = _exception_traceback_metadata(exc)
+    extra = {
+        "exception_type": exc_type.__name__ if exc_type else type(exc).__name__,
+        "exception_message": str(exc) or None,
+        **traceback_metadata,
+    }
+    if event == "on_interaction":
+        interaction = _args[0] if _args else None
+        extra.update(_interaction_diagnostics(interaction))
+        log.error("Unhandled exception in %s", event, exc_info=(exc_type, exc, tb), extra=extra)
+        await _send_interaction_error_ops_message(extra)
+        return
+
+    log.error("Unhandled exception in %s", event, exc_info=(exc_type, exc, tb), extra=extra)
 
 
 @bot.event

--- a/tests/test_app_interaction_errors.py
+++ b/tests/test_app_interaction_errors.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import app
+
+
+class BlankInteractionError(Exception):
+    def __str__(self) -> str:
+        return ""
+
+
+class FakeRuntime:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send_log_message(self, message: str) -> None:
+        self.messages.append(message)
+
+
+def _raise(exc: Exception) -> None:
+    raise exc
+
+
+def _interaction(*, data: dict, command: object | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=12345,
+        type=SimpleNamespace(name="component"),
+        user=SimpleNamespace(id=111),
+        guild=SimpleNamespace(id=222),
+        channel=SimpleNamespace(id=333),
+        message=SimpleNamespace(id=444, content="do not log this message content"),
+        data=data,
+        command=command,
+    )
+
+
+def test_on_error_logs_traceback_metadata_for_interaction(monkeypatch, caplog):
+    fake_runtime = FakeRuntime()
+    monkeypatch.setattr(app, "runtime", fake_runtime, raising=False)
+    caplog.set_level(logging.ERROR, logger="c1c.app")
+
+    try:
+        _raise(RuntimeError("boom"))
+    except RuntimeError:
+        asyncio.run(app.on_error("on_interaction", _interaction(data={"custom_id": "join_button"})))
+
+    record = next(rec for rec in caplog.records if rec.message == "Unhandled exception in on_interaction")
+    assert record.exception_type == "RuntimeError"
+    assert record.exception_message == "boom"
+    assert record.exception_origin_file.endswith("tests/test_app_interaction_errors.py")
+    assert isinstance(record.exception_origin_line, int)
+    assert record.exception_origin_function == "_raise"
+    assert record.exception_trace_frames[-1]["function"] == "_raise"
+    assert fake_runtime.messages[-1].startswith("⚠️ Interaction error")
+    assert "origin=tests/test_app_interaction_errors.py:" in fake_runtime.messages[-1]
+
+
+def test_on_interaction_logs_custom_id_for_component_failures(monkeypatch, caplog):
+    monkeypatch.setattr(app, "runtime", FakeRuntime(), raising=False)
+    caplog.set_level(logging.ERROR, logger="c1c.app")
+
+    try:
+        _raise(ValueError("component failed"))
+    except ValueError:
+        asyncio.run(app.on_error(
+            "on_interaction",
+            _interaction(data={"custom_id": "recruit:accept", "component_type": 2}),
+        ))
+
+    record = next(rec for rec in caplog.records if rec.message == "Unhandled exception in on_interaction")
+    assert record.custom_id == "recruit:accept"
+    assert record.component_type == 2
+    assert record.interaction_user_id == 111
+    assert record.guild_id == 222
+    assert record.channel_id == 333
+    assert record.message_id == 444
+
+
+def test_on_interaction_logs_command_name_for_app_command_failures(monkeypatch, caplog):
+    monkeypatch.setattr(app, "runtime", FakeRuntime(), raising=False)
+    caplog.set_level(logging.ERROR, logger="c1c.app")
+    command = SimpleNamespace(qualified_name="ops refresh", name="refresh")
+
+    try:
+        _raise(RuntimeError("slash failed"))
+    except RuntimeError:
+        asyncio.run(app.on_error(
+            "on_interaction",
+            _interaction(data={"name": "fallback"}, command=command),
+        ))
+
+    record = next(rec for rec in caplog.records if rec.message == "Unhandled exception in on_interaction")
+    assert record.command_name == "ops refresh"
+
+
+def test_on_interaction_does_not_log_message_content_or_modal_values(monkeypatch, caplog):
+    fake_runtime = FakeRuntime()
+    monkeypatch.setattr(app, "runtime", fake_runtime, raising=False)
+    caplog.set_level(logging.ERROR, logger="c1c.app")
+    secret_modal_value = "secret modal submitted value"
+    message_content = "do not log this message content"
+
+    try:
+        _raise(RuntimeError("modal failed"))
+    except RuntimeError:
+        asyncio.run(app.on_error(
+            "on_interaction",
+            _interaction(
+                data={
+                    "custom_id": "modal:submit",
+                    "components": [{"components": [{"custom_id": "field", "value": secret_modal_value}]}],
+                }
+            ),
+        ))
+
+    rendered_records = "\n".join(str(record.__dict__) for record in caplog.records)
+    rendered_ops = "\n".join(fake_runtime.messages)
+    assert secret_modal_value not in rendered_records
+    assert message_content not in rendered_records
+    assert secret_modal_value not in rendered_ops
+    assert message_content not in rendered_ops
+
+
+def test_blank_exception_messages_still_log_type_and_origin(monkeypatch, caplog):
+    fake_runtime = FakeRuntime()
+    monkeypatch.setattr(app, "runtime", fake_runtime, raising=False)
+    caplog.set_level(logging.ERROR, logger="c1c.app")
+
+    try:
+        _raise(BlankInteractionError())
+    except BlankInteractionError:
+        asyncio.run(app.on_error("on_interaction", _interaction(data={"custom_id": "blank"})))
+
+    record = next(rec for rec in caplog.records if rec.message == "Unhandled exception in on_interaction")
+    assert record.exception_type == "BlankInteractionError"
+    assert record.exception_origin_file.endswith("tests/test_app_interaction_errors.py")
+    assert record.exception_origin_function == "_raise"
+    assert "exception=BlankInteractionError" in fake_runtime.messages[-1]


### PR DESCRIPTION
### Motivation
- Unhandled interaction exceptions in production logged only `Unhandled exception in on_interaction` without type, traceback origin, interaction IDs, command/custom_id, or other useful metadata.
- The goal is to add diagnostics-only instrumentation so ops can triage interaction failures quickly while preserving existing behavior and avoiding logging any sensitive user-entered values.

### Description
- Preserve the existing global `on_error` handler while capturing the active exception and logging explicit `exc_info` and metadata via a new traceback helper ` _exception_traceback_metadata` in `app.py`.
- Add interaction-only metadata extraction via `_interaction_diagnostics` that safely extracts `interaction_type`, `interaction_id`, `interaction_user_id`, `guild_id`, `channel_id`, `message_id`, `command_name`, `custom_id`, and `component_type` without reading or logging message content or modal-submitted values.
- Emit a concise ops/log-channel notification via `_send_interaction_error_ops_message` for `on_interaction` failures formatted like: `⚠️ Interaction error — type=<type> custom_id=<custom_id or -> user=<id> channel=<id> origin=<file>:<line> <function> exception=<ExceptionType>`.
- Add small helpers `_traceback_file_label`, `_exception_origin_marker`, `_safe_id`, `_first_present`, and `_find_custom_id` to support compact traceback frames and safe payload inspection.
- Add focused tests in `tests/test_app_interaction_errors.py` that validate traceback metadata logging, component `custom_id` extraction, command-name extraction, absence of logged message/modal contents, and handling of blank exception messages.
- Files changed: `app.py` (instrumentation + helpers + modified `on_error`) and new test `tests/test_app_interaction_errors.py`.

### Testing
- Compiled `app.py` with `python -m py_compile app.py` and linted with `python -m ruff check app.py tests/test_app_interaction_errors.py`, both succeeded.
- Ran the new focused test suite with `pytest -q tests/test_app_interaction_errors.py` and it passed.
- Ran `pytest -q tests/test_app_interaction_errors.py tests/cogs/test_achievement_collector.py` to ensure no regression in existing traceback/ops diagnostics, and the run passed.
- No runtime feature behavior changes were introduced; this PR is diagnostics-only and does not alter intents, OAuth scopes, permissions, access lists, or sheet IDs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5602a665648323a01746932bcc572d)