### PR TITLE
Add progress guides extension with publishing, persistent FAQ, and tests

### DIFF
--- a/modules/community/__init__.py
+++ b/modules/community/__init__.py
@@ -5,6 +5,7 @@ COMMUNITY_EXTENSIONS: tuple[str, ...] = (
     "modules.community.fusion",
     "modules.community.leagues",
     "modules.community.reaction_roles",
+    "modules.community.progress_guides",
 )
 
 __all__ = ["COMMUNITY_EXTENSIONS"]

--- a/modules/community/progress_guides/__init__.py
+++ b/modules/community/progress_guides/__init__.py
@@ -1,0 +1,18 @@
+"""Read-only progress guide panel publishing."""
+
+from __future__ import annotations
+
+import logging
+
+from discord.ext import commands
+
+from .cog import ProgressGuidesCog
+
+log = logging.getLogger("c1c.community.progress_guides")
+
+__all__ = ["ProgressGuidesCog", "setup"]
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ProgressGuidesCog(bot))
+    log.info("Progress guides extension loaded")

--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.community.progress_guides.service import (
+    ProgressGuideFAQPersistentView,
+    PublishSummary,
+    publish_or_refresh,
+)
+
+
+def _summary_embed(action: str, summary: PublishSummary) -> discord.Embed:
+    embed = discord.Embed(
+        title=f"Progress guides {action}", color=discord.Color.blurple()
+    )
+    embed.add_field(name="Created", value=str(summary.created), inline=True)
+    embed.add_field(name="Refreshed", value=str(summary.refreshed), inline=True)
+    embed.add_field(name="Skipped", value=str(len(summary.skipped)), inline=True)
+    embed.add_field(name="Failures", value=str(len(summary.failures)), inline=True)
+    if summary.skipped:
+        embed.add_field(
+            name="Skipped details",
+            value="\n".join(summary.skipped)[:1024],
+            inline=False,
+        )
+    if summary.failures:
+        embed.add_field(
+            name="Failure details",
+            value="\n".join(summary.failures)[:1024],
+            inline=False,
+        )
+    return embed
+
+
+class ProgressGuidesCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        bot.add_view(ProgressGuideFAQPersistentView())
+
+    @tier("admin")
+    @help_metadata(
+        function_group="community", section="progress guides", access_tier="admin"
+    )
+    @commands.group(name="progressguides", invoke_without_command=True)
+    @admin_only()
+    async def progressguides(self, ctx: commands.Context) -> None:
+        embed = discord.Embed(
+            title="Progress guides",
+            description="Use `!progressguides publish` or `!progressguides refresh`.",
+            color=discord.Color.blurple(),
+        )
+        await ctx.send(embed=embed)
+
+    @progressguides.command(name="publish")
+    @admin_only()
+    async def publish(self, ctx: commands.Context) -> None:
+        summary = await publish_or_refresh(self.bot, refresh=False)
+        await ctx.send(embed=_summary_embed("publish", summary))
+
+    @progressguides.command(name="refresh")
+    @admin_only()
+    async def refresh(self, ctx: commands.Context) -> None:
+        summary = await publish_or_refresh(self.bot, refresh=True)
+        await ctx.send(embed=_summary_embed("refresh", summary))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ProgressGuidesCog(bot))

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+import re
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+import discord
+from discord.ext import commands
+
+from shared.config import get_milestones_sheet_id
+from shared.sheets import milestones_config
+from shared.sheets.async_core import (
+    acall_with_backoff,
+    afetch_records,
+    afetch_values,
+    aget_worksheet,
+)
+
+_FORUM_POSTS_KEY = "PROGRESS_FORUM_POSTS_TAB"
+_GUIDES_KEY = "PROGRESS_GUIDES_TAB"
+_FAQ_KEY = "PROGRESS_FAQ_TAB"
+_ASSETS_KEY = "PROGRESS_ASSETS_TAB"
+_MESSAGE_ID_COLUMN = "guide_panel_message_id"
+_EMBED_LIMIT = 3900
+_FIELD_LIMIT = 900
+_URL_RE = re.compile(r"https?://\S+")
+_FAQ_CUSTOM_ID_PREFIX = "progressguides:faq:"
+_PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
+_DATA_CACHE: "ProgressGuideData | None" = None
+_DATA_CACHE_LOCK = asyncio.Lock()
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _truthy(value: object) -> bool:
+    return _text(value).casefold() in {"1", "true", "yes", "y", "on", "enabled"}
+
+
+def _sort_num(value: object) -> float:
+    try:
+        return float(_text(value) or 0)
+    except ValueError:
+        return 0
+
+
+def _int_or_none(value: object) -> int | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _safe_url(value: object) -> str | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    parsed = urlparse(raw)
+    if parsed.scheme in {"http", "https"} and parsed.netloc:
+        return raw
+    return None
+
+
+@dataclass(slots=True)
+class ForumPost:
+    row_number: int
+    category: str
+    label: str
+    guide_channel_id: int | None
+    guide_thread_id: int | None
+    guide_panel_message_id: int | None
+    help_post_url: str
+    guide_asset_key: str
+    questions_enabled: bool
+    sort_order: float
+    enabled: bool
+
+    @classmethod
+    def from_row(cls, row_number: int, row: Mapping[str, object]) -> "ForumPost":
+        return cls(
+            row_number=row_number,
+            category=_text(row.get("category")),
+            label=_text(row.get("label")),
+            guide_channel_id=_int_or_none(row.get("guide_channel_id")),
+            guide_thread_id=_int_or_none(row.get("guide_thread_id")),
+            guide_panel_message_id=_int_or_none(row.get("guide_panel_message_id")),
+            help_post_url=_text(row.get("help_post_url")),
+            guide_asset_key=_text(row.get("guide_asset_key")),
+            questions_enabled=_truthy(row.get("questions_enabled")),
+            sort_order=_sort_num(row.get("sort_order")),
+            enabled=_truthy(row.get("enabled")),
+        )
+
+
+@dataclass(slots=True)
+class PublishSummary:
+    created: int = 0
+    refreshed: int = 0
+    skipped: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ProgressGuideData:
+    posts: list[ForumPost]
+    guides_by_category: dict[str, list[Mapping[str, object]]]
+    faq_by_category: dict[str, list[Mapping[str, object]]]
+    assets_by_category_key: dict[tuple[str, str], Mapping[str, object]]
+    forum_posts_tab: str
+
+
+def get_cached_progress_guide_data() -> ProgressGuideData | None:
+    return _DATA_CACHE
+
+
+def set_progress_guide_cache(data: ProgressGuideData) -> None:
+    global _DATA_CACHE
+    _DATA_CACHE = data
+
+
+def clear_progress_guide_cache() -> None:
+    global _DATA_CACHE
+    _DATA_CACHE = None
+
+
+async def get_or_load_progress_guide_data() -> ProgressGuideData:
+    cached = get_cached_progress_guide_data()
+    if cached is not None:
+        return cached
+    async with _DATA_CACHE_LOCK:
+        cached = get_cached_progress_guide_data()
+        if cached is not None:
+            return cached
+        data = await load_progress_guide_data()
+        set_progress_guide_cache(data)
+        return data
+
+
+async def load_progress_guide_data() -> ProgressGuideData:
+    sheet_id = get_milestones_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("MILESTONES_SHEET_ID not set")
+    forum_tab = await milestones_config.arequire_value(_FORUM_POSTS_KEY)
+    guides_tab = await milestones_config.arequire_value(_GUIDES_KEY)
+    faq_tab = await milestones_config.arequire_value(_FAQ_KEY)
+    assets_tab = await milestones_config.arequire_value(_ASSETS_KEY)
+    post_rows, guide_rows, faq_rows, asset_rows = await _gather_rows(
+        sheet_id, forum_tab, guides_tab, faq_tab, assets_tab
+    )
+    posts = [ForumPost.from_row(i, r) for i, r in enumerate(post_rows, start=2)]
+    guides: dict[str, list[Mapping[str, object]]] = {}
+    for row in guide_rows:
+        if _truthy(row.get("enabled")):
+            guides.setdefault(_text(row.get("category")), []).append(row)
+    faq: dict[str, list[Mapping[str, object]]] = {}
+    for row in faq_rows:
+        if _truthy(row.get("enabled")):
+            faq.setdefault(_text(row.get("category")), []).append(row)
+    assets: dict[tuple[str, str], Mapping[str, object]] = {}
+    for row in asset_rows:
+        if _truthy(row.get("enabled")):
+            assets[(_text(row.get("category")), _text(row.get("asset_key")))] = row
+    for bucket in (guides, faq):
+        for rows in bucket.values():
+            rows.sort(
+                key=lambda r: (
+                    _sort_num(r.get("sort_order")),
+                    _text(r.get("title") or r.get("question")),
+                )
+            )
+    posts.sort(key=lambda p: (p.sort_order, p.label, p.category))
+    return ProgressGuideData(posts, guides, faq, assets, forum_tab)
+
+
+async def _gather_rows(sheet_id: str, *tabs: str) -> tuple[list[dict[str, Any]], ...]:
+    import asyncio
+
+    return tuple(await asyncio.gather(*(afetch_records(sheet_id, tab) for tab in tabs)))  # type: ignore[return-value]
+
+
+def _strip_visible_urls(value: object) -> str:
+    return _URL_RE.sub("", _text(value)).strip()
+
+
+def _label_for_category(category: str, data: ProgressGuideData) -> str:
+    for post in data.posts:
+        if post.category == category:
+            return post.label or post.category
+    return category
+
+
+def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | None:
+    rows = data.faq_by_category.get(category, [])
+    if not rows:
+        return None
+    embed = discord.Embed(
+        title=f"{_label_for_category(category, data)} FAQ",
+        color=discord.Color.blurple(),
+    )
+    ordered = sorted(
+        rows, key=lambda r: (_sort_num(r.get("sort_order")), _text(r.get("question")))
+    )
+    for row in ordered[:25]:
+        question = _strip_visible_urls(row.get("question"))[:256]
+        answer = _strip_visible_urls(row.get("answer"))[:_FIELD_LIMIT]
+        if not question or not answer:
+            continue
+        embed.add_field(name=question, value=answer, inline=False)
+    return embed if embed.fields else None
+
+
+class ProgressGuideFAQButton(discord.ui.Button):
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(
+            label="FAQ",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{_FAQ_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            data = await get_or_load_progress_guide_data()
+            embed = build_faq_embed(self.category, data)
+            if embed is None:
+                embed = discord.Embed(
+                    title=f"{self.category} FAQ",
+                    description="No FAQ entries are currently available.",
+                    color=discord.Color.blurple(),
+                )
+        except Exception:
+            embed = discord.Embed(
+                title="Progress guide FAQ unavailable",
+                description="I couldn’t load that FAQ right now. Please try again later.",
+                color=discord.Color.red(),
+            )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+class ProgressGuideFAQPersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _PERSISTENT_FAQ_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(ProgressGuideFAQButton(category))
+
+
+def build_guide_embed(post: ForumPost, data: ProgressGuideData) -> discord.Embed | None:
+    guide_rows = data.guides_by_category.get(post.category, [])
+    if not guide_rows:
+        return None
+    embed = discord.Embed(
+        title=post.label or post.category, color=discord.Color.blurple()
+    )
+    used = 0
+    for row in guide_rows[:10]:
+        title = _text(row.get("title")) or _text(row.get("section_key")) or "Guide"
+        body = _text(row.get("body"))
+        if not body:
+            continue
+        value = _strip_visible_urls(body)[:_FIELD_LIMIT]
+        if not value:
+            continue
+        if used + len(title) + len(value) > _EMBED_LIMIT:
+            break
+        embed.add_field(name=title[:256], value=value, inline=False)
+        used += len(title) + len(value)
+    asset = data.assets_by_category_key.get((post.category, post.guide_asset_key))
+    if asset:
+        url = _safe_url(asset.get("asset_url"))
+        asset_type = _text(asset.get("asset_type")).casefold()
+        if url and (not asset_type or asset_type in {"image", "banner", "thumbnail"}):
+            embed.set_image(url=url)
+    return embed
+
+
+def build_guide_view(
+    post: ForumPost, data: ProgressGuideData
+) -> discord.ui.View | None:
+    view = discord.ui.View(timeout=None)
+    added = False
+    help_url = _safe_url(post.help_post_url)
+    if post.questions_enabled and help_url:
+        view.add_item(
+            discord.ui.Button(
+                label="Ask in Help", style=discord.ButtonStyle.link, url=help_url
+            )
+        )
+        added = True
+    if data.faq_by_category.get(post.category):
+        view.add_item(ProgressGuideFAQButton(post.category))
+        added = True
+    return view if added else None
+
+
+async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSummary:
+    data = await load_progress_guide_data()
+    set_progress_guide_cache(data)
+    sheet_id = get_milestones_sheet_id().strip()
+    worksheet = await aget_worksheet(sheet_id, data.forum_posts_tab)
+    header = await _load_header(sheet_id, data.forum_posts_tab)
+    col = _column_label(_header_index(header, _MESSAGE_ID_COLUMN))
+    summary = PublishSummary()
+    for post in data.posts:
+        label = post.label or post.category or f"row {post.row_number}"
+        if not post.enabled:
+            summary.skipped.append(f"{label}: disabled")
+            continue
+        target_id = post.guide_thread_id or post.guide_channel_id
+        if target_id is None:
+            summary.skipped.append(f"{label}: missing guide destination")
+            continue
+        embed = build_guide_embed(post, data)
+        if embed is None:
+            summary.skipped.append(f"{label}: missing guide content")
+            continue
+        channel = await _resolve_messageable(bot, target_id)
+        if channel is None:
+            summary.failures.append(f"{label}: invalid guide destination {target_id}")
+            continue
+        view = build_guide_view(post, data)
+        try:
+            if post.guide_panel_message_id:
+                message = None
+                try:
+                    message = await channel.fetch_message(post.guide_panel_message_id)  # type: ignore[attr-defined]
+                except discord.NotFound:
+                    message = None
+                except Exception:
+                    raise
+                if message is not None:
+                    await message.edit(embed=embed, view=view)
+                    summary.refreshed += 1
+                    continue
+                if not refresh:
+                    summary.skipped.append(
+                        f"{label}: stored panel missing; run refresh to recreate"
+                    )
+                    continue
+            message = await channel.send(embed=embed, view=view)  # type: ignore[attr-defined]
+            await acall_with_backoff(
+                worksheet.update,
+                f"{col}{post.row_number}",
+                [[str(message.id)]],
+                value_input_option="RAW",
+            )
+            summary.created += 1
+        except Exception as exc:
+            summary.failures.append(f"{label}: {type(exc).__name__}: {exc}")
+    return summary
+
+
+async def _load_header(sheet_id: str, tab: str) -> list[str]:
+    values = await afetch_values(sheet_id, tab)
+    return [str(c or "").strip().lower() for c in (values[0] if values else [])]
+
+
+def _header_index(header: Sequence[str], name: str) -> int:
+    try:
+        return header.index(name.lower())
+    except ValueError as exc:
+        raise RuntimeError(f"missing required header: {name}") from exc
+
+
+def _column_label(index: int) -> str:
+    index += 1
+    out = ""
+    while index:
+        index, rem = divmod(index - 1, 26)
+        out = chr(65 + rem) + out
+    return out
+
+
+async def _resolve_messageable(
+    bot: commands.Bot, channel_id: int
+) -> discord.abc.Messageable | None:
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(channel_id)
+        except Exception:
+            return None
+    if isinstance(channel, discord.abc.Messageable):
+        return channel
+    return None

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from modules.community.progress_guides import service
+from modules.community.progress_guides.cog import ProgressGuidesCog
+
+
+class FakeDiscordNotFound(Exception):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def clear_progress_guide_cache():
+    service.clear_progress_guide_cache()
+    yield
+    service.clear_progress_guide_cache()
+
+
+class FakeMessage:
+    def __init__(self, message_id=99):
+        self.id = message_id
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+class FakeChannel:
+    def __init__(self, *, existing=None, missing=False, fetch_error=None):
+        self.existing = existing
+        self.missing = missing
+        self.fetch_error = fetch_error
+        self.sent = []
+
+    async def fetch_message(self, message_id):
+        if self.fetch_error is not None:
+            raise self.fetch_error
+        if self.missing or self.existing is None:
+            raise FakeDiscordNotFound("missing")
+        return self.existing
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return FakeMessage(12345)
+
+
+class FakeWorksheet:
+    def __init__(self):
+        self.updates = []
+
+    def update(self, cell, values, **kwargs):
+        self.updates.append((cell, values, kwargs))
+
+
+class FakeBot:
+    def __init__(self):
+        self.views = []
+
+    def get_channel(self, channel_id):
+        return None
+
+    def add_view(self, view):
+        self.views.append(view)
+
+
+class FakeInteractionResponse:
+    def __init__(self):
+        self.deferred = []
+
+    async def defer(self, **kwargs):
+        self.deferred.append(kwargs)
+
+
+class FakeFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+
+
+class FakeInteraction:
+    def __init__(self):
+        self.response = FakeInteractionResponse()
+        self.followup = FakeFollowup()
+
+
+async def _run(monkeypatch, data, channels, worksheet, *, refresh=True):
+    async def load_data():
+        return data
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service.discord, "NotFound", FakeDiscordNotFound)
+
+    async def get_ws(sheet, tab):
+        return worksheet
+
+    async def fetch_values(sheet, tab):
+        return [["category", "guide_panel_message_id", "help_panel_message_id"]]
+
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(service, "afetch_values", fetch_values)
+
+    async def resolve(_bot, channel_id):
+        return channels.get(channel_id)
+
+    async def call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    return await service.publish_or_refresh(FakeBot(), refresh=refresh)
+
+
+def _data(*, post_overrides=None, guides=None, faq=None):
+    row = {
+        "category": "ARB",
+        "label": "Arena Rush Basics",
+        "guide_channel_id": "10",
+        "guide_thread_id": "",
+        "guide_panel_message_id": "",
+        "help_post_url": "https://discord.com/channels/1/2/3",
+        "guide_asset_key": "hero",
+        "questions_enabled": "TRUE",
+        "sort_order": "1",
+        "enabled": "TRUE",
+    }
+    row.update(post_overrides or {})
+    post = service.ForumPost.from_row(2, row)
+    return service.ProgressGuideData(
+        posts=[post],
+        guides_by_category={
+            "ARB": guides
+            if guides is not None
+            else [
+                {
+                    "category": "ARB",
+                    "title": "Overview",
+                    "body": "Use stamina wisely.",
+                    "sort_order": "1",
+                    "enabled": "TRUE",
+                }
+            ]
+        },
+        faq_by_category={
+            "ARB": faq
+            if faq is not None
+            else [
+                {
+                    "category": "ARB",
+                    "question": "What first?",
+                    "answer": "Start with the overview.",
+                    "sort_order": "1",
+                    "enabled": "TRUE",
+                }
+            ]
+        },
+        assets_by_category_key={
+            ("ARB", "hero"): {
+                "asset_url": "https://example.com/image.png",
+                "asset_type": "image",
+                "enabled": "TRUE",
+            }
+        },
+        forum_posts_tab="ProgressForumPosts",
+    )
+
+
+def _button_by_label(view, label):
+    return next(item for item in view.children if getattr(item, "label", "") == label)
+
+
+def test_publish_posts_only_guide_panels_and_writes_message_id(monkeypatch):
+    worksheet = FakeWorksheet()
+    guide = FakeChannel()
+    help_channel = FakeChannel()
+    summary = asyncio.run(
+        _run(monkeypatch, _data(), {10: guide, 20: help_channel}, worksheet)
+    )
+    assert summary.created == 1
+    assert len(guide.sent) == 1
+    assert help_channel.sent == []
+    assert worksheet.updates == [("B2", [["12345"]], {"value_input_option": "RAW"})]
+
+
+def test_publish_primes_progress_guide_cache(monkeypatch):
+    worksheet = FakeWorksheet()
+    data = _data()
+    summary = asyncio.run(_run(monkeypatch, data, {10: FakeChannel()}, worksheet))
+    assert summary.created == 1
+    assert service.get_cached_progress_guide_data() is data
+
+
+def test_refresh_edits_existing_guide_panel(monkeypatch):
+    worksheet = FakeWorksheet()
+    message = FakeMessage(777)
+    guide = FakeChannel(existing=message)
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"guide_panel_message_id": "777"}),
+            {10: guide},
+            worksheet,
+        )
+    )
+    assert summary.refreshed == 1
+    assert message.edits
+    assert guide.sent == []
+    assert worksheet.updates == []
+
+
+def test_missing_deleted_stored_message_recreates_and_updates_id(monkeypatch):
+    worksheet = FakeWorksheet()
+    guide = FakeChannel(missing=True)
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"guide_panel_message_id": "777"}),
+            {10: guide},
+            worksheet,
+        )
+    )
+    assert summary.created == 1
+    assert len(guide.sent) == 1
+    assert worksheet.updates[0][0] == "B2"
+
+
+def test_generic_fetch_error_does_not_recreate(monkeypatch):
+    worksheet = FakeWorksheet()
+    guide = FakeChannel(fetch_error=RuntimeError("transient"))
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"guide_panel_message_id": "777"}),
+            {10: guide},
+            worksheet,
+        )
+    )
+    assert summary.created == 0
+    assert guide.sent == []
+    assert worksheet.updates == []
+    assert "RuntimeError" in summary.failures[0]
+
+
+def test_help_panel_message_id_is_never_written(monkeypatch):
+    worksheet = FakeWorksheet()
+    asyncio.run(_run(monkeypatch, _data(), {10: FakeChannel()}, worksheet))
+    assert [cell for cell, _values, _kw in worksheet.updates] == ["B2"]
+
+
+def test_disabled_rows_are_skipped(monkeypatch):
+    worksheet = FakeWorksheet()
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"enabled": "FALSE"}),
+            {10: FakeChannel()},
+            worksheet,
+        )
+    )
+    assert summary.created == 0
+    assert summary.skipped == ["Arena Rush Basics: disabled"]
+    assert worksheet.updates == []
+
+
+def test_missing_guide_destination_is_reported_not_fatal(monkeypatch):
+    worksheet = FakeWorksheet()
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"guide_channel_id": "", "guide_thread_id": ""}),
+            {},
+            worksheet,
+        )
+    )
+    assert summary.created == 0
+    assert "missing guide destination" in summary.skipped[0]
+
+
+def test_source_urls_are_not_rendered_in_embed():
+    data = _data(
+        guides=[
+            {
+                "category": "ARB",
+                "title": "Overview",
+                "body": "Read https://secret.example/source but do not show asset URLs.",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            }
+        ]
+    )
+    embed = service.build_guide_embed(data.posts[0], data)
+    rendered = str(embed.to_dict())
+    assert (
+        "https://example.com/image.png" in rendered
+    )  # allowed only as Discord image metadata
+    assert "secret.example" not in rendered
+    assert "asset_url" not in rendered
+
+
+def test_url_only_guide_fields_are_skipped():
+    data = _data(
+        guides=[
+            {
+                "category": "ARB",
+                "title": "Source only",
+                "body": "https://secret.example/source",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            }
+        ]
+    )
+    embed = service.build_guide_embed(data.posts[0], data)
+    assert len(embed.fields) == 0
+
+
+def test_faq_button_opens_faq_content_from_progress_faq(monkeypatch):
+    data = _data(
+        faq=[
+            {
+                "category": "ARB",
+                "question": "Second?",
+                "answer": "After first.",
+                "sort_order": "2",
+                "enabled": "TRUE",
+            },
+            {
+                "category": "ARB",
+                "question": "First?",
+                "answer": "Start here. https://source.example/hidden",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            },
+        ]
+    )
+
+    async def load_data():
+        return data
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    button = service.ProgressGuideFAQButton("ARB")
+    interaction = FakeInteraction()
+
+    asyncio.run(button.callback(interaction))
+
+    assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    embed = sent["embed"]
+    assert embed.title == "Arena Rush Basics FAQ"
+    assert [field.name for field in embed.fields] == ["First?", "Second?"]
+    assert "source.example" not in embed.fields[0].value
+
+
+def test_faq_button_sends_clean_error_embed_when_loading_fails(monkeypatch):
+    async def load_data():
+        raise RuntimeError("sheets unavailable")
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    button = service.ProgressGuideFAQButton("ARB")
+    interaction = FakeInteraction()
+
+    asyncio.run(button.callback(interaction))
+
+    assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].title == "Progress guide FAQ unavailable"
+    assert "sheets unavailable" not in sent["embed"].description
+
+
+def test_faq_button_is_not_shown_when_no_faq_rows_exist():
+    view = service.build_guide_view(_data(faq=[]).posts[0], _data(faq=[]))
+    assert view is not None
+    assert [getattr(item, "label", "") for item in view.children] == ["Ask in Help"]
+
+
+def test_faq_button_does_not_link_to_help_post_url():
+    data = _data()
+    view = service.build_guide_view(data.posts[0], data)
+    faq_button = _button_by_label(view, "FAQ")
+    assert faq_button.custom_id == "progressguides:faq:ARB"
+    assert faq_button.url is None
+
+
+def test_ask_in_help_still_links_to_help_post_url():
+    data = _data()
+    view = service.build_guide_view(data.posts[0], data)
+    ask_button = _button_by_label(view, "Ask in Help")
+    assert ask_button.url == "https://discord.com/channels/1/2/3"
+
+
+def test_progress_guides_cog_setup_does_not_load_sheet_data(monkeypatch):
+    loads = 0
+
+    async def load_data():
+        nonlocal loads
+        loads += 1
+        raise AssertionError("startup should not load sheets")
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    ProgressGuidesCog(FakeBot())
+    assert loads == 0
+
+
+def test_first_faq_click_loads_once_and_caches_data(monkeypatch):
+    data = _data()
+    loads = 0
+
+    async def load_data():
+        nonlocal loads
+        loads += 1
+        return data
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.ProgressGuideFAQButton("ARB").callback(interaction))
+
+    assert loads == 1
+    assert service.get_cached_progress_guide_data() is data
+    assert interaction.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+
+
+def test_second_faq_click_uses_cache_without_loading_sheet(monkeypatch):
+    data = _data()
+    service.set_progress_guide_cache(data)
+
+    async def load_data():
+        raise AssertionError("cached FAQ click should not load sheets")
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.ProgressGuideFAQButton("ARB").callback(interaction))
+
+    assert interaction.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+
+
+def test_concurrent_faq_clicks_share_single_sheet_load(monkeypatch):
+    data = _data()
+    loads = 0
+
+    async def load_data():
+        nonlocal loads
+        loads += 1
+        await asyncio.sleep(0)
+        return data
+
+    async def click_twice():
+        monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+        first = FakeInteraction()
+        second = FakeInteraction()
+        await asyncio.gather(
+            service.ProgressGuideFAQButton("ARB").callback(first),
+            service.ProgressGuideFAQButton("ARB").callback(second),
+        )
+        return first, second
+
+    first, second = asyncio.run(click_twice())
+
+    assert loads == 1
+    assert first.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+    assert second.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+
+
+def test_progress_guides_cog_registers_persistent_faq_view():
+    bot = FakeBot()
+    ProgressGuidesCog(bot)
+    assert bot.views
+    assert {item.custom_id for item in bot.views[0].children} >= {
+        "progressguides:faq:ARB",
+        "progressguides:faq:RAM",
+        "progressguides:faq:MAR",
+        "progressguides:faq:FW_N",
+        "progressguides:faq:FW_H",
+    }


### PR DESCRIPTION
### Motivation
- Provide a read-only progress guide panel system driven from milestone sheets so staff can publish and refresh guide panels and surface category FAQ content via persistent buttons.
- Cache sheet data and serve FAQ content without loading sheets on cog setup to reduce startup cost and support concurrent FAQ requests efficiently.

### Description
- Register the new extension by adding `modules.community.progress_guides` to `COMMUNITY_EXTENSIONS` in `modules/community/__init__.py`.
- Add a new extension package `modules/community/progress_guides` containing a `ProgressGuidesCog` with admin-only `!progressguides publish` and `!progressguides refresh` commands and which registers a persistent FAQ view on setup.
- Implement `modules/community/progress_guides/service.py` to load rows from configured sheets, cache `ProgressGuideData`, build guide and FAQ embeds and `discord.ui.View` objects, publish or refresh guide panel messages, and update the sheet with created message IDs.
- Add persistent `ProgressGuideFAQButton` and `ProgressGuideFAQPersistentView` enabling ephemeral FAQ responses and safe URL-stripping logic for embed fields.
- Add comprehensive tests in `tests/community/test_progress_guides.py` covering publishing, refreshing, error handling, caching, concurrent FAQ loads, view/button behavior, and sheet update behavior.

### Testing
- Ran `pytest tests/community/test_progress_guides.py`, and all tests in that module passed.
- The new test module exercises `publish_or_refresh`, embed/view builders, FAQ button callbacks, caching, and cog setup behavior and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a575b2d9fc88323a497b6a9de79f0cc)