### PR TITLE
Ensure Config loaders ignore documentation columns

### DIFF
--- a/shared/sheets/config_service.py
+++ b/shared/sheets/config_service.py
@@ -58,6 +58,21 @@ def _normalize_key(row: Mapping[str, object]) -> str:
     return ""
 
 
+def _runtime_config_columns(row: Mapping[str, object]) -> dict[str, object]:
+    """Return only key/value fields from a Config row.
+
+    Additional Config columns (for example ``description``) are operator
+    documentation only and must not influence runtime feature behavior.
+    """
+
+    allowed = {"spec_key", "key", "name", "value", "val"}
+    return {
+        str(column): value
+        for column, value in row.items()
+        if str(column or "").strip().lower() in allowed
+    }
+
+
 def _filter_rows(rows: Iterable[Mapping[str, object]]) -> dict[str, Mapping[str, object]]:
     config: dict[str, Mapping[str, object]] = {}
     for row in rows or []:
@@ -66,7 +81,7 @@ def _filter_rows(rows: Iterable[Mapping[str, object]]) -> dict[str, Mapping[str,
             continue
         if _ALLOWED_KEYS and key not in _ALLOWED_KEYS:
             continue
-        config[key] = dict(row)
+        config[key] = _runtime_config_columns(row)
     return config
 
 

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -434,19 +434,10 @@ def _parse_config_records(records: Sequence[Dict[str, Any]]) -> Dict[str, str]:
                 key_value = str(value).strip().lower() if value is not None else ""
             elif col_norm in {"value", "val"}:
                 stored_value = str(value).strip() if value is not None else ""
-        if key_value:
-            if stored_value:
-                parsed[key_value] = stored_value
-                continue
-            for col, value in row.items():
-                if (col or "").strip().lower() == "key":
-                    continue
-                if value is None:
-                    continue
-                candidate = str(value).strip()
-                if candidate:
-                    parsed[key_value] = candidate
-                    break
+        # Config is a strict key/value contract: column C+ may contain human-only
+        # documentation and must never become a runtime fallback value.
+        if key_value and stored_value:
+            parsed[key_value] = stored_value
     return parsed
 
 

--- a/tests/shared/sheets/test_config_columns.py
+++ b/tests/shared/sheets/test_config_columns.py
@@ -1,0 +1,41 @@
+from shared.sheets import config_service, recruitment
+
+
+def test_recruitment_config_parser_uses_only_key_and_value_columns():
+    rows = [
+        {"Key": "CLANS_TAB", "Value": "bot_info", "description": "human docs"},
+        {"Key": "REPORTS_TAB", "Value": "", "description": "Statistics"},
+    ]
+
+    parsed = recruitment._parse_config_records(rows)
+
+    assert parsed == {"clans_tab": "bot_info"}
+    assert parsed.get("reports_tab") is None
+
+
+def test_config_service_keeps_runtime_payload_to_key_value_columns():
+    rows = [
+        {
+            "SPEC_KEY": "LEAGUE_LEGENDARY_TAB",
+            "VALUE": "Legendary",
+            "description": "human docs only",
+        },
+        {
+            "KEY": "LEAGUE_LEGENDARY_HEADER",
+            "VALUE": "A1:Z3",
+            "notes": "ignored too",
+        },
+    ]
+
+    parsed = config_service._filter_rows(rows)
+
+    assert parsed == {
+        "LEAGUE_LEGENDARY_TAB": {
+            "SPEC_KEY": "LEAGUE_LEGENDARY_TAB",
+            "VALUE": "Legendary",
+        },
+        "LEAGUE_LEGENDARY_HEADER": {
+            "KEY": "LEAGUE_LEGENDARY_HEADER",
+            "VALUE": "A1:Z3",
+        },
+    }


### PR DESCRIPTION
### Motivation
- Config worksheets may include human-readable documentation columns (e.g. `description`) and these must not be allowed to become runtime fallback values. 
- Preserve existing key/value semantics (columns A/B) so runtime behavior is unchanged when a third documentation column is present. 
- Add tests to prove extra Config columns are ignored by both the recruitment parser and the cached config service.

### Description
- Update `shared/sheets/recruitment.py` ` _parse_config_records` so values are accepted only when an explicit `value`/`val` column is present and stop falling back to column C+ as a candidate runtime value. 
- Add `_runtime_config_columns` helper to `shared/sheets/config_service.py` and use it from `_filter_rows` to keep cached rows limited to the accepted key/value aliases (`SPEC_KEY`, `KEY`, `NAME`, `VALUE`, `VAL`). 
- Add tests in `tests/shared/sheets/test_config_columns.py` that assert the recruitment parser ignores `description` and the config service strips non-runtime columns.

### Testing
- Ran `pytest -q tests/shared/sheets/test_config_columns.py` and the new tests passed. 
- Ran `pytest -q tests/shared/sheets/test_milestones_config.py tests/shared/sheets/test_recruitment_async_tab_names.py tests/shared/sheets/test_config_columns.py` and those config-related tests passed. 
- A full `pytest -q` run was attempted but encountered unrelated pre-existing failures/hangs outside the touched Config-column code; the targeted changes and tests for Config column behavior succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5783bcd6208323b5bc8e8ac52e6b6d)