### PR TITLE
Use sheet-driven guide/FAQ titles, descriptions and button labels with Discord-safe limits

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -24,7 +24,10 @@ _FAQ_KEY = "PROGRESS_FAQ_TAB"
 _ASSETS_KEY = "PROGRESS_ASSETS_TAB"
 _MESSAGE_ID_COLUMN = "guide_panel_message_id"
 _EMBED_LIMIT = 3900
+_EMBED_TITLE_LIMIT = 256
+_EMBED_DESCRIPTION_LIMIT = 4096
 _FIELD_LIMIT = 900
+_BUTTON_LABEL_LIMIT = 80
 _URL_RE = re.compile(r"https?://\S+")
 _FAQ_CUSTOM_ID_PREFIX = "progressguides:faq:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
@@ -72,6 +75,11 @@ class ForumPost:
     row_number: int
     category: str
     label: str
+    guide_title: str
+    faq_title: str
+    faq_description: str
+    faq_button_label: str
+    help_button_label: str
     guide_channel_id: int | None
     guide_thread_id: int | None
     guide_panel_message_id: int | None
@@ -87,6 +95,11 @@ class ForumPost:
             row_number=row_number,
             category=_text(row.get("category")),
             label=_text(row.get("label")),
+            guide_title=_text(row.get("guide_title")),
+            faq_title=_text(row.get("faq_title")),
+            faq_description=_text(row.get("faq_description")),
+            faq_button_label=_text(row.get("faq_button_label")),
+            help_button_label=_text(row.get("help_button_label")),
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
             guide_panel_message_id=_int_or_none(row.get("guide_panel_message_id")),
@@ -188,19 +201,43 @@ def _strip_visible_urls(value: object) -> str:
     return _URL_RE.sub("", _text(value)).strip()
 
 
-def _label_for_category(category: str, data: ProgressGuideData) -> str:
-    for post in data.posts:
-        if post.category == category:
-            return post.label or post.category
-    return category
+def _limit_text(value: object, limit: int) -> str:
+    return _text(value)[:limit]
+
+
+def _embed_title(value: object) -> str:
+    return _limit_text(value, _EMBED_TITLE_LIMIT)
+
+
+def _embed_description(value: object) -> str | None:
+    description = _limit_text(value, _EMBED_DESCRIPTION_LIMIT)
+    return description or None
+
+
+def _button_label(value: object) -> str:
+    return _limit_text(value, _BUTTON_LABEL_LIMIT)
+
+
+def _post_for_category(category: str, data: ProgressGuideData) -> ForumPost | None:
+    return next((post for post in data.posts if post.category == category), None)
+
+
+def _faq_title_for_category(category: str, data: ProgressGuideData) -> str:
+    post = _post_for_category(category, data)
+    if post is None:
+        return _embed_title(f"{category} FAQ")
+    base = post.guide_title or post.label or post.category
+    return _embed_title(post.faq_title or f"{base} FAQ")
 
 
 def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | None:
     rows = data.faq_by_category.get(category, [])
     if not rows:
         return None
+    post = _post_for_category(category, data)
     embed = discord.Embed(
-        title=f"{_label_for_category(category, data)} FAQ",
+        title=_faq_title_for_category(category, data),
+        description=_embed_description(post.faq_description) if post else None,
         color=discord.Color.blurple(),
     )
     ordered = sorted(
@@ -216,10 +253,10 @@ def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | N
 
 
 class ProgressGuideFAQButton(discord.ui.Button):
-    def __init__(self, category: str) -> None:
+    def __init__(self, category: str, label: str = "FAQ") -> None:
         self.category = category
         super().__init__(
-            label="FAQ",
+            label=_button_label(label or "FAQ"),
             style=discord.ButtonStyle.secondary,
             custom_id=f"{_FAQ_CUSTOM_ID_PREFIX}{category}",
         )
@@ -256,7 +293,8 @@ def build_guide_embed(post: ForumPost, data: ProgressGuideData) -> discord.Embed
     if not guide_rows:
         return None
     embed = discord.Embed(
-        title=post.label or post.category, color=discord.Color.blurple()
+        title=_embed_title(post.guide_title or post.label or post.category),
+        color=discord.Color.blurple(),
     )
     used = 0
     for row in guide_rows[:10]:
@@ -286,15 +324,19 @@ def build_guide_view(
     view = discord.ui.View(timeout=None)
     added = False
     help_url = _safe_url(post.help_post_url)
+    if data.faq_by_category.get(post.category):
+        view.add_item(
+            ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
+        )
+        added = True
     if post.questions_enabled and help_url:
         view.add_item(
             discord.ui.Button(
-                label="Ask in Help", style=discord.ButtonStyle.link, url=help_url
+                label=_button_label(post.help_button_label or "Ask in Help"),
+                style=discord.ButtonStyle.link,
+                url=help_url,
             )
         )
-        added = True
-    if data.faq_by_category.get(post.category):
-        view.add_item(ProgressGuideFAQButton(post.category))
         added = True
     return view if added else None
 

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -120,6 +120,11 @@ def _data(*, post_overrides=None, guides=None, faq=None):
     row = {
         "category": "ARB",
         "label": "Arena Rush Basics",
+        "guide_title": "🏟️ Arena Rush Basics",
+        "faq_title": "🏟️ Arena Rush Questions",
+        "faq_description": "Sheet-authored FAQ intro.",
+        "faq_button_label": "Read FAQ",
+        "help_button_label": "Ask the Helpers",
         "guide_channel_id": "10",
         "guide_thread_id": "",
         "guide_panel_message_id": "",
@@ -134,30 +139,34 @@ def _data(*, post_overrides=None, guides=None, faq=None):
     return service.ProgressGuideData(
         posts=[post],
         guides_by_category={
-            "ARB": guides
-            if guides is not None
-            else [
-                {
-                    "category": "ARB",
-                    "title": "Overview",
-                    "body": "Use stamina wisely.",
-                    "sort_order": "1",
-                    "enabled": "TRUE",
-                }
-            ]
+            "ARB": (
+                guides
+                if guides is not None
+                else [
+                    {
+                        "category": "ARB",
+                        "title": "Overview",
+                        "body": "Use stamina wisely.",
+                        "sort_order": "1",
+                        "enabled": "TRUE",
+                    }
+                ]
+            )
         },
         faq_by_category={
-            "ARB": faq
-            if faq is not None
-            else [
-                {
-                    "category": "ARB",
-                    "question": "What first?",
-                    "answer": "Start with the overview.",
-                    "sort_order": "1",
-                    "enabled": "TRUE",
-                }
-            ]
+            "ARB": (
+                faq
+                if faq is not None
+                else [
+                    {
+                        "category": "ARB",
+                        "question": "What first?",
+                        "answer": "Start with the overview.",
+                        "sort_order": "1",
+                        "enabled": "TRUE",
+                    }
+                ]
+            )
         },
         assets_by_category_key={
             ("ARB", "hero"): {
@@ -318,6 +327,126 @@ def test_url_only_guide_fields_are_skipped():
     assert len(embed.fields) == 0
 
 
+def test_guide_title_comes_from_guide_title_column():
+    data = _data()
+    embed = service.build_guide_embed(data.posts[0], data)
+    assert embed.title == "🏟️ Arena Rush Basics"
+
+
+def test_guide_title_falls_back_to_label_then_category():
+    label_data = _data(post_overrides={"guide_title": ""})
+    label_embed = service.build_guide_embed(label_data.posts[0], label_data)
+    assert label_embed.title == "Arena Rush Basics"
+
+    category_data = _data(post_overrides={"guide_title": "", "label": ""})
+    category_embed = service.build_guide_embed(category_data.posts[0], category_data)
+    assert category_embed.title == "ARB"
+
+
+def test_faq_embed_uses_sheet_title_and_description():
+    data = _data()
+    embed = service.build_faq_embed("ARB", data)
+    assert embed.title == "🏟️ Arena Rush Questions"
+    assert embed.description == "Sheet-authored FAQ intro."
+
+
+def test_faq_title_falls_back_through_public_display_values():
+    guide_title_data = _data(post_overrides={"faq_title": ""})
+    assert (
+        service.build_faq_embed("ARB", guide_title_data).title
+        == "🏟️ Arena Rush Basics FAQ"
+    )
+
+    label_data = _data(post_overrides={"faq_title": "", "guide_title": ""})
+    assert service.build_faq_embed("ARB", label_data).title == "Arena Rush Basics FAQ"
+
+    category_data = _data(
+        post_overrides={"faq_title": "", "guide_title": "", "label": ""}
+    )
+    assert service.build_faq_embed("ARB", category_data).title == "ARB FAQ"
+
+
+def test_blank_faq_description_is_omitted():
+    data = _data(post_overrides={"faq_description": ""})
+    embed = service.build_faq_embed("ARB", data)
+    assert embed.description is None
+
+
+def test_button_labels_and_order_come_from_forum_post_columns():
+    data = _data()
+    view = service.build_guide_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Read FAQ",
+        "Ask the Helpers",
+    ]
+
+
+def test_button_labels_fallback_and_help_remains_last():
+    data = _data(post_overrides={"faq_button_label": "", "help_button_label": ""})
+    view = service.build_guide_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "FAQ",
+        "Ask in Help",
+    ]
+
+
+def test_sheet_driven_visible_values_are_limited_for_discord():
+    data = _data(
+        post_overrides={
+            "guide_title": "G" * 300,
+            "faq_title": "F" * 300,
+            "faq_description": "D" * 5000,
+            "faq_button_label": "Q" * 100,
+            "help_button_label": "H" * 100,
+        }
+    )
+
+    guide_embed = service.build_guide_embed(data.posts[0], data)
+    faq_embed = service.build_faq_embed("ARB", data)
+    view = service.build_guide_view(data.posts[0], data)
+
+    assert guide_embed.title == "G" * 256
+    assert faq_embed.title == "F" * 256
+    assert faq_embed.description == "D" * 4096
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Q" * 80,
+        "H" * 80,
+    ]
+
+
+def test_progress_guides_title_renders_exactly_as_sheet_value():
+    exact_title = "✨ Top 1 Tip - Sheet Value"
+    data = _data(
+        guides=[
+            {
+                "category": "ARB",
+                "title": exact_title,
+                "body": "Use the title exactly.",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            }
+        ]
+    )
+    embed = service.build_guide_embed(data.posts[0], data)
+    assert embed.fields[0].name == exact_title
+
+
+def test_progress_guides_optional_display_columns_are_not_required():
+    data = _data(
+        guides=[
+            {
+                "category": "ARB",
+                "title": "Sheet Title",
+                "body": "No display_style, button_label, or image_asset_key needed.",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            }
+        ]
+    )
+    embed = service.build_guide_embed(data.posts[0], data)
+    assert embed.fields[0].name == "Sheet Title"
+
+
 def test_faq_button_opens_faq_content_from_progress_faq(monkeypatch):
     data = _data(
         faq=[
@@ -351,7 +480,8 @@ def test_faq_button_opens_faq_content_from_progress_faq(monkeypatch):
     sent = interaction.followup.sent[0]
     assert sent["ephemeral"] is True
     embed = sent["embed"]
-    assert embed.title == "Arena Rush Basics FAQ"
+    assert embed.title == "🏟️ Arena Rush Questions"
+    assert embed.description == "Sheet-authored FAQ intro."
     assert [field.name for field in embed.fields] == ["First?", "Second?"]
     assert "source.example" not in embed.fields[0].value
 
@@ -376,13 +506,13 @@ def test_faq_button_sends_clean_error_embed_when_loading_fails(monkeypatch):
 def test_faq_button_is_not_shown_when_no_faq_rows_exist():
     view = service.build_guide_view(_data(faq=[]).posts[0], _data(faq=[]))
     assert view is not None
-    assert [getattr(item, "label", "") for item in view.children] == ["Ask in Help"]
+    assert [getattr(item, "label", "") for item in view.children] == ["Ask the Helpers"]
 
 
 def test_faq_button_does_not_link_to_help_post_url():
     data = _data()
     view = service.build_guide_view(data.posts[0], data)
-    faq_button = _button_by_label(view, "FAQ")
+    faq_button = _button_by_label(view, "Read FAQ")
     assert faq_button.custom_id == "progressguides:faq:ARB"
     assert faq_button.url is None
 
@@ -390,7 +520,7 @@ def test_faq_button_does_not_link_to_help_post_url():
 def test_ask_in_help_still_links_to_help_post_url():
     data = _data()
     view = service.build_guide_view(data.posts[0], data)
-    ask_button = _button_by_label(view, "Ask in Help")
+    ask_button = _button_by_label(view, "Ask the Helpers")
     assert ask_button.url == "https://discord.com/channels/1/2/3"
 
 
@@ -423,7 +553,7 @@ def test_first_faq_click_loads_once_and_caches_data(monkeypatch):
 
     assert loads == 1
     assert service.get_cached_progress_guide_data() is data
-    assert interaction.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+    assert interaction.followup.sent[0]["embed"].title == "🏟️ Arena Rush Questions"
 
 
 def test_second_faq_click_uses_cache_without_loading_sheet(monkeypatch):
@@ -438,7 +568,7 @@ def test_second_faq_click_uses_cache_without_loading_sheet(monkeypatch):
 
     asyncio.run(service.ProgressGuideFAQButton("ARB").callback(interaction))
 
-    assert interaction.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+    assert interaction.followup.sent[0]["embed"].title == "🏟️ Arena Rush Questions"
 
 
 def test_concurrent_faq_clicks_share_single_sheet_load(monkeypatch):
@@ -464,8 +594,8 @@ def test_concurrent_faq_clicks_share_single_sheet_load(monkeypatch):
     first, second = asyncio.run(click_twice())
 
     assert loads == 1
-    assert first.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
-    assert second.followup.sent[0]["embed"].title == "Arena Rush Basics FAQ"
+    assert first.followup.sent[0]["embed"].title == "🏟️ Arena Rush Questions"
+    assert second.followup.sent[0]["embed"].title == "🏟️ Arena Rush Questions"
 
 
 def test_progress_guides_cog_registers_persistent_faq_view():


### PR DESCRIPTION
### Motivation
- Allow progress guide display values (guide title, FAQ title, FAQ description, and button labels) to be authored in the sheet and shown in Discord instead of deriving solely from internal labels or category names.
- Ensure those sheet-driven values are safe for Discord by enforcing platform limits on title, description, and button lengths.
- Preserve existing behaviour for fallbacks and ensure FAQ buttons remain persistent and cached correctly.

### Description
- Added new ForumPost fields: `guide_title`, `faq_title`, `faq_description`, `faq_button_label`, and `help_button_label`, and populated them in `ForumPost.from_row`.
- Introduced constants `_EMBED_TITLE_LIMIT`, `_EMBED_DESCRIPTION_LIMIT`, and `_BUTTON_LABEL_LIMIT` and helper functions `_limit_text`, `_embed_title`, `_embed_description`, and `_button_label` to enforce Discord-safe lengths.
- Added `_post_for_category` and `_faq_title_for_category` helpers to centralize fallbacks from `guide_title` -> `label` -> `category` for FAQ titles.
- Updated `build_faq_embed` and `build_guide_embed` to use sheet-driven titles/descriptions and the new length-limiting helpers, while preserving existing URL-stripping and field sizing logic.
- Changed `ProgressGuideFAQButton` to accept an optional `label` and updated `build_guide_view` to add the FAQ button (with sheet-provided label) before the help link, using sheet-provided help button label.
- Adjusted tests in `tests/community/test_progress_guides.py` to assert new title/description/button behaviours and added coverage for fallbacks and truncation.

### Testing
- Ran the test module `tests/community/test_progress_guides.py` which includes new and updated unit tests for title sources, FAQ description omission, button label fallbacks, ordering, and truncation limits, and all assertions passed.
- Existing tests for FAQ caching, error handling, embed field content, and image handling were exercised and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a578f9a9a008323a658b1d2f205bc77)