### PR TITLE
Progress guides: lazy Sheets access, quota-safe writeback, and sanitized admin errors

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -5,11 +5,43 @@ from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
 from c1c_coreops.rbac import admin_only
+from shared.sheets import milestones_config
+from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
     ProgressGuideFAQPersistentView,
     PublishSummary,
     publish_or_refresh,
 )
+
+
+def _quota_unavailable_embed() -> discord.Embed:
+    return discord.Embed(
+        title="Progress guides refresh unavailable",
+        description=(
+            "Google Sheets read quota was temporarily exceeded. "
+            "Please wait a minute and run the command again."
+        ),
+        color=discord.Color.red(),
+    )
+
+
+def _is_quota_or_config_failure(exc: BaseException) -> bool:
+    if isinstance(exc, milestones_config.MilestonesConfigLoadFailed):
+        return True
+    return is_rate_limited_error(exc)
+
+
+async def _send_publish_result(
+    ctx: commands.Context, bot: commands.Bot, *, action: str, refresh: bool
+) -> None:
+    try:
+        summary = await publish_or_refresh(bot, refresh=refresh)
+    except Exception as exc:
+        if _is_quota_or_config_failure(exc):
+            await ctx.send(embed=_quota_unavailable_embed())
+            return
+        raise
+    await ctx.send(embed=_summary_embed(action, summary))
 
 
 def _summary_embed(action: str, summary: PublishSummary) -> discord.Embed:
@@ -57,14 +89,12 @@ class ProgressGuidesCog(commands.Cog):
     @progressguides.command(name="publish")
     @admin_only()
     async def publish(self, ctx: commands.Context) -> None:
-        summary = await publish_or_refresh(self.bot, refresh=False)
-        await ctx.send(embed=_summary_embed("publish", summary))
+        await _send_publish_result(ctx, self.bot, action="publish", refresh=False)
 
     @progressguides.command(name="refresh")
     @admin_only()
     async def refresh(self, ctx: commands.Context) -> None:
-        summary = await publish_or_refresh(self.bot, refresh=True)
-        await ctx.send(embed=_summary_embed("refresh", summary))
+        await _send_publish_result(ctx, self.bot, action="refresh", refresh=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -17,6 +17,7 @@ from shared.sheets.async_core import (
     afetch_values,
     aget_worksheet,
 )
+from shared.sheets.core import is_rate_limited_error
 
 _FORUM_POSTS_KEY = "PROGRESS_FORUM_POSTS_TAB"
 _GUIDES_KEY = "PROGRESS_GUIDES_TAB"
@@ -342,12 +343,27 @@ def build_guide_view(
 
 
 async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSummary:
+    """Publish or refresh progress guide panels within a fixed Sheets budget.
+
+    Read budget per command run:
+    - Config is read through the existing milestones config path.
+    - ProgressForumPosts, ProgressGuides, ProgressFAQ, and ProgressAssets are read
+      once by :func:`load_progress_guide_data`.
+    - Worksheet/header reads are lazy and only allowed when
+      ``guide_panel_message_id`` must actually be written back.
+
+    Write budget per command run:
+    - ``guide_panel_message_id`` is written only after a new panel message is
+      created or a stored/deleted message is recreated.
+    - Refreshing an existing stored message only edits Discord and must not read
+      worksheet/header data or write back to Sheets.
+    """
+
     data = await load_progress_guide_data()
     set_progress_guide_cache(data)
     sheet_id = get_milestones_sheet_id().strip()
-    worksheet = await aget_worksheet(sheet_id, data.forum_posts_tab)
-    header = await _load_header(sheet_id, data.forum_posts_tab)
-    col = _column_label(_header_index(header, _MESSAGE_ID_COLUMN))
+    worksheet = None
+    message_id_col: str | None = None
     summary = PublishSummary()
     for post in data.posts:
         label = post.label or post.category or f"row {post.row_number}"
@@ -386,16 +402,36 @@ async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSumm
                     )
                     continue
             message = await channel.send(embed=embed, view=view)  # type: ignore[attr-defined]
-            await acall_with_backoff(
-                worksheet.update,
-                f"{col}{post.row_number}",
-                [[str(message.id)]],
-                value_input_option="RAW",
-            )
+            try:
+                if worksheet is None or message_id_col is None:
+                    worksheet = await aget_worksheet(sheet_id, data.forum_posts_tab)
+                    header = await _load_header(sheet_id, data.forum_posts_tab)
+                    message_id_col = _column_label(
+                        _header_index(header, _MESSAGE_ID_COLUMN)
+                    )
+                await acall_with_backoff(
+                    worksheet.update,
+                    f"{message_id_col}{post.row_number}",
+                    [[str(message.id)]],
+                    attempts=1,
+                    value_input_option="RAW",
+                )
+            except Exception:
+                await _delete_untracked_message(message)
+                raise
             summary.created += 1
         except Exception as exc:
+            if is_rate_limited_error(exc):
+                raise
             summary.failures.append(f"{label}: {type(exc).__name__}: {exc}")
     return summary
+
+
+async def _delete_untracked_message(message: discord.Message) -> None:
+    try:
+        await message.delete()
+    except Exception:
+        pass
 
 
 async def _load_header(sheet_id: str, tab: str) -> list[str]:

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -20,20 +20,31 @@ def clear_progress_guide_cache():
 
 
 class FakeMessage:
-    def __init__(self, message_id=99):
+    def __init__(self, message_id=99, *, delete_error=None):
         self.id = message_id
         self.edits = []
+        self.delete_error = delete_error
+        self.delete_attempted = False
+        self.deleted = False
 
     async def edit(self, **kwargs):
         self.edits.append(kwargs)
 
+    async def delete(self):
+        self.delete_attempted = True
+        if self.delete_error is not None:
+            raise self.delete_error
+        self.deleted = True
+
 
 class FakeChannel:
-    def __init__(self, *, existing=None, missing=False, fetch_error=None):
+    def __init__(self, *, existing=None, missing=False, fetch_error=None, send_message=None):
         self.existing = existing
         self.missing = missing
         self.fetch_error = fetch_error
+        self.send_message = send_message
         self.sent = []
+        self.sent_messages = []
 
     async def fetch_message(self, message_id):
         if self.fetch_error is not None:
@@ -44,7 +55,9 @@ class FakeChannel:
 
     async def send(self, **kwargs):
         self.sent.append(kwargs)
-        return FakeMessage(12345)
+        message = self.send_message or FakeMessage(12345)
+        self.sent_messages.append(message)
+        return message
 
 
 class FakeWorksheet:
@@ -109,6 +122,7 @@ async def _run(monkeypatch, data, channels, worksheet, *, refresh=True):
         return channels.get(channel_id)
 
     async def call(func, *args, **kwargs):
+        kwargs.pop("attempts", None)
         return func(*args, **kwargs)
 
     monkeypatch.setattr(service, "_resolve_messageable", resolve)
@@ -609,3 +623,305 @@ def test_progress_guides_cog_registers_persistent_faq_view():
         "progressguides:faq:FW_N",
         "progressguides:faq:FW_H",
     }
+
+
+def test_refresh_existing_stored_message_does_not_read_worksheet_or_header(monkeypatch):
+    data = _data(post_overrides={"guide_panel_message_id": "777"})
+    message = FakeMessage(777)
+    guide = FakeChannel(existing=message)
+
+    async def load_data():
+        return data
+
+    async def forbidden_ws(*_args, **_kwargs):
+        raise AssertionError("existing refresh must not fetch worksheet")
+
+    async def forbidden_header(*_args, **_kwargs):
+        raise AssertionError("existing refresh must not load header")
+
+    async def resolve(_bot, channel_id):
+        return {10: guide}.get(channel_id)
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service.discord, "NotFound", FakeDiscordNotFound)
+    monkeypatch.setattr(service, "aget_worksheet", forbidden_ws)
+    monkeypatch.setattr(service, "_load_header", forbidden_header)
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+
+    summary = asyncio.run(service.publish_or_refresh(FakeBot(), refresh=True))
+
+    assert summary.refreshed == 1
+    assert message.edits
+    assert guide.sent == []
+
+
+def test_refresh_existing_stored_message_does_not_write_guide_panel_message_id(monkeypatch):
+    worksheet = FakeWorksheet()
+    message = FakeMessage(777)
+    guide = FakeChannel(existing=message)
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(post_overrides={"guide_panel_message_id": "777"}),
+            {10: guide},
+            worksheet,
+        )
+    )
+
+    assert summary.refreshed == 1
+    assert worksheet.updates == []
+
+
+def test_create_path_still_writes_guide_panel_message_id(monkeypatch):
+    worksheet = FakeWorksheet()
+    summary = asyncio.run(_run(monkeypatch, _data(), {10: FakeChannel()}, worksheet))
+
+    assert summary.created == 1
+    assert worksheet.updates == [("B2", [["12345"]], {"value_input_option": "RAW"})]
+
+
+class FakeCtx:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+
+
+def test_quota_config_load_failure_produces_clean_admin_embed(monkeypatch):
+    from modules.community.progress_guides import cog
+    from shared.sheets import milestones_config
+
+    async def fail(*_args, **_kwargs):
+        raise milestones_config.MilestonesConfigLoadFailed("RESOURCE_EXHAUSTED 429")
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(cog, "publish_or_refresh", fail)
+
+    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+
+    embed = ctx.sent[0]["embed"]
+    assert embed.title == "Progress guides refresh unavailable"
+    assert "Google Sheets read quota was temporarily exceeded" in embed.description
+    assert "RESOURCE_EXHAUSTED" not in embed.description
+
+
+def test_quota_error_does_not_expose_raw_commandinvokeerror_to_discord(monkeypatch):
+    from modules.community.progress_guides import cog
+
+    async def fail(*_args, **_kwargs):
+        raise RuntimeError("429 RESOURCE_EXHAUSTED raw traceback details")
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(cog, "publish_or_refresh", fail)
+
+    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+
+    embed = ctx.sent[0]["embed"]
+    rendered = f"{embed.title}\n{embed.description}"
+    assert "CommandInvokeError" not in rendered
+    assert "traceback" not in rendered.casefold()
+    assert "RESOURCE_EXHAUSTED" not in rendered
+
+
+class FakeRateLimitError(RuntimeError):
+    status_code = 429
+
+
+async def _run_refresh_command_with_lazy_write_failure(monkeypatch, *, fail_at):
+    from modules.community.progress_guides import cog
+
+    data = _data()
+    worksheet = FakeWorksheet()
+
+    async def load_data():
+        return data
+
+    async def resolve(_bot, channel_id):
+        return {10: FakeChannel()}.get(channel_id)
+
+    async def get_ws(_sheet, _tab):
+        if fail_at == "aget_worksheet":
+            raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED")
+        return worksheet
+
+    async def load_header(_sheet, _tab):
+        if fail_at == "_load_header":
+            raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED")
+        return ["category", "guide_panel_message_id"]
+
+    async def call(_func, *_args, **_kwargs):
+        if fail_at == "acall_with_backoff":
+            raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED")
+        return None
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(service, "_load_header", load_header)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+
+    await cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    return ctx
+
+
+@pytest.mark.parametrize("fail_at", ["aget_worksheet", "_load_header", "acall_with_backoff"])
+def test_lazy_writeback_quota_errors_send_clean_embed_without_failure_details(
+    monkeypatch, fail_at
+):
+    ctx = asyncio.run(
+        _run_refresh_command_with_lazy_write_failure(monkeypatch, fail_at=fail_at)
+    )
+
+    assert len(ctx.sent) == 1
+    embed = ctx.sent[0]["embed"]
+    rendered = str(embed.to_dict())
+    assert embed.title == "Progress guides refresh unavailable"
+    assert "Google Sheets read quota was temporarily exceeded" in embed.description
+    assert "Failure details" not in rendered
+    assert "APIError" not in rendered
+    assert "RESOURCE_EXHAUSTED" not in rendered
+
+
+def test_non_quota_lazy_writeback_failure_stays_in_summary_failures(monkeypatch):
+    from modules.community.progress_guides import cog
+
+    data = _data()
+
+    async def load_data():
+        return data
+
+    async def resolve(_bot, channel_id):
+        return {10: FakeChannel()}.get(channel_id)
+
+    async def get_ws(_sheet, _tab):
+        raise RuntimeError("ordinary writeback problem")
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+
+    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+
+    embed = ctx.sent[0]["embed"]
+    assert embed.title == "Progress guides refresh"
+    assert any(field.name == "Failure details" for field in embed.fields)
+    assert "ordinary writeback problem" in str(embed.to_dict())
+
+
+def test_quota_writeback_failure_deletes_untracked_sent_message(monkeypatch):
+    from modules.community.progress_guides import cog
+
+    data = _data()
+    sent_message = FakeMessage(12345)
+    guide = FakeChannel(send_message=sent_message)
+
+    async def load_data():
+        return data
+
+    async def resolve(_bot, channel_id):
+        return {10: guide}.get(channel_id)
+
+    async def call(_func, *_args, **_kwargs):
+        raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED")
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "_load_header",
+        lambda *_args: asyncio.sleep(0, result=["category", "guide_panel_message_id"]),
+    )
+
+    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+
+    assert sent_message.delete_attempted is True
+    assert sent_message.deleted is True
+    embed = ctx.sent[0]["embed"]
+    rendered = str(embed.to_dict())
+    assert embed.title == "Progress guides refresh unavailable"
+    assert "APIError" not in rendered
+    assert "RESOURCE_EXHAUSTED" not in rendered
+
+
+def test_quota_writeback_failure_still_clean_embed_when_rollback_delete_fails(monkeypatch):
+    from modules.community.progress_guides import cog
+
+    data = _data()
+    sent_message = FakeMessage(12345, delete_error=RuntimeError("delete forbidden"))
+    guide = FakeChannel(send_message=sent_message)
+
+    async def load_data():
+        return data
+
+    async def resolve(_bot, channel_id):
+        return {10: guide}.get(channel_id)
+
+    async def call(_func, *_args, **_kwargs):
+        raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED")
+
+    ctx = FakeCtx()
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "_load_header",
+        lambda *_args: asyncio.sleep(0, result=["category", "guide_panel_message_id"]),
+    )
+
+    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+
+    assert sent_message.delete_attempted is True
+    assert sent_message.deleted is False
+    embed = ctx.sent[0]["embed"]
+    rendered = str(embed.to_dict())
+    assert embed.title == "Progress guides refresh unavailable"
+    assert "delete forbidden" not in rendered
+    assert "RESOURCE_EXHAUSTED" not in rendered
+
+
+def test_non_quota_writeback_failure_deletes_untracked_message_and_reports_failure(
+    monkeypatch,
+):
+    data = _data()
+    sent_message = FakeMessage(12345)
+    guide = FakeChannel(send_message=sent_message)
+
+    async def load_data():
+        return data
+
+    async def resolve(_bot, channel_id):
+        return {10: guide}.get(channel_id)
+
+    async def call(_func, *_args, **_kwargs):
+        raise RuntimeError("ordinary update failure")
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "_load_header",
+        lambda *_args: asyncio.sleep(0, result=["category", "guide_panel_message_id"]),
+    )
+
+    summary = asyncio.run(service.publish_or_refresh(FakeBot(), refresh=True))
+
+    assert sent_message.delete_attempted is True
+    assert sent_message.deleted is True
+    assert summary.created == 0
+    assert "ordinary update failure" in summary.failures[0]


### PR DESCRIPTION
### Motivation
- Reduce Google Sheets read/write usage during progress guide publish/refresh runs and avoid exposing raw quota/config errors to Discord admins.
- Ensure refreshes of existing stored panel messages do not perform unnecessary sheet reads or writes in order to stay within Sheets quotas.
- Provide safe rollback behavior when a writeback fails and present a cleaned admin-facing error message for quota/config failures.

### Description
- Introduced lazy worksheet/header loading inside `publish_or_refresh` so the sheet is only read when a new `guide_panel_message_id` must be written, and preserved a path that edits Discord messages without touching Sheets when possible.
- Added `_delete_untracked_message` to attempt rollback (delete) of newly sent messages if a subsequent writeback fails, and adjusted write calls to raise rate-limit errors up the stack for special handling.
- Added Cog helpers: `_quota_unavailable_embed`, `_is_quota_or_config_failure`, and `_send_publish_result` to map Sheets quota or config load failures to a sanitized admin embed and avoid leaking raw error details.
- Imported and used `is_rate_limited_error` and `milestones_config.MilestonesConfigLoadFailed` to detect quota/config problems and treat them distinctly from ordinary failures.

### Testing
- Ran the updated unit tests in `tests/community/test_progress_guides.py` which exercise lazy-load refresh behavior, create-path writeback, quota/config failure embedding, rollback delete on write failure, and ordinary writeback failure reporting, and they passed.
- Exercised scenarios where refreshes avoid worksheet/header reads via `test_refresh_existing_stored_message_does_not_read_worksheet_or_header` which passed.
- Verified that quota-related failures produce a clean admin-facing embed without internal error details via parameterized tests and they passed.
- Verified rollback deletion behavior on both successful and failing deletes and that non-quota writeback failures are recorded in the summary, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57947aa6588323a8a1374b59d086dc)