### PR TITLE
Add mission list UI with pagination and caching for progress guides

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -9,6 +9,7 @@ from shared.sheets import milestones_config
 from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
     ProgressGuideFAQPersistentView,
+    ProgressGuideMissionPersistentView,
     PublishSummary,
     publish_or_refresh,
 )
@@ -71,6 +72,7 @@ class ProgressGuidesCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         bot.add_view(ProgressGuideFAQPersistentView())
+        bot.add_view(ProgressGuideMissionPersistentView())
 
     @tier("admin")
     @help_metadata(

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -23,6 +23,7 @@ _FORUM_POSTS_KEY = "PROGRESS_FORUM_POSTS_TAB"
 _GUIDES_KEY = "PROGRESS_GUIDES_TAB"
 _FAQ_KEY = "PROGRESS_FAQ_TAB"
 _ASSETS_KEY = "PROGRESS_ASSETS_TAB"
+_CATEGORIES_KEY = "PROGRESS_CATEGORIES_TAB"
 _MESSAGE_ID_COLUMN = "guide_panel_message_id"
 _EMBED_LIMIT = 3900
 _EMBED_TITLE_LIMIT = 256
@@ -31,9 +32,14 @@ _FIELD_LIMIT = 900
 _BUTTON_LABEL_LIMIT = 80
 _URL_RE = re.compile(r"https?://\S+")
 _FAQ_CUSTOM_ID_PREFIX = "progressguides:faq:"
+_MISSIONS_CUSTOM_ID_PREFIX = "progressguides:missions:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
+_MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
+_MISSIONS_PER_PAGE = 15
 _DATA_CACHE: "ProgressGuideData | None" = None
 _DATA_CACHE_LOCK = asyncio.Lock()
+_MISSION_CACHE: dict[str, list["MissionRow"]] = {}
+_MISSION_CACHE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def _text(value: object) -> str:
@@ -81,6 +87,8 @@ class ForumPost:
     faq_description: str
     faq_button_label: str
     help_button_label: str
+    mission_list_button_label: str
+    mission_list_title: str
     guide_channel_id: int | None
     guide_thread_id: int | None
     guide_panel_message_id: int | None
@@ -101,6 +109,8 @@ class ForumPost:
             faq_description=_text(row.get("faq_description")),
             faq_button_label=_text(row.get("faq_button_label")),
             help_button_label=_text(row.get("help_button_label")),
+            mission_list_button_label=_text(row.get("mission_list_button_label")),
+            mission_list_title=_text(row.get("mission_list_title")),
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
             guide_panel_message_id=_int_or_none(row.get("guide_panel_message_id")),
@@ -110,6 +120,12 @@ class ForumPost:
             sort_order=_sort_num(row.get("sort_order")),
             enabled=_truthy(row.get("enabled")),
         )
+
+
+@dataclass(slots=True)
+class MissionRow:
+    number: int
+    text: str
 
 
 @dataclass(slots=True)
@@ -141,6 +157,12 @@ def set_progress_guide_cache(data: ProgressGuideData) -> None:
 def clear_progress_guide_cache() -> None:
     global _DATA_CACHE
     _DATA_CACHE = None
+    clear_mission_cache()
+
+
+def clear_mission_cache() -> None:
+    _MISSION_CACHE.clear()
+    _MISSION_CACHE_LOCKS.clear()
 
 
 async def get_or_load_progress_guide_data() -> ProgressGuideData:
@@ -231,6 +253,146 @@ def _faq_title_for_category(category: str, data: ProgressGuideData) -> str:
     return _embed_title(post.faq_title or f"{base} FAQ")
 
 
+def _mission_title_for_category(category: str, data: ProgressGuideData) -> str:
+    post = _post_for_category(category, data)
+    if post is None:
+        return _embed_title(category)
+    return _embed_title(
+        post.mission_list_title or post.guide_title or post.label or post.category
+    )
+
+
+def _supports_missions(post: ForumPost) -> bool:
+    return post.category in _MISSION_CATEGORIES and bool(
+        post.mission_list_button_label or post.mission_list_title
+    )
+
+
+def _mission_unavailable_embed(description: str) -> discord.Embed:
+    return discord.Embed(
+        title="Mission list unavailable",
+        description=description,
+        color=discord.Color.red(),
+    )
+
+
+def _is_quota_failure(exc: BaseException) -> bool:
+    if isinstance(exc, milestones_config.MilestonesConfigLoadFailed):
+        return True
+    return is_rate_limited_error(exc)
+
+
+def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow]:
+    parsed: list[MissionRow] = []
+    for order, row in enumerate(rows, start=1):
+        text = _strip_visible_urls(row.get("mission_text"))
+        if not text:
+            continue
+        number = _int_or_none(row.get("step_index")) or order
+        parsed.append(MissionRow(number=number, text=text))
+    return sorted(parsed, key=lambda mission: mission.number)
+
+
+async def _mission_tab_for_category(category: str) -> str | None:
+    sheet_id = get_milestones_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("MILESTONES_SHEET_ID not set")
+    categories_tab = await milestones_config.arequire_value(_CATEGORIES_KEY)
+    rows = await afetch_records(sheet_id, categories_tab)
+    for row in rows:
+        if _text(row.get("category")) == category:
+            config_key = _text(row.get("mission_tab_config_key"))
+            if not config_key:
+                return None
+            return await milestones_config.arequire_value(config_key)
+    return None
+
+
+async def get_or_load_missions(category: str) -> list[MissionRow]:
+    if category in _MISSION_CACHE:
+        return _MISSION_CACHE[category]
+    lock = _MISSION_CACHE_LOCKS.setdefault(category, asyncio.Lock())
+    async with lock:
+        if category in _MISSION_CACHE:
+            return _MISSION_CACHE[category]
+        tab = await _mission_tab_for_category(category)
+        if not tab:
+            return []
+        rows = await afetch_records(get_milestones_sheet_id().strip(), tab)
+        missions = _parse_mission_rows(rows)
+        _MISSION_CACHE[category] = missions
+        return missions
+
+
+def build_mission_embed(
+    category: str, data: ProgressGuideData, missions: Sequence[MissionRow], *, page: int
+) -> discord.Embed:
+    total = len(missions)
+    total_pages = max(1, (total + _MISSIONS_PER_PAGE - 1) // _MISSIONS_PER_PAGE)
+    page = max(0, min(page, total_pages - 1))
+    start = page * _MISSIONS_PER_PAGE
+    shown = missions[start : start + _MISSIONS_PER_PAGE]
+    lines = [
+        f"Missions {start + 1}-{start + len(shown)} of {total}",
+        f"Page {page + 1} / {total_pages}",
+        "",
+    ]
+    for mission in shown:
+        lines.append(f"{mission.number}. {_limit_text(mission.text, 220)}")
+    return discord.Embed(
+        title=_mission_title_for_category(category, data),
+        description=_embed_description("\n".join(lines)),
+        color=discord.Color.blurple(),
+    )
+
+
+class MissionListPaginationView(discord.ui.View):
+    def __init__(
+        self,
+        category: str,
+        data: ProgressGuideData,
+        missions: Sequence[MissionRow],
+        page: int = 0,
+    ) -> None:
+        super().__init__(timeout=900)
+        self.category = category
+        self.data = data
+        self.missions = list(missions)
+        self.page = page
+        self.total_pages = max(
+            1, (len(self.missions) + _MISSIONS_PER_PAGE - 1) // _MISSIONS_PER_PAGE
+        )
+        for emoji, target, disabled in (
+            ("⏮️", 0, self.page <= 0),
+            ("◀️", self.page - 1, self.page <= 0),
+            ("▶️", self.page + 1, self.page >= self.total_pages - 1),
+            ("⏭️", self.total_pages - 1, self.page >= self.total_pages - 1),
+        ):
+            self.add_item(MissionPageButton(emoji, target, disabled))
+
+
+class MissionPageButton(discord.ui.Button):
+    def __init__(self, emoji: str, target_page: int, disabled: bool) -> None:
+        self.target_page = target_page
+        super().__init__(
+            emoji=emoji, style=discord.ButtonStyle.secondary, disabled=disabled
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, MissionListPaginationView):
+            return
+        next_view = MissionListPaginationView(
+            view.category, view.data, view.missions, self.target_page
+        )
+        await interaction.response.edit_message(
+            embed=build_mission_embed(
+                view.category, view.data, view.missions, page=self.target_page
+            ),
+            view=next_view,
+        )
+
+
 def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | None:
     rows = data.faq_by_category.get(category, [])
     if not rows:
@@ -282,6 +444,58 @@ class ProgressGuideFAQButton(discord.ui.Button):
         await interaction.followup.send(embed=embed, ephemeral=True)
 
 
+class ProgressGuideMissionButton(discord.ui.Button):
+    def __init__(self, category: str, label: str = "Mission List") -> None:
+        self.category = category
+        super().__init__(
+            label=_button_label(label or "Mission List"),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{_MISSIONS_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        if self.category not in _MISSION_CATEGORIES:
+            embed = _mission_unavailable_embed(
+                "No mission list is configured for this guide yet."
+            )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+        try:
+            data = await get_or_load_progress_guide_data()
+            missions = await get_or_load_missions(self.category)
+        except Exception as exc:
+            if _is_quota_failure(exc):
+                embed = _mission_unavailable_embed(
+                    "Google Sheets read quota was temporarily exceeded. Please wait a minute and try again."
+                )
+            else:
+                embed = _mission_unavailable_embed(
+                    "No mission list is configured for this guide yet."
+                )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+        if not missions:
+            embed = _mission_unavailable_embed(
+                "No missions are currently available for this guide."
+            )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+        view = MissionListPaginationView(self.category, data, missions, 0)
+        await interaction.followup.send(
+            embed=build_mission_embed(self.category, data, missions, page=0),
+            view=view,
+            ephemeral=True,
+        )
+
+
+class ProgressGuideMissionPersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _MISSION_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(ProgressGuideMissionButton(category))
+
+
 class ProgressGuideFAQPersistentView(discord.ui.View):
     def __init__(self, categories: Sequence[str] = _PERSISTENT_FAQ_CATEGORIES) -> None:
         super().__init__(timeout=None)
@@ -330,6 +544,13 @@ def build_guide_view(
             ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
         )
         added = True
+    if _supports_missions(post):
+        view.add_item(
+            ProgressGuideMissionButton(
+                post.category, post.mission_list_button_label or "Mission List"
+            )
+        )
+        added = True
     if post.questions_enabled and help_url:
         view.add_item(
             discord.ui.Button(
@@ -360,6 +581,7 @@ async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSumm
     """
 
     data = await load_progress_guide_data()
+    clear_mission_cache()
     set_progress_guide_cache(data)
     sheet_id = get_milestones_sheet_id().strip()
     worksheet = None

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -38,7 +38,9 @@ class FakeMessage:
 
 
 class FakeChannel:
-    def __init__(self, *, existing=None, missing=False, fetch_error=None, send_message=None):
+    def __init__(
+        self, *, existing=None, missing=False, fetch_error=None, send_message=None
+    ):
         self.existing = existing
         self.missing = missing
         self.fetch_error = fetch_error
@@ -656,7 +658,9 @@ def test_refresh_existing_stored_message_does_not_read_worksheet_or_header(monke
     assert guide.sent == []
 
 
-def test_refresh_existing_stored_message_does_not_write_guide_panel_message_id(monkeypatch):
+def test_refresh_existing_stored_message_does_not_write_guide_panel_message_id(
+    monkeypatch,
+):
     worksheet = FakeWorksheet()
     message = FakeMessage(777)
     guide = FakeChannel(existing=message)
@@ -699,7 +703,9 @@ def test_quota_config_load_failure_produces_clean_admin_embed(monkeypatch):
     ctx = FakeCtx()
     monkeypatch.setattr(cog, "publish_or_refresh", fail)
 
-    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+    asyncio.run(
+        cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    )
 
     embed = ctx.sent[0]["embed"]
     assert embed.title == "Progress guides refresh unavailable"
@@ -716,7 +722,9 @@ def test_quota_error_does_not_expose_raw_commandinvokeerror_to_discord(monkeypat
     ctx = FakeCtx()
     monkeypatch.setattr(cog, "publish_or_refresh", fail)
 
-    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+    asyncio.run(
+        cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    )
 
     embed = ctx.sent[0]["embed"]
     rendered = f"{embed.title}\n{embed.description}"
@@ -768,7 +776,9 @@ async def _run_refresh_command_with_lazy_write_failure(monkeypatch, *, fail_at):
     return ctx
 
 
-@pytest.mark.parametrize("fail_at", ["aget_worksheet", "_load_header", "acall_with_backoff"])
+@pytest.mark.parametrize(
+    "fail_at", ["aget_worksheet", "_load_header", "acall_with_backoff"]
+)
 def test_lazy_writeback_quota_errors_send_clean_embed_without_failure_details(
     monkeypatch, fail_at
 ):
@@ -806,7 +816,9 @@ def test_non_quota_lazy_writeback_failure_stays_in_summary_failures(monkeypatch)
     monkeypatch.setattr(service, "_resolve_messageable", resolve)
     monkeypatch.setattr(service, "aget_worksheet", get_ws)
 
-    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+    asyncio.run(
+        cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    )
 
     embed = ctx.sent[0]["embed"]
     assert embed.title == "Progress guides refresh"
@@ -835,14 +847,20 @@ def test_quota_writeback_failure_deletes_untracked_sent_message(monkeypatch):
     monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(service, "_resolve_messageable", resolve)
     monkeypatch.setattr(service, "acall_with_backoff", call)
-    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "aget_worksheet",
+        lambda *_args: asyncio.sleep(0, result=FakeWorksheet()),
+    )
     monkeypatch.setattr(
         service,
         "_load_header",
         lambda *_args: asyncio.sleep(0, result=["category", "guide_panel_message_id"]),
     )
 
-    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+    asyncio.run(
+        cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    )
 
     assert sent_message.delete_attempted is True
     assert sent_message.deleted is True
@@ -853,7 +871,9 @@ def test_quota_writeback_failure_deletes_untracked_sent_message(monkeypatch):
     assert "RESOURCE_EXHAUSTED" not in rendered
 
 
-def test_quota_writeback_failure_still_clean_embed_when_rollback_delete_fails(monkeypatch):
+def test_quota_writeback_failure_still_clean_embed_when_rollback_delete_fails(
+    monkeypatch,
+):
     from modules.community.progress_guides import cog
 
     data = _data()
@@ -874,14 +894,20 @@ def test_quota_writeback_failure_still_clean_embed_when_rollback_delete_fails(mo
     monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(service, "_resolve_messageable", resolve)
     monkeypatch.setattr(service, "acall_with_backoff", call)
-    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "aget_worksheet",
+        lambda *_args: asyncio.sleep(0, result=FakeWorksheet()),
+    )
     monkeypatch.setattr(
         service,
         "_load_header",
         lambda *_args: asyncio.sleep(0, result=["category", "guide_panel_message_id"]),
     )
 
-    asyncio.run(cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True))
+    asyncio.run(
+        cog._send_publish_result(ctx, FakeBot(), action="refresh", refresh=True)
+    )
 
     assert sent_message.delete_attempted is True
     assert sent_message.deleted is False
@@ -912,7 +938,11 @@ def test_non_quota_writeback_failure_deletes_untracked_message_and_reports_failu
     monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(service, "_resolve_messageable", resolve)
     monkeypatch.setattr(service, "acall_with_backoff", call)
-    monkeypatch.setattr(service, "aget_worksheet", lambda *_args: asyncio.sleep(0, result=FakeWorksheet()))
+    monkeypatch.setattr(
+        service,
+        "aget_worksheet",
+        lambda *_args: asyncio.sleep(0, result=FakeWorksheet()),
+    )
     monkeypatch.setattr(
         service,
         "_load_header",
@@ -925,3 +955,238 @@ def test_non_quota_writeback_failure_deletes_untracked_message_and_reports_failu
     assert sent_message.deleted is True
     assert summary.created == 0
     assert "ordinary update failure" in summary.failures[0]
+
+
+def test_mission_button_appears_between_faq_and_help_with_sheet_label():
+    data = _data(
+        post_overrides={
+            "mission_list_button_label": "View Missions",
+            "mission_list_title": "Arbiter Mission List",
+        }
+    )
+    view = service.build_guide_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Read FAQ",
+        "View Missions",
+        "Ask the Helpers",
+    ]
+    assert view.children[1].custom_id == "progressguides:missions:ARB"
+
+
+@pytest.mark.parametrize("category", ["FW_N", "FW_H"])
+def test_fw_guides_do_not_get_mission_button(category):
+    data = _data(
+        post_overrides={
+            "category": category,
+            "mission_list_button_label": "Mission List",
+            "mission_list_title": "Faction Wars Mission List",
+        }
+    )
+    data.faq_by_category[category] = data.faq_by_category.pop("ARB")
+    view = service.build_guide_view(data.posts[0], data)
+    assert f"progressguides:missions:{category}" not in [
+        getattr(item, "custom_id", "") for item in view.children
+    ]
+
+
+def test_mission_rows_sort_skip_and_hide_internal_metadata():
+    rows = [
+        {
+            "step_index": "2",
+            "mission_text": "Second https://source.example/x",
+            "source_url": "https://source.example",
+            "system_tags": "secret",
+        },
+        {"step_index": "", "mission_text": "Fallback order", "resource_tags": "hidden"},
+        {"step_index": "1", "mission_text": "First"},
+        {"step_index": "3", "mission_text": ""},
+    ]
+    missions = service._parse_mission_rows(rows)
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    embed = service.build_mission_embed("ARB", data, missions, page=0)
+    rendered = embed.description
+    assert [m.number for m in missions] == [1, 2, 2]
+    assert "1. First" in rendered
+    assert "2. Second" in rendered
+    assert "source.example" not in rendered
+    assert "secret" not in rendered
+    assert "hidden" not in rendered
+
+
+def test_first_mission_click_reads_only_configured_category_tab_and_caches(monkeypatch):
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    service.set_progress_guide_cache(data)
+    calls = []
+
+    async def require_value(key):
+        calls.append(("config", key))
+        return {
+            "PROGRESS_CATEGORIES_TAB": "ProgressCategories",
+            "PROGRESS_MISSIONS_ARB_TAB": "Configured_ARB_Tab",
+        }[key]
+
+    async def fetch_records(_sheet, tab):
+        calls.append(("tab", tab))
+        if tab == "ProgressCategories":
+            return [
+                {
+                    "category": "ARB",
+                    "mission_tab_config_key": "PROGRESS_MISSIONS_ARB_TAB",
+                }
+            ]
+        if tab == "Configured_ARB_Tab":
+            return [
+                {
+                    "step_index": "1",
+                    "mission_text": "Do the first mission",
+                    "source_url": "https://hide.example",
+                }
+            ]
+        raise AssertionError(f"unexpected tab {tab}")
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", require_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+
+    first = FakeInteraction()
+    second = FakeInteraction()
+    asyncio.run(service.ProgressGuideMissionButton("ARB").callback(first))
+    asyncio.run(service.ProgressGuideMissionButton("ARB").callback(second))
+
+    assert first.response.deferred == [{"ephemeral": True, "thinking": True}]
+    assert calls == [
+        ("config", "PROGRESS_CATEGORIES_TAB"),
+        ("tab", "ProgressCategories"),
+        ("config", "PROGRESS_MISSIONS_ARB_TAB"),
+        ("tab", "Configured_ARB_Tab"),
+    ]
+    assert first.followup.sent[0]["embed"].title == "Arbiter Mission List"
+    assert "Do the first mission" in first.followup.sent[0]["embed"].description
+    assert "hide.example" not in first.followup.sent[0]["embed"].description
+    assert second.followup.sent[0]["embed"].title == "Arbiter Mission List"
+
+
+def test_concurrent_mission_clicks_share_one_mission_tab_load(monkeypatch):
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    service.set_progress_guide_cache(data)
+    tab_loads = 0
+
+    async def require_value(key):
+        return {
+            "PROGRESS_CATEGORIES_TAB": "ProgressCategories",
+            "PROGRESS_MISSIONS_ARB_TAB": "ARB_Tab",
+        }[key]
+
+    async def fetch_records(_sheet, tab):
+        nonlocal tab_loads
+        if tab == "ProgressCategories":
+            return [
+                {
+                    "category": "ARB",
+                    "mission_tab_config_key": "PROGRESS_MISSIONS_ARB_TAB",
+                }
+            ]
+        tab_loads += 1
+        await asyncio.sleep(0)
+        return [{"step_index": "1", "mission_text": "Only once"}]
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", require_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+
+    async def click_twice():
+        await asyncio.gather(
+            service.ProgressGuideMissionButton("ARB").callback(FakeInteraction()),
+            service.ProgressGuideMissionButton("ARB").callback(FakeInteraction()),
+        )
+
+    asyncio.run(click_twice())
+    assert tab_loads == 1
+
+
+def test_mission_pagination_emoji_only_and_disabled_states():
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    missions = [service.MissionRow(i, f"Mission {i}") for i in range(1, 17)]
+    first = service.MissionListPaginationView("ARB", data, missions, 0)
+    assert [item.emoji.name for item in first.children] == ["⏮️", "◀️", "▶️", "⏭️"]
+    assert [item.label for item in first.children] == [None, None, None, None]
+    assert [item.disabled for item in first.children] == [True, True, False, False]
+    final = service.MissionListPaginationView("ARB", data, missions, 1)
+    assert [item.disabled for item in final.children] == [False, False, True, True]
+    assert (
+        "Missions 1-15 of 16"
+        in service.build_mission_embed("ARB", data, missions, page=0).description
+    )
+    assert (
+        "Missions 16-16 of 16"
+        in service.build_mission_embed("ARB", data, missions, page=1).description
+    )
+
+
+def test_mission_click_quota_error_is_clean(monkeypatch):
+    service.clear_mission_cache()
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    service.set_progress_guide_cache(data)
+
+    async def fail(_key):
+        raise FakeRateLimitError("APIError 429 RESOURCE_EXHAUSTED traceback")
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", fail)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    interaction = FakeInteraction()
+    asyncio.run(service.ProgressGuideMissionButton("ARB").callback(interaction))
+    embed = interaction.followup.sent[0]["embed"]
+    rendered = str(embed.to_dict())
+    assert embed.title == "Mission list unavailable"
+    assert "Google Sheets read quota was temporarily exceeded" in embed.description
+    assert "APIError" not in rendered
+    assert "RESOURCE_EXHAUSTED" not in rendered
+    assert "traceback" not in rendered.casefold()
+
+
+def test_publish_refresh_clears_mission_cache_without_reading_mission_tabs(monkeypatch):
+    data = _data(post_overrides={"mission_list_title": "Arbiter Mission List"})
+    service.set_progress_guide_cache(data)
+    mission_tab_loads = 0
+    category_tab_loads = 0
+
+    async def require_value(key):
+        return {
+            "PROGRESS_CATEGORIES_TAB": "ProgressCategories",
+            "PROGRESS_MISSIONS_ARB_TAB": "Configured_ARB_Tab",
+        }[key]
+
+    async def fetch_records(_sheet, tab):
+        nonlocal category_tab_loads, mission_tab_loads
+        if tab == "ProgressCategories":
+            category_tab_loads += 1
+            return [
+                {
+                    "category": "ARB",
+                    "mission_tab_config_key": "PROGRESS_MISSIONS_ARB_TAB",
+                }
+            ]
+        if tab == "Configured_ARB_Tab":
+            mission_tab_loads += 1
+            return [{"step_index": "1", "mission_text": f"Loaded {mission_tab_loads}"}]
+        raise AssertionError(f"unexpected tab {tab}")
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", require_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+
+    first = FakeInteraction()
+    asyncio.run(service.ProgressGuideMissionButton("ARB").callback(first))
+    assert category_tab_loads == 1
+    assert mission_tab_loads == 1
+    assert "Loaded 1" in first.followup.sent[0]["embed"].description
+
+    worksheet = FakeWorksheet()
+    asyncio.run(_run(monkeypatch, data, {10: FakeChannel()}, worksheet))
+    assert category_tab_loads == 1
+    assert mission_tab_loads == 1
+
+    second = FakeInteraction()
+    asyncio.run(service.ProgressGuideMissionButton("ARB").callback(second))
+    assert mission_tab_loads == 2
+    assert "Loaded 2" in second.followup.sent[0]["embed"].description


### PR DESCRIPTION
### Motivation
- Provide per-guide mission lists surfaced from Sheets via a new mission button and paginated view. 
- Avoid repeated Sheets reads by caching mission data and protect publish/refresh flows from mission-related quota errors. 

### Description
- Add mission support in `modules/community/progress_guides/service.py` including `MissionRow`, mission parsing (`_parse_mission_rows`), category-to-tab lookup (`_mission_tab_for_category`), cached loads (`get_or_load_missions`), and cache management (`clear_mission_cache`).
- Implement mission UI: `build_mission_embed`, `MissionListPaginationView`, `MissionPageButton`, `ProgressGuideMissionButton`, and `ProgressGuideMissionPersistentView`, and wire mission button into `build_guide_view` when configured. 
- Add constants and helpers for mission behavior and quota-aware error rendering and register the persistent mission view in the cog (`ProgressGuideMissionPersistentView`).
- Ensure mission cache is cleared on publish/refresh and update `cog.py` and tests to exercise mission flows and formatting adjustments.

### Testing
- Ran the progress guides unit tests in `tests/community/test_progress_guides.py`, which include new mission-specific tests for parsing, pagination, caching, concurrency, quota/error handling, and UI composition, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a3d488408323867d86be0060cefb)