### PR TITLE
Use `description` as primary mission text with `mission_text` fallback

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -285,7 +285,7 @@ def _is_quota_failure(exc: BaseException) -> bool:
 def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow]:
     parsed: list[MissionRow] = []
     for order, row in enumerate(rows, start=1):
-        text = _strip_visible_urls(row.get("mission_text"))
+        text = _strip_visible_urls(row.get("description") or row.get("mission_text"))
         if not text:
             continue
         number = _int_or_none(row.get("step_index")) or order

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -993,12 +993,12 @@ def test_mission_rows_sort_skip_and_hide_internal_metadata():
     rows = [
         {
             "step_index": "2",
-            "mission_text": "Second https://source.example/x",
+            "description": "Second https://source.example/x",
             "source_url": "https://source.example",
             "system_tags": "secret",
         },
-        {"step_index": "", "mission_text": "Fallback order", "resource_tags": "hidden"},
-        {"step_index": "1", "mission_text": "First"},
+        {"step_index": "", "description": "Fallback order", "resource_tags": "hidden"},
+        {"step_index": "1", "description": "First", "mission_key": "internal-key"},
         {"step_index": "3", "mission_text": ""},
     ]
     missions = service._parse_mission_rows(rows)
@@ -1011,6 +1011,26 @@ def test_mission_rows_sort_skip_and_hide_internal_metadata():
     assert "source.example" not in rendered
     assert "secret" not in rendered
     assert "hidden" not in rendered
+    assert "internal-key" not in rendered
+
+
+def test_mission_rows_use_description_before_mission_text_fallback():
+    rows = [
+        {
+            "step_index": "1",
+            "description": "Description mission",
+            "mission_text": "Legacy text",
+        },
+        {"step_index": "2", "mission_text": "Fallback mission"},
+        {"step_index": "3", "title": "Missing text"},
+    ]
+
+    missions = service._parse_mission_rows(rows)
+
+    assert [(mission.number, mission.text) for mission in missions] == [
+        (1, "Description mission"),
+        (2, "Fallback mission"),
+    ]
 
 
 def test_first_mission_click_reads_only_configured_category_tab_and_caches(monkeypatch):


### PR DESCRIPTION
### Motivation
- Live mission tabs use a `description` column for mission text but the parser only read `mission_text`, which caused all live rows to be skipped. 
- Update parsing so the bot shows live missions correctly without changing sheet columns or adding new columns.

### Description
- Change `_parse_mission_rows` to prefer `row.get("description")` and fall back to `row.get("mission_text")`, passing the result through `_strip_visible_urls`. 
- Keep mission numbering derived from `step_index` (falling back to ordinal order) and continue skipping rows with no usable text. 
- Ensure rendered embeds do not expose `source_url`, internal/system/resource tags, or `mission_key`, and do not render `source_url` or internal metadata.
- Update tests to cover description-first parsing and preserve `mission_text` as a compatibility fallback by adding `test_mission_rows_use_description_before_mission_text_fallback` and adjusting fixtures.

### Testing
- Ran `pytest tests/community/test_progress_guides.py -q` and the test suite passed (all tests in that file succeeded). 
- The changes include the new/updated tests which also passed under the same test run. 
- No changes were made to intents, OAuth scopes, access lists, or sheet IDs per repository guardrails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57bcd62af48323a85014f00958d679)