### PR TITLE
Add 'My Progress' personal tracking to progress guides (Sheets-backed, modal + persistent view)

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -10,6 +10,7 @@ from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
     ProgressGuideFAQPersistentView,
     ProgressGuideMissionPersistentView,
+    ProgressGuideMyProgressPersistentView,
     PublishSummary,
     publish_or_refresh,
 )
@@ -73,6 +74,7 @@ class ProgressGuidesCog(commands.Cog):
         self.bot = bot
         bot.add_view(ProgressGuideFAQPersistentView())
         bot.add_view(ProgressGuideMissionPersistentView())
+        bot.add_view(ProgressGuideMyProgressPersistentView())
 
     @tier("admin")
     @help_metadata(

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 import re
 from typing import Any, Mapping, Sequence
@@ -24,6 +25,7 @@ _GUIDES_KEY = "PROGRESS_GUIDES_TAB"
 _FAQ_KEY = "PROGRESS_FAQ_TAB"
 _ASSETS_KEY = "PROGRESS_ASSETS_TAB"
 _CATEGORIES_KEY = "PROGRESS_CATEGORIES_TAB"
+_USER_STATE_KEY = "PROGRESS_USER_STATE_TAB"
 _MESSAGE_ID_COLUMN = "guide_panel_message_id"
 _EMBED_LIMIT = 3900
 _EMBED_TITLE_LIMIT = 256
@@ -33,6 +35,8 @@ _BUTTON_LABEL_LIMIT = 80
 _URL_RE = re.compile(r"https?://\S+")
 _FAQ_CUSTOM_ID_PREFIX = "progressguides:faq:"
 _MISSIONS_CUSTOM_ID_PREFIX = "progressguides:missions:"
+_MY_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:myprogress:"
+_SET_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:setprogress:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
 _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
 _MISSIONS_PER_PAGE = 15
@@ -89,6 +93,18 @@ class ForumPost:
     help_button_label: str
     mission_list_button_label: str
     mission_list_title: str
+    my_progress_button_label: str
+    my_progress_title: str
+    my_progress_body_template: str
+    my_progress_empty_description: str
+    my_progress_set_button_label: str
+    my_progress_modal_title: str
+    my_progress_modal_step_label: str
+    my_progress_saved_description: str
+    my_progress_invalid_step_description: str
+    my_progress_missing_step_description: str
+    my_progress_unavailable_description: str
+    progress_tracking_enabled: bool
     guide_channel_id: int | None
     guide_thread_id: int | None
     guide_panel_message_id: int | None
@@ -111,6 +127,28 @@ class ForumPost:
             help_button_label=_text(row.get("help_button_label")),
             mission_list_button_label=_text(row.get("mission_list_button_label")),
             mission_list_title=_text(row.get("mission_list_title")),
+            my_progress_button_label=_text(row.get("my_progress_button_label")),
+            my_progress_title=_text(row.get("my_progress_title")),
+            my_progress_body_template=_text(row.get("my_progress_body_template")),
+            my_progress_empty_description=_text(
+                row.get("my_progress_empty_description")
+            ),
+            my_progress_set_button_label=_text(row.get("my_progress_set_button_label")),
+            my_progress_modal_title=_text(row.get("my_progress_modal_title")),
+            my_progress_modal_step_label=_text(row.get("my_progress_modal_step_label")),
+            my_progress_saved_description=_text(
+                row.get("my_progress_saved_description")
+            ),
+            my_progress_invalid_step_description=_text(
+                row.get("my_progress_invalid_step_description")
+            ),
+            my_progress_missing_step_description=_text(
+                row.get("my_progress_missing_step_description")
+            ),
+            my_progress_unavailable_description=_text(
+                row.get("my_progress_unavailable_description")
+            ),
+            progress_tracking_enabled=_truthy(row.get("progress_tracking_enabled")),
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
             guide_panel_message_id=_int_or_none(row.get("guide_panel_message_id")),
@@ -126,6 +164,7 @@ class ForumPost:
 class MissionRow:
     number: int
     text: str
+    key: str = ""
 
 
 @dataclass(slots=True)
@@ -268,6 +307,14 @@ def _supports_missions(post: ForumPost) -> bool:
     )
 
 
+def _supports_my_progress(post: ForumPost) -> bool:
+    return (
+        post.category in _MISSION_CATEGORIES
+        and post.progress_tracking_enabled
+        and bool(post.my_progress_button_label)
+    )
+
+
 def _mission_unavailable_embed(description: str) -> discord.Embed:
     return discord.Embed(
         title="Mission list unavailable",
@@ -289,7 +336,9 @@ def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow
         if not text:
             continue
         number = _int_or_none(row.get("step_index")) or order
-        parsed.append(MissionRow(number=number, text=text))
+        parsed.append(
+            MissionRow(number=number, text=text, key=_text(row.get("mission_key")))
+        )
     return sorted(parsed, key=lambda mission: mission.number)
 
 
@@ -489,6 +538,314 @@ class ProgressGuideMissionButton(discord.ui.Button):
         )
 
 
+@dataclass(slots=True)
+class ProgressCategory:
+    category: str
+    label: str
+    total_steps: int | None
+    mission_tab_config_key: str
+
+
+async def _progress_category(category: str) -> ProgressCategory | None:
+    sheet_id = get_milestones_sheet_id().strip()
+    categories_tab = await milestones_config.arequire_value(_CATEGORIES_KEY)
+    rows = await afetch_records(sheet_id, categories_tab)
+    for row in rows:
+        if _text(row.get("category")) == category:
+            return ProgressCategory(
+                category=category,
+                label=_text(row.get("label")) or category,
+                total_steps=_int_or_none(row.get("total_steps")),
+                mission_tab_config_key=_text(row.get("mission_tab_config_key")),
+            )
+    return None
+
+
+async def _user_state_rows() -> tuple[str, list[dict[str, Any]]]:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab = await milestones_config.arequire_value(_USER_STATE_KEY)
+    return tab, await afetch_records(sheet_id, tab)
+
+
+def _find_user_state(
+    rows: Sequence[Mapping[str, object]], user_id: int, category: str
+) -> tuple[int, Mapping[str, object]] | None:
+    user = str(user_id)
+    for index, row in enumerate(rows, start=2):
+        if _text(row.get("user_id")) == user and _text(row.get("category")) == category:
+            return index, row
+    return None
+
+
+def _format_percent(current: int | None, total: int | None) -> str:
+    if not current or not total:
+        return ""
+    value = current / total * 100
+    return f"{int(value)}" if value.is_integer() else f"{value:.1f}"
+
+
+def _mission_for_state(
+    state: Mapping[str, object], missions: Sequence[MissionRow]
+) -> MissionRow | None:
+    key = _text(state.get("current_mission_key"))
+    if key:
+        found = next((m for m in missions if m.key == key), None)
+        if found:
+            return found
+    step = _int_or_none(state.get("current_step_index"))
+    return (
+        next((m for m in missions if m.number == step), None)
+        if step is not None
+        else None
+    )
+
+
+def build_my_progress_embed(
+    post: ForumPost,
+    category_info: ProgressCategory | None,
+    state: Mapping[str, object] | None,
+    missions: Sequence[MissionRow],
+) -> discord.Embed:
+    title = _embed_title(
+        post.my_progress_title or f"{post.label or post.category} Progress"
+    )
+    if state is None:
+        return discord.Embed(
+            title=title,
+            description=_embed_description(post.my_progress_empty_description),
+            color=discord.Color.blurple(),
+        )
+    mission = _mission_for_state(state, missions)
+    current = (
+        mission.number if mission else _int_or_none(state.get("current_step_index"))
+    )
+    total = category_info.total_steps if category_info else None
+    values = {
+        "category_label": (
+            category_info.label if category_info else (post.label or post.category)
+        ),
+        "current_step_index": str(current) if current is not None else "",
+        "total_steps": str(total) if total is not None else "",
+        "mission_description": mission.text if mission else "",
+        "percent_complete": _format_percent(current, total),
+        "remaining_steps": (
+            str(max(total - current, 0))
+            if total is not None and current is not None
+            else ""
+        ),
+        "status": _text(state.get("status")),
+    }
+    body = (
+        post.my_progress_body_template
+        or "Current mission: {current_step_index} / {total_steps}\n\nMission: {mission_description}\n\nProgress: {percent_complete}% complete\n{remaining_steps} missions remaining"
+    )
+    for key, value in values.items():
+        body = body.replace("{" + key + "}", value)
+    return discord.Embed(
+        title=title, description=_embed_description(body), color=discord.Color.blurple()
+    )
+
+
+class SetProgressButton(discord.ui.Button):
+    def __init__(self, category: str, label: str) -> None:
+        self.category = category
+        super().__init__(
+            label=_button_label(label),
+            style=discord.ButtonStyle.primary,
+            custom_id=f"{_SET_PROGRESS_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        data = await get_or_load_progress_guide_data()
+        post = _post_for_category(self.category, data)
+        if post is None:
+            await interaction.response.send_message(
+                embed=_progress_unavailable_embed(None), ephemeral=True
+            )
+            return
+        await interaction.response.send_modal(SetProgressModal(self.category, post))
+
+
+class MyProgressView(discord.ui.View):
+    def __init__(self, post: ForumPost) -> None:
+        super().__init__(timeout=900)
+        if post.my_progress_set_button_label:
+            self.add_item(
+                SetProgressButton(post.category, post.my_progress_set_button_label)
+            )
+
+
+class SetProgressModal(discord.ui.Modal):
+    def __init__(self, category: str, post: ForumPost) -> None:
+        super().__init__(
+            title=_embed_title(post.my_progress_modal_title or post.my_progress_title)
+        )
+        self.category = category
+        self.post = post
+        self.step = discord.ui.TextInput(
+            label=_button_label(post.my_progress_modal_step_label),
+            required=True,
+        )
+        self.add_item(self.step)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        post = self.post
+        raw = str(self.step.value).strip()
+        if not raw.isdigit():
+            await interaction.response.send_message(
+                embed=_progress_notice_embed(
+                    self.post, self.post.my_progress_invalid_step_description
+                ),
+                ephemeral=True,
+            )
+            return
+        selected = int(raw)
+        try:
+            data = await get_or_load_progress_guide_data()
+            post = _post_for_category(self.category, data) or self.post
+            category_info = await _progress_category(self.category)
+            missions = await get_or_load_missions(self.category)
+            mission = next((m for m in missions if m.number == selected), None)
+            if mission is None:
+                await interaction.response.send_message(
+                    embed=_progress_notice_embed(
+                        self.post, self.post.my_progress_missing_step_description
+                    ),
+                    ephemeral=True,
+                )
+                return
+            await upsert_progress_user_state(
+                interaction.user.id, self.category, mission
+            )
+            state = {
+                "current_step_index": str(mission.number),
+                "current_mission_key": mission.key,
+                "status": "in_progress",
+            }
+            embed = build_my_progress_embed(post, category_info, state, missions)
+            if post.my_progress_saved_description:
+                embed.set_footer(text=post.my_progress_saved_description)
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+        except Exception as exc:
+            if _is_quota_failure(exc):
+                await interaction.response.send_message(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            raise
+
+
+async def upsert_progress_user_state(
+    user_id: int, category: str, mission: MissionRow
+) -> None:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab, rows = await _user_state_rows()
+    found = _find_user_state(rows, user_id, category)
+    worksheet = await aget_worksheet(sheet_id, tab)
+    header = await _load_header(sheet_id, tab)
+    now = datetime.now(timezone.utc).isoformat()
+    values = {
+        "user_id": str(user_id),
+        "category": category,
+        "current_step_index": str(mission.number),
+        "current_mission_key": mission.key,
+        "status": "in_progress",
+        "notify_plan_ahead": "",
+        "private_thread_id": "",
+        "last_panel_message_id": "",
+        "notes": "",
+        "updated_at_utc": now,
+    }
+    if found is None:
+        row = [values.get(name, "") for name in header]
+        await acall_with_backoff(worksheet.append_row, row, value_input_option="RAW")
+        return
+    row_number, existing = found
+    preserve = {
+        "notify_plan_ahead",
+        "private_thread_id",
+        "last_panel_message_id",
+        "notes",
+    }
+    full_row = [
+        _text(existing.get(name)) if name in preserve else values.get(name, "")
+        for name in header
+    ]
+    start_col = _column_label(0)
+    end_col = _column_label(len(header) - 1)
+    await acall_with_backoff(
+        worksheet.update,
+        f"{start_col}{row_number}:{end_col}{row_number}",
+        [full_row],
+        value_input_option="RAW",
+    )
+
+
+def _progress_notice_embed(post: ForumPost | None, description: str) -> discord.Embed:
+    title = post.my_progress_title if post else "My Progress"
+    return discord.Embed(
+        title=_embed_title(title),
+        description=_embed_description(description or "Unavailable."),
+        color=discord.Color.red(),
+    )
+
+
+def _progress_unavailable_embed(post: ForumPost | None = None) -> discord.Embed:
+    description = post.my_progress_unavailable_description if post else "Unavailable."
+    return _progress_notice_embed(post, description)
+
+
+class ProgressGuideMyProgressButton(discord.ui.Button):
+    def __init__(self, category: str, label: str = "My Progress") -> None:
+        self.category = category
+        super().__init__(
+            label=_button_label(label or "My Progress"),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{_MY_PROGRESS_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        post: ForumPost | None = None
+        if self.category not in _MISSION_CATEGORIES:
+            await interaction.followup.send(
+                embed=_progress_unavailable_embed(post), ephemeral=True
+            )
+            return
+        try:
+            data = await get_or_load_progress_guide_data()
+            post = _post_for_category(self.category, data)
+            if post is None:
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            category_info = await _progress_category(self.category)
+            _tab, rows = await _user_state_rows()
+            found = _find_user_state(rows, interaction.user.id, self.category)
+            missions = await get_or_load_missions(self.category) if found else []
+            state = found[1] if found else None
+            await interaction.followup.send(
+                embed=build_my_progress_embed(post, category_info, state, missions),
+                view=MyProgressView(post),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            if _is_quota_failure(exc):
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            raise
+
+
+class ProgressGuideMyProgressPersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _MISSION_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(ProgressGuideMyProgressButton(category))
+
+
 class ProgressGuideMissionPersistentView(discord.ui.View):
     def __init__(self, categories: Sequence[str] = _MISSION_CATEGORIES) -> None:
         super().__init__(timeout=None)
@@ -539,16 +896,21 @@ def build_guide_view(
     view = discord.ui.View(timeout=None)
     added = False
     help_url = _safe_url(post.help_post_url)
-    if data.faq_by_category.get(post.category):
-        view.add_item(
-            ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
-        )
-        added = True
     if _supports_missions(post):
         view.add_item(
             ProgressGuideMissionButton(
                 post.category, post.mission_list_button_label or "Mission List"
             )
+        )
+        added = True
+    if _supports_my_progress(post):
+        view.add_item(
+            ProgressGuideMyProgressButton(post.category, post.my_progress_button_label)
+        )
+        added = True
+    if data.faq_by_category.get(post.category):
+        view.add_item(
+            ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
         )
         added = True
     if post.questions_enabled and help_url:

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -65,9 +65,13 @@ class FakeChannel:
 class FakeWorksheet:
     def __init__(self):
         self.updates = []
+        self.appended = []
 
     def update(self, cell, values, **kwargs):
         self.updates.append((cell, values, kwargs))
+
+    def append_row(self, row, **kwargs):
+        self.appended.append((row, kwargs))
 
 
 class FakeBot:
@@ -84,9 +88,17 @@ class FakeBot:
 class FakeInteractionResponse:
     def __init__(self):
         self.deferred = []
+        self.sent = []
+        self.modals = []
 
     async def defer(self, **kwargs):
         self.deferred.append(kwargs)
+
+    async def send_message(self, **kwargs):
+        self.sent.append(kwargs)
+
+    async def send_modal(self, modal):
+        self.modals.append(modal)
 
 
 class FakeFollowup:
@@ -97,10 +109,15 @@ class FakeFollowup:
         self.sent.append(kwargs)
 
 
+class FakeUser:
+    id = 123456
+
+
 class FakeInteraction:
     def __init__(self):
         self.response = FakeInteractionResponse()
         self.followup = FakeFollowup()
+        self.user = FakeUser()
 
 
 async def _run(monkeypatch, data, channels, worksheet, *, refresh=True):
@@ -146,6 +163,27 @@ def _data(*, post_overrides=None, guides=None, faq=None):
         "guide_panel_message_id": "",
         "help_post_url": "https://discord.com/channels/1/2/3",
         "guide_asset_key": "hero",
+        "guide_post_url": "",
+        "help_channel_id": "",
+        "help_thread_id": "",
+        "help_panel_message_id": "",
+        "progress_tracking_enabled": "TRUE",
+        "leaderboard_enabled": "FALSE",
+        "notes": "",
+        "updated_at_utc": "",
+        "mission_list_button_label": "",
+        "mission_list_title": "",
+        "my_progress_button_label": "",
+        "my_progress_title": "Arbiter Progress",
+        "my_progress_body_template": "Current mission: {current_step_index} / {total_steps}\n\nMission: {mission_description}\n\nProgress: {percent_complete}% complete\n{remaining_steps} missions remaining\nStatus: {status}",
+        "my_progress_empty_description": "No progress saved yet.",
+        "my_progress_set_button_label": "Set Progress",
+        "my_progress_modal_title": "Set Arbiter Progress",
+        "my_progress_modal_step_label": "Current mission number",
+        "my_progress_saved_description": "Progress saved.",
+        "my_progress_invalid_step_description": "Sheet says enter a valid mission number.",
+        "my_progress_missing_step_description": "Sheet says that mission is not available.",
+        "my_progress_unavailable_description": "Sheet says progress is temporarily unavailable.",
         "questions_enabled": "TRUE",
         "sort_order": "1",
         "enabled": "TRUE",
@@ -957,20 +995,23 @@ def test_non_quota_writeback_failure_deletes_untracked_message_and_reports_failu
     assert "ordinary update failure" in summary.failures[0]
 
 
-def test_mission_button_appears_between_faq_and_help_with_sheet_label():
+def test_guide_button_order_includes_my_progress_with_sheet_label():
     data = _data(
         post_overrides={
             "mission_list_button_label": "View Missions",
             "mission_list_title": "Arbiter Mission List",
+            "my_progress_button_label": "My Progress",
         }
     )
     view = service.build_guide_view(data.posts[0], data)
     assert [getattr(item, "label", "") for item in view.children] == [
-        "Read FAQ",
         "View Missions",
+        "My Progress",
+        "Read FAQ",
         "Ask the Helpers",
     ]
-    assert view.children[1].custom_id == "progressguides:missions:ARB"
+    assert view.children[0].custom_id == "progressguides:missions:ARB"
+    assert view.children[1].custom_id == "progressguides:myprogress:ARB"
 
 
 @pytest.mark.parametrize("category", ["FW_N", "FW_H"])
@@ -1210,3 +1251,279 @@ def test_publish_refresh_clears_mission_cache_without_reading_mission_tabs(monke
     asyncio.run(service.ProgressGuideMissionButton("ARB").callback(second))
     assert mission_tab_loads == 2
     assert "Loaded 2" in second.followup.sent[0]["embed"].description
+
+
+def test_my_progress_button_hides_when_label_blank_or_tracking_false():
+    data = _data(post_overrides={"my_progress_button_label": ""})
+    assert "progressguides:myprogress:ARB" not in [
+        getattr(i, "custom_id", "")
+        for i in service.build_guide_view(data.posts[0], data).children
+    ]
+    data = _data(post_overrides={"progress_tracking_enabled": "FALSE"})
+    assert "progressguides:myprogress:ARB" not in [
+        getattr(i, "custom_id", "")
+        for i in service.build_guide_view(data.posts[0], data).children
+    ]
+
+
+@pytest.mark.parametrize("category", ["FW_N", "FW_H"])
+def test_fw_guides_do_not_get_my_progress_button(category):
+    data = _data(
+        post_overrides={
+            "category": category,
+            "my_progress_button_label": "My Progress",
+            "progress_tracking_enabled": "TRUE",
+        }
+    )
+    data.faq_by_category[category] = data.faq_by_category.pop("ARB")
+    view = service.build_guide_view(data.posts[0], data)
+    assert f"progressguides:myprogress:{category}" not in [
+        getattr(item, "custom_id", "") for item in view.children
+    ]
+
+
+def test_my_progress_empty_state_uses_sheet_copy_and_set_button():
+    data = _data()
+    embed = service.build_my_progress_embed(data.posts[0], None, None, [])
+    assert embed.title == "Arbiter Progress"
+    assert embed.description == "No progress saved yet."
+    view = service.MyProgressView(data.posts[0])
+    assert [getattr(item, "label", "") for item in view.children] == ["Set Progress"]
+
+
+def test_existing_progress_renders_template_prefers_mission_key_and_hides_metadata():
+    data = _data()
+    category = service.ProgressCategory(
+        "ARB", "Arena Rush Basics", 286, "PROGRESS_MISSIONS_ARB_TAB"
+    )
+    missions = [
+        service.MissionRow(10, "Wrong fallback", "old"),
+        service.MissionRow(
+            145, "Clear Stage 20 of the Dragon’s Lair 10 times on Auto.", "dragon-20"
+        ),
+    ]
+    state = {
+        "current_step_index": "10",
+        "current_mission_key": "dragon-20",
+        "status": "in_progress",
+    }
+    embed = service.build_my_progress_embed(data.posts[0], category, state, missions)
+    rendered = embed.description
+    assert "145 / 286" in rendered
+    assert "50.7% complete" in rendered
+    assert "141 missions remaining" in rendered
+    assert "Clear Stage 20" in rendered
+    assert "dragon-20" not in rendered
+    assert "system_tags" not in rendered
+    assert "resource_tags" not in rendered
+    assert "source_url" not in rendered
+    assert "Wrong fallback" not in rendered
+
+
+def test_existing_progress_falls_back_to_step_index_and_description_column():
+    data = _data()
+    category = service.ProgressCategory(
+        "ARB", "Arena Rush Basics", 3, "PROGRESS_MISSIONS_ARB_TAB"
+    )
+    missions = service._parse_mission_rows(
+        [
+            {
+                "step_index": "2",
+                "mission_key": "two",
+                "description": "Description column text",
+                "mission_text": "Do not use",
+            }
+        ]
+    )
+    embed = service.build_my_progress_embed(
+        data.posts[0],
+        category,
+        {"current_step_index": "2", "current_mission_key": "", "status": "in_progress"},
+        missions,
+    )
+    assert "Description column text" in embed.description
+    assert "Do not use" not in embed.description
+
+
+def test_upsert_progress_user_state_appends_and_updates_with_exact_headers(monkeypatch):
+    worksheet = FakeWorksheet()
+    headers = [
+        "user_id",
+        "category",
+        "current_step_index",
+        "current_mission_key",
+        "status",
+        "notify_plan_ahead",
+        "private_thread_id",
+        "last_panel_message_id",
+        "notes",
+        "updated_at_utc",
+    ]
+
+    async def config_value(key):
+        assert key == "PROGRESS_USER_STATE_TAB"
+        return "ProgressUserState"
+
+    async def fetch_records(_sheet, _tab):
+        return []
+
+    async def fetch_values(_sheet, _tab):
+        return [headers]
+
+    async def get_ws(_sheet, _tab):
+        return worksheet
+
+    async def call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service.milestones_config, "arequire_value", config_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "afetch_values", fetch_values)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    asyncio.run(
+        service.upsert_progress_user_state(
+            123456, "ARB", service.MissionRow(145, "x", "dragon-20")
+        )
+    )
+    appended = worksheet.appended[0][0]
+    assert appended[:5] == ["123456", "ARB", "145", "dragon-20", "in_progress"]
+    assert appended[5:9] == ["", "", "", ""]
+
+    async def fetch_existing(_sheet, _tab):
+        return [
+            {
+                "user_id": "123456",
+                "category": "ARB",
+                "notify_plan_ahead": "yes",
+                "private_thread_id": "7",
+                "last_panel_message_id": "8",
+                "notes": "keep",
+            }
+        ]
+
+    worksheet.appended.clear()
+    monkeypatch.setattr(service, "afetch_records", fetch_existing)
+    asyncio.run(
+        service.upsert_progress_user_state(
+            123456, "ARB", service.MissionRow(146, "x", "next")
+        )
+    )
+    assert len(worksheet.updates) == 1
+    cell, values, kwargs = worksheet.updates[0]
+    assert cell == "A2:J2"
+    assert values[0][:5] == ["123456", "ARB", "146", "next", "in_progress"]
+    assert values[0][5:9] == ["yes", "7", "8", "keep"]
+    assert kwargs == {"value_input_option": "RAW"}
+    assert worksheet.appended == []
+
+
+def test_my_progress_persistent_view_has_no_startup_sheet_reads(monkeypatch):
+    async def forbidden(*_args, **_kwargs):
+        raise AssertionError("startup must not read sheets")
+
+    monkeypatch.setattr(service, "afetch_records", forbidden)
+    bot = FakeBot()
+    ProgressGuidesCog(bot)
+    custom_ids = [
+        getattr(item, "custom_id", "") for view in bot.views for item in view.children
+    ]
+    assert "progressguides:myprogress:ARB" in custom_ids
+
+
+def _set_modal_step_value(modal, value: str) -> None:
+    from types import SimpleNamespace
+
+    modal.step = SimpleNamespace(value=value)
+
+
+def test_set_progress_modal_rejects_non_numeric_with_embed_and_no_write(monkeypatch):
+    data = _data(post_overrides={"my_progress_button_label": "My Progress"})
+    modal = service.SetProgressModal("ARB", data.posts[0])
+    _set_modal_step_value(modal, "abc")
+    writes = []
+
+    async def write(*_args, **_kwargs):
+        writes.append(True)
+
+    monkeypatch.setattr(service, "upsert_progress_user_state", write)
+    interaction = FakeInteraction()
+    asyncio.run(modal.on_submit(interaction))
+
+    assert writes == []
+    assert (
+        interaction.response.sent[0]["embed"].description
+        == "Sheet says enter a valid mission number."
+    )
+    assert "content" not in interaction.response.sent[0]
+
+
+def test_set_progress_modal_rejects_out_of_range_with_embed_and_no_write(monkeypatch):
+    data = _data(post_overrides={"my_progress_button_label": "My Progress"})
+    service.set_progress_guide_cache(data)
+    modal = service.SetProgressModal("ARB", data.posts[0])
+    _set_modal_step_value(modal, "999")
+    writes = []
+
+    async def category(_category):
+        return service.ProgressCategory(
+            "ARB", "Arena Rush Basics", 2, "PROGRESS_MISSIONS_ARB_TAB"
+        )
+
+    async def missions(_category):
+        return [service.MissionRow(1, "First", "first")]
+
+    async def write(*_args, **_kwargs):
+        writes.append(True)
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    monkeypatch.setattr(service, "upsert_progress_user_state", write)
+    interaction = FakeInteraction()
+    asyncio.run(modal.on_submit(interaction))
+
+    assert writes == []
+    assert (
+        interaction.response.sent[0]["embed"].description
+        == "Sheet says that mission is not available."
+    )
+    assert "content" not in interaction.response.sent[0]
+
+
+def test_set_progress_modal_success_is_embed_only(monkeypatch):
+    data = _data(post_overrides={"my_progress_button_label": "My Progress"})
+    service.set_progress_guide_cache(data)
+    modal = service.SetProgressModal("ARB", data.posts[0])
+    _set_modal_step_value(modal, "1")
+    writes = []
+
+    async def category(_category):
+        return service.ProgressCategory(
+            "ARB", "Arena Rush Basics", 2, "PROGRESS_MISSIONS_ARB_TAB"
+        )
+
+    async def missions(_category):
+        return [service.MissionRow(1, "First", "first")]
+
+    async def write(user_id, category_name, mission):
+        writes.append((user_id, category_name, mission.number, mission.key))
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    monkeypatch.setattr(service, "upsert_progress_user_state", write)
+    interaction = FakeInteraction()
+    asyncio.run(modal.on_submit(interaction))
+
+    assert writes == [(123456, "ARB", 1, "first")]
+    sent = interaction.response.sent[0]
+    assert "content" not in sent
+    assert sent["embed"].footer.text == "Progress saved."
+    assert "First" in sent["embed"].description
+
+
+def test_my_progress_unavailable_embed_uses_sheet_description():
+    data = _data(post_overrides={"my_progress_button_label": "My Progress"})
+    embed = service._progress_unavailable_embed(data.posts[0])
+    assert embed.title == "Arbiter Progress"
+    assert embed.description == "Sheet says progress is temporarily unavailable."


### PR DESCRIPTION
### Motivation

- Add a personal "My Progress" feature to progress guide panels so users can view and set their mission progress stored in the milestones Google Sheet.
- Support mission lookup by stable `mission_key` in addition to numeric step index so saved state can reference canonical mission IDs.

### Description

- Introduce sheet wiring and constants (`_USER_STATE_KEY`, `_MY_PROGRESS_CUSTOM_ID_PREFIX`, `_SET_PROGRESS_CUSTOM_ID_PREFIX`) and extend `ForumPost` with multiple `my_progress_*` configuration fields and `progress_tracking_enabled` to drive behavior.
- Add mission metadata support by extending `MissionRow` with `key` and parsing it in `_parse_mission_rows`, and add `ProgressCategory`, `_progress_category`, `_user_state_rows`, and `_find_user_state` helpers for category and user-state access.
- Implement the UI flow: `ProgressGuideMyProgressButton`, `ProgressGuideMyProgressPersistentView`, `MyProgressView`, `SetProgressButton`, and `SetProgressModal`, plus `build_my_progress_embed` to render templated user progress and `upsert_progress_user_state` to append/update the user state row in Sheets with UTC timestamps.
- Wire the feature into existing flows by registering `ProgressGuideMyProgressPersistentView` in `ProgressGuidesCog.__init__`, adding the my-progress button to `build_guide_view` (and adjusting button order), and adding quota/unavailable handling alongside other mission logic.

### Testing

- Ran `pytest tests/community/test_progress_guides.py` which includes added and updated unit tests covering button visibility, persistent view registration, embed rendering, mission key selection, `upsert_progress_user_state` append/update behavior, and modal validation, and all tests passed.
- Updated test helpers to simulate worksheet `append_row` and modal interactions and validated that no startup sheet reads occur when registering persistent views with the bot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d0f80bbc8323a69eca6694228798)