### PR TITLE
Schedule-only housekeeping cleanup registration (no startup scan)

### DIFF
--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import inspect
 import logging
 import math
 import os
@@ -1675,33 +1674,7 @@ class Runtime:
                 except Exception:
                     cleanup_logger.exception("cleanup watcher failure notice failed")
 
-        async def startup_validation_runner() -> None:
-            try:
-                run_cleanup_kwargs: dict[str, Any] = {
-                    "startup_validation": True,
-                    "writeback": False,
-                }
-                try:
-                    if "resolved_config" in inspect.signature(
-                        housekeeping_cleanup.run_cleanup
-                    ).parameters:
-                        run_cleanup_kwargs["resolved_config"] = cleanup_config
-                except (TypeError, ValueError):
-                    run_cleanup_kwargs["resolved_config"] = cleanup_config
-                await housekeeping_cleanup.run_cleanup(
-                    self.bot, cleanup_logger, **run_cleanup_kwargs
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                cleanup_logger.exception(
-                    "cleanup startup validation failed; recurring cleanup remains scheduled"
-                )
-
         cleanup_job.do(cleanup_runner)
-        self.scheduler.spawn(
-            startup_validation_runner(), name="cleanup_startup_validation"
-        )
 
         next_run = getattr(cleanup_job, "next_run", None)
         next_run_text = (

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -1363,9 +1363,7 @@ class _FakeLoop:
         coro.close()
 
 
-def test_global_housekeeping_disabled_prevents_cleanup_resolution_and_startup_validation(
-    monkeypatch, caplog
-):
+def test_global_housekeeping_disabled_prevents_cleanup_resolution(monkeypatch, caplog):
     caplog.set_level("INFO", logger="c1c.housekeeping.cleanup")
     rt = object.__new__(runtime.Runtime)
     rt.scheduler = _FakeScheduler()
@@ -1377,7 +1375,7 @@ def test_global_housekeeping_disabled_prevents_cleanup_resolution_and_startup_va
     cleanup_module = SimpleNamespace(
         resolve_cleanup_config_async=fail_resolve,
         run_cleanup=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("startup validation must not run")
+            AssertionError("cleanup must not run during registration")
         ),
     )
 
@@ -1443,9 +1441,12 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(
         {"hours": 6.0, "tag": "cleanup", "name": "cleanup_watcher"}
     ]
     assert [task["name"] for task in rt.scheduler.spawned] == [
-        "cleanup_startup_validation",
         "cleanup_registration_notice",
     ]
+    assert "cleanup_startup_validation" not in [
+        task["name"] for task in rt.scheduler.spawned
+    ]
+    assert run_cleanup_calls == []
     assert rt.bot.loop.created == []
     assert rt.scheduler.jobs[0].runner is not None
     assert successes[0][0].bucket == "cleanup"
@@ -1453,13 +1454,6 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(
         "cleanup watcher scheduled: every=6h dry_run=true tab=CleanupRows "
         "next_run=2026-06-26T12:00:00Z"
     ) in caplog.text
-
-    startup_validation = rt.scheduler.spawned[0]["coro"]
-    asyncio.run(startup_validation)
-    assert run_cleanup_calls[-1][1] == {
-        "startup_validation": True,
-        "writeback": False,
-    }
 
     asyncio.run(rt.scheduler.jobs[0].runner())
 
@@ -1469,7 +1463,7 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(
         "writeback": True,
     }
 
-    registration_notice = rt.scheduler.spawned[1]["coro"]
+    registration_notice = rt.scheduler.spawned[0]["coro"]
     asyncio.run(registration_notice)
     assert sent_logs == [
         "🧹 cleanup watcher tick: startup_validation=false writeback=true",


### PR DESCRIPTION
### Motivation
- Startup was resolving cleanup config and scheduling the watcher but also running a startup dry-run scan, which is unintended; registration should only schedule the recurring cleanup watcher and send the registration notice.

### Description
- Removed the startup validation runner from `Runtime._register_cleanup_scheduler` so startup now only resolves cleanup config, creates the recurring `cleanup_watcher` job, and attaches `cleanup_runner` and the registration notice.
- Removed the now-unused `inspect` import which was only used by the removed startup validation path.
- Updated `tests/modules/housekeeping/test_cleanup.py` to assert that registration does not spawn a `cleanup_startup_validation` task and does not call `run_cleanup` during registration.
- Did not change `modules/housekeeping/cleanup.py` behavior, cleanup row parsing, or sheet schema, and the scheduled cleanup execution remains unchanged.

### Testing
- Ran `pytest tests/modules/housekeeping/test_cleanup.py tests/housekeeping/test_cleanup_config.py -q` and all tests passed.
- Ran `python -m py_compile modules/common/runtime.py modules/housekeeping/cleanup.py` and compilation succeeded.
- Tests verify that registration logs the `cleanup watcher scheduled...` message and that the first actual cleanup run only happens via the scheduled `cleanup_runner` (with `startup_validation=false` and `writeback=true`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e94b01f08323a829ad5f4a350d96)