### PR TITLE
Add "Plan Ahead" feature to progress guides (embed, button, and persistent view)

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -10,6 +10,7 @@ from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
     ProgressGuideFAQPersistentView,
     ProgressGuideMissionPersistentView,
+    ProgressGuidePlanAheadPersistentView,
     ProgressGuideMyProgressPersistentView,
     PublishSummary,
     publish_or_refresh,
@@ -75,6 +76,7 @@ class ProgressGuidesCog(commands.Cog):
         bot.add_view(ProgressGuideFAQPersistentView())
         bot.add_view(ProgressGuideMissionPersistentView())
         bot.add_view(ProgressGuideMyProgressPersistentView())
+        bot.add_view(ProgressGuidePlanAheadPersistentView())
 
     @tier("admin")
     @help_metadata(

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -37,6 +37,7 @@ _FAQ_CUSTOM_ID_PREFIX = "progressguides:faq:"
 _MISSIONS_CUSTOM_ID_PREFIX = "progressguides:missions:"
 _MY_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:myprogress:"
 _SET_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:setprogress:"
+_PLAN_AHEAD_CUSTOM_ID_PREFIX = "progressguides:planahead:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
 _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
 _MISSIONS_PER_PAGE = 15
@@ -115,6 +116,18 @@ class ForumPost:
     my_progress_complete_saved_description: str
     my_progress_next_mission_saved_description: str
     my_progress_completed_template: str
+    plan_ahead_button_label: str
+    plan_ahead_title: str
+    plan_ahead_intro_template: str
+    plan_ahead_no_progress_description: str
+    plan_ahead_no_items_description: str
+    plan_ahead_upcoming_field_title: str
+    plan_ahead_save_field_title: str
+    plan_ahead_avoid_field_title: str
+    plan_ahead_time_gate_field_title: str
+    plan_ahead_warning_field_title: str
+    plan_ahead_footer: str
+    plan_ahead_lookahead_count: int | None
     progress_tracking_enabled: bool
     guide_channel_id: int | None
     guide_thread_id: int | None
@@ -184,6 +197,30 @@ class ForumPost:
             my_progress_completed_template=_text(
                 row.get("my_progress_completed_template")
             ),
+            plan_ahead_button_label=_text(row.get("plan_ahead_button_label")),
+            plan_ahead_title=_text(row.get("plan_ahead_title")),
+            plan_ahead_intro_template=_text(row.get("plan_ahead_intro_template")),
+            plan_ahead_no_progress_description=_text(
+                row.get("plan_ahead_no_progress_description")
+            ),
+            plan_ahead_no_items_description=_text(
+                row.get("plan_ahead_no_items_description")
+            ),
+            plan_ahead_upcoming_field_title=_text(
+                row.get("plan_ahead_upcoming_field_title")
+            ),
+            plan_ahead_save_field_title=_text(row.get("plan_ahead_save_field_title")),
+            plan_ahead_avoid_field_title=_text(row.get("plan_ahead_avoid_field_title")),
+            plan_ahead_time_gate_field_title=_text(
+                row.get("plan_ahead_time_gate_field_title")
+            ),
+            plan_ahead_warning_field_title=_text(
+                row.get("plan_ahead_warning_field_title")
+            ),
+            plan_ahead_footer=_text(row.get("plan_ahead_footer")),
+            plan_ahead_lookahead_count=_int_or_none(
+                row.get("plan_ahead_lookahead_count")
+            ),
             progress_tracking_enabled=_truthy(row.get("progress_tracking_enabled")),
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
@@ -203,6 +240,13 @@ class MissionRow:
     key: str
     title: str
     text: str
+    tips: str
+    avoid_doing: str
+    resource_tags: str
+    time_gate: bool
+    difficulty_note: str
+    guide_priority: str
+    retroactive_note: str
 
     def __init__(
         self,
@@ -211,12 +255,26 @@ class MissionRow:
         key: str = "",
         title: str = "",
         step_index: int | None = None,
+        tips: str = "",
+        avoid_doing: str = "",
+        resource_tags: str = "",
+        time_gate: bool = False,
+        difficulty_note: str = "",
+        guide_priority: str = "",
+        retroactive_note: str = "",
     ) -> None:
         self.sequence_number = sequence_number
         self.step_index = step_index if step_index is not None else sequence_number
         self.key = key
         self.title = title
         self.text = text
+        self.tips = tips
+        self.avoid_doing = avoid_doing
+        self.resource_tags = resource_tags
+        self.time_gate = time_gate
+        self.difficulty_note = difficulty_note
+        self.guide_priority = guide_priority
+        self.retroactive_note = retroactive_note
 
     @property
     def number(self) -> int:
@@ -363,6 +421,14 @@ def _supports_missions(post: ForumPost) -> bool:
     )
 
 
+def _supports_plan_ahead(post: ForumPost) -> bool:
+    return (
+        post.category in _MISSION_CATEGORIES
+        and post.progress_tracking_enabled
+        and bool(post.plan_ahead_button_label)
+    )
+
+
 def _supports_my_progress(post: ForumPost) -> bool:
     return (
         post.category in _MISSION_CATEGORIES
@@ -399,6 +465,13 @@ def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow
                 key=_text(row.get("mission_key")),
                 title=_text(row.get("title")),
                 text=text,
+                tips=_strip_visible_urls(row.get("tips")),
+                avoid_doing=_strip_visible_urls(row.get("avoid_doing")),
+                resource_tags=_text(row.get("resource_tags")),
+                time_gate=_truthy(row.get("time_gate")),
+                difficulty_note=_strip_visible_urls(row.get("difficulty_note")),
+                guide_priority=_text(row.get("guide_priority")),
+                retroactive_note=_strip_visible_urls(row.get("retroactive_note")),
             )
         )
     return parsed
@@ -838,6 +911,225 @@ class MarkMissionDoneButton(discord.ui.Button):
             raise
 
 
+def _plan_lookahead_count(post: ForumPost) -> int:
+    count = post.plan_ahead_lookahead_count or 12
+    return max(1, min(count, 25))
+
+
+def _dedupe(values: Sequence[str], limit: int = 8) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        clean = _strip_visible_urls(value)
+        key = clean.casefold()
+        if not clean or key in seen:
+            continue
+        seen.add(key)
+        result.append(clean)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _display_resource_tags(value: object, limit: int = 8) -> list[str]:
+    parts = re.split(r"[,;]", _text(value))
+    seen: set[str] = set()
+    result: list[str] = []
+    for part in parts:
+        clean = part.strip().replace("_", " ")
+        clean = re.sub(r"\s+", " ", clean).strip()
+        key = clean.casefold()
+        if not clean or key in seen:
+            continue
+        seen.add(key)
+        result.append(clean)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _plan_line(mission: MissionRow) -> str:
+    title = mission.title or "Missions"
+    text = _limit_text(mission.text, 140)
+    return f"- {title}, {mission.step_index}: {text}"
+
+
+def build_plan_ahead_embed(
+    post: ForumPost,
+    category_info: ProgressCategory | None,
+    state: Mapping[str, object] | None,
+    missions: Sequence[MissionRow],
+) -> discord.Embed:
+    title = _embed_title(post.plan_ahead_title or post.my_progress_title or post.label)
+    if state is None:
+        return discord.Embed(
+            title=title,
+            description=_embed_description(post.plan_ahead_no_progress_description),
+            color=discord.Color.blurple(),
+        )
+    current = _mission_for_state(state, missions)
+    if current is None:
+        return discord.Embed(
+            title=title,
+            description=_embed_description(post.plan_ahead_no_progress_description),
+            color=discord.Color.blurple(),
+        )
+    total = category_info.total_steps if category_info else len(missions)
+    completed = max(current.sequence_number - 1, 0)
+    remaining = max(total - completed, 0) if total is not None else None
+    lookahead_count = _plan_lookahead_count(post)
+    upcoming = [m for m in missions if m.sequence_number > current.sequence_number][
+        :lookahead_count
+    ]
+    chapter_total = sum(
+        1 for m in missions if (m.title or "Missions") == (current.title or "Missions")
+    )
+    values = {
+        "category_label": category_info.label
+        if category_info
+        else (post.label or post.category),
+        "chapter_title": current.title,
+        "chapter_step_index": str(current.step_index),
+        "chapter_total_steps": str(chapter_total),
+        "current_sequence_number": str(current.sequence_number),
+        "completed_steps": str(completed),
+        "total_steps": str(total) if total is not None else "",
+        "remaining_steps": str(remaining) if remaining is not None else "",
+        "percent_complete": _format_percent(completed, total),
+        "lookahead_count": str(lookahead_count),
+        "mission_description": current.text,
+    }
+    description = post.plan_ahead_intro_template
+    for key, value in values.items():
+        description = description.replace("{" + key + "}", value)
+    embed = discord.Embed(
+        title=title,
+        description=_embed_description(description),
+        color=discord.Color.blurple(),
+    )
+    if upcoming and post.plan_ahead_upcoming_field_title:
+        embed.add_field(
+            name=_embed_title(post.plan_ahead_upcoming_field_title),
+            value=_limit_text("\n".join(_plan_line(m) for m in upcoming), _FIELD_LIMIT),
+            inline=False,
+        )
+    save_values: list[str] = []
+    for m in upcoming:
+        save_values.append(m.tips)
+        save_values.extend(_display_resource_tags(m.resource_tags))
+    if post.plan_ahead_save_field_title:
+        lines = _dedupe(save_values)
+        if lines:
+            embed.add_field(
+                name=_embed_title(post.plan_ahead_save_field_title),
+                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                inline=False,
+            )
+    avoid_values: list[str] = []
+    for m in upcoming:
+        avoid_values.extend([m.avoid_doing, m.retroactive_note])
+    if post.plan_ahead_avoid_field_title:
+        lines = _dedupe(avoid_values)
+        if lines:
+            embed.add_field(
+                name=_embed_title(post.plan_ahead_avoid_field_title),
+                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                inline=False,
+            )
+    gate_values = [
+        f"{m.title or 'Missions'}, {m.step_index}: {m.retroactive_note or m.text}"
+        for m in upcoming
+        if m.time_gate or m.retroactive_note
+    ]
+    if post.plan_ahead_time_gate_field_title:
+        lines = _dedupe(gate_values)
+        if lines:
+            embed.add_field(
+                name=_embed_title(post.plan_ahead_time_gate_field_title),
+                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                inline=False,
+            )
+    warning_values: list[str] = []
+    priority_words = ("critical", "high", "major_wall", "major wall", "wall")
+    for m in sorted(
+        upcoming,
+        key=lambda m: (
+            0
+            if any(
+                w in m.guide_priority.casefold() or w in m.difficulty_note.casefold()
+                for w in priority_words
+            )
+            else 1
+        ),
+    ):
+        warning_values.extend([m.difficulty_note, m.guide_priority])
+    if post.plan_ahead_warning_field_title:
+        lines = _dedupe(warning_values)
+        if lines:
+            embed.add_field(
+                name=_embed_title(post.plan_ahead_warning_field_title),
+                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                inline=False,
+            )
+    if not embed.fields and post.plan_ahead_no_items_description:
+        embed.description = _embed_description(post.plan_ahead_no_items_description)
+    if post.plan_ahead_footer:
+        embed.set_footer(text=_limit_text(post.plan_ahead_footer, 2048))
+    return embed
+
+
+class PlanAheadButton(discord.ui.Button):
+    def __init__(self, category: str, label: str = "Plan Ahead") -> None:
+        self.category = category
+        super().__init__(
+            label=_button_label(label or "Plan Ahead"),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{_PLAN_AHEAD_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        post: ForumPost | None = None
+        try:
+            data = await get_or_load_progress_guide_data()
+            post = _post_for_category(self.category, data)
+            if post is None or not _supports_plan_ahead(post):
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            category_info = await _progress_category(self.category)
+            _tab, rows = await _user_state_rows()
+            found = _find_user_state(rows, interaction.user.id, self.category)
+            missions = await get_or_load_missions(self.category) if found else []
+            state = found[1] if found else None
+            view = (
+                PlanAheadNoProgressView(post)
+                if state is None and post.my_progress_set_button_label
+                else None
+            )
+            await interaction.followup.send(
+                embed=build_plan_ahead_embed(post, category_info, state, missions),
+                view=view,
+                ephemeral=True,
+            )
+        except Exception as exc:
+            if _is_quota_failure(exc):
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            raise
+
+
+class PlanAheadNoProgressView(discord.ui.View):
+    def __init__(self, post: ForumPost) -> None:
+        super().__init__(timeout=900)
+        self.add_item(
+            SetProgressButton(post.category, post.my_progress_set_button_label)
+        )
+
+
 class MyProgressView(discord.ui.View):
     def __init__(self, post: ForumPost) -> None:
         super().__init__(timeout=900)
@@ -851,6 +1143,8 @@ class MyProgressView(discord.ui.View):
                     post.category, post.my_progress_complete_button_label
                 )
             )
+        if _supports_plan_ahead(post):
+            self.add_item(PlanAheadButton(post.category, post.plan_ahead_button_label))
 
 
 def build_progress_picker_embed(
@@ -1029,9 +1323,7 @@ class ProgressChapterPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(
-                ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter")
-            )
+            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter"))
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "chapter"
@@ -1067,9 +1359,7 @@ class ProgressMissionPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(
-                ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission")
-            )
+            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission"))
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "mission"
@@ -1276,6 +1566,13 @@ class ProgressGuideMyProgressButton(discord.ui.Button):
             raise
 
 
+class ProgressGuidePlanAheadPersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _MISSION_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(PlanAheadButton(category))
+
+
 class ProgressGuideMyProgressPersistentView(discord.ui.View):
     def __init__(self, categories: Sequence[str] = _MISSION_CATEGORIES) -> None:
         super().__init__(timeout=None)
@@ -1344,6 +1641,9 @@ def build_guide_view(
         view.add_item(
             ProgressGuideMyProgressButton(post.category, post.my_progress_button_label)
         )
+        added = True
+    if _supports_plan_ahead(post):
+        view.add_item(PlanAheadButton(post.category, post.plan_ahead_button_label))
         added = True
     if data.faq_by_category.get(post.category):
         view.add_item(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -1732,3 +1732,191 @@ def test_my_progress_unavailable_embed_uses_sheet_description():
     embed = service._progress_unavailable_embed(data.posts[0])
     assert embed.title == "Arbiter Progress"
     assert embed.description == "Sheet says progress is temporarily unavailable."
+
+
+def _plan_data(**overrides):
+    base = {
+        "mission_list_button_label": "Mission List",
+        "mission_list_title": "Mission List",
+        "my_progress_button_label": "My Progress",
+        "plan_ahead_button_label": "Plan Ahead",
+        "plan_ahead_title": "Plan Ahead Title",
+        "plan_ahead_intro_template": "Planning {category_label}: {chapter_title} {chapter_step_index}/{chapter_total_steps}; scan {lookahead_count}; current {mission_description}",
+        "plan_ahead_no_progress_description": "Set progress first.",
+        "plan_ahead_no_items_description": "Nothing to plan.",
+        "plan_ahead_upcoming_field_title": "Coming soon",
+        "plan_ahead_save_field_title": "Save or prepare",
+        "plan_ahead_avoid_field_title": "Do not do too early",
+        "plan_ahead_time_gate_field_title": "Time-gated",
+        "plan_ahead_warning_field_title": "Watch-outs",
+        "plan_ahead_footer": "Sheet footer",
+        "plan_ahead_lookahead_count": "2",
+        "my_progress_complete_button_label": "Mark Mission Done",
+    }
+    base.update(overrides)
+    return _data(post_overrides=base)
+
+
+def _plan_missions():
+    return [
+        service.MissionRow(1, "Current text", "current-key", "Marius - Part 1", 1),
+        service.MissionRow(
+            2,
+            "Clear Stage 1",
+            "next-key",
+            "Marius - Part 1",
+            2,
+            tips="Save energy",
+            resource_tags="hydra_keys, arena_refills",
+            time_gate=True,
+            difficulty_note="wall",
+            guide_priority="high",
+            retroactive_note="Must be active",
+        ),
+        service.MissionRow(
+            3,
+            "Upgrade gear",
+            "third-key",
+            "Marius - Part 1",
+            3,
+            tips="Save energy",
+            avoid_doing="Do not claim reward",
+            resource_tags="hydra_keys; silver",
+            difficulty_note="medium",
+            guide_priority="normal",
+        ),
+        service.MissionRow(4, "Hidden future", "future-key", "Marius - Part 1", 4),
+    ]
+
+
+def test_plan_ahead_main_guide_button_order_and_visibility_rules():
+    data = _plan_data()
+    view = service.build_guide_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Mission List",
+        "My Progress",
+        "Plan Ahead",
+        "Read FAQ",
+        "Ask the Helpers",
+    ]
+    assert view.children[2].custom_id == "progressguides:planahead:ARB"
+
+    assert "progressguides:planahead:ARB" not in [
+        getattr(item, "custom_id", "")
+        for item in service.build_guide_view(
+            _plan_data(plan_ahead_button_label="").posts[0], data
+        ).children
+    ]
+    assert "progressguides:planahead:ARB" not in [
+        getattr(item, "custom_id", "")
+        for item in service.build_guide_view(
+            _plan_data(progress_tracking_enabled="FALSE").posts[0], data
+        ).children
+    ]
+    fw = _plan_data(category="FW_N")
+    fw.faq_by_category["FW_N"] = fw.faq_by_category.pop("ARB")
+    assert "progressguides:planahead:FW_N" not in [
+        getattr(item, "custom_id", "")
+        for item in service.build_guide_view(fw.posts[0], fw).children
+    ]
+
+
+def test_plan_ahead_persistent_view_has_no_startup_sheet_reads(monkeypatch):
+    async def forbidden(*_args, **_kwargs):
+        raise AssertionError("startup must not read sheets")
+
+    monkeypatch.setattr(service, "afetch_records", forbidden)
+    bot = FakeBot()
+    ProgressGuidesCog(bot)
+    assert "progressguides:planahead:ARB" in [
+        getattr(item, "custom_id", "") for view in bot.views for item in view.children
+    ]
+
+
+def test_plan_ahead_no_saved_progress_uses_sheet_copy_and_set_progress(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+
+    async def category(_category):
+        return service.ProgressCategory("ARB", "Arena Rush Basics", 4, "TAB")
+
+    async def rows():
+        return "ProgressUserState", []
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    interaction = FakeInteraction()
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+    sent = interaction.followup.sent[0]
+    assert sent["embed"].description == "Set progress first."
+    assert [getattr(item, "label", "") for item in sent["view"].children] == [
+        "Set Progress"
+    ]
+    assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
+
+
+def test_plan_ahead_saved_progress_builds_fields_from_future_missions(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+    state = {
+        "user_id": "123456",
+        "category": "ARB",
+        "current_step_index": "99",
+        "current_mission_key": "current-key",
+        "status": "in_progress",
+    }
+
+    async def category(_category):
+        return service.ProgressCategory("ARB", "Arena Rush Basics", 4, "TAB")
+
+    async def rows():
+        return "ProgressUserState", [state]
+
+    async def missions(_category):
+        return _plan_missions()
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    interaction = FakeInteraction()
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+    embed = interaction.followup.sent[0]["embed"]
+    fields = {field.name: field.value for field in embed.fields}
+    assert "Clear Stage 1" in fields["Coming soon"]
+    assert "Upgrade gear" in fields["Coming soon"]
+    assert "Current text" not in fields["Coming soon"]
+    assert "Save energy" in fields["Save or prepare"]
+    assert "hydra keys" in fields["Save or prepare"]
+    assert "arena refills" in fields["Save or prepare"]
+    assert "hydra_keys" not in fields["Save or prepare"]
+    assert "high" not in fields["Save or prepare"]
+    assert fields["Save or prepare"].count("Save energy") == 1
+    assert fields["Save or prepare"].count("hydra keys") == 1
+    assert "Do not claim reward" in fields["Do not do too early"]
+    assert "Must be active" in fields["Time-gated"]
+    assert "wall" in fields["Watch-outs"]
+    assert "high" in fields["Watch-outs"]
+    rendered = embed.description + "\n" + "\n".join(fields.values())
+    assert "current-key" not in rendered
+    assert "next-key" not in rendered
+    assert "source_url" not in rendered
+    assert "Hidden future" not in rendered
+
+
+def test_empty_plan_uses_no_items_description_and_my_progress_shortcut():
+    data = _plan_data(plan_ahead_lookahead_count="12")
+    post = data.posts[0]
+    embed = service.build_plan_ahead_embed(
+        post,
+        service.ProgressCategory("ARB", "Arena Rush Basics", 1, "TAB"),
+        {"current_mission_key": "current-key", "current_step_index": "1"},
+        [service.MissionRow(1, "Current text", "current-key", "Chapter", 1)],
+    )
+    assert embed.description == "Nothing to plan."
+    assert [
+        getattr(item, "label", "") for item in service.MyProgressView(post).children
+    ] == [
+        "Set Progress",
+        "Mark Mission Done",
+        "Plan Ahead",
+    ]


### PR DESCRIPTION
### Motivation
- Introduce a "Plan Ahead" user-facing feature to surface upcoming missions, saves, avoidances, time-gates, and warnings for users planning future progress. 
- Persist a plan-ahead button on guide panels and expose it from the My Progress flow so users can quickly inspect upcoming items.
- Enrich mission and forum post models with additional fields required to render plan-ahead content.

### Description
- Added new plan-ahead fields to `ForumPost` and additional attributes to `MissionRow` to capture `tips`, `avoid_doing`, `resource_tags`, `time_gate`, `difficulty_note`, `guide_priority`, and `retroactive_note`.
- Implemented `build_plan_ahead_embed`, helper utilities (`_plan_lookahead_count`, `_dedupe`, `_display_resource_tags`, `_plan_line`) and support check `_supports_plan_ahead` to assemble the plan-ahead embed from mission data.
- Added interactive components: `PlanAheadButton`, `PlanAheadNoProgressView`, and `ProgressGuidePlanAheadPersistentView`, and integrated the plan-ahead button into `build_guide_view` and `MyProgressView` and registered the persistent view in `ProgressGuidesCog`.
- Updated mission parsing and caching logic to populate the new mission fields, added the `_PLAN_AHEAD_CUSTOM_ID_PREFIX` constant, and ensured plan-ahead behavior respects progress tracking and category rules.

### Testing
- Ran the progress guides unit tests in `tests/community/test_progress_guides.py`, including new plan-ahead tests such as `test_plan_ahead_main_guide_button_order_and_visibility_rules`, `test_plan_ahead_persistent_view_has_no_startup_sheet_reads`, `test_plan_ahead_no_saved_progress_uses_sheet_copy_and_set_progress`, and `test_plan_ahead_saved_progress_builds_fields_from_future_missions`, and all tests passed. 
- Verified `ProgressGuidesCog` startup does not perform worksheet reads by running the persistent view startup test, which succeeded. 
- Confirmed embed rendering tests for empty and populated plan-ahead scenarios passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5894c7b51083238f9a2f246741fbaa)