### PR TITLE
Add interactive FAQ picker with pagination and select-based answers

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -42,7 +42,9 @@ _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
 _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
 _MISSIONS_PER_PAGE = 15
 _PICKER_OPTIONS_PER_PAGE = 25
+_FAQ_OPTIONS_PER_PAGE = 25
 _SELECT_LABEL_LIMIT = 100
+_SELECT_VALUE_LIMIT = 100
 _DATA_CACHE: "ProgressGuideData | None" = None
 _DATA_CACHE_LOCK = asyncio.Lock()
 _MISSION_CACHE: dict[str, list["MissionRow"]] = {}
@@ -577,6 +579,72 @@ class MissionPageButton(discord.ui.Button):
         )
 
 
+def _faq_rows_for_category(
+    category: str, data: ProgressGuideData
+) -> list[Mapping[str, object]]:
+    rows = [
+        row
+        for row in data.faq_by_category.get(category, [])
+        if _truthy(row.get("enabled"))
+        and _text(row.get("question"))
+        and _text(row.get("answer"))
+    ]
+    return sorted(
+        rows,
+        key=lambda r: (
+            _sort_num(r.get("sort_order")),
+            _text(r.get("question") or r.get("faq_key")),
+        ),
+    )
+
+
+def _faq_option_value(row: Mapping[str, object], sorted_index: int) -> str:
+    key = _text(row.get("faq_key"))
+    if key:
+        return _limit_text(key, _SELECT_VALUE_LIMIT)
+    return f"idx:{sorted_index}"
+
+
+def build_faq_picker_embed(
+    category: str,
+    data: ProgressGuideData,
+    rows: Sequence[Mapping[str, object]],
+    *,
+    page: int,
+) -> discord.Embed:
+    post = _post_for_category(category, data)
+    description = _embed_description(post.faq_description) if post else None
+    total_pages = max(
+        1, (len(rows) + _FAQ_OPTIONS_PER_PAGE - 1) // _FAQ_OPTIONS_PER_PAGE
+    )
+    if total_pages > 1:
+        page_note = f"Page {page + 1} / {total_pages}"
+        description = f"{description}\n\n{page_note}" if description else page_note
+    return discord.Embed(
+        title=_faq_title_for_category(category, data),
+        description=_embed_description(description),
+        color=discord.Color.blurple(),
+    )
+
+
+def build_selected_faq_embed(
+    category: str, data: ProgressGuideData, row: Mapping[str, object]
+) -> discord.Embed:
+    question = _strip_visible_urls(row.get("question"))
+    answer = _strip_visible_urls(row.get("answer"))
+    prefix = f"**{question}**\n\n" if question else ""
+    note = "\n\n*(Answer shortened because it is too long for one Discord embed.)*"
+    description = f"{prefix}{answer}"
+    if len(description) > _EMBED_DESCRIPTION_LIMIT:
+        available = _EMBED_DESCRIPTION_LIMIT - len(prefix) - len(note)
+        description = f"{prefix}{answer[:max(0, available)].rstrip()}{note}"
+    return discord.Embed(
+        title=_faq_title_for_category(category, data),
+        description=_embed_description(description),
+        color=discord.Color.blurple(),
+    )
+
+
 def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | None:
     rows = data.faq_by_category.get(category, [])
     if not rows:
@@ -599,6 +667,108 @@ def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | N
     return embed if embed.fields else None
 
 
+class ProgressGuideFAQSelect(discord.ui.Select):
+    def __init__(self, rows: Sequence[Mapping[str, object]], page: int) -> None:
+        self.page = page
+        start = page * _FAQ_OPTIONS_PER_PAGE
+        page_rows = list(enumerate(rows, start=0))[
+            start : start + _FAQ_OPTIONS_PER_PAGE
+        ]
+        options = [
+            discord.SelectOption(
+                label=_limit_text(_text(row.get("question")), _SELECT_LABEL_LIMIT),
+                value=_faq_option_value(row, index),
+            )
+            for index, row in page_rows
+        ]
+        super().__init__(
+            placeholder="Choose a FAQ question…",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, ProgressGuideFAQPickerView):
+            return
+        selected = self.values[0]
+        row = view.row_by_value.get(selected)
+        if row is None:
+            await interaction.response.edit_message(
+                embed=build_faq_picker_embed(
+                    view.category, view.data, view.rows, page=view.page
+                ),
+                view=ProgressGuideFAQPickerView(
+                    view.category, view.data, view.rows, view.page
+                ),
+            )
+            return
+        await interaction.response.edit_message(
+            embed=build_selected_faq_embed(view.category, view.data, row),
+            view=ProgressGuideFAQPickerView(
+                view.category, view.data, view.rows, view.page
+            ),
+        )
+
+
+class ProgressGuideFAQPageButton(discord.ui.Button):
+    def __init__(self, label: str, target_page: int, disabled: bool) -> None:
+        self.target_page = target_page
+        super().__init__(
+            label=label, style=discord.ButtonStyle.secondary, disabled=disabled
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, ProgressGuideFAQPickerView):
+            return
+        next_view = ProgressGuideFAQPickerView(
+            view.category, view.data, view.rows, self.target_page
+        )
+        await interaction.response.edit_message(
+            embed=build_faq_picker_embed(
+                view.category, view.data, view.rows, page=self.target_page
+            ),
+            view=next_view,
+        )
+
+
+class ProgressGuideFAQPickerView(discord.ui.View):
+    def __init__(
+        self,
+        category: str,
+        data: ProgressGuideData,
+        rows: Sequence[Mapping[str, object]],
+        page: int = 0,
+    ) -> None:
+        super().__init__(timeout=900)
+        self.category = category
+        self.data = data
+        self.rows = list(rows)
+        self.total_pages = max(
+            1, (len(self.rows) + _FAQ_OPTIONS_PER_PAGE - 1) // _FAQ_OPTIONS_PER_PAGE
+        )
+        self.page = max(0, min(page, self.total_pages - 1))
+        self.row_by_value = {
+            _faq_option_value(row, index): row for index, row in enumerate(self.rows)
+        }
+        self.add_item(ProgressGuideFAQSelect(self.rows, self.page))
+        if self.total_pages > 1:
+            self.add_item(
+                ProgressGuideFAQPageButton("Previous", self.page - 1, self.page <= 0)
+            )
+            self.add_item(
+                ProgressGuideFAQPageButton(
+                    "Next", self.page + 1, self.page >= self.total_pages - 1
+                )
+            )
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True
+
+
 class ProgressGuideFAQButton(discord.ui.Button):
     def __init__(self, category: str, label: str = "FAQ") -> None:
         self.category = category
@@ -612,13 +782,19 @@ class ProgressGuideFAQButton(discord.ui.Button):
         await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             data = await get_or_load_progress_guide_data()
-            embed = build_faq_embed(self.category, data)
-            if embed is None:
+            rows = _faq_rows_for_category(self.category, data)
+            if not rows:
                 embed = discord.Embed(
                     title=f"{self.category} FAQ",
                     description="No FAQ entries are currently available.",
                     color=discord.Color.blurple(),
                 )
+                await interaction.followup.send(embed=embed, ephemeral=True)
+                return
+            view = ProgressGuideFAQPickerView(self.category, data, rows, 0)
+            embed = build_faq_picker_embed(self.category, data, rows, page=0)
+            await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+            return
         except Exception:
             embed = discord.Embed(
                 title="Progress guide FAQ unavailable",
@@ -985,9 +1161,9 @@ def build_plan_ahead_embed(
         1 for m in missions if (m.title or "Missions") == (current.title or "Missions")
     )
     values = {
-        "category_label": category_info.label
-        if category_info
-        else (post.label or post.category),
+        "category_label": (
+            category_info.label if category_info else (post.label or post.category)
+        ),
         "chapter_title": current.title,
         "chapter_step_index": str(current.step_index),
         "chapter_total_steps": str(chapter_total),
@@ -1323,7 +1499,9 @@ class ProgressChapterPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter"))
+            self.add_item(
+                ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter")
+            )
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "chapter"
@@ -1359,7 +1537,9 @@ class ProgressMissionPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission"))
+            self.add_item(
+                ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission")
+            )
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "mission"

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -540,8 +540,167 @@ def test_faq_button_opens_faq_content_from_progress_faq(monkeypatch):
     embed = sent["embed"]
     assert embed.title == "🏟️ Arena Rush Questions"
     assert embed.description == "Sheet-authored FAQ intro."
-    assert [field.name for field in embed.fields] == ["First?", "Second?"]
-    assert "source.example" not in embed.fields[0].value
+    assert embed.fields == []
+    view = sent["view"]
+    select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    assert [option.label for option in select.options] == ["First?", "Second?"]
+    assert [option.value for option in select.options] == ["idx:0", "idx:1"]
+
+
+def test_faq_picker_uses_faq_key_values_and_selects_single_answer(monkeypatch):
+    data = _data(
+        faq=[
+            {
+                "category": "ARB",
+                "faq_key": "second_key",
+                "question": "Second?",
+                "answer": "Second answer.",
+                "sort_order": "2",
+                "enabled": "TRUE",
+                "tags": "internal",
+            },
+            {
+                "category": "ARB",
+                "faq_key": "first_key",
+                "question": "📌 First?",
+                "answer": "First answer. https://source.example/hidden",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            },
+            {
+                "category": "ARB",
+                "faq_key": "disabled_key",
+                "question": "Disabled?",
+                "answer": "Hidden.",
+                "sort_order": "0",
+                "enabled": "FALSE",
+            },
+        ]
+    )
+    view = service.ProgressGuideFAQPickerView(
+        "ARB", data, service._faq_rows_for_category("ARB", data)
+    )
+    select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    assert [option.label for option in select.options] == ["📌 First?", "Second?"]
+    assert [option.value for option in select.options] == ["first_key", "second_key"]
+    monkeypatch.setattr(
+        service.ProgressGuideFAQSelect, "values", property(lambda _self: ["first_key"])
+    )
+    interaction = FakeInteraction()
+
+    asyncio.run(select.callback(interaction))
+
+    edit = interaction.response.edits[0]
+    assert edit["embed"].title == "🏟️ Arena Rush Questions"
+    assert "**📌 First?**" in edit["embed"].description
+    assert "First answer." in edit["embed"].description
+    assert "source.example" not in edit["embed"].description
+    assert "first_key" not in edit["embed"].description
+    assert "internal" not in edit["embed"].description
+    assert any(
+        isinstance(item, service.ProgressGuideFAQSelect)
+        for item in edit["view"].children
+    )
+
+
+def test_faq_picker_paginates_and_page_change_resets_to_intro():
+    faq = [
+        {
+            "category": "ARB",
+            "faq_key": f"q{i:02d}",
+            "question": f"Question {i:02d}?",
+            "answer": f"Answer {i:02d}.",
+            "sort_order": str(i),
+            "enabled": "TRUE",
+        }
+        for i in range(1, 27)
+    ]
+    data = _data(faq=faq)
+    rows = service._faq_rows_for_category("ARB", data)
+    view = service.ProgressGuideFAQPickerView("ARB", data, rows)
+    embed = service.build_faq_picker_embed("ARB", data, rows, page=0)
+
+    assert "Page 1 / 2" in embed.description
+    buttons = [
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQPageButton)
+    ]
+    assert [(button.label, button.disabled) for button in buttons] == [
+        ("Previous", True),
+        ("Next", False),
+    ]
+    select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    assert len(select.options) == 25
+    assert select.options[0].label == "Question 01?"
+    assert select.options[-1].label == "Question 25?"
+
+    interaction = FakeInteraction()
+    asyncio.run(buttons[1].callback(interaction))
+
+    edit = interaction.response.edits[0]
+    assert "Page 2 / 2" in edit["embed"].description
+    assert "Answer 26" not in edit["embed"].description
+    next_select = next(
+        item
+        for item in edit["view"].children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    assert [option.label for option in next_select.options] == ["Question 26?"]
+    next_buttons = [
+        item
+        for item in edit["view"].children
+        if isinstance(item, service.ProgressGuideFAQPageButton)
+    ]
+    assert [(button.label, button.disabled) for button in next_buttons] == [
+        ("Previous", False),
+        ("Next", True),
+    ]
+
+
+def test_faq_picker_does_not_show_paging_for_twenty_five_rows():
+    data = _data(
+        faq=[
+            {
+                "category": "ARB",
+                "question": f"Question {i}?",
+                "answer": f"Answer {i}.",
+                "sort_order": str(i),
+                "enabled": "TRUE",
+            }
+            for i in range(1, 26)
+        ]
+    )
+    rows = service._faq_rows_for_category("ARB", data)
+    view = service.ProgressGuideFAQPickerView("ARB", data, rows)
+    embed = service.build_faq_picker_embed("ARB", data, rows, page=0)
+
+    assert "Page" not in embed.description
+    assert not any(
+        isinstance(item, service.ProgressGuideFAQPageButton) for item in view.children
+    )
+
+
+def test_long_selected_faq_answer_is_shortened_with_note():
+    data = _data()
+    embed = service.build_selected_faq_embed(
+        "ARB", data, {"question": "Long?", "answer": "x" * 5000}
+    )
+
+    assert len(embed.description) <= service._EMBED_DESCRIPTION_LIMIT
+    assert "Answer shortened" in embed.description
 
 
 def test_faq_button_sends_clean_error_embed_when_loading_fails(monkeypatch):


### PR DESCRIPTION
### Motivation
- Replace long FAQ embeds with an interactive, paged selector to avoid embed field limits and improve UX for large FAQ sets.
- Provide stable select values using sheet `faq_key` and fall back to index-based values when keys are missing.
- Limit label/value lengths and strip visible URLs from displayed FAQ content to keep embeds concise and safe.

### Description
- Added constants `_FAQ_OPTIONS_PER_PAGE` and `_SELECT_VALUE_LIMIT` and helper functions `_faq_rows_for_category` and `_faq_option_value` to prepare and normalize FAQ rows for the picker.
- Implemented `ProgressGuideFAQSelect`, `ProgressGuideFAQPageButton`, and `ProgressGuideFAQPickerView` to render a paginated select UI and handle navigation and selection callbacks.
- Added `build_faq_picker_embed` and `build_selected_faq_embed` for rendering the picker intro and the selected-answer embed (with truncation note when needed), and updated `ProgressGuideFAQButton` to send the ephemeral picker view when FAQ rows exist.
- Minor formatting and tuple/parentheses adjustments in unrelated views to keep code style consistent.

### Testing
- Ran the module tests for FAQs via `pytest tests/community/test_progress_guides.py` which include tests for UI creation, select option values, selection callback behavior, pagination, and long-answer truncation, and they all passed.
- Verified error handling test where `load_progress_guide_data` raises an exception still returns a cleaned error embed, and that test passed.
- Confirmed the original FAQ button behavior when no FAQ rows exist remains unchanged via the corresponding unit test, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58ad4597fc832380fad7e0172fd564)