### PR TITLE
Add tag filtering to Progress Guide FAQ picker

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -598,6 +598,54 @@ def _faq_rows_for_category(
     )
 
 
+def _faq_tag_label(tag: object) -> str:
+    cleaned = _text(tag).replace("_", " ")
+    return " ".join(cleaned.split()).title()
+
+
+def _faq_tag_key(tag: object) -> str:
+    label = _faq_tag_label(tag)
+    return _limit_text(label.casefold(), _SELECT_VALUE_LIMIT)
+
+
+def _parse_faq_tags(value: object) -> list[tuple[str, str]]:
+    raw = _text(value)
+    if not raw:
+        return []
+    tags: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for part in re.split(r"[,;]", raw):
+        label = _faq_tag_label(part)
+        if not label:
+            continue
+        key = _faq_tag_key(label)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        tags.append((key, label))
+    return tags
+
+
+def _faq_tag_options(rows: Sequence[Mapping[str, object]]) -> list[tuple[str, str]]:
+    by_key: dict[str, str] = {}
+    for row in rows:
+        for key, label in _parse_faq_tags(row.get("tags")):
+            by_key.setdefault(key, label)
+    return sorted(by_key.items(), key=lambda item: item[1].casefold())
+
+
+def _filter_faq_rows_by_tag(
+    rows: Sequence[Mapping[str, object]], selected_tag: str | None
+) -> list[Mapping[str, object]]:
+    if not selected_tag:
+        return list(rows)
+    return [
+        row
+        for row in rows
+        if any(key == selected_tag for key, _label in _parse_faq_tags(row.get("tags")))
+    ]
+
+
 def _faq_option_value(row: Mapping[str, object], sorted_index: int) -> str:
     key = _text(row.get("faq_key"))
     if key:
@@ -611,9 +659,13 @@ def build_faq_picker_embed(
     rows: Sequence[Mapping[str, object]],
     *,
     page: int,
+    selected_tag_label: str | None = None,
 ) -> discord.Embed:
     post = _post_for_category(category, data)
     description = _embed_description(post.faq_description) if post else None
+    if selected_tag_label:
+        filter_note = f"Filter: {selected_tag_label}"
+        description = f"{description}\n\n{filter_note}" if description else filter_note
     total_pages = max(
         1, (len(rows) + _FAQ_OPTIONS_PER_PAGE - 1) // _FAQ_OPTIONS_PER_PAGE
     )
@@ -637,7 +689,7 @@ def build_selected_faq_embed(
     description = f"{prefix}{answer}"
     if len(description) > _EMBED_DESCRIPTION_LIMIT:
         available = _EMBED_DESCRIPTION_LIMIT - len(prefix) - len(note)
-        description = f"{prefix}{answer[:max(0, available)].rstrip()}{note}"
+        description = f"{prefix}{answer[: max(0, available)].rstrip()}{note}"
     return discord.Embed(
         title=_faq_title_for_category(category, data),
         description=_embed_description(description),
@@ -665,6 +717,51 @@ def build_faq_embed(category: str, data: ProgressGuideData) -> discord.Embed | N
             continue
         embed.add_field(name=question, value=answer, inline=False)
     return embed if embed.fields else None
+
+
+class ProgressGuideFAQTagSelect(discord.ui.Select):
+    def __init__(
+        self, tag_options: Sequence[tuple[str, str]], selected_tag: str | None
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label="All questions", value="__all__", default=selected_tag is None
+            )
+        ]
+        options.extend(
+            discord.SelectOption(
+                label=_limit_text(label, _SELECT_LABEL_LIMIT),
+                value=key,
+                default=key == selected_tag,
+            )
+            for key, label in list(tag_options)[:24]
+        )
+        super().__init__(
+            placeholder="Filter FAQ questions by tag…",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, ProgressGuideFAQPickerView):
+            return
+        selected = self.values[0]
+        selected_tag = None if selected == "__all__" else selected
+        next_view = ProgressGuideFAQPickerView(
+            view.category, view.data, view.all_rows, 0, selected_tag=selected_tag
+        )
+        await interaction.response.edit_message(
+            embed=build_faq_picker_embed(
+                view.category,
+                view.data,
+                next_view.filtered_rows,
+                page=next_view.page,
+                selected_tag_label=next_view.selected_tag_label,
+            ),
+            view=next_view,
+        )
 
 
 class ProgressGuideFAQSelect(discord.ui.Select):
@@ -697,17 +794,29 @@ class ProgressGuideFAQSelect(discord.ui.Select):
         if row is None:
             await interaction.response.edit_message(
                 embed=build_faq_picker_embed(
-                    view.category, view.data, view.rows, page=view.page
+                    view.category,
+                    view.data,
+                    view.filtered_rows,
+                    page=view.page,
+                    selected_tag_label=view.selected_tag_label,
                 ),
                 view=ProgressGuideFAQPickerView(
-                    view.category, view.data, view.rows, view.page
+                    view.category,
+                    view.data,
+                    view.all_rows,
+                    view.page,
+                    selected_tag=view.selected_tag,
                 ),
             )
             return
         await interaction.response.edit_message(
             embed=build_selected_faq_embed(view.category, view.data, row),
             view=ProgressGuideFAQPickerView(
-                view.category, view.data, view.rows, view.page
+                view.category,
+                view.data,
+                view.all_rows,
+                view.page,
+                selected_tag=view.selected_tag,
             ),
         )
 
@@ -724,11 +833,19 @@ class ProgressGuideFAQPageButton(discord.ui.Button):
         if not isinstance(view, ProgressGuideFAQPickerView):
             return
         next_view = ProgressGuideFAQPickerView(
-            view.category, view.data, view.rows, self.target_page
+            view.category,
+            view.data,
+            view.all_rows,
+            self.target_page,
+            selected_tag=view.selected_tag,
         )
         await interaction.response.edit_message(
             embed=build_faq_picker_embed(
-                view.category, view.data, view.rows, page=self.target_page
+                view.category,
+                view.data,
+                next_view.filtered_rows,
+                page=next_view.page,
+                selected_tag_label=next_view.selected_tag_label,
             ),
             view=next_view,
         )
@@ -741,19 +858,40 @@ class ProgressGuideFAQPickerView(discord.ui.View):
         data: ProgressGuideData,
         rows: Sequence[Mapping[str, object]],
         page: int = 0,
+        *,
+        selected_tag: str | None = None,
     ) -> None:
         super().__init__(timeout=900)
         self.category = category
         self.data = data
-        self.rows = list(rows)
+        self.all_rows = list(rows)
+        self.tag_options = _faq_tag_options(self.all_rows)
+        self.selected_tag = (
+            selected_tag
+            if any(key == selected_tag for key, _ in self.tag_options)
+            else None
+        )
+        self.selected_tag_label = next(
+            (label for key, label in self.tag_options if key == self.selected_tag), None
+        )
+        self.filtered_rows = _filter_faq_rows_by_tag(self.all_rows, self.selected_tag)
+        self.rows = self.filtered_rows
         self.total_pages = max(
-            1, (len(self.rows) + _FAQ_OPTIONS_PER_PAGE - 1) // _FAQ_OPTIONS_PER_PAGE
+            1,
+            (len(self.filtered_rows) + _FAQ_OPTIONS_PER_PAGE - 1)
+            // _FAQ_OPTIONS_PER_PAGE,
         )
         self.page = max(0, min(page, self.total_pages - 1))
         self.row_by_value = {
-            _faq_option_value(row, index): row for index, row in enumerate(self.rows)
+            _faq_option_value(row, index): row
+            for index, row in enumerate(self.filtered_rows)
         }
-        self.add_item(ProgressGuideFAQSelect(self.rows, self.page))
+        if self.tag_options:
+            self.add_item(
+                ProgressGuideFAQTagSelect(self.tag_options, self.selected_tag)
+            )
+        if self.filtered_rows:
+            self.add_item(ProgressGuideFAQSelect(self.filtered_rows, self.page))
         if self.total_pages > 1:
             self.add_item(
                 ProgressGuideFAQPageButton("Previous", self.page - 1, self.page <= 0)
@@ -1499,9 +1637,7 @@ class ProgressChapterPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(
-                ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter")
-            )
+            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter"))
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "chapter"
@@ -1537,9 +1673,7 @@ class ProgressMissionPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(
-                ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission")
-            )
+            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission"))
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "mission"

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -703,6 +703,231 @@ def test_long_selected_faq_answer_is_shortened_with_note():
     assert "Answer shortened" in embed.description
 
 
+def test_faq_picker_tag_select_parses_formats_and_labels():
+    data = _data(
+        faq=[
+            {
+                "category": "ARB",
+                "faq_key": "one",
+                "question": "One?",
+                "answer": "One.",
+                "sort_order": "1",
+                "enabled": "TRUE",
+                "tags": "great_hall, clan_boss; Great_Hall ; ",
+            },
+            {
+                "category": "ARB",
+                "faq_key": "two",
+                "question": "Two?",
+                "answer": "Two.",
+                "sort_order": "2",
+                "enabled": "TRUE",
+                "tags": "fire_knight",
+            },
+            {
+                "category": "ARB",
+                "faq_key": "disabled",
+                "question": "Disabled?",
+                "answer": "Hidden.",
+                "sort_order": "3",
+                "enabled": "FALSE",
+                "tags": "secret_tag",
+            },
+            {
+                "category": "ARB",
+                "faq_key": "blank_answer",
+                "question": "Blank?",
+                "answer": "",
+                "sort_order": "4",
+                "enabled": "TRUE",
+                "tags": "empty_answer_tag",
+            },
+        ]
+    )
+    view = service.ProgressGuideFAQPickerView(
+        "ARB", data, service._faq_rows_for_category("ARB", data)
+    )
+
+    tag_select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQTagSelect)
+    )
+    assert [option.label for option in tag_select.options] == [
+        "All questions",
+        "Clan Boss",
+        "Fire Knight",
+        "Great Hall",
+    ]
+    assert "Secret Tag" not in [option.label for option in tag_select.options]
+    assert "Empty Answer Tag" not in [option.label for option in tag_select.options]
+
+
+def test_faq_picker_omits_tag_select_when_no_tags_exist():
+    data = _data()
+    view = service.ProgressGuideFAQPickerView(
+        "ARB", data, service._faq_rows_for_category("ARB", data)
+    )
+
+    assert not any(
+        isinstance(item, service.ProgressGuideFAQTagSelect) for item in view.children
+    )
+    assert any(
+        isinstance(item, service.ProgressGuideFAQSelect) for item in view.children
+    )
+
+
+def test_faq_tag_selection_filters_resets_page_and_all_restores(monkeypatch):
+    faq = [
+        {
+            "category": "ARB",
+            "faq_key": f"keep{i:02d}",
+            "question": f"Keep {i:02d}?",
+            "answer": f"Keep answer {i:02d}.",
+            "sort_order": str(i),
+            "enabled": "TRUE",
+            "tags": "clan_boss",
+        }
+        for i in range(1, 28)
+    ] + [
+        {
+            "category": "ARB",
+            "faq_key": "other",
+            "question": "Other?",
+            "answer": "Other answer.",
+            "sort_order": "99",
+            "enabled": "TRUE",
+            "tags": "great_hall",
+        }
+    ]
+    data = _data(faq=faq)
+    rows = service._faq_rows_for_category("ARB", data)
+    view = service.ProgressGuideFAQPickerView("ARB", data, rows, page=1)
+    tag_select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQTagSelect)
+    )
+    clan_key = next(
+        option.value for option in tag_select.options if option.label == "Clan Boss"
+    )
+    monkeypatch.setattr(
+        service.ProgressGuideFAQTagSelect, "values", property(lambda _self: [clan_key])
+    )
+    interaction = FakeInteraction()
+
+    asyncio.run(tag_select.callback(interaction))
+
+    edit = interaction.response.edits[0]
+    assert "Filter: Clan Boss" in edit["embed"].description
+    assert "Page 1 / 2" in edit["embed"].description
+    filtered_view = edit["view"]
+    assert filtered_view.page == 0
+    faq_select = next(
+        item
+        for item in filtered_view.children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    assert len(faq_select.options) == 25
+    assert all(option.label.startswith("Keep") for option in faq_select.options)
+
+    all_select = next(
+        item
+        for item in filtered_view.children
+        if isinstance(item, service.ProgressGuideFAQTagSelect)
+    )
+    monkeypatch.setattr(
+        service.ProgressGuideFAQTagSelect, "values", property(lambda _self: ["__all__"])
+    )
+    second = FakeInteraction()
+    asyncio.run(all_select.callback(second))
+
+    restored = second.response.edits[0]
+    assert "Filter:" not in restored["embed"].description
+    assert len(restored["view"].filtered_rows) == 28
+
+
+def test_faq_page_preserves_tag_filter_and_selected_answer_scrubs_metadata(monkeypatch):
+    faq = [
+        {
+            "category": "ARB",
+            "faq_key": f"keep{i:02d}",
+            "question": f"Keep {i:02d}?",
+            "answer": f"Keep answer {i:02d}. https://example.com/hidden",
+            "sort_order": str(i),
+            "enabled": "TRUE",
+            "tags": "clan_boss",
+        }
+        for i in range(1, 27)
+    ]
+    data = _data(faq=faq)
+    rows = service._faq_rows_for_category("ARB", data)
+    tag_key = service._faq_tag_key("clan_boss")
+    view = service.ProgressGuideFAQPickerView("ARB", data, rows, selected_tag=tag_key)
+    next_button = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQPageButton) and item.label == "Next"
+    )
+    interaction = FakeInteraction()
+
+    asyncio.run(next_button.callback(interaction))
+
+    edit = interaction.response.edits[0]
+    assert "Filter: Clan Boss" in edit["embed"].description
+    assert "Page 2 / 2" in edit["embed"].description
+    assert edit["view"].selected_tag == tag_key
+
+    select = next(
+        item
+        for item in edit["view"].children
+        if isinstance(item, service.ProgressGuideFAQSelect)
+    )
+    monkeypatch.setattr(
+        service.ProgressGuideFAQSelect, "values", property(lambda _self: ["keep26"])
+    )
+    answer_interaction = FakeInteraction()
+    asyncio.run(select.callback(answer_interaction))
+
+    answer = answer_interaction.response.edits[0]
+    assert "**Keep 26?**" in answer["embed"].description
+    assert "Keep answer 26." in answer["embed"].description
+    assert "example.com" not in answer["embed"].description
+    assert "keep26" not in answer["embed"].description
+    assert "clan_boss" not in answer["embed"].description
+    assert any(
+        isinstance(item, service.ProgressGuideFAQTagSelect)
+        for item in answer["view"].children
+    )
+
+
+def test_faq_tag_select_caps_options_at_discord_limit():
+    faq = [
+        {
+            "category": "ARB",
+            "faq_key": f"q{i:02d}",
+            "question": f"Question {i:02d}?",
+            "answer": f"Answer {i:02d}.",
+            "sort_order": str(i),
+            "enabled": "TRUE",
+            "tags": f"tag_{i:02d}",
+        }
+        for i in range(1, 31)
+    ]
+    data = _data(faq=faq)
+    view = service.ProgressGuideFAQPickerView(
+        "ARB", data, service._faq_rows_for_category("ARB", data)
+    )
+    tag_select = next(
+        item
+        for item in view.children
+        if isinstance(item, service.ProgressGuideFAQTagSelect)
+    )
+
+    assert len(tag_select.options) == 25
+    assert tag_select.options[0].label == "All questions"
+
+
 def test_faq_button_sends_clean_error_embed_when_loading_fails(monkeypatch):
     async def load_data():
         raise RuntimeError("sheets unavailable")


### PR DESCRIPTION
### Motivation
- Provide users a way to filter Progress Guide FAQ questions by topic using the existing `tags` column while keeping the ephemeral compact FAQ picker UI and avoiding extra sheet reads or schema changes.
- Preserve existing behavior for selected answers (URL scrubbing, no internal metadata rendered) while improving discoverability of related questions.

### Description
- Parse tags from `ProgressFAQ.tags` with comma/semicolon splitting, trimming, case-insensitive de-dupe, underscore→space label formatting, and stable alphabetic sorting, implemented as `_faq_tag_label`, `_faq_tag_key`, `_parse_faq_tags`, and `_faq_tag_options` in `modules/community/progress_guides/service.py`.
- Add in-memory filtering via `_filter_faq_rows_by_tag` and surface a new `ProgressGuideFAQTagSelect` component with an `All questions` option and Discord-safe 25-option cap.
- Extend `ProgressGuideFAQPickerView` to carry `all_rows`, `filtered_rows`, `tag_options`, `selected_tag`, and `selected_tag_label`, and update `ProgressGuideFAQSelect`, `ProgressGuideFAQPageButton`, and embed builder `build_faq_picker_embed` to use the filtered rows and display a short "Filter: <Tag Label>" status line when a tag is active.
- No sheet schema changes, no new columns, no renames, no hard-coded FAQ content, and no sheet writes or additional sheet reads introduced by tag selection or paging.

### Testing
- Ran formatting/lint checks with `ruff` and unit tests for the progress guides module using `python3 -m pytest tests/community/test_progress_guides.py -q`, and the updated FAQ picker tests passed.
- Repository-wide `python3 -m pytest -q` was attempted but reported unrelated pre-existing failures outside the changed area; these failures were not caused by this change.
- Added targeted tests covering tag parsing/labeling, no-tag behavior, filtering and restore to All, page reset on tag change, pagination over filtered rows, preservation of tag on paging, selected-answer metadata/URL scrubbing, disabled/blank-answer row exclusion from tags, and >25-tag safety in `tests/community/test_progress_guides.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58ba365060832380d01d7fa57d3fee)