### PR TITLE
HOTFIX: Ensure Plan Ahead always answers deferred interactions

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
 import re
@@ -49,6 +50,7 @@ _DATA_CACHE: "ProgressGuideData | None" = None
 _DATA_CACHE_LOCK = asyncio.Lock()
 _MISSION_CACHE: dict[str, list["MissionRow"]] = {}
 _MISSION_CACHE_LOCKS: dict[str, asyncio.Lock] = {}
+log = logging.getLogger("c1c.community.progress_guides.service")
 
 
 def _text(value: object) -> str:
@@ -1295,7 +1297,18 @@ class PlanAheadButton(discord.ui.Button):
                     embed=_progress_unavailable_embed(post), ephemeral=True
                 )
                 return
-            raise
+            log.exception(
+                "plan ahead callback failed",
+                extra={
+                    "category": self.category,
+                    "user_id": getattr(getattr(interaction, "user", None), "id", None),
+                    "guild_id": getattr(getattr(interaction, "guild", None), "id", None),
+                    "channel_id": getattr(getattr(interaction, "channel", None), "id", None),
+                },
+            )
+            await interaction.followup.send(
+                embed=_progress_unavailable_embed(post), ephemeral=True
+            )
 
 
 class PlanAheadNoProgressView(discord.ui.View):

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -2062,6 +2062,105 @@ def test_plan_ahead_saved_progress_builds_fields_from_future_missions(monkeypatc
     assert "Hidden future" not in rendered
 
 
+
+def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_not_reraise(monkeypatch, caplog):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+
+    async def category(_category):
+        raise RuntimeError("raw google schema boom current_mission_key")
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    interaction = FakeInteraction()
+
+    with caplog.at_level("ERROR", logger="c1c.community.progress_guides.service"):
+        asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert "raw google schema boom" not in sent["embed"].description
+    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    assert record.exc_info is not None
+    assert record.category == "ARB"
+    assert record.user_id == 123456
+
+
+def test_plan_ahead_quota_failure_keeps_clean_unavailable_embed(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+
+    async def category(_category):
+        raise RuntimeError("quota details should not leak")
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_is_quota_failure", lambda exc: True)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert "quota details" not in sent["embed"].description
+
+
+def test_plan_ahead_saved_progress_missing_mission_key_sends_clean_no_progress(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+    state = {
+        "user_id": "123456",
+        "category": "ARB",
+        "current_step_index": "99",
+        "current_mission_key": "missing-key",
+        "status": "in_progress",
+    }
+
+    async def category(_category):
+        return None
+
+    async def rows():
+        return "ProgressUserState", [state]
+
+    async def missions(_category):
+        return _plan_missions()
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].description == "Set progress first."
+    assert "missing-key" not in sent["embed"].description
+
+
+def test_plan_ahead_does_not_write_sheets(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+
+    async def category(_category):
+        return service.ProgressCategory("ARB", "Arena Rush Basics", 4, "TAB")
+
+    async def rows():
+        return "ProgressUserState", []
+
+    async def forbidden_write(*_args, **_kwargs):
+        raise AssertionError("Plan Ahead must not write sheets")
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    monkeypatch.setattr(service, "acall_with_backoff", forbidden_write)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    assert interaction.followup.sent[0]["embed"].description == "Set progress first."
+
 def test_empty_plan_uses_no_items_description_and_my_progress_shortcut():
     data = _plan_data(plan_ahead_lookahead_count="12")
     post = data.posts[0]


### PR DESCRIPTION
### Motivation
- Fix a case where clicking Plan Ahead deferred the interaction and then raised, leaving Discord showing “C1C Woadkeeper is thinking...” with no ephemeral reply.
- Ensure non-quota failures are logged with useful context and the user always receives a private unavailable embed without leaking internal error text.
- Preserve the existing clean quota/unavailable behavior and ensure no sheet writes occur as a result of this hotfix.

### Description
- Add a module logger `log = logging.getLogger("c1c.community.progress_guides.service")` for progress guide failures.
- In `PlanAheadButton.callback` replace the final `raise` with `log.exception(...)` including `category`, `user_id`, `guild_id`, and `channel_id`, and then send an ephemeral `_progress_unavailable_embed(post)` so deferred interactions are always answered.
- Keep the existing quota branch (`_is_quota_failure`) and its clean unavailable response path intact, and rely on existing `build_plan_ahead_embed` behavior to avoid raising on missing mission keys or blank templates.
- Add regression tests in `tests/community/test_progress_guides.py` that cover non-quota fallback behavior, quota fallback behavior, missing saved mission keys, no saved progress, and assert no sheet writes occur.

### Testing
- Ran `pytest tests/community/test_progress_guides.py -q` and all tests in that file passed.
- Ran `python -m ruff check modules/community/progress_guides/service.py tests/community/test_progress_guides.py` and the linter passed.
- Ran `git diff --check` with no issues reported.

[meta]
labels: bug, P0, robustness, observability, tests, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bc45881483239d7ae79b16045b14)