### PR TITLE
Log Plan Ahead exception diagnostics

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -1406,6 +1406,9 @@ class PlanAheadButton(discord.ui.Button):
     async def callback(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True, thinking=True)
         post: ForumPost | None = None
+        category_info: ProgressCategory | None = None
+        state: dict[str, Any] | None = None
+        missions: list[MissionRow] = []
         try:
             data = await get_or_load_progress_guide_data()
             post = _post_for_category(self.category, data)
@@ -1417,8 +1420,8 @@ class PlanAheadButton(discord.ui.Button):
             category_info = await _progress_category(self.category)
             _tab, rows = await _user_state_rows()
             found = _find_user_state(rows, interaction.user.id, self.category)
-            missions = await get_or_load_missions(self.category) if found else []
             state = found[1] if found else None
+            missions = await get_or_load_missions(self.category) if found else []
             view = (
                 PlanAheadNoProgressView(post)
                 if state is None and post.my_progress_set_button_label
@@ -1442,6 +1445,14 @@ class PlanAheadButton(discord.ui.Button):
                     "user_id": getattr(getattr(interaction, "user", None), "id", None),
                     "guild_id": getattr(getattr(interaction, "guild", None), "id", None),
                     "channel_id": getattr(getattr(interaction, "channel", None), "id", None),
+                    "exc_type": type(exc).__name__,
+                    "exc_message": str(exc),
+                    "post_found": post is not None,
+                    "state_found": state is not None,
+                    "current_mission_key": _text(state.get("current_mission_key")) if state else "",
+                    "current_step_index": _text(state.get("current_step_index")) if state else "",
+                    "missions_loaded_count": len(missions) if missions is not None else 0,
+                    "category_info_found": category_info is not None,
                 },
             )
             await interaction.followup.send(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -2310,6 +2310,87 @@ def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_n
     assert record.exc_info is not None
     assert record.category == "ARB"
     assert record.user_id == 123456
+    assert record.guild_id is None
+    assert record.channel_id is None
+    assert record.exc_type == "RuntimeError"
+    assert record.exc_message == "raw google schema boom current_mission_key"
+    assert record.post_found is True
+    assert record.state_found is False
+    assert record.current_mission_key == ""
+    assert record.current_step_index == ""
+    assert record.missions_loaded_count == 0
+    assert record.category_info_found is False
+
+
+def test_plan_ahead_failure_after_state_and_missions_logs_diagnostics(monkeypatch, caplog):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+    state = {
+        "user_id": "123456",
+        "category": "ARB",
+        "current_step_index": "40",
+        "current_mission_key": "ram_100",
+        "status": "in_progress",
+    }
+
+    async def category(_category):
+        return service.ProgressCategory("ARB", "Arena Rush Basics", 4, "TAB")
+
+    async def rows():
+        return "ProgressUserState", [state]
+
+    async def missions(_category):
+        return _plan_missions()
+
+    def broken_embed(*_args, **_kwargs):
+        raise ValueError("embed render boom")
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    monkeypatch.setattr(service, "build_plan_ahead_embed", broken_embed)
+    interaction = FakeInteraction()
+
+    with caplog.at_level("ERROR", logger="c1c.community.progress_guides.service"):
+        asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    sent = interaction.followup.sent[0]
+    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert "embed render boom" not in sent["embed"].description
+    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    assert record.exc_type == "ValueError"
+    assert record.exc_message == "embed render boom"
+    assert record.current_mission_key == "ram_100"
+    assert record.current_step_index == "40"
+    assert record.missions_loaded_count == 4
+    assert record.category_info_found is True
+    assert record.state_found is True
+
+
+def test_plan_ahead_failure_before_context_assignment_logs_safe_defaults(monkeypatch, caplog):
+    service.set_progress_guide_cache(None)
+
+    async def data():
+        raise LookupError("data load failed")
+
+    monkeypatch.setattr(service, "get_or_load_progress_guide_data", data)
+    interaction = FakeInteraction()
+
+    with caplog.at_level("ERROR", logger="c1c.community.progress_guides.service"):
+        asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    sent = interaction.followup.sent[0]
+    assert sent["embed"].description == "Unavailable."
+    assert "data load failed" not in sent["embed"].description
+    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    assert record.exc_type == "LookupError"
+    assert record.exc_message == "data load failed"
+    assert record.post_found is False
+    assert record.state_found is False
+    assert record.current_mission_key == ""
+    assert record.current_step_index == ""
+    assert record.missions_loaded_count == 0
+    assert record.category_info_found is False
 
 
 def test_plan_ahead_quota_failure_keeps_clean_unavailable_embed(monkeypatch):


### PR DESCRIPTION
### Motivation
- Production Plan Ahead failures were logging an opaque record without structured exception type/message or safe contextual fields, making post-mortems difficult.
- The exception handler could itself fail when the error happened before local context variables were assigned, so diagnostics must have safe defaults.

### Description
- Initialize Plan Ahead diagnostic locals (`post`, `category_info`, `state`, `missions`) before the `try` so the except handler always has safe values. 
- Ensure saved `state` is assigned before loading `missions` so `current_mission_key`/`current_step_index` are available for logs when present. 
- Expand the `log.exception` call with explicit structured fields: `exc_type`, `exc_message`, `category`, `user_id`, `guild_id`, `channel_id`, `post_found`, `state_found`, `current_mission_key`, `current_step_index`, `missions_loaded_count`, and `category_info_found`, while keeping `log.exception` to preserve tracebacks. 
- Add and update unit tests in `tests/community/test_progress_guides.py` to assert the presence and values of the new structured log fields and to verify the user-facing fallback embed does not leak raw exception text.

### Testing
- Ran compilation check with `python -m compileall -q modules/community/progress_guides/service.py tests/community/test_progress_guides.py` which succeeded. 
- Ran the Plan Ahead unit tests with `pytest tests/community/test_progress_guides.py -k 'plan_ahead'` and all selected tests passed (10 passed, 80 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58c4e4029c8323a46b5d7256be8b96)