### PR TITLE
Plan Ahead: omit `view` when None to avoid discord.py TypeError

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -1427,11 +1427,11 @@ class PlanAheadButton(discord.ui.Button):
                 if state is None and post.my_progress_set_button_label
                 else None
             )
-            await interaction.followup.send(
-                embed=build_plan_ahead_embed(post, category_info, state, missions),
-                view=view,
-                ephemeral=True,
-            )
+            embed = build_plan_ahead_embed(post, category_info, state, missions)
+            send_kwargs: dict[str, Any] = {"embed": embed, "ephemeral": True}
+            if view is not None:
+                send_kwargs["view"] = view
+            await interaction.followup.send(**send_kwargs)
         except Exception as exc:
             if _is_quota_failure(exc):
                 await interaction.followup.send(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -2287,6 +2287,38 @@ def test_plan_ahead_saved_progress_builds_fields_from_future_missions(monkeypatc
     assert "Hidden future" not in rendered
 
 
+def test_plan_ahead_saved_progress_does_not_pass_none_view(monkeypatch):
+    data = _plan_data()
+    service.set_progress_guide_cache(data)
+    state = {
+        "user_id": "123456",
+        "category": "ARB",
+        "current_step_index": "99",
+        "current_mission_key": "current-key",
+        "status": "in_progress",
+    }
+
+    async def category(_category):
+        return service.ProgressCategory("ARB", "Arena Rush Basics", 4, "TAB")
+
+    async def rows():
+        return "ProgressUserState", [state]
+
+    async def missions(_category):
+        return _plan_missions()
+
+    monkeypatch.setattr(service, "_progress_category", category)
+    monkeypatch.setattr(service, "_user_state_rows", rows)
+    monkeypatch.setattr(service, "get_or_load_missions", missions)
+    interaction = FakeInteraction()
+
+    asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
+
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert "view" not in sent
+    assert sent["embed"].title == "Plan Ahead Title"
+
 
 def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_not_reraise(monkeypatch, caplog):
     data = _plan_data()


### PR DESCRIPTION
### Motivation
- A TypeError occurred when `interaction.followup.send` received `view=None` from the Plan Ahead callback, causing crashes when a saved-progress path was used. 
- The intent is to avoid passing a `None` view while preserving existing embed content, quota fallback behavior, and avoiding any sheet writes or schema changes.

### Description
- Updated `PlanAheadButton.callback` to build the embed once (`embed = build_plan_ahead_embed(...)`) and assemble `send_kwargs` so `view` is only added when `view is not None` before calling `await interaction.followup.send(**send_kwargs)` in `modules/community/progress_guides/service.py`.
- Added a regression test `test_plan_ahead_saved_progress_does_not_pass_none_view` in `tests/community/test_progress_guides.py` to assert the saved-progress path sends the embed ephemeral and does not include a `view` kwarg.
- Kept all existing behavior for quota failures and other fallbacks, and made no changes to sheet schema, embed content, FAQs, mission lists, or write paths.

### Testing
- Ran `pytest tests/community/test_progress_guides.py -q` and observed an initial failure due to an assertion expecting a different embed title, then updated the test so it matches the sheet-authored title and re-ran `pytest tests/community/test_progress_guides.py -q`, which passed.
- The final test run completed with the test suite for `tests/community/test_progress_guides.py` passing.

[meta]
labels: bug, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58ce4faa408323ad51368a4cfe3801)