### PR TITLE
Plan-ahead: support prep_window ranking and improved deduped, limited bullet fields

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -251,6 +251,7 @@ class MissionRow:
     difficulty_note: str
     guide_priority: str
     retroactive_note: str
+    prep_window: str
 
     def __init__(
         self,
@@ -266,6 +267,7 @@ class MissionRow:
         difficulty_note: str = "",
         guide_priority: str = "",
         retroactive_note: str = "",
+        prep_window: str = "",
     ) -> None:
         self.sequence_number = sequence_number
         self.step_index = step_index if step_index is not None else sequence_number
@@ -279,6 +281,7 @@ class MissionRow:
         self.difficulty_note = difficulty_note
         self.guide_priority = guide_priority
         self.retroactive_note = retroactive_note
+        self.prep_window = prep_window
 
     @property
     def number(self) -> int:
@@ -476,6 +479,7 @@ def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow
                 difficulty_note=_strip_visible_urls(row.get("difficulty_note")),
                 guide_priority=_text(row.get("guide_priority")),
                 retroactive_note=_strip_visible_urls(row.get("retroactive_note")),
+                prep_window=_text(row.get("prep_window")),
             )
         )
     return parsed
@@ -1247,27 +1251,108 @@ def _dedupe(values: Sequence[str], limit: int = 8) -> list[str]:
     return result
 
 
+_RAW_PLAN_TOKENS = {
+    "normal",
+    "medium",
+    "high",
+    "wall",
+    "major_wall",
+    "critical",
+}
+_PREP_WINDOW_RANK = {
+    "critical": 6,
+    "major_wall": 5,
+    "major wall": 5,
+    "wall": 4,
+    "high": 3,
+    "medium": 2,
+    "normal": 1,
+}
+
+
+def _normalized_line(value: object) -> str:
+    clean = _strip_visible_urls(value)
+    clean = re.sub(r"\s+", " ", clean).strip()
+    if not clean:
+        return ""
+    folded = clean.casefold()
+    if folded in _RAW_PLAN_TOKENS:
+        return ""
+    if re.fullmatch(r"[a-z0-9]+(?:_[a-z0-9]+)+", clean):
+        return ""
+    return clean
+
+
+def _append_unique_line(lines: list[str], value: object) -> None:
+    clean = _normalized_line(value)
+    if not clean:
+        return
+    key = clean.casefold()
+    if key not in {line.casefold() for line in lines}:
+        lines.append(clean)
+
+
+def _mission_plan_label(current_title: str, mission: MissionRow) -> str:
+    text = _limit_text(mission.text, 140)
+    if (mission.title or "Missions") == (current_title or "Missions"):
+        return f"{mission.step_index}: {text}"
+    return f"{mission.title or 'Missions'}, {mission.step_index}: {text}"
+
+
+def _limited_bullets(
+    lines: Sequence[str], limit: int, overflow_label: str | None = None
+) -> str:
+    visible = [line for line in lines if line]
+    selected = visible[:limit]
+    bullets = [f"- {line}" for line in selected]
+    overflow = len(visible) - len(selected)
+    if overflow > 0 and overflow_label:
+        bullets.append(f"- +{overflow} {overflow_label}{'' if overflow == 1 else 's'}.")
+    result: list[str] = []
+    used = 0
+    for bullet in bullets:
+        extra = len(bullet) + (1 if result else 0)
+        if used + extra > _FIELD_LIMIT:
+            break
+        result.append(bullet)
+        used += extra
+    return "\n".join(result)
+
+
+def _prep_window_rank(value: object) -> int:
+    raw_text = _text(value)
+    if not raw_text:
+        return 0
+    try:
+        return int(float(raw_text))
+    except ValueError:
+        pass
+    raw = raw_text.casefold().replace("-", "_")
+    return _PREP_WINDOW_RANK.get(raw, 0)
+
+
+def _plan_warning_candidates(upcoming_missions: Sequence[MissionRow]) -> list[str]:
+    candidates: list[tuple[int, int, str]] = []
+    for order, mission in enumerate(upcoming_missions):
+        clean = _normalized_line(mission.difficulty_note)
+        if clean:
+            candidates.append((-_prep_window_rank(mission.prep_window), order, clean))
+    lines: list[str] = []
+    for _rank, _order, line in sorted(candidates):
+        _append_unique_line(lines, line)
+        if len(lines) >= 2:
+            break
+    return lines
+
+
 def _display_resource_tags(value: object, limit: int = 8) -> list[str]:
     parts = re.split(r"[,;]", _text(value))
-    seen: set[str] = set()
     result: list[str] = []
     for part in parts:
-        clean = part.strip().replace("_", " ")
-        clean = re.sub(r"\s+", " ", clean).strip()
-        key = clean.casefold()
-        if not clean or key in seen:
-            continue
-        seen.add(key)
-        result.append(clean)
+        _append_unique_line(result, part.strip().replace("_", " "))
         if len(result) >= limit:
             break
     return result
-
-
-def _plan_line(mission: MissionRow) -> str:
-    title = mission.title or "Missions"
-    text = _limit_text(mission.text, 140)
-    return f"- {title}, {mission.step_index}: {text}"
 
 
 def build_plan_ahead_embed(
@@ -1323,68 +1408,71 @@ def build_plan_ahead_embed(
         description=_embed_description(description),
         color=discord.Color.blurple(),
     )
+    current_title = current.title or "Missions"
     if upcoming and post.plan_ahead_upcoming_field_title:
-        embed.add_field(
-            name=_embed_title(post.plan_ahead_upcoming_field_title),
-            value=_limit_text("\n".join(_plan_line(m) for m in upcoming), _FIELD_LIMIT),
-            inline=False,
-        )
-    save_values: list[str] = []
-    for m in upcoming:
-        save_values.append(m.tips)
-        save_values.extend(_display_resource_tags(m.resource_tags))
+        upcoming_lines = [_mission_plan_label(current_title, m) for m in upcoming]
+        value = _limited_bullets(upcoming_lines, lookahead_count)
+        if value:
+            embed.add_field(
+                name=_embed_title(post.plan_ahead_upcoming_field_title),
+                value=value,
+                inline=False,
+            )
+
     if post.plan_ahead_save_field_title:
-        lines = _dedupe(save_values)
-        if lines:
+        save_lines: list[str] = []
+        for m in upcoming:
+            if _normalized_line(m.tips):
+                _append_unique_line(save_lines, m.tips)
+            else:
+                for resource_line in _display_resource_tags(m.resource_tags):
+                    _append_unique_line(save_lines, resource_line)
+        value = _limited_bullets(save_lines, 4)
+        if value:
             embed.add_field(
                 name=_embed_title(post.plan_ahead_save_field_title),
-                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                value=value,
                 inline=False,
             )
-    avoid_values: list[str] = []
-    for m in upcoming:
-        avoid_values.extend([m.avoid_doing, m.retroactive_note])
+
     if post.plan_ahead_avoid_field_title:
-        lines = _dedupe(avoid_values)
-        if lines:
+        avoid_lines: list[str] = []
+        for m in upcoming:
+            _append_unique_line(avoid_lines, m.avoid_doing)
+        value = _limited_bullets(avoid_lines, 3)
+        if value:
             embed.add_field(
                 name=_embed_title(post.plan_ahead_avoid_field_title),
-                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                value=value,
                 inline=False,
             )
-    gate_values = [
-        f"{m.title or 'Missions'}, {m.step_index}: {m.retroactive_note or m.text}"
-        for m in upcoming
-        if m.time_gate or m.retroactive_note
-    ]
+
     if post.plan_ahead_time_gate_field_title:
-        lines = _dedupe(gate_values)
-        if lines:
+        timing_lines: list[str] = []
+        for m in upcoming:
+            note = _normalized_line(m.retroactive_note)
+            if not note:
+                continue
+            prefix = (
+                f"{m.step_index}"
+                if (m.title or "Missions") == current_title
+                else f"{m.title or 'Missions'}, {m.step_index}"
+            )
+            _append_unique_line(timing_lines, f"{prefix}: {note}")
+        value = _limited_bullets(timing_lines, 3, "more timing note")
+        if value:
             embed.add_field(
                 name=_embed_title(post.plan_ahead_time_gate_field_title),
-                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                value=value,
                 inline=False,
             )
-    warning_values: list[str] = []
-    priority_words = ("critical", "high", "major_wall", "major wall", "wall")
-    for m in sorted(
-        upcoming,
-        key=lambda m: (
-            0
-            if any(
-                w in m.guide_priority.casefold() or w in m.difficulty_note.casefold()
-                for w in priority_words
-            )
-            else 1
-        ),
-    ):
-        warning_values.extend([m.difficulty_note, m.guide_priority])
+
     if post.plan_ahead_warning_field_title:
-        lines = _dedupe(warning_values)
-        if lines:
+        value = _limited_bullets(_plan_warning_candidates(upcoming), 2)
+        if value:
             embed.add_field(
                 name=_embed_title(post.plan_ahead_warning_field_title),
-                value=_limit_text("\n".join(f"- {v}" for v in lines), _FIELD_LIMIT),
+                value=value,
                 inline=False,
             )
     if not embed.fields and post.plan_ahead_no_items_description:
@@ -1443,15 +1531,25 @@ class PlanAheadButton(discord.ui.Button):
                 extra={
                     "category": self.category,
                     "user_id": getattr(getattr(interaction, "user", None), "id", None),
-                    "guild_id": getattr(getattr(interaction, "guild", None), "id", None),
-                    "channel_id": getattr(getattr(interaction, "channel", None), "id", None),
+                    "guild_id": getattr(
+                        getattr(interaction, "guild", None), "id", None
+                    ),
+                    "channel_id": getattr(
+                        getattr(interaction, "channel", None), "id", None
+                    ),
                     "exc_type": type(exc).__name__,
                     "exc_message": str(exc),
                     "post_found": post is not None,
                     "state_found": state is not None,
-                    "current_mission_key": _text(state.get("current_mission_key")) if state else "",
-                    "current_step_index": _text(state.get("current_step_index")) if state else "",
-                    "missions_loaded_count": len(missions) if missions is not None else 0,
+                    "current_mission_key": (
+                        _text(state.get("current_mission_key")) if state else ""
+                    ),
+                    "current_step_index": (
+                        _text(state.get("current_step_index")) if state else ""
+                    ),
+                    "missions_loaded_count": (
+                        len(missions) if missions is not None else 0
+                    ),
                     "category_info_found": category_info is not None,
                 },
             )
@@ -1661,7 +1759,9 @@ class ProgressChapterPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter"))
+            self.add_item(
+                ProgressPickerPageButton("◀️", page - 1, page <= 0, "chapter")
+            )
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "chapter"
@@ -1697,7 +1797,9 @@ class ProgressMissionPickerView(discord.ui.View):
             // _PICKER_OPTIONS_PER_PAGE,
         )
         if total_pages > 1:
-            self.add_item(ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission"))
+            self.add_item(
+                ProgressPickerPageButton("◀️", page - 1, page <= 0, "mission")
+            )
             self.add_item(
                 ProgressPickerPageButton(
                     "▶️", page + 1, page >= total_pages - 1, "mission"

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -2270,21 +2270,179 @@ def test_plan_ahead_saved_progress_builds_fields_from_future_missions(monkeypatc
     assert "Upgrade gear" in fields["Coming soon"]
     assert "Current text" not in fields["Coming soon"]
     assert "Save energy" in fields["Save or prepare"]
-    assert "hydra keys" in fields["Save or prepare"]
-    assert "arena refills" in fields["Save or prepare"]
+    assert "hydra keys" not in fields["Save or prepare"]
+    assert "arena refills" not in fields["Save or prepare"]
     assert "hydra_keys" not in fields["Save or prepare"]
     assert "high" not in fields["Save or prepare"]
     assert fields["Save or prepare"].count("Save energy") == 1
-    assert fields["Save or prepare"].count("hydra keys") == 1
     assert "Do not claim reward" in fields["Do not do too early"]
     assert "Must be active" in fields["Time-gated"]
-    assert "wall" in fields["Watch-outs"]
-    assert "high" in fields["Watch-outs"]
+    assert "Watch-outs" not in fields
     rendered = embed.description + "\n" + "\n".join(fields.values())
     assert "current-key" not in rendered
     assert "next-key" not in rendered
     assert "source_url" not in rendered
     assert "Hidden future" not in rendered
+
+
+def test_plan_ahead_prep_window_rank_supports_numeric_and_text_values():
+    assert service._prep_window_rank("30") > service._prep_window_rank("20")
+    assert service._prep_window_rank("20") > service._prep_window_rank("8")
+    assert service._prep_window_rank("") == 0
+    assert service._prep_window_rank("critical") > service._prep_window_rank(
+        "major_wall"
+    )
+    assert service._prep_window_rank("major-wall") == service._prep_window_rank(
+        "major_wall"
+    )
+    assert service._prep_window_rank("high") > service._prep_window_rank("normal")
+
+
+def test_plan_ahead_warning_selection_prefers_numeric_prep_window_values():
+    warnings = service._plan_warning_candidates(
+        [
+            service.MissionRow(
+                41,
+                "Lower priority",
+                "low",
+                "Ramantu - Part 2",
+                41,
+                difficulty_note="Lower priority warning.",
+                prep_window="20",
+            ),
+            service.MissionRow(
+                42,
+                "Higher priority",
+                "high",
+                "Ramantu - Part 2",
+                42,
+                difficulty_note="Higher priority warning.",
+                prep_window="30",
+            ),
+            service.MissionRow(
+                43,
+                "Lowest priority",
+                "lowest",
+                "Ramantu - Part 2",
+                43,
+                difficulty_note="Lowest priority warning.",
+                prep_window="8",
+            ),
+        ]
+    )
+
+    assert warnings == ["Higher priority warning.", "Lower priority warning."]
+
+
+def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
+    data = _plan_data(plan_ahead_lookahead_count="5", plan_ahead_footer="")
+    post = data.posts[0]
+    missions = [
+        service.MissionRow(40, "Current", "ram-40", "Ramantu - Part 2", 40),
+        service.MissionRow(
+            41,
+            "Earn 25,000 Points in Tournaments",
+            "ram-41",
+            "Ramantu - Part 2",
+            41,
+            tips="Save energy, gems, and refill resources for this point mission.",
+            resource_tags="Keep: energy",
+            avoid_doing="Do not chase points before this mission is active.",
+            retroactive_note="Earn the points while this mission is active.",
+            difficulty_note="normal",
+            guide_priority="critical",
+            prep_window="normal",
+        ),
+        service.MissionRow(
+            42,
+            "Clear Secret Room 1",
+            "ram-42",
+            "Ramantu - Part 2",
+            42,
+            resource_tags="Keep: silver keys",
+            avoid_doing="Do not spend Silver Keys early.",
+            retroactive_note="Doom Tower access depends on rotation and reset.",
+            difficulty_note="Doom Tower missions can force a wait if the room, boss, or rotation is not available.",
+            guide_priority="major_wall",
+            prep_window="critical",
+        ),
+        service.MissionRow(
+            43,
+            "Clear Stage 7",
+            "ram-43",
+            "Ramantu - Part 2",
+            43,
+            tips="Prepare a safe Nightmare Campaign duo for this stage.",
+            avoid_doing="Do not farm the wrong stage.",
+            retroactive_note="Use keys after reset.",
+            difficulty_note="Campaign steps are easy with a duo ready.",
+            prep_window="medium",
+        ),
+        service.MissionRow(
+            44,
+            "Craft 10 Artifacts",
+            "ram-44",
+            "Ramantu - Part 2",
+            44,
+            tips="Save Accuracy Charms and enough Forge materials.",
+            avoid_doing="Do not spend Accuracy Charms before this mission if you are low.",
+            retroactive_note="Craft or equip after this mission is active.",
+            difficulty_note="Forge steps are only easy if the exact charms and materials were saved.",
+            prep_window="high",
+        ),
+        service.MissionRow(
+            184,
+            "Iron Twins",
+            "ram-pt3-1",
+            "Ramantu - Part 3",
+            1,
+            tips="Save fortress keys.",
+            avoid_doing="Do not spend fortress keys.",
+            retroactive_note="Wait for Force affinity.",
+            difficulty_note="critical",
+            guide_priority="normal",
+            prep_window="wall",
+        ),
+        service.MissionRow(
+            185,
+            "Hidden sixth",
+            "ram-pt3-2",
+            "Ramantu - Part 3",
+            2,
+            tips="Should not render",
+        ),
+    ]
+
+    embed = service.build_plan_ahead_embed(
+        post,
+        service.ProgressCategory("RAM", "Ramantu", 185, "TAB"),
+        {"current_mission_key": "ram-40", "current_step_index": "40"},
+        missions,
+    )
+    fields = {field.name: field.value for field in embed.fields}
+
+    assert "- 41: Earn 25,000 Points" in fields["Coming soon"]
+    assert "Ramantu - Part 2, 41" not in fields["Coming soon"]
+    assert "- Ramantu - Part 3, 1: Iron Twins" in fields["Coming soon"]
+    assert "184: Iron Twins" not in fields["Coming soon"]
+    assert "Hidden sixth" not in fields["Coming soon"]
+    assert "Keep: energy" not in fields["Save or prepare"]
+    assert "Keep: silver keys" in fields["Save or prepare"]
+    assert fields["Save or prepare"].count("- ") == 4
+    assert "Earn the points" not in fields["Do not do too early"]
+    assert "Keep:" not in fields["Do not do too early"]
+    assert "- 41: Earn the points while this mission is active." in fields["Time-gated"]
+    assert "Ramantu - Part 2, 41" not in fields["Time-gated"]
+    assert "+2 more timing notes." in fields["Time-gated"]
+    assert "Doom Tower missions can force a wait" in fields["Watch-outs"]
+    assert "Forge steps are only easy" in fields["Watch-outs"]
+    assert "Campaign steps" not in fields["Watch-outs"]
+    assert "guide_priority" not in "\n".join(fields.values())
+    assert "prep_window" not in "\n".join(fields.values())
+    assert "major_wall" not in "\n".join(fields.values())
+    assert "ram-41" not in "\n".join(fields.values())
+    assert "system_tags" not in "\n".join(fields.values())
+    assert not embed.footer.text
 
 
 def test_plan_ahead_saved_progress_does_not_pass_none_view(monkeypatch):
@@ -2320,7 +2478,9 @@ def test_plan_ahead_saved_progress_does_not_pass_none_view(monkeypatch):
     assert sent["embed"].title == "Plan Ahead Title"
 
 
-def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_not_reraise(monkeypatch, caplog):
+def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_not_reraise(
+    monkeypatch, caplog
+):
     data = _plan_data()
     service.set_progress_guide_cache(data)
 
@@ -2336,9 +2496,13 @@ def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_n
     assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
     sent = interaction.followup.sent[0]
     assert sent["ephemeral"] is True
-    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert (
+        sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    )
     assert "raw google schema boom" not in sent["embed"].description
-    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    record = next(
+        r for r in caplog.records if r.message == "plan ahead callback failed"
+    )
     assert record.exc_info is not None
     assert record.category == "ARB"
     assert record.user_id == 123456
@@ -2354,7 +2518,9 @@ def test_plan_ahead_non_quota_failure_after_defer_sends_fallback_logs_and_does_n
     assert record.category_info_found is False
 
 
-def test_plan_ahead_failure_after_state_and_missions_logs_diagnostics(monkeypatch, caplog):
+def test_plan_ahead_failure_after_state_and_missions_logs_diagnostics(
+    monkeypatch, caplog
+):
     data = _plan_data()
     service.set_progress_guide_cache(data)
     state = {
@@ -2387,9 +2553,13 @@ def test_plan_ahead_failure_after_state_and_missions_logs_diagnostics(monkeypatc
         asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
 
     sent = interaction.followup.sent[0]
-    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert (
+        sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    )
     assert "embed render boom" not in sent["embed"].description
-    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    record = next(
+        r for r in caplog.records if r.message == "plan ahead callback failed"
+    )
     assert record.exc_type == "ValueError"
     assert record.exc_message == "embed render boom"
     assert record.current_mission_key == "ram_100"
@@ -2399,7 +2569,9 @@ def test_plan_ahead_failure_after_state_and_missions_logs_diagnostics(monkeypatc
     assert record.state_found is True
 
 
-def test_plan_ahead_failure_before_context_assignment_logs_safe_defaults(monkeypatch, caplog):
+def test_plan_ahead_failure_before_context_assignment_logs_safe_defaults(
+    monkeypatch, caplog
+):
     service.set_progress_guide_cache(None)
 
     async def data():
@@ -2414,7 +2586,9 @@ def test_plan_ahead_failure_before_context_assignment_logs_safe_defaults(monkeyp
     sent = interaction.followup.sent[0]
     assert sent["embed"].description == "Unavailable."
     assert "data load failed" not in sent["embed"].description
-    record = next(r for r in caplog.records if r.message == "plan ahead callback failed")
+    record = next(
+        r for r in caplog.records if r.message == "plan ahead callback failed"
+    )
     assert record.exc_type == "LookupError"
     assert record.exc_message == "data load failed"
     assert record.post_found is False
@@ -2440,11 +2614,15 @@ def test_plan_ahead_quota_failure_keeps_clean_unavailable_embed(monkeypatch):
 
     sent = interaction.followup.sent[0]
     assert sent["ephemeral"] is True
-    assert sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    assert (
+        sent["embed"].description == "Sheet says progress is temporarily unavailable."
+    )
     assert "quota details" not in sent["embed"].description
 
 
-def test_plan_ahead_saved_progress_missing_mission_key_sends_clean_no_progress(monkeypatch):
+def test_plan_ahead_saved_progress_missing_mission_key_sends_clean_no_progress(
+    monkeypatch,
+):
     data = _plan_data()
     service.set_progress_guide_cache(data)
     state = {
@@ -2498,6 +2676,7 @@ def test_plan_ahead_does_not_write_sheets(monkeypatch):
     asyncio.run(service.PlanAheadButton("ARB", "Plan Ahead").callback(interaction))
 
     assert interaction.followup.sent[0]["embed"].description == "Set progress first."
+
 
 def test_empty_plan_uses_no_items_description_and_my_progress_shortcut():
     data = _plan_data(plan_ahead_lookahead_count="12")


### PR DESCRIPTION
### Motivation
- Improve plan-ahead rendering by surfacing player-facing short lines, deduping them, and limiting field sizes to fit embed constraints. 
- Introduce a `prep_window` concept so higher-priority upcoming missions can influence warning ordering and selection. 

### Description
- Add `prep_window` to `MissionRow` and parse it in `_parse_mission_rows` so sheet columns can provide numeric or textual prep window values.  
- Introduce helpers: `_normalized_line`, `_append_unique_line`, `_limited_bullets`, `_prep_window_rank`, and `_plan_warning_candidates` to normalize lines, dedupe, enforce embed field size limits, and rank warnings by `prep_window`.  
- Replace several inline dedupe/formatting implementations (resource tags, upcoming/save/avoid/time-gate/warning assembly) with the new helpers and produce bulletized compact fields in `build_plan_ahead_embed`.  
- Small logging and formatting cleanups in the plan-ahead callback and minor view/button layout formatting fixes.  
- Update and add unit tests in `tests/community/test_progress_guides.py` to cover `prep_window` ranking, warning selection, and the new rendering behavior.  

### Testing
- Ran the updated progress guides test module with `pytest tests/community/test_progress_guides.py` and all tests passed.  
- Added `test_plan_ahead_prep_window_rank_supports_numeric_and_text_values` and `test_plan_ahead_warning_selection_prefers_numeric_prep_window_values` which passed.  
- Updated renderer tests (including `test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output` and other plan-ahead related tests) and they passed against the new output formatting and limits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e2bb42a8832386173763c05dff8e)