### PR TITLE
Respect mission `completion_rule` and filter active-only timing notes in Plan Ahead rendering

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -252,6 +252,7 @@ class MissionRow:
     guide_priority: str
     retroactive_note: str
     prep_window: str
+    completion_rule: str
 
     def __init__(
         self,
@@ -268,6 +269,7 @@ class MissionRow:
         guide_priority: str = "",
         retroactive_note: str = "",
         prep_window: str = "",
+        completion_rule: str = "",
     ) -> None:
         self.sequence_number = sequence_number
         self.step_index = step_index if step_index is not None else sequence_number
@@ -282,6 +284,7 @@ class MissionRow:
         self.guide_priority = guide_priority
         self.retroactive_note = retroactive_note
         self.prep_window = prep_window
+        self.completion_rule = completion_rule
 
     @property
     def number(self) -> int:
@@ -480,6 +483,7 @@ def _parse_mission_rows(rows: Sequence[Mapping[str, object]]) -> list[MissionRow
                 guide_priority=_text(row.get("guide_priority")),
                 retroactive_note=_strip_visible_urls(row.get("retroactive_note")),
                 prep_window=_text(row.get("prep_window")),
+                completion_rule=_text(row.get("completion_rule")),
             )
         )
     return parsed
@@ -1292,11 +1296,15 @@ def _append_unique_line(lines: list[str], value: object) -> None:
         lines.append(clean)
 
 
+def _mission_plan_prefix(current_title: str, mission: MissionRow) -> str:
+    if (mission.title or "Missions") == (current_title or "Missions"):
+        return f"{mission.step_index}"
+    return f"{mission.title or 'Missions'}, {mission.step_index}"
+
+
 def _mission_plan_label(current_title: str, mission: MissionRow) -> str:
     text = _limit_text(mission.text, 140)
-    if (mission.title or "Missions") == (current_title or "Missions"):
-        return f"{mission.step_index}: {text}"
-    return f"{mission.title or 'Missions'}, {mission.step_index}: {text}"
+    return f"{_mission_plan_prefix(current_title, mission)}: {text}"
 
 
 def _limited_bullets(
@@ -1329,6 +1337,25 @@ def _prep_window_rank(value: object) -> int:
         pass
     raw = raw_text.casefold().replace("-", "_")
     return _PREP_WINDOW_RANK.get(raw, 0)
+
+
+_ACTIVE_ONLY_TIMING_PHRASES = (
+    "after this mission is active",
+    "while this mission is active",
+    "if it does not auto-complete",
+    "after the mission is active",
+    "while the mission is active",
+    "if the mission does not auto-complete",
+)
+
+
+def _is_active_only_mission(mission: MissionRow) -> bool:
+    return mission.completion_rule.strip().casefold() == "active_only"
+
+
+def _is_active_only_instruction_note(note: str) -> bool:
+    folded = note.casefold()
+    return any(phrase in folded for phrase in _ACTIVE_ONLY_TIMING_PHRASES)
 
 
 def _plan_warning_candidates(upcoming_missions: Sequence[MissionRow]) -> list[str]:
@@ -1438,7 +1465,11 @@ def build_plan_ahead_embed(
     if post.plan_ahead_avoid_field_title:
         avoid_lines: list[str] = []
         for m in upcoming:
-            _append_unique_line(avoid_lines, m.avoid_doing)
+            avoid = _normalized_line(m.avoid_doing)
+            if avoid and _is_active_only_mission(m):
+                _append_unique_line(
+                    avoid_lines, f"{_mission_plan_prefix(current_title, m)}: {avoid}"
+                )
         value = _limited_bullets(avoid_lines, 3)
         if value:
             embed.add_field(
@@ -1453,12 +1484,11 @@ def build_plan_ahead_embed(
             note = _normalized_line(m.retroactive_note)
             if not note:
                 continue
-            prefix = (
-                f"{m.step_index}"
-                if (m.title or "Missions") == current_title
-                else f"{m.title or 'Missions'}, {m.step_index}"
+            if _is_active_only_instruction_note(note):
+                continue
+            _append_unique_line(
+                timing_lines, f"{_mission_plan_prefix(current_title, m)}: {note}"
             )
-            _append_unique_line(timing_lines, f"{prefix}: {note}")
         value = _limited_bullets(timing_lines, 3, "more timing note")
         if value:
             embed.add_field(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -2168,6 +2168,7 @@ def _plan_missions():
             resource_tags="hydra_keys; silver",
             difficulty_note="medium",
             guide_priority="normal",
+            completion_rule="active_only",
         ),
         service.MissionRow(4, "Hidden future", "future-key", "Marius - Part 1", 4),
     ]
@@ -2275,7 +2276,7 @@ def test_plan_ahead_saved_progress_builds_fields_from_future_missions(monkeypatc
     assert "hydra_keys" not in fields["Save or prepare"]
     assert "high" not in fields["Save or prepare"]
     assert fields["Save or prepare"].count("Save energy") == 1
-    assert "Do not claim reward" in fields["Do not do too early"]
+    assert "- 3: Do not claim reward" in fields["Do not do too early"]
     assert "Must be active" in fields["Time-gated"]
     assert "Watch-outs" not in fields
     rendered = embed.description + "\n" + "\n".join(fields.values())
@@ -2352,6 +2353,7 @@ def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
             difficulty_note="normal",
             guide_priority="critical",
             prep_window="normal",
+            completion_rule="active_only",
         ),
         service.MissionRow(
             42,
@@ -2389,6 +2391,7 @@ def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
             retroactive_note="Craft or equip after this mission is active.",
             difficulty_note="Forge steps are only easy if the exact charms and materials were saved.",
             prep_window="high",
+            completion_rule="active_only",
         ),
         service.MissionRow(
             184,
@@ -2402,6 +2405,7 @@ def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
             difficulty_note="critical",
             guide_priority="normal",
             prep_window="wall",
+            completion_rule="active_only",
         ),
         service.MissionRow(
             185,
@@ -2431,9 +2435,23 @@ def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
     assert fields["Save or prepare"].count("- ") == 4
     assert "Earn the points" not in fields["Do not do too early"]
     assert "Keep:" not in fields["Do not do too early"]
-    assert "- 41: Earn the points while this mission is active." in fields["Time-gated"]
+    assert (
+        "- 41: Do not chase points before this mission is active."
+        in fields["Do not do too early"]
+    )
+    assert "Ramantu - Part 2, 41" not in fields["Do not do too early"]
+    assert "- 44: Do not spend Accuracy Charms" in fields["Do not do too early"]
+    assert (
+        "- Ramantu - Part 3, 1: Do not spend fortress keys."
+        in fields["Do not do too early"]
+    )
+    assert "Do not spend Silver Keys early." not in fields["Do not do too early"]
+    assert "Earn the points while this mission is active." not in fields["Time-gated"]
+    assert "Craft or equip after this mission is active." not in fields["Time-gated"]
     assert "Ramantu - Part 2, 41" not in fields["Time-gated"]
-    assert "+2 more timing notes." in fields["Time-gated"]
+    assert "Doom Tower access depends on rotation and reset." in fields["Time-gated"]
+    assert "Use keys after reset." in fields["Time-gated"]
+    assert "Wait for Force affinity." in fields["Time-gated"]
     assert "Doom Tower missions can force a wait" in fields["Watch-outs"]
     assert "Forge steps are only easy" in fields["Watch-outs"]
     assert "Campaign steps" not in fields["Watch-outs"]
@@ -2443,6 +2461,31 @@ def test_plan_ahead_renderer_uses_player_facing_columns_and_limits_output():
     assert "ram-41" not in "\n".join(fields.values())
     assert "system_tags" not in "\n".join(fields.values())
     assert not embed.footer.text
+
+
+def test_plan_ahead_timing_note_filter_keeps_real_timing_gates():
+    active_only_notes = [
+        "Spend medals after this mission is active.",
+        "Farm potions while this mission is active.",
+        "Claim it if it does not auto-complete.",
+        "Earn tournament points while the mission is active.",
+        "Do the upgrade after the mission is active.",
+        "Claim it if the mission does not auto-complete.",
+    ]
+    real_timing_notes = [
+        "Arcane Keep is open every day.",
+        "Magic Keep opens Monday and Thursday.",
+        "Doom Tower access depends on rotation and reset.",
+        "Crypt access depends on Faction Wars rotation.",
+        "Rank checks depend on weekly reset.",
+    ]
+
+    assert all(
+        service._is_active_only_instruction_note(note) for note in active_only_notes
+    )
+    assert not any(
+        service._is_active_only_instruction_note(note) for note in real_timing_notes
+    )
 
 
 def test_plan_ahead_saved_progress_does_not_pass_none_view(monkeypatch):


### PR DESCRIPTION
### Motivation

- Ensure missions with a `completion_rule` (e.g. `active_only`) are represented correctly in Plan Ahead output and avoid confusing timing notes that are merely instructions to wait until a mission is active.
- Improve labeling of mission lines so step prefixes include the mission title when necessary for clarity.

### Description

- Add `completion_rule` field to `MissionRow` and wire parsing via `completion_rule=_text(row.get("completion_rule"))` in `_parse_mission_rows`.
- Introduce `_mission_plan_prefix` helper and refactor `_mission_plan_label` to use it so prefixes are consistent when mission title differs from the current title.
- Add `_ACTIVE_ONLY_TIMING_PHRASES`, `_is_active_only_mission`, and `_is_active_only_instruction_note` to detect active-only completion rules and filter out instruction-like timing notes from true timing gates.
- Update Plan Ahead embed construction to include mission prefixes for active-only `avoid_doing` lines and to skip active-only instruction notes from the time-gated field.
- Update tests in `tests/community/test_progress_guides.py` to include `completion_rule` in fixtures, adjust expected field contents, and add `test_plan_ahead_timing_note_filter_keeps_real_timing_gates` to validate the timing-note filtering logic.

### Testing

- Ran the module test file `pytest tests/community/test_progress_guides.py`, which includes updated fixtures and the new timing-note filter test, and all tests passed.
- Existing Plan Ahead rendering tests were exercised and updated expectations were validated by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59284065d48323b5dd52f2e854ee2d)