### PR TITLE
Add managed help panels and persist guide/help post URLs to Sheets

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -28,6 +28,15 @@ _ASSETS_KEY = "PROGRESS_ASSETS_TAB"
 _CATEGORIES_KEY = "PROGRESS_CATEGORIES_TAB"
 _USER_STATE_KEY = "PROGRESS_USER_STATE_TAB"
 _MESSAGE_ID_COLUMN = "guide_panel_message_id"
+_GUIDE_POST_URL_COLUMN = "guide_post_url"
+_HELP_MESSAGE_ID_COLUMN = "help_panel_message_id"
+_HELP_POST_URL_COLUMN = "help_post_url"
+_HELP_PANEL_COLUMNS = (
+    "help_panel_title",
+    "help_panel_description",
+    "help_panel_footer",
+    "help_back_button_label",
+)
 _EMBED_LIMIT = 3900
 _EMBED_TITLE_LIMIT = 256
 _EMBED_DESCRIPTION_LIMIT = 4096
@@ -136,7 +145,15 @@ class ForumPost:
     guide_channel_id: int | None
     guide_thread_id: int | None
     guide_panel_message_id: int | None
+    guide_post_url: str
+    help_channel_id: int | None
+    help_thread_id: int | None
     help_post_url: str
+    help_panel_message_id: int | None
+    help_panel_title: str
+    help_panel_description: str
+    help_panel_footer: str
+    help_back_button_label: str
     guide_asset_key: str
     questions_enabled: bool
     sort_order: float
@@ -229,7 +246,15 @@ class ForumPost:
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
             guide_panel_message_id=_int_or_none(row.get("guide_panel_message_id")),
+            guide_post_url=_text(row.get("guide_post_url")),
+            help_channel_id=_int_or_none(row.get("help_channel_id")),
+            help_thread_id=_int_or_none(row.get("help_thread_id")),
             help_post_url=_text(row.get("help_post_url")),
+            help_panel_message_id=_int_or_none(row.get("help_panel_message_id")),
+            help_panel_title=_text(row.get("help_panel_title")),
+            help_panel_description=_text(row.get("help_panel_description")),
+            help_panel_footer=_text(row.get("help_panel_footer")),
+            help_back_button_label=_text(row.get("help_back_button_label")),
             guide_asset_key=_text(row.get("guide_asset_key")),
             questions_enabled=_truthy(row.get("questions_enabled")),
             sort_order=_sort_num(row.get("sort_order")),
@@ -2064,6 +2089,47 @@ class ProgressGuideFAQPersistentView(discord.ui.View):
             self.add_item(ProgressGuideFAQButton(category))
 
 
+def build_help_embed(post: ForumPost) -> discord.Embed | None:
+    if not (post.help_panel_title or post.help_panel_description):
+        return None
+    embed = discord.Embed(
+        title=_embed_title(post.help_panel_title),
+        description=_embed_description(post.help_panel_description),
+        color=discord.Color.blurple(),
+    )
+    if post.help_panel_footer:
+        embed.set_footer(text=_limit_text(post.help_panel_footer, 2048))
+    return embed
+
+
+def build_help_view(post: ForumPost, data: ProgressGuideData) -> discord.ui.View | None:
+    view = discord.ui.View(timeout=None)
+    added = False
+    if data.faq_by_category.get(post.category):
+        view.add_item(
+            ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
+        )
+        added = True
+    if _supports_missions(post):
+        view.add_item(
+            ProgressGuideMissionButton(
+                post.category, post.mission_list_button_label or "Mission List"
+            )
+        )
+        added = True
+    guide_url = _safe_url(post.guide_post_url)
+    if guide_url:
+        view.add_item(
+            discord.ui.Button(
+                label=_button_label(post.help_back_button_label or "Back"),
+                style=discord.ButtonStyle.link,
+                url=guide_url,
+            )
+        )
+        added = True
+    return view if added else None
+
+
 def build_guide_embed(post: ForumPost, data: ProgressGuideData) -> discord.Embed | None:
     guide_rows = data.guides_by_category.get(post.category, [])
     if not guide_rows:
@@ -2133,28 +2199,13 @@ def build_guide_view(
 
 
 async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSummary:
-    """Publish or refresh progress guide panels within a fixed Sheets budget.
-
-    Read budget per command run:
-    - Config is read through the existing milestones config path.
-    - ProgressForumPosts, ProgressGuides, ProgressFAQ, and ProgressAssets are read
-      once by :func:`load_progress_guide_data`.
-    - Worksheet/header reads are lazy and only allowed when
-      ``guide_panel_message_id`` must actually be written back.
-
-    Write budget per command run:
-    - ``guide_panel_message_id`` is written only after a new panel message is
-      created or a stored/deleted message is recreated.
-    - Refreshing an existing stored message only edits Discord and must not read
-      worksheet/header data or write back to Sheets.
-    """
+    """Publish or refresh progress guide and managed help panels."""
 
     data = await load_progress_guide_data()
     clear_mission_cache()
     set_progress_guide_cache(data)
     sheet_id = get_milestones_sheet_id().strip()
-    worksheet = None
-    message_id_col: str | None = None
+    sheet_state = _ForumPostsSheetState(sheet_id, data.forum_posts_tab)
     summary = PublishSummary()
     for post in data.posts:
         label = post.label or post.category or f"row {post.row_number}"
@@ -2173,49 +2224,175 @@ async def publish_or_refresh(bot: commands.Bot, *, refresh: bool) -> PublishSumm
         if channel is None:
             summary.failures.append(f"{label}: invalid guide destination {target_id}")
             continue
-        view = build_guide_view(post, data)
+        initial_help_post_url = post.help_post_url
         try:
+            message = None
+            guide_created = False
             if post.guide_panel_message_id:
-                message = None
-                try:
-                    message = await channel.fetch_message(post.guide_panel_message_id)  # type: ignore[attr-defined]
-                except discord.NotFound:
-                    message = None
-                except Exception:
-                    raise
-                if message is not None:
-                    await message.edit(embed=embed, view=view)
-                    summary.refreshed += 1
-                    continue
-                if not refresh:
+                message = await _fetch_message_or_none(
+                    channel, post.guide_panel_message_id
+                )
+                if message is None and not refresh:
                     summary.skipped.append(
                         f"{label}: stored panel missing; run refresh to recreate"
                     )
                     continue
-            message = await channel.send(embed=embed, view=view)  # type: ignore[attr-defined]
-            try:
-                if worksheet is None or message_id_col is None:
-                    worksheet = await aget_worksheet(sheet_id, data.forum_posts_tab)
-                    header = await _load_header(sheet_id, data.forum_posts_tab)
-                    message_id_col = _column_label(
-                        _header_index(header, _MESSAGE_ID_COLUMN)
+            if message is None:
+                message = await channel.send(embed=embed, view=build_guide_view(post, data))  # type: ignore[attr-defined]
+                guide_created = True
+                try:
+                    await sheet_state.write_if_changed(
+                        post.row_number,
+                        _MESSAGE_ID_COLUMN,
+                        str(message.id),
+                        post.guide_panel_message_id,
                     )
-                await acall_with_backoff(
-                    worksheet.update,
-                    f"{message_id_col}{post.row_number}",
-                    [[str(message.id)]],
-                    attempts=1,
-                    value_input_option="RAW",
+                    post.guide_panel_message_id = message.id
+                except Exception:
+                    await _delete_untracked_message(message)
+                    raise
+            jump_url = getattr(message, "jump_url", "")
+            if jump_url:
+                await sheet_state.write_if_changed(
+                    post.row_number,
+                    _GUIDE_POST_URL_COLUMN,
+                    jump_url,
+                    post.guide_post_url,
                 )
-            except Exception:
-                await _delete_untracked_message(message)
-                raise
-            summary.created += 1
+                post.guide_post_url = jump_url
+            await _publish_or_refresh_help_post(
+                bot, post, data, sheet_state, summary, label
+            )
+            final_view = build_guide_view(post, data)
+            if guide_created:
+                if post.help_post_url != initial_help_post_url:
+                    await message.edit(embed=embed, view=final_view)
+                summary.created += 1
+            else:
+                await message.edit(embed=embed, view=final_view)
+                summary.refreshed += 1
         except Exception as exc:
             if is_rate_limited_error(exc):
                 raise
             summary.failures.append(f"{label}: {type(exc).__name__}: {exc}")
     return summary
+
+
+async def _publish_or_refresh_help_post(
+    bot: commands.Bot,
+    post: ForumPost,
+    data: ProgressGuideData,
+    sheet_state: "_ForumPostsSheetState",
+    summary: PublishSummary,
+    label: str,
+) -> None:
+    target_id = post.help_thread_id or post.help_channel_id
+    if target_id is None:
+        summary.skipped.append(f"{label}: missing help destination")
+        return
+    embed = build_help_embed(post)
+    if embed is None:
+        summary.skipped.append(f"{label}: missing help panel copy")
+        return
+    channel = await _resolve_messageable(bot, target_id)
+    if channel is None:
+        summary.failures.append(f"{label}: invalid help destination {target_id}")
+        return
+    view = build_help_view(post, data)
+    try:
+        if post.help_panel_message_id:
+            message = await _fetch_message_or_none(channel, post.help_panel_message_id)
+            if message is not None:
+                await message.edit(embed=embed, view=view, content=None)
+                jump_url = getattr(message, "jump_url", "")
+                if jump_url:
+                    await sheet_state.write_if_changed(
+                        post.row_number,
+                        _HELP_POST_URL_COLUMN,
+                        jump_url,
+                        post.help_post_url,
+                    )
+                    post.help_post_url = jump_url
+                summary.refreshed += 1
+                return
+        message = await channel.send(embed=embed, view=view)  # type: ignore[attr-defined]
+        jump_url = getattr(message, "jump_url", "")
+        try:
+            await sheet_state.write_if_changed(
+                post.row_number,
+                _HELP_MESSAGE_ID_COLUMN,
+                str(message.id),
+                post.help_panel_message_id,
+            )
+            if jump_url:
+                await sheet_state.write_if_changed(
+                    post.row_number, _HELP_POST_URL_COLUMN, jump_url, post.help_post_url
+                )
+                post.help_post_url = jump_url
+        except Exception:
+            await _delete_untracked_message(message)
+            raise
+        summary.created += 1
+    except Exception as exc:
+        if is_rate_limited_error(exc):
+            raise
+        summary.failures.append(f"{label} help: {type(exc).__name__}: {exc}")
+
+
+async def _fetch_message_or_none(
+    channel: discord.abc.Messageable, message_id: int
+) -> discord.Message | None:
+    try:
+        return await channel.fetch_message(message_id)  # type: ignore[attr-defined]
+    except discord.NotFound:
+        return None
+
+
+class _ForumPostsSheetState:
+    def __init__(self, sheet_id: str, tab: str) -> None:
+        self.sheet_id = sheet_id
+        self.tab = tab
+        self.worksheet = None
+        self.header: list[str] | None = None
+
+    async def _ensure_loaded(self) -> None:
+        if self.worksheet is None:
+            self.worksheet = await aget_worksheet(self.sheet_id, self.tab)
+        if self.header is None:
+            self.header = await _load_header(self.sheet_id, self.tab)
+
+    async def ensure_help_columns(self) -> None:
+        await self._ensure_loaded()
+        assert self.header is not None
+        missing = [col for col in _HELP_PANEL_COLUMNS if col not in self.header]
+        if not missing:
+            return
+        self.header.extend(missing)
+        assert self.worksheet is not None
+        end_col = _column_label(len(self.header) - 1)
+        await acall_with_backoff(
+            self.worksheet.update,
+            f"A1:{end_col}1",
+            [self.header],
+            attempts=1,
+            value_input_option="RAW",
+        )
+
+    async def write_if_changed(
+        self, row_number: int, column: str, value: str, current: object
+    ) -> None:
+        if _text(current) == value:
+            return
+        await self.ensure_help_columns()
+        assert self.header is not None and self.worksheet is not None
+        col = _column_label(_header_index(self.header, column))
+        await acall_with_backoff(
+            self.worksheet.update,
+            f"{col}{row_number}",
+            [[value]],
+            attempts=1,
+            value_input_option="RAW",
+        )
 
 
 async def _delete_untracked_message(message: discord.Message) -> None:

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -26,6 +26,7 @@ class FakeMessage:
         self.delete_error = delete_error
         self.delete_attempted = False
         self.deleted = False
+        self.jump_url = f"https://discord.com/channels/1/2/{message_id}"
 
     async def edit(self, **kwargs):
         self.edits.append(kwargs)
@@ -136,7 +137,19 @@ async def _run(monkeypatch, data, channels, worksheet, *, refresh=True):
         return worksheet
 
     async def fetch_values(sheet, tab):
-        return [["category", "guide_panel_message_id", "help_panel_message_id"]]
+        return [
+            [
+                "category",
+                "guide_panel_message_id",
+                "guide_post_url",
+                "help_panel_message_id",
+                "help_post_url",
+                "help_panel_title",
+                "help_panel_description",
+                "help_panel_footer",
+                "help_back_button_label",
+            ]
+        ]
 
     monkeypatch.setattr(service, "aget_worksheet", get_ws)
     monkeypatch.setattr(service, "afetch_values", fetch_values)
@@ -171,6 +184,10 @@ def _data(*, post_overrides=None, guides=None, faq=None):
         "help_channel_id": "",
         "help_thread_id": "",
         "help_panel_message_id": "",
+        "help_panel_title": "Help for Arbiter",
+        "help_panel_description": "Use these sheet-authored buttons for help.",
+        "help_panel_footer": "Sheet footer.",
+        "help_back_button_label": "Back to Guide",
         "progress_tracking_enabled": "TRUE",
         "leaderboard_enabled": "FALSE",
         "notes": "",
@@ -251,7 +268,246 @@ def test_publish_posts_only_guide_panels_and_writes_message_id(monkeypatch):
     assert summary.created == 1
     assert len(guide.sent) == 1
     assert help_channel.sent == []
-    assert worksheet.updates == [("B2", [["12345"]], {"value_input_option": "RAW"})]
+    assert worksheet.updates == [
+        ("B2", [["12345"]], {"value_input_option": "RAW"}),
+        (
+            "C2",
+            [["https://discord.com/channels/1/2/12345"]],
+            {"value_input_option": "RAW"},
+        ),
+    ]
+
+
+def test_refresh_creates_managed_help_post_and_updates_guide_link(monkeypatch):
+    worksheet = FakeWorksheet()
+    guide = FakeChannel()
+    help_channel = FakeChannel(send_message=FakeMessage(555))
+    data = _data(
+        post_overrides={
+            "help_channel_id": "20",
+            "help_post_url": "",
+            "mission_list_button_label": "Mission List",
+            "mission_list_title": "Missions",
+        }
+    )
+    summary = asyncio.run(
+        _run(monkeypatch, data, {10: guide, 20: help_channel}, worksheet)
+    )
+    assert summary.created == 2
+    assert (
+        help_channel.sent[0]["content"] is None
+        if "content" in help_channel.sent[0]
+        else True
+    )
+    help_embed = help_channel.sent[0]["embed"]
+    assert help_embed.title == "Help for Arbiter"
+    assert help_embed.description == "Use these sheet-authored buttons for help."
+    labels = [
+        getattr(item, "label", "") for item in help_channel.sent[0]["view"].children
+    ]
+    assert labels == ["Read FAQ", "Mission List", "Back to Guide"]
+    final_guide_view = guide.sent_messages[0].edits[-1]["view"]
+    guide_labels = [getattr(item, "label", "") for item in final_guide_view.children]
+    assert "Ask the Helpers" in guide_labels
+    ask = _button_by_label(final_guide_view, "Ask the Helpers")
+    assert ask.url == "https://discord.com/channels/1/2/555"
+    assert ("D2", [["555"]], {"value_input_option": "RAW"}) in worksheet.updates
+    assert (
+        "E2",
+        [["https://discord.com/channels/1/2/555"]],
+        {"value_input_option": "RAW"},
+    ) in worksheet.updates
+
+
+def test_existing_guide_panel_with_stale_guide_post_url_updates_sheet(monkeypatch):
+    worksheet = FakeWorksheet()
+    message = FakeMessage(777)
+    guide = FakeChannel(existing=message)
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/old",
+                }
+            ),
+            {10: guide},
+            worksheet,
+        )
+    )
+    assert summary.refreshed == 1
+    assert (
+        "C2",
+        [["https://discord.com/channels/1/2/777"]],
+        {"value_input_option": "RAW"},
+    ) in worksheet.updates
+
+
+def test_recreated_guide_panel_updates_help_back_button_target(monkeypatch):
+    worksheet = FakeWorksheet()
+    guide = FakeChannel(missing=True, send_message=FakeMessage(444))
+    help_channel = FakeChannel(send_message=FakeMessage(555))
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/deleted",
+                    "help_channel_id": "20",
+                    "help_post_url": "",
+                }
+            ),
+            {10: guide, 20: help_channel},
+            worksheet,
+        )
+    )
+    assert summary.created == 2
+    assert ("B2", [["444"]], {"value_input_option": "RAW"}) in worksheet.updates
+    assert (
+        "C2",
+        [["https://discord.com/channels/1/2/444"]],
+        {"value_input_option": "RAW"},
+    ) in worksheet.updates
+    assert (
+        _button_by_label(help_channel.sent[0]["view"], "Back to Guide").url
+        == "https://discord.com/channels/1/2/444"
+    )
+
+
+def test_refresh_edits_existing_help_post(monkeypatch):
+    worksheet = FakeWorksheet()
+    message = FakeMessage(888)
+    help_channel = FakeChannel(existing=message)
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(
+                post_overrides={
+                    "help_channel_id": "20",
+                    "help_panel_message_id": "888",
+                    "help_post_url": "https://discord.com/channels/1/2/888",
+                }
+            ),
+            {10: FakeChannel(), 20: help_channel},
+            worksheet,
+        )
+    )
+    assert summary.refreshed == 1
+    assert message.edits
+    assert help_channel.sent == []
+    assert not any(update[0] in {"D2", "E2"} for update in worksheet.updates)
+
+
+def test_refresh_recreates_deleted_help_post(monkeypatch):
+    worksheet = FakeWorksheet()
+    help_channel = FakeChannel(missing=True, send_message=FakeMessage(999))
+    summary = asyncio.run(
+        _run(
+            monkeypatch,
+            _data(
+                post_overrides={"help_channel_id": "20", "help_panel_message_id": "888"}
+            ),
+            {10: FakeChannel(), 20: help_channel},
+            worksheet,
+        )
+    )
+    assert summary.created == 2
+    assert ("D2", [["999"]], {"value_input_option": "RAW"}) in worksheet.updates
+    assert (
+        "E2",
+        [["https://discord.com/channels/1/2/999"]],
+        {"value_input_option": "RAW"},
+    ) in worksheet.updates
+
+
+def test_help_post_back_button_uses_guide_post_url(monkeypatch):
+    worksheet = FakeWorksheet()
+    help_channel = FakeChannel()
+    asyncio.run(
+        _run(
+            monkeypatch,
+            _data(
+                post_overrides={
+                    "help_channel_id": "20",
+                    "guide_post_url": "https://discord.com/channels/1/2/333",
+                }
+            ),
+            {10: FakeChannel(), 20: help_channel},
+            worksheet,
+        )
+    )
+    labels = [
+        getattr(item, "label", "") for item in help_channel.sent[0]["view"].children
+    ]
+    assert "Back to Guide" in labels
+    assert (
+        _button_by_label(help_channel.sent[0]["view"], "Back to Guide").url
+        == "https://discord.com/channels/1/2/12345"
+    )
+
+
+def test_help_view_omits_back_button_without_guide_post_url():
+    data = _data(post_overrides={"guide_post_url": ""})
+    view = service.build_help_view(data.posts[0], data)
+    labels = [getattr(item, "label", "") for item in view.children]
+    assert "Back to Guide" not in labels
+
+
+def test_progress_forum_posts_help_columns_are_appended_when_missing(monkeypatch):
+    worksheet = FakeWorksheet()
+    data = _data(post_overrides={"help_channel_id": "20", "help_post_url": ""})
+
+    async def load_data():
+        return data
+
+    async def get_ws(sheet, tab):
+        return worksheet
+
+    async def fetch_values(sheet, tab):
+        return [
+            [
+                "category",
+                "guide_panel_message_id",
+                "guide_post_url",
+                "help_panel_message_id",
+                "help_post_url",
+            ]
+        ]
+
+    async def resolve(_bot, channel_id):
+        return {10: FakeChannel(), 20: FakeChannel()}.get(channel_id)
+
+    async def call(func, *args, **kwargs):
+        kwargs.pop("attempts", None)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(service, "load_progress_guide_data", load_data)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service.discord, "NotFound", FakeDiscordNotFound)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(service, "afetch_values", fetch_values)
+    monkeypatch.setattr(service, "_resolve_messageable", resolve)
+    monkeypatch.setattr(service, "acall_with_backoff", call)
+    asyncio.run(service.publish_or_refresh(FakeBot(), refresh=True))
+    assert worksheet.updates[0] == (
+        "A1:I1",
+        [
+            [
+                "category",
+                "guide_panel_message_id",
+                "guide_post_url",
+                "help_panel_message_id",
+                "help_post_url",
+                "help_panel_title",
+                "help_panel_description",
+                "help_panel_footer",
+                "help_back_button_label",
+            ]
+        ],
+        {"value_input_option": "RAW"},
+    )
 
 
 def test_publish_primes_progress_guide_cache(monkeypatch):
@@ -269,7 +525,12 @@ def test_refresh_edits_existing_guide_panel(monkeypatch):
     summary = asyncio.run(
         _run(
             monkeypatch,
-            _data(post_overrides={"guide_panel_message_id": "777"}),
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/777",
+                }
+            ),
             {10: guide},
             worksheet,
         )
@@ -286,7 +547,12 @@ def test_missing_deleted_stored_message_recreates_and_updates_id(monkeypatch):
     summary = asyncio.run(
         _run(
             monkeypatch,
-            _data(post_overrides={"guide_panel_message_id": "777"}),
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/777",
+                }
+            ),
             {10: guide},
             worksheet,
         )
@@ -302,7 +568,12 @@ def test_generic_fetch_error_does_not_recreate(monkeypatch):
     summary = asyncio.run(
         _run(
             monkeypatch,
-            _data(post_overrides={"guide_panel_message_id": "777"}),
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/777",
+                }
+            ),
             {10: guide},
             worksheet,
         )
@@ -316,7 +587,7 @@ def test_generic_fetch_error_does_not_recreate(monkeypatch):
 def test_help_panel_message_id_is_never_written(monkeypatch):
     worksheet = FakeWorksheet()
     asyncio.run(_run(monkeypatch, _data(), {10: FakeChannel()}, worksheet))
-    assert [cell for cell, _values, _kw in worksheet.updates] == ["B2"]
+    assert [cell for cell, _values, _kw in worksheet.updates] == ["B2", "C2"]
 
 
 def test_disabled_rows_are_skipped(monkeypatch):
@@ -345,7 +616,7 @@ def test_missing_guide_destination_is_reported_not_fatal(monkeypatch):
         )
     )
     assert summary.created == 0
-    assert "missing guide destination" in summary.skipped[0]
+    assert any("missing guide destination" in item for item in summary.skipped)
 
 
 def test_source_urls_are_not_rendered_in_embed():
@@ -1054,7 +1325,12 @@ def test_progress_guides_cog_registers_persistent_faq_view():
 
 
 def test_refresh_existing_stored_message_does_not_read_worksheet_or_header(monkeypatch):
-    data = _data(post_overrides={"guide_panel_message_id": "777"})
+    data = _data(
+        post_overrides={
+            "guide_panel_message_id": "777",
+            "guide_post_url": "https://discord.com/channels/1/2/777",
+        }
+    )
     message = FakeMessage(777)
     guide = FakeChannel(existing=message)
 
@@ -1093,7 +1369,12 @@ def test_refresh_existing_stored_message_does_not_write_guide_panel_message_id(
     summary = asyncio.run(
         _run(
             monkeypatch,
-            _data(post_overrides={"guide_panel_message_id": "777"}),
+            _data(
+                post_overrides={
+                    "guide_panel_message_id": "777",
+                    "guide_post_url": "https://discord.com/channels/1/2/777",
+                }
+            ),
             {10: guide},
             worksheet,
         )
@@ -1108,7 +1389,14 @@ def test_create_path_still_writes_guide_panel_message_id(monkeypatch):
     summary = asyncio.run(_run(monkeypatch, _data(), {10: FakeChannel()}, worksheet))
 
     assert summary.created == 1
-    assert worksheet.updates == [("B2", [["12345"]], {"value_input_option": "RAW"})]
+    assert worksheet.updates == [
+        ("B2", [["12345"]], {"value_input_option": "RAW"}),
+        (
+            "C2",
+            [["https://discord.com/channels/1/2/12345"]],
+            {"value_input_option": "RAW"},
+        ),
+    ]
 
 
 class FakeCtx:


### PR DESCRIPTION
### Motivation

- Provide first-class support for separate "help" panels managed by the service and ensure bidirectional linking between guide and help posts using persistent jump URLs in Sheets.  

### Description

- Add new sheet-backed fields and header columns (`guide_post_url`, `help_post_url`, `help_panel_message_id`, and help panel metadata) and extend `ForumPost` to expose these values.  
- Implement `build_help_embed` and `build_help_view` for rendering managed help panels and wire them into the publish/refresh flow via `_publish_or_refresh_help_post`.  
- Make publishing more robust by introducing `_fetch_message_or_none` and `_ForumPostsSheetState` which lazily loads worksheet/header, appends missing help columns, and writes cell values only when changed.  
- Update `publish_or_refresh` to record message jump URLs for guide posts, refresh views to include updated back-button targets, and handle recreate/edit semantics correctly; add tests exercising the new behaviours.  

### Testing

- Ran the unit tests in `tests/community/test_progress_guides.py` covering creation, refresh, recreation, URL persistence, help back-button behaviour, and header-appending; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5950b644c88323aeba6991899bebee)