### PR TITLE
Add progress guide How to use helper

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -9,6 +9,7 @@ from shared.sheets import milestones_config
 from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
     ProgressGuideFAQPersistentView,
+    ProgressGuideHowToUsePersistentView,
     ProgressGuideMissionPersistentView,
     ProgressGuidePlanAheadPersistentView,
     ProgressGuideMyProgressPersistentView,
@@ -77,6 +78,7 @@ class ProgressGuidesCog(commands.Cog):
         bot.add_view(ProgressGuideMissionPersistentView())
         bot.add_view(ProgressGuideMyProgressPersistentView())
         bot.add_view(ProgressGuidePlanAheadPersistentView())
+        bot.add_view(ProgressGuideHowToUsePersistentView())
 
     @tier("admin")
     @help_metadata(

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -48,6 +48,7 @@ _MISSIONS_CUSTOM_ID_PREFIX = "progressguides:missions:"
 _MY_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:myprogress:"
 _SET_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:setprogress:"
 _PLAN_AHEAD_CUSTOM_ID_PREFIX = "progressguides:planahead:"
+_HOW_TO_USE_CUSTOM_ID_PREFIX = "progressguides:howto:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
 _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
 _MISSIONS_PER_PAGE = 15
@@ -154,6 +155,10 @@ class ForumPost:
     help_panel_description: str
     help_panel_footer: str
     help_back_button_label: str
+    how_to_use_button_label: str
+    how_to_use_title: str
+    how_to_use_description: str
+    guide_footer: str
     guide_asset_key: str
     questions_enabled: bool
     sort_order: float
@@ -255,6 +260,10 @@ class ForumPost:
             help_panel_description=_text(row.get("help_panel_description")),
             help_panel_footer=_text(row.get("help_panel_footer")),
             help_back_button_label=_text(row.get("help_back_button_label")),
+            how_to_use_button_label=_text(row.get("how_to_use_button_label")),
+            how_to_use_title=_text(row.get("how_to_use_title")),
+            how_to_use_description=_text(row.get("how_to_use_description")),
+            guide_footer=_text(row.get("guide_footer")),
             guide_asset_key=_text(row.get("guide_asset_key")),
             questions_enabled=_truthy(row.get("questions_enabled")),
             sort_order=_sort_num(row.get("sort_order")),
@@ -470,6 +479,10 @@ def _supports_my_progress(post: ForumPost) -> bool:
         and post.progress_tracking_enabled
         and bool(post.my_progress_button_label)
     )
+
+
+def _supports_how_to_use(post: ForumPost) -> bool:
+    return bool(post.how_to_use_button_label and post.how_to_use_description)
 
 
 def _mission_unavailable_embed(description: str) -> discord.Embed:
@@ -2089,6 +2102,13 @@ class ProgressGuideFAQPersistentView(discord.ui.View):
             self.add_item(ProgressGuideFAQButton(category))
 
 
+class ProgressGuideHowToUsePersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _PERSISTENT_FAQ_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(ProgressGuideHowToUseButton(category))
+
+
 def build_help_embed(post: ForumPost) -> discord.Embed | None:
     if not (post.help_panel_title or post.help_panel_description):
         return None
@@ -2157,7 +2177,51 @@ def build_guide_embed(post: ForumPost, data: ProgressGuideData) -> discord.Embed
         asset_type = _text(asset.get("asset_type")).casefold()
         if url and (not asset_type or asset_type in {"image", "banner", "thumbnail"}):
             embed.set_image(url=url)
+    if post.guide_footer:
+        embed.set_footer(text=_limit_text(post.guide_footer, 2048))
     return embed
+
+
+def build_how_to_use_embed(post: ForumPost) -> discord.Embed:
+    return discord.Embed(
+        title=_embed_title(post.how_to_use_title) or None,
+        description=_embed_description(post.how_to_use_description),
+        color=discord.Color.blurple(),
+    )
+
+
+class ProgressGuideHowToUseButton(discord.ui.Button):
+    def __init__(self, category: str, label: str = "How to use") -> None:
+        self.category = category
+        super().__init__(
+            label=_button_label(label or "How to use"),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{_HOW_TO_USE_CUSTOM_ID_PREFIX}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            data = await get_or_load_progress_guide_data()
+            post = _post_for_category(self.category, data)
+            if post is None or not _supports_how_to_use(post):
+                embed = discord.Embed(
+                    title="Progress guide help unavailable",
+                    description="This guide helper is not configured right now.",
+                    color=discord.Color.red(),
+                )
+            else:
+                embed = build_how_to_use_embed(post)
+        except Exception:
+            embed = discord.Embed(
+                title="Progress guide help unavailable",
+                description=(
+                    "I couldn’t load that guide helper right now. "
+                    "Please try again later."
+                ),
+                color=discord.Color.red(),
+            )
+        await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 def build_guide_view(
@@ -2193,6 +2257,11 @@ def build_guide_view(
                 style=discord.ButtonStyle.link,
                 url=help_url,
             )
+        )
+        added = True
+    if _supports_how_to_use(post):
+        view.add_item(
+            ProgressGuideHowToUseButton(post.category, post.how_to_use_button_label)
         )
         added = True
     return view if added else None

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -188,6 +188,10 @@ def _data(*, post_overrides=None, guides=None, faq=None):
         "help_panel_description": "Use these sheet-authored buttons for help.",
         "help_panel_footer": "Sheet footer.",
         "help_back_button_label": "Back to Guide",
+        "how_to_use_button_label": "",
+        "how_to_use_title": "",
+        "how_to_use_description": "",
+        "guide_footer": "",
         "progress_tracking_enabled": "TRUE",
         "leaderboard_enabled": "FALSE",
         "notes": "",
@@ -717,6 +721,71 @@ def test_button_labels_fallback_and_help_remains_last():
         "FAQ",
         "Ask in Help",
     ]
+
+
+def test_how_to_use_button_appears_after_ask_and_sends_sheet_embed():
+    data = _data(
+        post_overrides={
+            "how_to_use_button_label": "❔ How to use",
+            "how_to_use_title": "How to use this Interactive Guide",
+            "how_to_use_description": "Mission List shows the full mission chain.",
+        }
+    )
+    service.set_progress_guide_cache(data)
+    view = service.build_guide_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Read FAQ",
+        "Ask the Helpers",
+        "❔ How to use",
+    ]
+    button = _button_by_label(view, "❔ How to use")
+    assert button.custom_id == "progressguides:howto:ARB"
+
+    interaction = FakeInteraction()
+    asyncio.run(button.callback(interaction))
+
+    assert interaction.response.deferred == [{"ephemeral": True, "thinking": True}]
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].title == "How to use this Interactive Guide"
+    assert sent["embed"].description == "Mission List shows the full mission chain."
+
+
+def test_how_to_use_button_is_omitted_without_label_or_description():
+    for overrides in (
+        {
+            "how_to_use_button_label": "",
+            "how_to_use_description": "Mission List shows the full mission chain.",
+        },
+        {"how_to_use_button_label": "How to use", "how_to_use_description": ""},
+    ):
+        data = _data(post_overrides=overrides)
+        view = service.build_guide_view(data.posts[0], data)
+        assert "progressguides:howto:ARB" not in [
+            getattr(item, "custom_id", "") for item in view.children
+        ]
+
+
+def test_how_to_use_button_is_not_added_to_managed_help_posts():
+    data = _data(
+        post_overrides={
+            "guide_post_url": "https://discord.com/channels/1/2/333",
+            "how_to_use_button_label": "How to use",
+            "how_to_use_title": "How to use this Interactive Guide",
+            "how_to_use_description": "Mission List shows the full mission chain.",
+        }
+    )
+    view = service.build_help_view(data.posts[0], data)
+    assert [getattr(item, "label", "") for item in view.children] == [
+        "Read FAQ",
+        "Back to Guide",
+    ]
+
+
+def test_main_guide_embed_uses_sheet_footer_when_populated():
+    data = _data(post_overrides={"guide_footer": "New here? Use How to use."})
+    embed = service.build_guide_embed(data.posts[0], data)
+    assert embed.footer.text == "New here? Use How to use."
 
 
 def test_sheet_driven_visible_values_are_limited_for_discord():
@@ -2463,7 +2532,11 @@ def _plan_missions():
 
 
 def test_plan_ahead_main_guide_button_order_and_visibility_rules():
-    data = _plan_data()
+    data = _plan_data(
+        how_to_use_button_label="❔ How to use",
+        how_to_use_title="How to use this Interactive Guide",
+        how_to_use_description="Mission List shows the full mission chain.",
+    )
     view = service.build_guide_view(data.posts[0], data)
     assert [getattr(item, "label", "") for item in view.children] == [
         "Mission List",
@@ -2471,6 +2544,7 @@ def test_plan_ahead_main_guide_button_order_and_visibility_rules():
         "Plan Ahead",
         "Read FAQ",
         "Ask the Helpers",
+        "❔ How to use",
     ]
     assert view.children[2].custom_id == "progressguides:planahead:ARB"
 


### PR DESCRIPTION
## Summary
- read `how_to_use_button_label`, `how_to_use_title`, `how_to_use_description`, and `guide_footer` from `ProgressForumPosts` rows
- add a main-guide-only How to use button after Ask in Help that opens an ephemeral sheet-driven embed
- render `guide_footer` on the main guide embed and register the persistent button handler without startup sheet reads

## Validation
- Live sheet header checked: `ProgressForumPosts!A1:BM1` includes `how_to_use_button_label`, `how_to_use_title`, `how_to_use_description`, and `guide_footer`.
- `PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest tests/community/test_progress_guides.py`
- Result: `107 passed, 2 warnings`