### PR TITLE
Fix clan ads card button timeout

### DIFF
--- a/cogs/recruitment_clan_ads.py
+++ b/cogs/recruitment_clan_ads.py
@@ -62,15 +62,16 @@ class ClanAdsCog(commands.Cog):
         if not custom_id or not str(custom_id).startswith("clan_ads:view_card:"):
             return
         tag = str(custom_id).rsplit(":", 1)[-1]
+        await interaction.response.defer(ephemeral=True, thinking=True)
         embeds, files, _state = await clan_ads.build_clan_card(
             self.bot, tag, interaction.guild
         )
         if not embeds:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"Unknown clan tag `{tag}`.", ephemeral=True
             )
             return
-        await interaction.response.send_message(
+        await interaction.followup.send(
             embeds=embeds, files=files, ephemeral=True
         )
 

--- a/shared/sheets/async_facade.py
+++ b/shared/sheets/async_facade.py
@@ -60,7 +60,7 @@ async def fetch_clan_tags_index(*args: Any, **kwargs: Any) -> Any:
 
 
 async def get_clan_by_tag(*args: Any, **kwargs: Any) -> Any:
-    return await _to_thread(_recruitment_sync.get_clan_by_tag, *args, **kwargs)
+    return await _recruitment_sync.aget_clan_by_tag(*args, **kwargs)
 
 
 # === Core helpers that touch network/files ===

--- a/shared/sheets/recruitment.py
+++ b/shared/sheets/recruitment.py
@@ -915,6 +915,39 @@ def get_clan_by_tag(tag: str, *, force: bool = False) -> List[str] | None:
     return None
 
 
+async def aget_clan_by_tag(tag: str, *, force: bool = False) -> List[str] | None:
+    """Async lookup of a clan row by tag, using warm in-memory cache directly."""
+
+    global _CLAN_TAG_INDEX, _CLAN_TAG_INDEX_TS
+    normalized = _normalize_tag(tag)
+    if not normalized:
+        return None
+
+    now = time.time()
+    if not force and _CLAN_TAG_INDEX is not None and (
+        now - _CLAN_TAG_INDEX_TS
+    ) < _CACHE_TTL:
+        return _CLAN_TAG_INDEX.get(normalized)
+
+    rows = await afetch_clans(force=force)
+    now = time.time()
+    if force or _CLAN_TAG_INDEX is None or (
+        now - _CLAN_TAG_INDEX_TS
+    ) >= _CACHE_TTL:
+        _CLAN_TAG_INDEX = _build_tag_index(rows)
+        _CLAN_TAG_INDEX_TS = now
+    if _CLAN_TAG_INDEX:
+        return _CLAN_TAG_INDEX.get(normalized)
+
+    tag_index = (_CLAN_HEADER_MAP or {}).get("clan_tag", 2)
+    for row in rows:
+        if tag_index >= len(row):
+            continue
+        if _normalize_tag(row[tag_index]) == normalized:
+            return row
+    return None
+
+
 def find_clan_row(
     clan_tag: str, *, force: bool = False
 ) -> tuple[int, List[str]] | None:

--- a/tests/recruitment/test_clan_ads_fields.py
+++ b/tests/recruitment/test_clan_ads_fields.py
@@ -377,6 +377,45 @@ def test_manual_clanads_summary_auto_deletes_only_in_ad_channel(monkeypatch):
     assert sends == [("Posted 1 clan ad(s).", {"delete_after": 20})]
 
 
+def test_clan_ads_button_defers_before_building_profile(monkeypatch):
+    import asyncio
+    from types import SimpleNamespace
+    import discord
+    from cogs.recruitment_clan_ads import ClanAdsCog
+
+    calls = []
+
+    class Response:
+        async def defer(self, **kwargs):
+            calls.append(("defer", kwargs))
+
+    class Followup:
+        async def send(self, **kwargs):
+            calls.append(("followup", kwargs))
+
+    async def fake_build_clan_card(*args, **kwargs):
+        calls.append(("build", args, kwargs))
+        return [discord.Embed(title="Profile")], [], SimpleNamespace()
+
+    monkeypatch.setattr(clan_ads, "build_clan_card", fake_build_clan_card)
+    interaction = SimpleNamespace(
+        data={"custom_id": "clan_ads:view_card:C1CE"},
+        guild=SimpleNamespace(id=123),
+        response=Response(),
+        followup=Followup(),
+    )
+
+    asyncio.run(
+        ClanAdsCog(SimpleNamespace()).clan_ad_card_interaction(interaction)
+    )
+
+    assert calls[0] == ("defer", {"ephemeral": True, "thinking": True})
+    assert calls[1][0] == "build"
+    assert calls[2][0] == "followup"
+    assert calls[2][1]["embeds"][0].title == "Profile"
+    assert calls[2][1]["ephemeral"] is True
+
+
 def test_embed_color_parsing_and_fallbacks(monkeypatch):
     import asyncio
 

--- a/tests/recruitment/test_recruitment_clan_cache.py
+++ b/tests/recruitment/test_recruitment_clan_cache.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from shared.sheets import recruitment
+
+
+def test_aget_clan_by_tag_uses_warm_index_without_fetch(monkeypatch):
+    row = ["Clan One", "C1CE"]
+
+    monkeypatch.setattr(recruitment, "_CACHE_TTL", 900)
+    monkeypatch.setattr(recruitment, "_CLAN_TAG_INDEX", {"C1CE": row})
+    monkeypatch.setattr(recruitment, "_CLAN_TAG_INDEX_TS", time.time())
+
+    async def fail_fetch(*args, **kwargs):
+        raise AssertionError("warm tag lookup should not fetch clan rows")
+
+    monkeypatch.setattr(recruitment, "afetch_clans", fail_fetch)
+
+    assert asyncio.run(recruitment.aget_clan_by_tag("c1ce")) is row
+
+
+def test_aget_clan_by_tag_builds_index_after_async_fetch(monkeypatch):
+    row = ["Clan One", "C1CE"]
+
+    monkeypatch.setattr(recruitment, "_CACHE_TTL", 900)
+    monkeypatch.setattr(recruitment, "_CLAN_TAG_INDEX", None)
+    monkeypatch.setattr(recruitment, "_CLAN_TAG_INDEX_TS", 0)
+    monkeypatch.setattr(recruitment, "_CLAN_HEADER_MAP", {"clan_tag": 1})
+
+    async def fake_fetch(*, force=False):
+        assert force is False
+        return [row]
+
+    monkeypatch.setattr(recruitment, "afetch_clans", fake_fetch)
+
+    assert asyncio.run(recruitment.aget_clan_by_tag("c1ce")) is row
+    assert recruitment._CLAN_TAG_INDEX == {"C1CE": row}


### PR DESCRIPTION
## What changed
- Defer `View Clan Card` button interactions immediately before building the clan profile payload.
- Send the clan card through the deferred interaction follow-up, preserving the existing ephemeral behavior.
- Add an async cache-first clan tag lookup so warm clan data does not queue through the Sheets executor unnecessarily.
- Add regression coverage for the button defer path and cache lookup behavior.

## Why
The clan ads themselves posted successfully, but clicking `View Clan Card` could time out before Discord received an interaction acknowledgement. Logs showed repeated `TimeoutError` failures for `clan_ads:view_card:<tag>` component interactions after a successful full ad refresh.

## Validation
- `PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest tests/recruitment/test_clan_ads_fields.py tests/recruitment/test_recruitment_clan_cache.py -q` -> 18 passed.
- `python -m py_compile cogs/recruitment_clan_ads.py shared/sheets/async_facade.py shared/sheets/recruitment.py tests/recruitment/test_clan_ads_fields.py tests/recruitment/test_recruitment_clan_cache.py` -> passed.

Note: the broader async-boundary test currently reports pre-existing violations in `modules/recruitment/availability.py`; none are from this PR's touched files.