### PR TITLE
Add Faction Wars support to progress guides (stars, progress, guides, conditions)

### DIFF
--- a/modules/community/progress_guides/cog.py
+++ b/modules/community/progress_guides/cog.py
@@ -8,6 +8,7 @@ from c1c_coreops.rbac import admin_only
 from shared.sheets import milestones_config
 from shared.sheets.core import is_rate_limited_error
 from modules.community.progress_guides.service import (
+    FactionWarsPersistentView,
     ProgressGuideFAQPersistentView,
     ProgressGuideHowToUsePersistentView,
     ProgressGuideMissionPersistentView,
@@ -79,6 +80,7 @@ class ProgressGuidesCog(commands.Cog):
         bot.add_view(ProgressGuideMyProgressPersistentView())
         bot.add_view(ProgressGuidePlanAheadPersistentView())
         bot.add_view(ProgressGuideHowToUsePersistentView())
+        bot.add_view(FactionWarsPersistentView())
 
     @tier("admin")
     @help_metadata(

--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -48,9 +48,20 @@ _MISSIONS_CUSTOM_ID_PREFIX = "progressguides:missions:"
 _MY_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:myprogress:"
 _SET_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:setprogress:"
 _PLAN_AHEAD_CUSTOM_ID_PREFIX = "progressguides:planahead:"
+_FW_STARS_CUSTOM_ID_PREFIX = "progressguides:fwstars:"
+_FW_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:fwprogress:"
+_FW_GUIDE_CUSTOM_ID_PREFIX = "progressguides:fwguide:"
+_FW_CONDITIONS_CUSTOM_ID_PREFIX = "progressguides:fwconditions:"
 _HOW_TO_USE_CUSTOM_ID_PREFIX = "progressguides:howto:"
 _PERSISTENT_FAQ_CATEGORIES = ("ARB", "RAM", "MAR", "FW_N", "FW_H")
 _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
+_FACTION_WARS_CATEGORIES = ("FW_N", "FW_H")
+_FW_HARD_CATEGORY = "FW_H"
+_FW_USER_COUNTERS_KEY = "PROGRESS_USER_COUNTERS_TAB"
+_FW_FACTIONS_KEY = "PROGRESS_FW_FACTIONS_TAB"
+_FW_CHAMPION_GUIDES_KEY = "PROGRESS_FW_CHAMPION_GUIDES_TAB"
+_FW_HARD_STAGE_CONDITIONS_KEY = "PROGRESS_FW_HARD_STAGE_CONDITIONS_TAB"
+_FW_HARD_STAGE_SOLVERS_KEY = "PROGRESS_FW_HARD_STAGE_SOLVERS_TAB"
 _MISSIONS_PER_PAGE = 15
 _PICKER_OPTIONS_PER_PAGE = 25
 _FAQ_OPTIONS_PER_PAGE = 25
@@ -60,6 +71,8 @@ _DATA_CACHE: "ProgressGuideData | None" = None
 _DATA_CACHE_LOCK = asyncio.Lock()
 _MISSION_CACHE: dict[str, list["MissionRow"]] = {}
 _MISSION_CACHE_LOCKS: dict[str, asyncio.Lock] = {}
+_FW_DATA_CACHE: "FactionWarsData | None" = None
+_FW_DATA_CACHE_LOCK = asyncio.Lock()
 log = logging.getLogger("c1c.community.progress_guides.service")
 
 
@@ -142,6 +155,36 @@ class ForumPost:
     plan_ahead_warning_field_title: str
     plan_ahead_footer: str
     plan_ahead_lookahead_count: int | None
+    counter_stars_button_label: str
+    counter_progress_button_label: str
+    faction_guide_button_label: str
+    conditions_button_label: str
+    counter_stars_title: str
+    counter_stars_empty_description: str
+    counter_stars_saved_description: str
+    counter_stars_invalid_value_description: str
+    counter_stars_faction_select_placeholder: str
+    counter_stars_modal_title: str
+    counter_stars_modal_value_label: str
+    counter_progress_title: str
+    counter_progress_intro_template: str
+    counter_progress_empty_description: str
+    counter_progress_footer: str
+    counter_progress_finished_field_title: str
+    counter_progress_close_field_title: str
+    counter_progress_focus_field_title: str
+    faction_guide_title: str
+    faction_guide_select_placeholder: str
+    faction_guide_champions_field_title: str
+    faction_guide_roles_field_title: str
+    faction_guide_accessible_field_title: str
+    faction_guide_note_field_title: str
+    faction_guide_empty_description: str
+    conditions_title: str
+    conditions_select_placeholder: str
+    conditions_summary_field_title: str
+    conditions_stages_field_title: str
+    conditions_empty_description: str
     progress_tracking_enabled: bool
     guide_channel_id: int | None
     guide_thread_id: int | None
@@ -247,6 +290,76 @@ class ForumPost:
             plan_ahead_lookahead_count=_int_or_none(
                 row.get("plan_ahead_lookahead_count")
             ),
+            counter_stars_button_label=_text(row.get("counter_stars_button_label")),
+            counter_progress_button_label=_text(
+                row.get("counter_progress_button_label")
+            ),
+            faction_guide_button_label=_text(row.get("faction_guide_button_label")),
+            conditions_button_label=_text(row.get("conditions_button_label")),
+            counter_stars_title=_text(row.get("counter_stars_title")),
+            counter_stars_empty_description=_text(
+                row.get("counter_stars_empty_description")
+            ),
+            counter_stars_saved_description=_text(
+                row.get("counter_stars_saved_description")
+            ),
+            counter_stars_invalid_value_description=_text(
+                row.get("counter_stars_invalid_value_description")
+            ),
+            counter_stars_faction_select_placeholder=_text(
+                row.get("counter_stars_faction_select_placeholder")
+            ),
+            counter_stars_modal_title=_text(row.get("counter_stars_modal_title")),
+            counter_stars_modal_value_label=_text(
+                row.get("counter_stars_modal_value_label")
+            ),
+            counter_progress_title=_text(row.get("counter_progress_title")),
+            counter_progress_intro_template=_text(
+                row.get("counter_progress_intro_template")
+            ),
+            counter_progress_empty_description=_text(
+                row.get("counter_progress_empty_description")
+            ),
+            counter_progress_footer=_text(row.get("counter_progress_footer")),
+            counter_progress_finished_field_title=_text(
+                row.get("counter_progress_finished_field_title")
+            ),
+            counter_progress_close_field_title=_text(
+                row.get("counter_progress_close_field_title")
+            ),
+            counter_progress_focus_field_title=_text(
+                row.get("counter_progress_focus_field_title")
+            ),
+            faction_guide_title=_text(row.get("faction_guide_title")),
+            faction_guide_select_placeholder=_text(
+                row.get("faction_guide_select_placeholder")
+            ),
+            faction_guide_champions_field_title=_text(
+                row.get("faction_guide_champions_field_title")
+            ),
+            faction_guide_roles_field_title=_text(
+                row.get("faction_guide_roles_field_title")
+            ),
+            faction_guide_accessible_field_title=_text(
+                row.get("faction_guide_accessible_field_title")
+            ),
+            faction_guide_note_field_title=_text(
+                row.get("faction_guide_note_field_title")
+            ),
+            faction_guide_empty_description=_text(
+                row.get("faction_guide_empty_description")
+            ),
+            conditions_title=_text(row.get("conditions_title")),
+            conditions_select_placeholder=_text(
+                row.get("conditions_select_placeholder")
+            ),
+            conditions_summary_field_title=_text(
+                row.get("conditions_summary_field_title")
+            ),
+            conditions_stages_field_title=_text(
+                row.get("conditions_stages_field_title")
+            ),
+            conditions_empty_description=_text(row.get("conditions_empty_description")),
             progress_tracking_enabled=_truthy(row.get("progress_tracking_enabled")),
             guide_channel_id=_int_or_none(row.get("guide_channel_id")),
             guide_thread_id=_int_or_none(row.get("guide_thread_id")),
@@ -355,11 +468,17 @@ def clear_progress_guide_cache() -> None:
     global _DATA_CACHE
     _DATA_CACHE = None
     clear_mission_cache()
+    clear_faction_wars_cache()
 
 
 def clear_mission_cache() -> None:
     _MISSION_CACHE.clear()
     _MISSION_CACHE_LOCKS.clear()
+
+
+def clear_faction_wars_cache() -> None:
+    global _FW_DATA_CACHE
+    _FW_DATA_CACHE = None
 
 
 async def get_or_load_progress_guide_data() -> ProgressGuideData:
@@ -2109,6 +2228,707 @@ class ProgressGuideHowToUsePersistentView(discord.ui.View):
             self.add_item(ProgressGuideHowToUseButton(category))
 
 
+@dataclass(slots=True)
+class FactionWarsData:
+    factions: list[Mapping[str, object]]
+    champion_guides: list[Mapping[str, object]]
+    hard_stage_conditions: list[Mapping[str, object]]
+    hard_stage_solvers: list[Mapping[str, object]]
+
+
+async def get_or_load_faction_wars_data() -> FactionWarsData:
+    global _FW_DATA_CACHE
+    if _FW_DATA_CACHE is not None:
+        return _FW_DATA_CACHE
+    async with _FW_DATA_CACHE_LOCK:
+        if _FW_DATA_CACHE is not None:
+            return _FW_DATA_CACHE
+        sheet_id = get_milestones_sheet_id().strip()
+        tabs = await asyncio.gather(
+            milestones_config.arequire_value(_FW_FACTIONS_KEY),
+            milestones_config.arequire_value(_FW_CHAMPION_GUIDES_KEY),
+            milestones_config.arequire_value(_FW_HARD_STAGE_CONDITIONS_KEY),
+            milestones_config.arequire_value(_FW_HARD_STAGE_SOLVERS_KEY),
+        )
+        rows = await _gather_rows(sheet_id, *tabs)
+        _FW_DATA_CACHE = FactionWarsData(*rows)
+        return _FW_DATA_CACHE
+
+
+def _format_template(template: str, values: Mapping[str, object]) -> str:
+    result = template
+    for key, value in values.items():
+        result = result.replace("{" + key + "}", _text(value))
+    return result
+
+
+def _fw_enabled_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    return [
+        row
+        for row in rows
+        if not _text(row.get("enabled")) or _truthy(row.get("enabled"))
+    ]
+
+
+def _fw_mode(category: str) -> str:
+    return "hard" if category == _FW_HARD_CATEGORY else "normal"
+
+
+def _fw_row_matches_category(row: Mapping[str, object], category: str) -> bool:
+    row_category = _text(row.get("category"))
+    if row_category and row_category != category:
+        return False
+    row_mode = _text(row.get("mode")).casefold()
+    return not row_mode or row_mode == _fw_mode(category)
+
+
+def _fw_faction_key(row: Mapping[str, object]) -> str:
+    return _text(row.get("faction_key") or row.get("counter_key"))
+
+
+def _fw_faction_name(row: Mapping[str, object]) -> str:
+    return _text(
+        row.get("faction_name")
+        or row.get("name")
+        or row.get("counter_label")
+        or _fw_faction_key(row)
+    )
+
+
+def _fw_faction_rows(data: FactionWarsData) -> list[Mapping[str, object]]:
+    return sorted(
+        _fw_enabled_rows(data.factions),
+        key=lambda r: (_fw_faction_name(r).casefold(), _fw_faction_key(r).casefold()),
+    )
+
+
+def _fw_faction_options(data: FactionWarsData) -> list[tuple[str, str, int]]:
+    options: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for row in _fw_faction_rows(data):
+        key = _fw_faction_key(row)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        options.append((key, _fw_faction_name(row) or key, _fw_max_stars(row)))
+    return options
+
+
+def _fw_faction_lookup(data: FactionWarsData) -> dict[str, tuple[str, int]]:
+    return {
+        key: (label, max_stars) for key, label, max_stars in _fw_faction_options(data)
+    }
+
+
+def _fw_max_stars(row: Mapping[str, object] | None) -> int:
+    if row is None:
+        return 63
+    return _int_or_none(row.get("max_stars")) or 63
+
+
+async def _fw_user_counter_rows() -> tuple[str, list[dict[str, Any]]]:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab = await milestones_config.arequire_value(_FW_USER_COUNTERS_KEY)
+    return tab, await afetch_records(sheet_id, tab)
+
+
+def _fw_user_rows(
+    rows: Sequence[Mapping[str, object]], user_id: int, category: str
+) -> list[Mapping[str, object]]:
+    user = str(user_id)
+    return [
+        row
+        for row in rows
+        if _text(row.get("user_id")) == user and _text(row.get("category")) == category
+    ]
+
+
+def _fw_counter_value(row: Mapping[str, object]) -> int:
+    return _int_or_none(row.get("current_value")) or 0
+
+
+def _fw_goal_value(row: Mapping[str, object], fallback: int = 63) -> int:
+    return _int_or_none(row.get("goal_value")) or fallback
+
+
+def _fw_rows_by_key(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, Mapping[str, object]]:
+    return {_fw_faction_key(row): row for row in rows if _fw_faction_key(row)}
+
+
+def build_faction_wars_stars_embed(
+    post: ForumPost,
+    fw: FactionWarsData,
+    user_rows: Sequence[Mapping[str, object]],
+) -> discord.Embed:
+    title = post.counter_stars_title or f"{post.label or post.category} — My Stars"
+    if not user_rows:
+        return discord.Embed(
+            title=_embed_title(title),
+            description=_embed_description(
+                post.counter_stars_empty_description
+                or "No Faction Wars stars are saved for you yet."
+            ),
+            color=discord.Color.blurple(),
+        )
+    lookup = _fw_faction_lookup(fw)
+    lines = []
+    total = 0
+    for row in sorted(user_rows, key=lambda r: _fw_faction_name(r).casefold())[:25]:
+        key = _fw_faction_key(row)
+        label, fallback_goal = lookup.get(key, (_fw_faction_name(row) or key, 63))
+        stars = _fw_counter_value(row)
+        goal = _fw_goal_value(row, fallback_goal)
+        total += stars
+        status = _text(row.get("status"))
+        suffix = f" — {status}" if status else ""
+        lines.append(f"- {label}: {stars}/{goal}⭐{suffix}")
+    description = f"Total saved stars: **{total}**\n\n" + "\n".join(lines)
+    return discord.Embed(
+        title=_embed_title(title),
+        description=_embed_description(description),
+        color=discord.Color.blurple(),
+    )
+
+
+def build_faction_wars_progress_embed(
+    post: ForumPost,
+    fw: FactionWarsData,
+    user_rows: Sequence[Mapping[str, object]],
+) -> discord.Embed:
+    lookup = _fw_faction_lookup(fw)
+    saved = _fw_rows_by_key(user_rows)
+    progress_rows: list[tuple[str, str, int, int]] = []
+    for key, label, max_stars in _fw_faction_options(fw):
+        row = saved.get(key)
+        current = _fw_counter_value(row) if row else 0
+        goal = _fw_goal_value(row, max_stars) if row else max_stars
+        progress_rows.append((key, label, current, goal))
+    for key, row in saved.items():
+        if key not in lookup:
+            label = _fw_faction_name(row) or key
+            current = _fw_counter_value(row)
+            progress_rows.append((key, label, current, _fw_goal_value(row)))
+    total = sum(current for _key, _label, current, _goal in progress_rows)
+    max_total = sum(goal for _key, _label, _current, goal in progress_rows)
+    remaining = max(max_total - total, 0)
+    finished = [r for r in progress_rows if r[3] and r[2] >= r[3]]
+    close = [r for r in progress_rows if r[3] and 0 < r[3] - r[2] <= 3]
+    focus = sorted(
+        [r for r in progress_rows if r[2] < r[3]], key=lambda r: (r[2], r[1])
+    )[:5]
+    if not user_rows and post.counter_progress_empty_description:
+        description = post.counter_progress_empty_description
+    else:
+        values = {
+            "category": post.category,
+            "category_label": post.label or post.category,
+            "current_value": total,
+            "goal_value": max_total,
+            "percent_complete": _format_percent(total, max_total),
+            "remaining_value": remaining,
+        }
+        description = _format_template(
+            post.counter_progress_intro_template
+            or "Total stars: {current_value}/{goal_value}⭐ ({percent_complete}% complete)",
+            values,
+        )
+    embed = discord.Embed(
+        title=_embed_title(
+            post.counter_progress_title or f"{post.label or post.category} — Progress"
+        ),
+        description=_embed_description(description),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name=_embed_title(
+            post.counter_progress_finished_field_title or "Finished factions"
+        ),
+        value=_limited_bullets(
+            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in finished], 8
+        )
+        or "None yet.",
+        inline=False,
+    )
+    embed.add_field(
+        name=_embed_title(post.counter_progress_close_field_title or "Close to finish"),
+        value=_limited_bullets(
+            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in close], 8
+        )
+        or "None yet.",
+        inline=False,
+    )
+    embed.add_field(
+        name=_embed_title(post.counter_progress_focus_field_title or "Focus factions"),
+        value=_limited_bullets(
+            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in focus], 8
+        )
+        or "All tracked factions are complete.",
+        inline=False,
+    )
+    if post.counter_progress_footer:
+        embed.set_footer(text=_limit_text(post.counter_progress_footer, 2048))
+    return embed
+
+
+def _fw_champion_guide_row(
+    fw: FactionWarsData, category: str, faction_key: str
+) -> Mapping[str, object] | None:
+    return next(
+        (
+            row
+            for row in _fw_enabled_rows(fw.champion_guides)
+            if _fw_row_matches_category(row, category)
+            and _fw_faction_key(row) == faction_key
+        ),
+        None,
+    )
+
+
+def build_faction_wars_guide_embed(
+    post: ForumPost, fw: FactionWarsData, faction_key: str
+) -> discord.Embed:
+    lookup = _fw_faction_lookup(fw)
+    row = _fw_champion_guide_row(fw, post.category, faction_key)
+    label = (
+        _fw_faction_name(row) if row else lookup.get(faction_key, (faction_key, 63))[0]
+    )
+    embed = discord.Embed(
+        title=_embed_title(post.faction_guide_title or f"{label} — Faction Guide"),
+        color=discord.Color.blurple(),
+    )
+    if row is None:
+        embed.description = _embed_description(
+            post.faction_guide_empty_description
+            or "No champion guide is configured for that faction yet."
+        )
+        return embed
+    for title, key, fallback in (
+        (
+            post.faction_guide_champions_field_title,
+            "recommended_champions",
+            "Recommended champions",
+        ),
+        (post.faction_guide_roles_field_title, "core_roles", "Core roles"),
+        (
+            post.faction_guide_accessible_field_title,
+            "accessible_options",
+            "Accessible options",
+        ),
+        (post.faction_guide_note_field_title, "planning_note", "Planning note"),
+    ):
+        value = _strip_visible_urls(row.get(key))
+        if value:
+            embed.add_field(
+                name=_embed_title(title or fallback),
+                value=_limit_text(value, _FIELD_LIMIT),
+                inline=False,
+            )
+    if not embed.fields:
+        embed.description = _embed_description(
+            post.faction_guide_empty_description
+            or "No champion guide details are configured for that faction yet."
+        )
+    return embed
+
+
+def _fw_condition_row(
+    fw: FactionWarsData, category: str, faction_key: str
+) -> Mapping[str, object] | None:
+    return next(
+        (
+            row
+            for row in _fw_enabled_rows(fw.hard_stage_conditions)
+            if _fw_row_matches_category(row, category)
+            and _fw_faction_key(row) == faction_key
+        ),
+        None,
+    )
+
+
+def _fw_solver_rows(
+    fw: FactionWarsData, category: str, faction_key: str
+) -> dict[int, list[Mapping[str, object]]]:
+    solvers: dict[int, list[Mapping[str, object]]] = {}
+    for row in _fw_enabled_rows(fw.hard_stage_solvers):
+        if (
+            not _fw_row_matches_category(row, category)
+            or _fw_faction_key(row) != faction_key
+        ):
+            continue
+        stage = _int_or_none(row.get("stage_number"))
+        if stage is not None:
+            solvers.setdefault(stage, []).append(row)
+    return solvers
+
+
+def build_faction_wars_conditions_embed(
+    post: ForumPost, fw: FactionWarsData, faction_key: str
+) -> discord.Embed:
+    lookup = _fw_faction_lookup(fw)
+    row = _fw_condition_row(fw, post.category, faction_key)
+    label = (
+        _fw_faction_name(row) if row else lookup.get(faction_key, (faction_key, 63))[0]
+    )
+    embed = discord.Embed(
+        title=_embed_title(post.conditions_title or f"{label} — Hard Conditions"),
+        color=discord.Color.blurple(),
+    )
+    if row is None:
+        embed.description = _embed_description(
+            post.conditions_empty_description
+            or "No hard mode conditions are configured for that faction yet."
+        )
+        return embed
+    summary = _strip_visible_urls(row.get("challenge_summary"))
+    if summary:
+        embed.add_field(
+            name=_embed_title(
+                post.conditions_summary_field_title or "Challenge summary"
+            ),
+            value=_limit_text(summary, _FIELD_LIMIT),
+            inline=False,
+        )
+    solver_map = _fw_solver_rows(fw, post.category, faction_key)
+    stage_lines = []
+    solver_lines = []
+    for stage in range(1, 22):
+        condition = _strip_visible_urls(row.get(f"stage_{stage}"))
+        if condition:
+            stage_lines.append(f"{stage}: {condition}")
+        for solver in solver_map.get(stage, []):
+            parts = [
+                _strip_visible_urls(solver.get("condition")),
+                _strip_visible_urls(solver.get("solver_roles")),
+                _strip_visible_urls(solver.get("suggested_champions")),
+                _strip_visible_urls(solver.get("notes")),
+            ]
+            detail = " • ".join(part for part in parts if part)
+            if detail:
+                solver_lines.append(f"{stage} solver: {detail}")
+    combined_stage_lines = [*stage_lines, *solver_lines]
+    stages_value = _limited_bullets(combined_stage_lines, 25)
+    if stages_value:
+        embed.add_field(
+            name=_embed_title(post.conditions_stages_field_title or "Stage conditions"),
+            value=stages_value,
+            inline=False,
+        )
+    if not embed.fields:
+        embed.description = _embed_description(
+            post.conditions_empty_description
+            or "No hard mode condition details are configured for that faction yet."
+        )
+    return embed
+
+
+class FactionWarsStarModal(discord.ui.Modal):
+    def __init__(
+        self, post: ForumPost, faction_key: str, faction_label: str, max_stars: int
+    ) -> None:
+        super().__init__(
+            title=_limit_text(
+                post.counter_stars_modal_title or f"Set {faction_label} stars", 45
+            )
+        )
+        self.post = post
+        self.faction_key = faction_key
+        self.faction_label = faction_label
+        self.max_stars = max_stars
+        self.stars = discord.ui.TextInput(
+            label=_limit_text(
+                post.counter_stars_modal_value_label or "Saved stars", 45
+            ),
+            placeholder=f"0-{max_stars}",
+            required=True,
+            max_length=3,
+        )
+        self.add_item(self.stars)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = _text(self.stars.value)
+        try:
+            value = int(raw)
+        except ValueError:
+            await interaction.response.send_message(
+                embed=_progress_notice_embed(
+                    self.post,
+                    self.post.counter_stars_invalid_value_description
+                    or "Enter a whole number of stars.",
+                ),
+                ephemeral=True,
+            )
+            return
+        if value < 0 or value > self.max_stars:
+            await interaction.response.send_message(
+                embed=_progress_notice_embed(
+                    self.post,
+                    self.post.counter_stars_invalid_value_description
+                    or f"Enter a star value from 0 to {self.max_stars}.",
+                ),
+                ephemeral=True,
+            )
+            return
+        await upsert_faction_wars_counter(
+            interaction.user.id,
+            self.post.category,
+            self.faction_key,
+            self.faction_label,
+            value,
+            self.max_stars,
+        )
+        saved_template = (
+            self.post.counter_stars_saved_description
+            or "Saved {current_value}/{goal_value} stars for {counter_label}."
+        )
+        saved_description = _format_template(
+            saved_template,
+            {
+                "counter_key": self.faction_key,
+                "counter_label": self.faction_label,
+                "current_value": value,
+                "goal_value": self.max_stars,
+                "category": self.post.category,
+                "category_label": self.post.label or self.post.category,
+            },
+        )
+        await interaction.response.send_message(
+            embed=_progress_notice_embed(self.post, saved_description),
+            ephemeral=True,
+        )
+
+
+class FactionWarsFactionSelect(discord.ui.Select):
+    def __init__(self, post: ForumPost, fw: FactionWarsData, kind: str) -> None:
+        self.post = post
+        self.kind = kind
+        options = [
+            discord.SelectOption(label=_select_label(label), value=key)
+            for key, label, _max_stars in _fw_faction_options(fw)[:25]
+        ]
+        placeholder = {
+            "stars": post.counter_stars_faction_select_placeholder,
+            "guide": post.faction_guide_select_placeholder,
+            "conditions": post.conditions_select_placeholder,
+        }.get(kind) or "Choose a faction…"
+        super().__init__(
+            placeholder=_select_label(placeholder),
+            options=options,
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FactionWarsFactionPickerView):
+            return
+        selected = self.values[0]
+        label, max_stars = _fw_faction_lookup(view.fw).get(selected, (selected, 63))
+        if view.kind == "stars":
+            await interaction.response.send_modal(
+                FactionWarsStarModal(view.post, selected, label, max_stars)
+            )
+            return
+        if view.kind == "guide":
+            embed = build_faction_wars_guide_embed(view.post, view.fw, selected)
+        else:
+            embed = build_faction_wars_conditions_embed(view.post, view.fw, selected)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class FactionWarsFactionPickerView(discord.ui.View):
+    def __init__(self, post: ForumPost, fw: FactionWarsData, kind: str) -> None:
+        super().__init__(timeout=900)
+        self.post = post
+        self.fw = fw
+        self.kind = kind
+        if _fw_faction_options(fw):
+            self.add_item(FactionWarsFactionSelect(post, fw, kind))
+
+
+async def upsert_faction_wars_counter(
+    user_id: int,
+    category: str,
+    counter_key: str,
+    counter_label: str,
+    current_value: int,
+    goal_value: int,
+) -> None:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab, rows = await _fw_user_counter_rows()
+    worksheet = await aget_worksheet(sheet_id, tab)
+    header = await _load_header(sheet_id, tab)
+    now = datetime.now(timezone.utc).isoformat()
+    values = {
+        "user_id": str(user_id),
+        "category": category,
+        "counter_key": counter_key,
+        "counter_label": counter_label,
+        "current_value": str(current_value),
+        "goal_value": str(goal_value),
+        "status": (
+            "complete" if goal_value and current_value >= goal_value else "in_progress"
+        ),
+        "notes": "",
+        "updated_at_utc": now,
+    }
+    found: tuple[int, Mapping[str, object]] | None = None
+    for row_number, row in enumerate(rows, start=2):
+        if (
+            _text(row.get("user_id")) == str(user_id)
+            and _text(row.get("category")) == category
+            and _text(row.get("counter_key")) == counter_key
+        ):
+            found = (row_number, row)
+            break
+    if found is None:
+        await acall_with_backoff(
+            worksheet.append_row,
+            [values.get(name, "") for name in header],
+            value_input_option="RAW",
+        )
+        return
+    row_number, existing = found
+    full_row = [
+        (
+            _text(existing.get(name))
+            if name == "notes"
+            else values.get(name, _text(existing.get(name)))
+        )
+        for name in header
+    ]
+    await acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(0)}{row_number}:{_column_label(len(header) - 1)}{row_number}",
+        [full_row],
+        value_input_option="RAW",
+    )
+
+
+class FactionWarsPanelButton(discord.ui.Button):
+    def __init__(self, category: str, label: str, kind: str) -> None:
+        self.category = category
+        self.kind = kind
+        prefixes = {
+            "stars": _FW_STARS_CUSTOM_ID_PREFIX,
+            "progress": _FW_PROGRESS_CUSTOM_ID_PREFIX,
+            "guide": _FW_GUIDE_CUSTOM_ID_PREFIX,
+            "conditions": _FW_CONDITIONS_CUSTOM_ID_PREFIX,
+        }
+        super().__init__(
+            label=_button_label(label),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{prefixes[kind]}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        post: ForumPost | None = None
+        try:
+            data = await get_or_load_progress_guide_data()
+            post = _post_for_category(self.category, data)
+            if post is None or self.category not in _FACTION_WARS_CATEGORIES:
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            if self.kind == "conditions" and self.category != _FW_HARD_CATEGORY:
+                await interaction.followup.send(
+                    embed=discord.Embed(
+                        title="Hard mode only",
+                        description="Conditions are only available for hard mode Faction Wars.",
+                        color=discord.Color.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            fw = await get_or_load_faction_wars_data()
+            if self.kind == "stars":
+                _tab, rows = await _fw_user_counter_rows()
+                user_rows = _fw_user_rows(rows, interaction.user.id, self.category)
+                await interaction.followup.send(
+                    embed=build_faction_wars_stars_embed(post, fw, user_rows),
+                    view=FactionWarsFactionPickerView(post, fw, "stars"),
+                    ephemeral=True,
+                )
+                return
+            if self.kind == "progress":
+                _tab, rows = await _fw_user_counter_rows()
+                user_rows = _fw_user_rows(rows, interaction.user.id, self.category)
+                await interaction.followup.send(
+                    embed=build_faction_wars_progress_embed(post, fw, user_rows),
+                    ephemeral=True,
+                )
+                return
+            view_kind = "guide" if self.kind == "guide" else "conditions"
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title=_embed_title(
+                        post.faction_guide_title
+                        if view_kind == "guide"
+                        else post.conditions_title
+                    )
+                    or "Choose a faction",
+                    description="Choose a faction to view details.",
+                    color=discord.Color.blurple(),
+                ),
+                view=FactionWarsFactionPickerView(post, fw, view_kind),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            if _is_quota_failure(exc):
+                await interaction.followup.send(
+                    embed=_progress_unavailable_embed(post), ephemeral=True
+                )
+                return
+            raise
+
+
+class FactionWarsPersistentView(discord.ui.View):
+    def __init__(self, categories: Sequence[str] = _FACTION_WARS_CATEGORIES) -> None:
+        super().__init__(timeout=None)
+        for category in categories:
+            self.add_item(FactionWarsPanelButton(category, "My Stars", "stars"))
+            self.add_item(FactionWarsPanelButton(category, "Progress", "progress"))
+            self.add_item(FactionWarsPanelButton(category, "Faction Guide", "guide"))
+            if category == _FW_HARD_CATEGORY:
+                self.add_item(
+                    FactionWarsPanelButton(category, "Conditions", "conditions")
+                )
+
+
+def _add_faction_wars_panel_buttons(view: discord.ui.View, post: ForumPost) -> bool:
+    if post.category not in _FACTION_WARS_CATEGORIES:
+        return False
+    view.add_item(
+        FactionWarsPanelButton(
+            post.category, post.counter_stars_button_label or "My Stars", "stars"
+        )
+    )
+    view.add_item(
+        FactionWarsPanelButton(
+            post.category, post.counter_progress_button_label or "Progress", "progress"
+        )
+    )
+    view.add_item(
+        FactionWarsPanelButton(
+            post.category, post.faction_guide_button_label or "Faction Guide", "guide"
+        )
+    )
+    if post.category == _FW_HARD_CATEGORY:
+        view.add_item(
+            FactionWarsPanelButton(
+                post.category,
+                post.conditions_button_label or "Conditions",
+                "conditions",
+            )
+        )
+    return True
+
+
 def build_help_embed(post: ForumPost) -> discord.Embed | None:
     if not (post.help_panel_title or post.help_panel_description):
         return None
@@ -2129,6 +2949,8 @@ def build_help_view(post: ForumPost, data: ProgressGuideData) -> discord.ui.View
         view.add_item(
             ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
         )
+        added = True
+    if _add_faction_wars_panel_buttons(view, post):
         added = True
     if _supports_missions(post):
         view.add_item(
@@ -2230,6 +3052,8 @@ def build_guide_view(
     view = discord.ui.View(timeout=None)
     added = False
     help_url = _safe_url(post.help_post_url)
+    if _add_faction_wars_panel_buttons(view, post):
+        added = True
     if _supports_missions(post):
         view.add_item(
             ProgressGuideMissionButton(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -3099,4 +3100,427 @@ def test_empty_plan_uses_no_items_description_and_my_progress_shortcut():
         "Set Progress",
         "Mark Mission Done",
         "Plan Ahead",
+    ]
+
+
+def _fw_data(category="FW_H"):
+    data = _data(
+        post_overrides={
+            "category": category,
+            "label": (
+                "Faction Wars Hard" if category == "FW_H" else "Faction Wars Normal"
+            ),
+            "guide_title": "Faction Wars",
+            "counter_stars_button_label": "Sheet My Stars",
+            "counter_progress_button_label": "Sheet Progress",
+            "faction_guide_button_label": "Sheet Faction Guide",
+            "conditions_button_label": "Sheet Conditions",
+            "counter_stars_title": "Sheet Stars Title",
+            "counter_stars_empty_description": "No sheet stars saved.",
+            "counter_stars_saved_description": "Stars saved for {counter_label}: {current_value}/{goal_value} in {category_label} ({counter_key}, {category}).",
+            "counter_stars_invalid_value_description": "Sheet invalid stars.",
+            "counter_stars_faction_select_placeholder": "Pick stars faction",
+            "counter_stars_modal_value_label": "Sheet Stars Value",
+            "counter_progress_title": "Sheet Progress Title",
+            "counter_progress_intro_template": "{category_label}: {current_value}/{goal_value} stars, {percent_complete}% done, {remaining_value} left.",
+            "counter_progress_empty_description": "No sheet progress saved.",
+            "counter_progress_footer": "Sheet progress footer.",
+            "counter_progress_finished_field_title": "Sheet Finished",
+            "counter_progress_close_field_title": "Sheet Close",
+            "counter_progress_focus_field_title": "Sheet Focus",
+            "faction_guide_title": "Sheet Faction Guide Title",
+            "faction_guide_select_placeholder": "Pick guide faction",
+            "faction_guide_champions_field_title": "Sheet Champions",
+            "faction_guide_roles_field_title": "Sheet Roles",
+            "faction_guide_accessible_field_title": "Sheet Accessible",
+            "faction_guide_note_field_title": "Sheet Note",
+            "faction_guide_empty_description": "Sheet guide empty.",
+            "conditions_title": "Sheet Conditions Title",
+            "conditions_select_placeholder": "Pick conditions faction",
+            "conditions_summary_field_title": "Sheet Summary",
+            "conditions_stages_field_title": "Sheet Stages",
+            "conditions_empty_description": "Sheet conditions empty.",
+        },
+        guides=[
+            {
+                "category": category,
+                "title": "Overview",
+                "body": "Beat crypt stages.",
+                "sort_order": "1",
+                "enabled": "TRUE",
+            }
+        ],
+    )
+    data.guides_by_category[category] = data.guides_by_category.pop("ARB")
+    data.faq_by_category[category] = data.faq_by_category.pop("ARB")
+    return data
+
+
+def _fw_static_data():
+    return service.FactionWarsData(
+        factions=[
+            {
+                "faction_key": "banner_lords",
+                "name": "Banner Lords",
+                "stages": "21",
+                "stars_per_stage": "3",
+                "max_stars": "63",
+            },
+            {
+                "faction_key": "high_elves",
+                "name": "High Elves",
+                "stages": "21",
+                "stars_per_stage": "3",
+                "max_stars": "63",
+            },
+            {
+                "faction_key": "orcs",
+                "name": "Orcs",
+                "stages": "21",
+                "stars_per_stage": "3",
+                "max_stars": "63",
+            },
+        ],
+        champion_guides=[
+            {
+                "category": "FW_H",
+                "mode": "hard",
+                "faction_key": "banner_lords",
+                "faction_name": "Banner Lords",
+                "recommended_champions": "Ragash, Baron",
+                "core_roles": "Revive, decrease ATK",
+                "accessible_options": "Stag Knight, Valerie",
+                "planning_note": "Build control first.",
+                "enabled": "TRUE",
+            }
+        ],
+        hard_stage_conditions=[
+            {
+                "category": "FW_H",
+                "mode": "hard",
+                "faction_key": "banner_lords",
+                "faction_name": "Banner Lords",
+                "stage_1": "Use only Rare champions.",
+                "stage_2": "No support champions.",
+                "stage_21": "No revives.",
+                "challenge_summary": "Hard conditions rotate by stage.",
+                "enabled": "TRUE",
+            }
+        ],
+        hard_stage_solvers=[
+            {
+                "category": "FW_H",
+                "mode": "hard",
+                "faction_key": "banner_lords",
+                "faction_name": "Banner Lords",
+                "stage_number": "21",
+                "condition": "No revives.",
+                "solver_roles": "Shields and control",
+                "suggested_champions": "Ragash",
+                "notes": "Manual boss wave.",
+                "enabled": "TRUE",
+            }
+        ],
+    )
+
+
+def test_fw_guide_view_uses_sheet_labels_and_hard_conditions_only():
+    hard = _fw_data("FW_H")
+    hard_view = service.build_guide_view(hard.posts[0], hard)
+    assert [getattr(i, "label", "") for i in hard_view.children[:4]] == [
+        "Sheet My Stars",
+        "Sheet Progress",
+        "Sheet Faction Guide",
+        "Sheet Conditions",
+    ]
+    assert [getattr(i, "custom_id", "") for i in hard_view.children[:4]] == [
+        "progressguides:fwstars:FW_H",
+        "progressguides:fwprogress:FW_H",
+        "progressguides:fwguide:FW_H",
+        "progressguides:fwconditions:FW_H",
+    ]
+
+    normal = _fw_data("FW_N")
+    normal_view = service.build_guide_view(normal.posts[0], normal)
+    normal_ids = [getattr(i, "custom_id", "") for i in normal_view.children]
+    assert "progressguides:fwstars:FW_N" in normal_ids
+    assert "progressguides:fwprogress:FW_N" in normal_ids
+    assert "progressguides:fwguide:FW_N" in normal_ids
+    assert "progressguides:fwconditions:FW_N" not in normal_ids
+
+
+def test_fw_my_stars_reads_progress_user_counters(monkeypatch):
+    data = _fw_data("FW_H")
+    service.set_progress_guide_cache(data)
+    service._FW_DATA_CACHE = _fw_static_data()
+    calls = []
+
+    async def require_value(key):
+        calls.append(("config", key))
+        return {"PROGRESS_USER_COUNTERS_TAB": "ProgressUserCounters"}[key]
+
+    async def fetch_records(_sheet, tab):
+        calls.append(("tab", tab))
+        return [
+            {
+                "user_id": "123456",
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "counter_label": "Banner Lords",
+                "current_value": "61",
+                "goal_value": "63",
+                "status": "in_progress",
+                "notes": "",
+                "updated_at_utc": "",
+            },
+            {
+                "user_id": "999",
+                "category": "FW_H",
+                "counter_key": "orcs",
+                "counter_label": "Orcs",
+                "current_value": "63",
+                "goal_value": "63",
+            },
+        ]
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", require_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+
+    interaction = FakeInteraction()
+    asyncio.run(
+        service.FactionWarsPanelButton("FW_H", "Sheet My Stars", "stars").callback(
+            interaction
+        )
+    )
+
+    assert calls == [
+        ("config", "PROGRESS_USER_COUNTERS_TAB"),
+        ("tab", "ProgressUserCounters"),
+    ]
+    embed = interaction.followup.sent[0]["embed"]
+    assert embed.title == "Sheet Stars Title"
+    assert "Banner Lords: 61/63" in embed.description
+    assert "Orcs" not in embed.description
+    assert (
+        interaction.followup.sent[0]["view"].children[0].placeholder
+        == "Pick stars faction"
+    )
+
+
+def test_fw_star_save_appends_and_updates_by_headers(monkeypatch):
+    header = [
+        "user_id",
+        "category",
+        "counter_key",
+        "counter_label",
+        "current_value",
+        "goal_value",
+        "status",
+        "notes",
+        "updated_at_utc",
+    ]
+    worksheet = FakeWorksheet()
+    rows = []
+
+    async def user_rows():
+        return "ProgressUserCounters", rows
+
+    async def get_ws(_sheet, _tab):
+        return worksheet
+
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_fw_user_counter_rows", user_rows)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(
+        service, "_load_header", lambda *_args: asyncio.sleep(0, result=header)
+    )
+    monkeypatch.setattr(
+        service,
+        "acall_with_backoff",
+        lambda func, *a, **kw: asyncio.sleep(
+            0, result=func(*a, **{k: v for k, v in kw.items() if k != "attempts"})
+        ),
+    )
+
+    asyncio.run(
+        service.upsert_faction_wars_counter(
+            123456, "FW_H", "banner_lords", "Banner Lords", 61, 63
+        )
+    )
+    assert worksheet.appended[0][0][:7] == [
+        "123456",
+        "FW_H",
+        "banner_lords",
+        "Banner Lords",
+        "61",
+        "63",
+        "in_progress",
+    ]
+
+    rows[:] = [
+        {
+            "user_id": "123456",
+            "category": "FW_H",
+            "counter_key": "banner_lords",
+            "counter_label": "Banner Lords",
+            "current_value": "61",
+            "goal_value": "63",
+            "status": "in_progress",
+            "notes": "keep this",
+            "updated_at_utc": "old",
+        }
+    ]
+    asyncio.run(
+        service.upsert_faction_wars_counter(
+            123456, "FW_H", "banner_lords", "Banner Lords", 63, 63
+        )
+    )
+    assert worksheet.updates[0][0] == "A2:I2"
+    assert worksheet.updates[0][1][0][:8] == [
+        "123456",
+        "FW_H",
+        "banner_lords",
+        "Banner Lords",
+        "63",
+        "63",
+        "complete",
+        "keep this",
+    ]
+
+
+def test_fw_star_modal_uses_value_label_and_formats_messages(monkeypatch):
+    post = _fw_data("FW_H").posts[0]
+    modal = service.FactionWarsStarModal(post, "banner_lords", "Banner Lords", 63)
+    assert modal.stars.label == "Sheet Stars Value"
+
+    saved = []
+
+    async def save(*args):
+        saved.append(args)
+
+    monkeypatch.setattr(service, "upsert_faction_wars_counter", save)
+    interaction = FakeInteraction()
+    modal.stars._value = "62"
+    asyncio.run(modal.on_submit(interaction))
+
+    assert saved == [(123456, "FW_H", "banner_lords", "Banner Lords", 62, 63)]
+    description = interaction.response.sent[0]["embed"].description
+    assert description == (
+        "Stars saved for Banner Lords: 62/63 in Faction Wars Hard "
+        "(banner_lords, FW_H)."
+    )
+    assert "{counter_label}" not in description
+
+
+def test_fw_star_modal_invalid_input_uses_configured_text():
+    post = _fw_data("FW_H").posts[0]
+    modal = service.FactionWarsStarModal(post, "banner_lords", "Banner Lords", 63)
+    interaction = FakeInteraction()
+    modal.stars._value = "many"
+
+    asyncio.run(modal.on_submit(interaction))
+
+    assert interaction.response.sent[0]["embed"].description == "Sheet invalid stars."
+
+
+def test_fw_progress_summary_uses_saved_user_counters():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "user_id": "123456",
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "counter_label": "Banner Lords",
+                "current_value": "63",
+                "goal_value": "63",
+            },
+            {
+                "user_id": "123456",
+                "category": "FW_H",
+                "counter_key": "high_elves",
+                "counter_label": "High Elves",
+                "current_value": "61",
+                "goal_value": "63",
+            },
+        ],
+    )
+    fields = {field.name: field.value for field in embed.fields}
+    assert embed.description == "Faction Wars Hard: 124/189 stars, 65.6% done, 65 left."
+    assert embed.footer.text == "Sheet progress footer."
+    assert "Banner Lords: 63/63" in fields["Sheet Finished"]
+    assert "High Elves: 61/63" in fields["Sheet Close"]
+    assert "Orcs: 0/63" in fields["Sheet Focus"]
+
+
+def test_fw_faction_guide_uses_live_headers_and_sheet_field_titles():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_guide_embed(
+        post, _fw_static_data(), "banner_lords"
+    )
+    fields = {field.name: field.value for field in embed.fields}
+    assert embed.title == "Sheet Faction Guide Title"
+    assert fields["Sheet Champions"] == "Ragash, Baron"
+    assert fields["Sheet Roles"] == "Revive, decrease ATK"
+    assert fields["Sheet Accessible"] == "Stag Knight, Valerie"
+    assert fields["Sheet Note"] == "Build control first."
+
+
+def test_fw_conditions_uses_stage_columns_and_solver_stage_number():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_conditions_embed(
+        post, _fw_static_data(), "banner_lords"
+    )
+    fields = {field.name: field.value for field in embed.fields}
+    assert embed.title == "Sheet Conditions Title"
+    assert fields["Sheet Summary"] == "Hard conditions rotate by stage."
+    assert "1: Use only Rare champions." in fields["Sheet Stages"]
+    assert "2: No support champions." in fields["Sheet Stages"]
+    assert "21: No revives." in fields["Sheet Stages"]
+    assert (
+        "21 solver: No revives. • Shields and control • Ragash • Manual boss wave."
+        in fields["Sheet Stages"]
+    )
+
+
+def test_fw_empty_states_use_configured_copy():
+    post = _fw_data("FW_H").posts[0]
+    fw = _fw_static_data()
+
+    guide = service.build_faction_wars_guide_embed(post, fw, "orcs")
+    conditions = service.build_faction_wars_conditions_embed(post, fw, "orcs")
+    progress = service.build_faction_wars_progress_embed(post, fw, [])
+
+    assert guide.description == "Sheet guide empty."
+    assert conditions.description == "Sheet conditions empty."
+    assert progress.description == "No sheet progress saved."
+
+
+def test_fw_cleanup_has_no_invented_progress_forum_post_fields():
+    forbidden = [
+        "counter_stars_modal_" + "label",
+        "faction_guide_recommended_" + "field_title",
+        "faction_guide_planning_" + "field_title",
+        "counter_progress_total_" + "field_title",
+        "conditions_solvers_" + "field_title",
+    ]
+    service_text = Path("modules/community/progress_guides/service.py").read_text()
+    test_text = Path("tests/community/test_progress_guides.py").read_text()
+    for field in forbidden:
+        assert field not in service_text
+        assert field not in test_text
+
+
+def test_faction_wars_persistent_view_has_no_startup_sheet_reads(monkeypatch):
+    async def forbidden(*_args, **_kwargs):
+        raise AssertionError("startup must not read sheets")
+
+    monkeypatch.setattr(service, "afetch_records", forbidden)
+    bot = FakeBot()
+    ProgressGuidesCog(bot)
+    assert "progressguides:fwstars:FW_H" in [
+        getattr(item, "custom_id", "") for view in bot.views for item in view.children
     ]


### PR DESCRIPTION
### Motivation
- Provide first-class Faction Wars support in progress guides so users can view and save per-faction stars, see overall progress, and view champion guides and hard-mode conditions from Google Sheets.
- Expose persistent UI buttons for Faction Wars (normal and hard) on guide/help panels without triggering sheet reads at startup.
- Persist and update per-user counters in the milestones sheet and present user-facing modals and picker views for interaction.
- Reuse existing progress guide patterns (embeds, views, caching) to keep feature consistent with other guide panels.

### Description
- Added new sheet keys and constants for Faction Wars (`_FW_*` keys) and new top-level dataclass `FactionWarsData` plus a dedicated cache `_FW_DATA_CACHE` and loader `get_or_load_faction_wars_data`.
- Implemented embed builders `build_faction_wars_stars_embed`, `build_faction_wars_progress_embed`, `build_faction_wars_guide_embed`, and `build_faction_wars_conditions_embed` with formatting helper `_format_template` and various helpers for faction lookup and filtering.
- Added interactive UI: `FactionWarsStarModal` for entering stars, `FactionWarsFactionSelect` and `FactionWarsFactionPickerView` for choosing factions, `FactionWarsPanelButton` for per-panel actions, and `FactionWarsPersistentView` registered on startup in `ProgressGuidesCog`.
- Implemented sheet persistence via `upsert_faction_wars_counter` and integrated Faction Wars buttons into guide/help views via `_add_faction_wars_panel_buttons` and guarded hard-mode-only behavior.
- Updated tests and test utilities: added Faction Wars-specific unit tests in `tests/community/test_progress_guides.py` and a small import (`Path`) for test assertions.

### Testing
- Ran the progress guides unit tests with `pytest tests/community/test_progress_guides.py` and the new Faction Wars tests passed.
- Tests cover UI composition (`build_guide_view`), read path for user counters, `upsert_faction_wars_counter` append/update behavior, `FactionWarsStarModal` value handling and messages, progress summary aggregation, champion guide and conditions rendering, empty-state copy, and that persistent view registration does not perform startup sheet reads.
- Existing progress guides tests were left intact and continued to pass locally when running the updated test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a4b76d0cc8323b9324cefec4fbb52)