### PR TITLE
Clean up Faction Wars help buttons

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -2900,7 +2900,7 @@ class FactionWarsPersistentView(discord.ui.View):
                 )
 
 
-def _add_faction_wars_panel_buttons(view: discord.ui.View, post: ForumPost) -> bool:
+def _add_faction_wars_main_buttons(view: discord.ui.View, post: ForumPost) -> bool:
     if post.category not in _FACTION_WARS_CATEGORIES:
         return False
     view.add_item(
@@ -2913,6 +2913,25 @@ def _add_faction_wars_panel_buttons(view: discord.ui.View, post: ForumPost) -> b
             post.category, post.counter_progress_button_label or "Progress", "progress"
         )
     )
+    view.add_item(
+        FactionWarsPanelButton(
+            post.category, post.faction_guide_button_label or "Faction Guide", "guide"
+        )
+    )
+    if post.category == _FW_HARD_CATEGORY:
+        view.add_item(
+            FactionWarsPanelButton(
+                post.category,
+                post.conditions_button_label or "Conditions",
+                "conditions",
+            )
+        )
+    return True
+
+
+def _add_faction_wars_help_buttons(view: discord.ui.View, post: ForumPost) -> bool:
+    if post.category not in _FACTION_WARS_CATEGORIES:
+        return False
     view.add_item(
         FactionWarsPanelButton(
             post.category, post.faction_guide_button_label or "Faction Guide", "guide"
@@ -2950,7 +2969,7 @@ def build_help_view(post: ForumPost, data: ProgressGuideData) -> discord.ui.View
             ProgressGuideFAQButton(post.category, post.faq_button_label or "FAQ")
         )
         added = True
-    if _add_faction_wars_panel_buttons(view, post):
+    if _add_faction_wars_help_buttons(view, post):
         added = True
     if _supports_missions(post):
         view.add_item(
@@ -3052,7 +3071,7 @@ def build_guide_view(
     view = discord.ui.View(timeout=None)
     added = False
     help_url = _safe_url(post.help_post_url)
-    if _add_faction_wars_panel_buttons(view, post):
+    if _add_faction_wars_main_buttons(view, post):
         added = True
     if _supports_missions(post):
         view.add_item(

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -3249,6 +3249,39 @@ def test_fw_guide_view_uses_sheet_labels_and_hard_conditions_only():
     assert "progressguides:fwconditions:FW_N" not in normal_ids
 
 
+def test_fw_help_view_uses_sheet_labels_without_user_progress_actions():
+    hard = _fw_data("FW_H")
+    hard.posts[0].guide_post_url = "https://discord.com/channels/1/2/333"
+    hard_view = service.build_help_view(hard.posts[0], hard)
+    hard_labels = [getattr(i, "label", "") for i in hard_view.children]
+    hard_ids = [getattr(i, "custom_id", "") for i in hard_view.children]
+    assert hard_labels == [
+        "Read FAQ",
+        "Sheet Faction Guide",
+        "Sheet Conditions",
+        "Back to Guide",
+    ]
+    assert "progressguides:fwstars:FW_H" not in hard_ids
+    assert "progressguides:fwprogress:FW_H" not in hard_ids
+    assert "progressguides:fwguide:FW_H" in hard_ids
+    assert "progressguides:fwconditions:FW_H" in hard_ids
+
+    normal = _fw_data("FW_N")
+    normal.posts[0].guide_post_url = "https://discord.com/channels/1/2/444"
+    normal_view = service.build_help_view(normal.posts[0], normal)
+    normal_labels = [getattr(i, "label", "") for i in normal_view.children]
+    normal_ids = [getattr(i, "custom_id", "") for i in normal_view.children]
+    assert normal_labels == [
+        "Read FAQ",
+        "Sheet Faction Guide",
+        "Back to Guide",
+    ]
+    assert "progressguides:fwstars:FW_N" not in normal_ids
+    assert "progressguides:fwprogress:FW_N" not in normal_ids
+    assert "progressguides:fwguide:FW_N" in normal_ids
+    assert "progressguides:fwconditions:FW_N" not in normal_ids
+
+
 def test_fw_my_stars_reads_progress_user_counters(monkeypatch):
     data = _fw_data("FW_H")
     service.set_progress_guide_cache(data)


### PR DESCRIPTION
### Motivation
- The Faction Wars help embeds exposed user progress actions (`My Stars`, `Progress`) which should only appear on the main guide panel, not in help threads.
- Keep sheet-driven labels and hard-mode-only `Conditions` behavior while making the help view smaller and focused on navigation/help actions.

### Description
- Split the Faction Wars button assembly into two helpers: ` _add_faction_wars_main_buttons` for the main guide panel and `_add_faction_wars_help_buttons` for help embeds, so progress actions are not added to help views.
- Updated `build_help_view()` to use the new help-only helper and left `build_guide_view()` using the main helper so persistent view registration and runtime behavior are unchanged.
- Preserved sheet-driven labels for `Faction Guide` and `Conditions`, and kept `Conditions` restricted to `FW_H` only.
- Modified tests to add coverage for help-view behavior and ensure the main guide still includes `My Stars` and `Progress` while help embeds do not; changed files: `modules/community/progress_guides/service.py` and `tests/community/test_progress_guides.py`.

### Testing
- Ran `python -m black modules/community/progress_guides/service.py tests/community/test_progress_guides.py` which completed successfully.
- Ran `pytest -q tests/community/test_progress_guides.py` which passed; the new test `test_fw_help_view_uses_sheet_labels_without_user_progress_actions` verifies FW_H and FW_N help-view button sets and succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues and there were no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5289ec0483238bd4a73fea4b2f8f)