### PR TITLE
Add boss solver support and hints to Faction Wars progress; show status icons for stars

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -62,6 +62,7 @@ _FW_FACTIONS_KEY = "PROGRESS_FW_FACTIONS_TAB"
 _FW_CHAMPION_GUIDES_KEY = "PROGRESS_FW_CHAMPION_GUIDES_TAB"
 _FW_HARD_STAGE_CONDITIONS_KEY = "PROGRESS_FW_HARD_STAGE_CONDITIONS_TAB"
 _FW_HARD_STAGE_SOLVERS_KEY = "PROGRESS_FW_HARD_STAGE_SOLVERS_TAB"
+_FW_BOSS_SOLVERS_KEY = "PROGRESS_FW_BOSS_SOLVERS_TAB"
 _MISSIONS_PER_PAGE = 15
 _PICKER_OPTIONS_PER_PAGE = 25
 _FAQ_OPTIONS_PER_PAGE = 25
@@ -2234,6 +2235,7 @@ class FactionWarsData:
     champion_guides: list[Mapping[str, object]]
     hard_stage_conditions: list[Mapping[str, object]]
     hard_stage_solvers: list[Mapping[str, object]]
+    boss_solvers: list[Mapping[str, object]]
 
 
 async def get_or_load_faction_wars_data() -> FactionWarsData:
@@ -2249,6 +2251,7 @@ async def get_or_load_faction_wars_data() -> FactionWarsData:
             milestones_config.arequire_value(_FW_CHAMPION_GUIDES_KEY),
             milestones_config.arequire_value(_FW_HARD_STAGE_CONDITIONS_KEY),
             milestones_config.arequire_value(_FW_HARD_STAGE_SOLVERS_KEY),
+            milestones_config.arequire_value(_FW_BOSS_SOLVERS_KEY),
         )
         rows = await _gather_rows(sheet_id, *tabs)
         _FW_DATA_CACHE = FactionWarsData(*rows)
@@ -2281,7 +2284,7 @@ def _fw_row_matches_category(row: Mapping[str, object], category: str) -> bool:
     if row_category and row_category != category:
         return False
     row_mode = _text(row.get("mode")).casefold()
-    return not row_mode or row_mode == _fw_mode(category)
+    return not row_mode or row_mode == "any" or row_mode == _fw_mode(category)
 
 
 def _fw_faction_key(row: Mapping[str, object]) -> str:
@@ -2383,15 +2386,93 @@ def build_faction_wars_stars_embed(
         stars = _fw_counter_value(row)
         goal = _fw_goal_value(row, fallback_goal)
         total += stars
-        status = _text(row.get("status"))
-        suffix = f" — {status}" if status else ""
-        lines.append(f"- {label}: {stars}/{goal}⭐{suffix}")
+        status = _text(row.get("status")).casefold()
+        icon = "✅" if status == "complete" or stars >= goal else "⏳"
+        lines.append(f"- {icon} {label}: {stars}/{goal}⭐")
     description = f"Total saved stars: **{total}**\n\n" + "\n".join(lines)
     return discord.Embed(
         title=_embed_title(title),
         description=_embed_description(description),
         color=discord.Color.blurple(),
     )
+
+
+def _fw_estimated_next_stage(current_stars: int, goal_stars: int) -> int | None:
+    if goal_stars <= 0 or current_stars >= goal_stars:
+        return None
+    return min((current_stars // 3) + 1, 21)
+
+
+def _fw_row_matches_mode(row: Mapping[str, object], category: str) -> bool:
+    row_mode = _text(row.get("mode")).casefold()
+    return not row_mode or row_mode == "any" or row_mode == _fw_mode(category)
+
+
+def _fw_boss_solver_row(
+    fw: FactionWarsData, category: str, faction_key: str, boss_stage: int
+) -> Mapping[str, object] | None:
+    if boss_stage not in {7, 14, 21}:
+        return None
+    return next(
+        (
+            row
+            for row in _fw_enabled_rows(fw.boss_solvers)
+            if _fw_row_matches_category(row, category)
+            and _fw_row_matches_mode(row, category)
+            and _fw_faction_key(row) == faction_key
+            and _int_or_none(row.get("boss_stage")) == boss_stage
+        ),
+        None,
+    )
+
+
+def _fw_hard_solver_hint(
+    fw: FactionWarsData, category: str, faction_key: str, stage: int
+) -> str:
+    if category != _FW_HARD_CATEGORY:
+        return ""
+    solver = next(iter(_fw_solver_rows(fw, category, faction_key).get(stage, [])), None)
+    if solver is None:
+        return ""
+    parts = [
+        _strip_visible_urls(solver.get("condition")),
+        _strip_visible_urls(solver.get("solver_roles")),
+        _strip_visible_urls(solver.get("suggested_champions")),
+    ]
+    detail = " • ".join(part for part in parts if part)
+    return _limit_text(f"Stage {stage}: {detail}", 180) if detail else ""
+
+
+def _fw_boss_solver_hint(
+    fw: FactionWarsData, category: str, faction_key: str, stage: int
+) -> str:
+    row = _fw_boss_solver_row(fw, category, faction_key, stage)
+    if row is None:
+        return ""
+    parts = [
+        _strip_visible_urls(row.get("boss_type")),
+        _strip_visible_urls(row.get("recommended_roles")),
+        _strip_visible_urls(row.get("strategy_note")),
+    ]
+    detail = " • ".join(part for part in parts if part)
+    return _limit_text(f"Boss {stage}: {detail}", 180) if detail else ""
+
+
+def _fw_focus_line(
+    fw: FactionWarsData, category: str, key: str, label: str, current: int, goal: int
+) -> str:
+    line = f"{label}: {current}/{goal}⭐"
+    stage = _fw_estimated_next_stage(current, goal)
+    if stage is None:
+        return line
+    hints = [
+        _fw_hard_solver_hint(fw, category, key, stage),
+        _fw_boss_solver_hint(fw, category, key, stage),
+    ]
+    hints = [hint for hint in hints if hint]
+    if hints:
+        line += "\n" + "\n".join(hints)
+    return line
 
 
 def build_faction_wars_progress_embed(
@@ -2464,7 +2545,11 @@ def build_faction_wars_progress_embed(
     embed.add_field(
         name=_embed_title(post.counter_progress_focus_field_title or "Focus factions"),
         value=_limited_bullets(
-            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in focus], 8
+            [
+                _fw_focus_line(fw, post.category, key, label, current, goal)
+                for key, label, current, goal in focus
+            ],
+            8,
         )
         or "All tracked factions are complete.",
         inline=False,

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -3221,6 +3221,36 @@ def _fw_static_data():
                 "enabled": "TRUE",
             }
         ],
+        boss_solvers=[
+            {
+                "category": "FW_H",
+                "mode": "any",
+                "faction_key": "banner_lords",
+                "faction_name": "Banner Lords",
+                "boss_stage": "21",
+                "boss_type": "Health-swap boss",
+                "boss_problem": "Sustain pressure",
+                "recommended_roles": "Shield and control",
+                "strategy_note": "Save cooldowns",
+                "accessible_options": "Valerie",
+                "source_url": "https://boss.example/hide",
+                "enabled": "TRUE",
+            },
+            {
+                "category": "FW_N",
+                "mode": "normal",
+                "faction_key": "high_elves",
+                "faction_name": "High Elves",
+                "boss_stage": "7",
+                "boss_type": "Turn meter boss",
+                "boss_problem": "Turn meter cuts",
+                "recommended_roles": "Decrease speed",
+                "strategy_note": "Control the boss",
+                "accessible_options": "Apothecary",
+                "source_url": "https://normal.example/hide",
+                "enabled": "TRUE",
+            },
+        ],
     )
 
 
@@ -3457,6 +3487,39 @@ def test_fw_star_modal_invalid_input_uses_configured_text():
     assert interaction.response.sent[0]["embed"].description == "Sheet invalid stars."
 
 
+def test_fw_my_stars_uses_status_icons_without_raw_status_text():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_stars_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "user_id": "123456",
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "counter_label": "Banner Lords",
+                "current_value": "63",
+                "goal_value": "63",
+                "status": "complete",
+            },
+            {
+                "user_id": "123456",
+                "category": "FW_H",
+                "counter_key": "high_elves",
+                "counter_label": "High Elves",
+                "current_value": "60",
+                "goal_value": "63",
+                "status": "in_progress",
+            },
+        ],
+    )
+
+    assert "- ✅ Banner Lords: 63/63⭐" in embed.description
+    assert "- ⏳ High Elves: 60/63⭐" in embed.description
+    assert "complete" not in embed.description
+    assert "in_progress" not in embed.description
+
+
 def test_fw_progress_summary_uses_saved_user_counters():
     post = _fw_data("FW_H").posts[0]
     embed = service.build_faction_wars_progress_embed(
@@ -3557,3 +3620,139 @@ def test_faction_wars_persistent_view_has_no_startup_sheet_reads(monkeypatch):
     assert "progressguides:fwstars:FW_H" in [
         getattr(item, "custom_id", "") for view in bot.views for item in view.children
     ]
+
+
+def test_fw_data_loads_boss_solvers_from_configured_header_tab(monkeypatch):
+    service._FW_DATA_CACHE = None
+    calls = []
+
+    async def require_value(key):
+        calls.append(("config", key))
+        return {
+            "PROGRESS_FW_FACTIONS_TAB": "FWFactions",
+            "PROGRESS_FW_CHAMPION_GUIDES_TAB": "FWChampionGuides",
+            "PROGRESS_FW_HARD_STAGE_CONDITIONS_TAB": "FWHardStageConditions",
+            "PROGRESS_FW_HARD_STAGE_SOLVERS_TAB": "FWHardStageSolvers",
+            "PROGRESS_FW_BOSS_SOLVERS_TAB": "ConfiguredBossSolvers",
+        }[key]
+
+    async def fetch_records(_sheet, tab):
+        calls.append(("tab", tab))
+        if tab == "ConfiguredBossSolvers":
+            return [
+                {
+                    "category": "FW_N",
+                    "mode": "normal",
+                    "faction_key": "high_elves",
+                    "boss_stage": "7",
+                    "boss_type": "Turn meter boss",
+                    "enabled": "TRUE",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(service.milestones_config, "arequire_value", require_value)
+    monkeypatch.setattr(service, "afetch_records", fetch_records)
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+
+    fw = asyncio.run(service.get_or_load_faction_wars_data())
+
+    assert fw.boss_solvers[0]["boss_type"] == "Turn meter boss"
+    assert calls == [
+        ("config", "PROGRESS_FW_FACTIONS_TAB"),
+        ("config", "PROGRESS_FW_CHAMPION_GUIDES_TAB"),
+        ("config", "PROGRESS_FW_HARD_STAGE_CONDITIONS_TAB"),
+        ("config", "PROGRESS_FW_HARD_STAGE_SOLVERS_TAB"),
+        ("config", "PROGRESS_FW_BOSS_SOLVERS_TAB"),
+        ("tab", "FWFactions"),
+        ("tab", "FWChampionGuides"),
+        ("tab", "FWHardStageConditions"),
+        ("tab", "FWHardStageSolvers"),
+        ("tab", "ConfiguredBossSolvers"),
+    ]
+
+
+def test_fw_normal_progress_shows_matching_boss_tip_for_boss_stage_only():
+    post = _fw_data("FW_N").posts[0]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_N",
+                "counter_key": "high_elves",
+                "current_value": "18",
+                "goal_value": "63",
+            }
+        ],
+    )
+    focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
+
+    assert "High Elves: 18/63" in focus
+    assert " — " not in focus
+    assert "\nBoss 7: Turn meter boss • Decrease speed • Control the boss" in focus
+    assert "Turn meter cuts" not in focus
+    assert "Apothecary" not in focus
+    assert "normal.example" not in focus
+
+    no_tip = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_N",
+                "counter_key": "high_elves",
+                "current_value": "21",
+                "goal_value": "63",
+            }
+        ],
+    )
+    no_tip_focus = {field.name: field.value for field in no_tip.fields}["Sheet Focus"]
+    assert "High Elves: 21/63" in no_tip_focus
+    assert "Boss 7:" not in no_tip_focus
+
+
+def test_fw_hard_progress_combines_hard_solver_and_boss_tip_without_notes():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "current_value": "60",
+                "goal_value": "63",
+            }
+        ],
+    )
+    focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
+
+    assert " — " not in focus
+    assert "\nStage 21: No revives. • Shields and control • Ragash" in focus
+    assert "\nBoss 21: Health-swap boss • Shield and control • Save cooldowns" in focus
+    assert "Sustain pressure" not in focus
+    assert "Valerie" not in focus
+    assert "boss.example" not in focus
+    assert "Manual boss wave" not in focus
+
+
+def test_fw_progress_does_not_fallback_to_earlier_boss_stage():
+    post = _fw_data("FW_N").posts[0]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_N",
+                "counter_key": "high_elves",
+                "current_value": "39",
+                "goal_value": "63",
+            }
+        ],
+    )
+    focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
+
+    assert "High Elves: 39/63" in focus
+    assert "Boss 7:" not in focus
+    assert "Boss 14:" not in focus


### PR DESCRIPTION
### Motivation
- Extend Faction Wars data to include boss-specific solver tips and display them in progress/focus views. 
- Improve star listing readability by replacing raw status text with simple completion icons. 

### Description
- Add `_FW_BOSS_SOLVERS_KEY` config key and a `boss_solvers` field to `FactionWarsData`, and load the configured boss solvers tab in `get_or_load_faction_wars_data`. 
- Add boss solver lookup and hinting helpers: `_fw_estimated_next_stage`, `_fw_row_matches_mode`, `_fw_boss_solver_row`, `_fw_hard_solver_hint`, `_fw_boss_solver_hint`, and combine hints in `_fw_focus_line` which is used in the progress embed. 
- Change `_fw_row_matches_category` to treat a `mode` of `"any"` as a match so boss solver rows with `mode: any` apply correctly. 
- Replace raw `status` text in `build_faction_wars_stars_embed` with icons (`✅` / `⏳`) based on completeness. 

### Testing
- Ran the progress guides unit tests in `tests/community/test_progress_guides.py`, including newly added tests `test_fw_my_stars_uses_status_icons_without_raw_status_text`, `test_fw_data_loads_boss_solvers_from_configured_header_tab`, `test_fw_normal_progress_shows_matching_boss_tip_for_boss_stage_only`, `test_fw_hard_progress_combines_hard_solver_and_boss_tip_without_notes`, and `test_fw_progress_does_not_fallback_to_earlier_boss_stage`.
- All targeted tests completed successfully (no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b686233748323aa0e3ec0f8e15f3f)