### PR TITLE
Add Guides & Help forum tag index (scheduler + admin commands)

### DIFF
--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -16,6 +16,7 @@ from modules.common import feature_flags, runtime as runtime_helpers
 from modules.common.discord_utils import resolve_message_target
 from modules.common.logs import channel_label
 from modules.ops import cluster_role_map, server_map
+from modules.housekeeping import guides_help_index
 from shared.config import get_who_we_are_channel_id
 from shared.sheets import recruitment as recruitment_sheet
 
@@ -36,6 +37,7 @@ HOUSEKEEPING_JOBS = {
     "server_map_refresh",
     "cleanup_watcher",
     "housekeeping_keepalive",
+    "guides_help_index_refresh",
 }
 GROUP_ORDER = ("Cache Refresh", "recruitment", "housekeeping", "other")
 
@@ -291,6 +293,52 @@ class AppAdmin(commands.Cog):
         reason = result.reason or "unknown"
         await ctx.reply(
             f"Server map refresh failed ({reason}). Check logs for details.",
+            mention_author=False,
+        )
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational",
+        section="utilities",
+        access_tier="admin",
+    )
+    @commands.group(
+        name="guideshelpindex",
+        invoke_without_command=True,
+        hidden=True,
+        help="Admin tools for the automated Guides & Help tag index.",
+    )
+    @admin_only()
+    async def guideshelpindex(self, ctx: commands.Context) -> None:
+        if ctx.invoked_subcommand is not None:
+            return
+        await ctx.reply("Usage: !guideshelpindex refresh", mention_author=False)
+
+    @guideshelpindex.command(
+        name="refresh",
+        help="Rebuild the Guides & Help forum-tag index immediately from Discord.",
+    )
+    @admin_only()
+    async def guideshelpindex_refresh(self, ctx: commands.Context) -> None:
+        result = await guides_help_index.refresh_guides_help_index(
+            self.bot, force=True, actor="command"
+        )
+        if result.status == "ok":
+            await ctx.reply(
+                "Guides & Help index refreshed — "
+                f"messages={result.message_count} • posts={result.indexed_posts} • tags={result.tag_groups}.",
+                mention_author=False,
+            )
+            return
+        if result.status == "disabled":
+            await ctx.reply(
+                "Guides & Help index feature is currently disabled in FeatureToggles.",
+                mention_author=False,
+            )
+            return
+        reason = result.reason or "unknown"
+        await ctx.reply(
+            f"Guides & Help index refresh failed ({reason}). Check logs for details.",
             mention_author=False,
         )
 

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1765,6 +1765,7 @@ class Runtime:
         from modules.housekeeping import keepalive as housekeeping_keepalive
         from modules.housekeeping import mirralith_overview as housekeeping_mirralith
         from modules.housekeeping import c1c_ad as housekeeping_c1c_ad
+        from modules.housekeeping import guides_help_index as housekeeping_guides_help_index
         from modules.recruitment import clan_ads as recruitment_clan_ads
         from modules.common import feature_flags
         from shared.sheets import recruitment as recruitment_sheets
@@ -1981,6 +1982,12 @@ class Runtime:
             "Feature Toggle:SERVER_MAP / shared config",
             lambda: server_map_module.schedule_server_map_job(self),
             logger=logging.getLogger("c1c.server_map"),
+        )
+        self._register_optional_scheduler(
+            "guides_help_index",
+            "Feature Toggle:GUIDES_HELP_INDEX_ENABLED / Config",
+            lambda: housekeeping_guides_help_index.schedule_guides_help_index_job(self),
+            logger=logging.getLogger("c1c.housekeeping.guides_help_index"),
         )
         self._register_optional_scheduler(
             "leagues",

--- a/modules/housekeeping/guides_help_index.py
+++ b/modules/housekeeping/guides_help_index.py
@@ -1,0 +1,493 @@
+"""Automated Guides & Help forum tag index."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence, Set, TYPE_CHECKING
+
+import discord
+
+from modules.common import feature_flags, runtime as runtime_helpers
+from modules.ops import server_map_state
+from shared.logfmt import channel_label
+from shared.sheets import recruitment
+
+if TYPE_CHECKING:  # pragma: no cover
+    from modules.common.runtime import Runtime
+
+log = logging.getLogger("c1c.housekeeping.guides_help_index")
+
+FEATURE_KEY = "GUIDES_HELP_INDEX_ENABLED"
+DEFAULT_MESSAGE_THRESHOLD = 1800
+BULLET = "🔹"
+HEADER = "# 🛠️ Guides & Help Index"
+INTRO = "Generated from tagged forum posts in 🆘GUIDES & HELP."
+
+CONFIG_SOURCE_CATEGORY_ID = "GUIDES_HELP_INDEX_SOURCE_CATEGORY_ID"
+CONFIG_TARGET_CHANNEL_ID = "GUIDES_HELP_INDEX_TARGET_CHANNEL_ID"
+CONFIG_REFRESH_DAYS = "GUIDES_HELP_INDEX_REFRESH_DAYS"
+CONFIG_FORUM_BLACKLIST = "GUIDES_HELP_INDEX_FORUM_CHANNEL_BLACKLIST"
+CONFIG_TAG_BLACKLIST = "GUIDES_HELP_INDEX_TAG_BLACKLIST"
+CONFIG_POST_BLACKLIST = "GUIDES_HELP_INDEX_POST_BLACKLIST"
+STATE_MESSAGE_PREFIX = "GUIDES_HELP_INDEX_MESSAGE_ID_"
+STATE_LAST_RUN_AT = "GUIDES_HELP_INDEX_LAST_RUN_AT"
+
+
+@dataclass(slots=True)
+class GuidesHelpIndexResult:
+    status: str
+    message_count: int = 0
+    indexed_posts: int = 0
+    tag_groups: int = 0
+    reason: str | None = None
+    last_run: str | None = None
+    stale_deleted: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class IndexedThread:
+    thread: object
+    forum: object
+
+
+def _text(value: object | None) -> str | None:
+    cleaned = str(value or "").strip()
+    return cleaned or None
+
+
+def _parse_int(value: object | None) -> int | None:
+    text = _text(value)
+    if not text:
+        return None
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_csv(raw: object | None) -> Set[str]:
+    values: Set[str] = set()
+    if raw is None:
+        return values
+    for chunk in str(raw).split(","):
+        item = chunk.strip()
+        if item:
+            values.add(item)
+    return values
+
+
+def _parse_timestamp(value: str | None) -> dt.datetime | None:
+    text = _text(value)
+    if not text:
+        return None
+    try:
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _now_iso(now: dt.datetime | None = None) -> str:
+    timestamp = (now or dt.datetime.now(dt.timezone.utc)).astimezone(dt.timezone.utc)
+    return timestamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def should_refresh(
+    last_run: dt.datetime | None, refresh_days: int, *, now: dt.datetime | None = None
+) -> bool:
+    if last_run is None:
+        return True
+    return ((now or dt.datetime.now(dt.timezone.utc)) - last_run) >= dt.timedelta(
+        days=max(1, refresh_days)
+    )
+
+
+def _sort_key(channel: object) -> tuple[int, int]:
+    return (
+        _parse_int(getattr(channel, "position", 0)) or 0,
+        _parse_int(getattr(channel, "id", 0)) or 0,
+    )
+
+
+def discover_forum_channels(
+    category: object, *, blacklist: Iterable[str] | None = None
+) -> list[object]:
+    blacklisted = {str(item).strip() for item in (blacklist or []) if str(item).strip()}
+    forums: list[object] = []
+    for channel in getattr(category, "channels", []) or []:
+        channel_id = str(getattr(channel, "id", "")).strip()
+        if channel_id and channel_id in blacklisted:
+            continue
+        channel_type = getattr(channel, "type", None)
+        if (
+            isinstance(channel, discord.ForumChannel)
+            or channel_type == discord.ChannelType.forum
+            or hasattr(channel, "available_tags")
+        ):
+            forums.append(channel)
+    return sorted(forums, key=_sort_key)
+
+
+def _tag_group_sort_key(
+    item: tuple[str, tuple[int | None, list[IndexedThread]]],
+) -> tuple[int, int, str]:
+    tag_name, (available_tag_index, _) = item
+    if available_tag_index is None:
+        return (1, 0, tag_name.casefold())
+    return (0, available_tag_index, tag_name.casefold())
+
+
+def _thread_sort_key(item: IndexedThread) -> tuple[int, float, str]:
+    thread = item.thread
+    created = getattr(thread, "created_at", None)
+    if isinstance(created, dt.datetime):
+        created_key = created.timestamp()
+    else:
+        created_key = 0.0
+    return (
+        _sort_key(item.forum)[0],
+        created_key,
+        str(getattr(thread, "name", "")).casefold(),
+    )
+
+
+def _thread_mention(thread: object) -> str:
+    mention = _text(getattr(thread, "mention", None))
+    if mention:
+        return mention
+    jump_url = _text(getattr(thread, "jump_url", None))
+    name = _text(getattr(thread, "name", None)) or f"thread-{getattr(thread, 'id', '')}"
+    return f"[{name}]({jump_url})" if jump_url else name
+
+
+async def _collect_forum_threads(forum: object) -> tuple[list[object], bool]:
+    threads: dict[int, object] = {}
+    for thread in getattr(forum, "threads", []) or []:
+        tid = _parse_int(getattr(thread, "id", None))
+        if tid is not None:
+            threads[tid] = thread
+    active = getattr(forum, "active_threads", None)
+    if callable(active):
+        for thread in await active():
+            tid = _parse_int(getattr(thread, "id", None))
+            if tid is not None:
+                threads[tid] = thread
+    try:
+        async for thread in forum.archived_threads(limit=None):
+            tid = _parse_int(getattr(thread, "id", None))
+            if tid is not None:
+                threads[tid] = thread
+    except AttributeError:
+        pass
+    return list(threads.values()), True
+
+
+def build_index_messages(
+    forums: Sequence[object],
+    threads_by_forum: Mapping[int, Sequence[object]],
+    *,
+    tag_blacklist: Iterable[str] | None = None,
+    post_blacklist: Iterable[str] | None = None,
+    threshold: int = DEFAULT_MESSAGE_THRESHOLD,
+) -> tuple[list[str], int, int]:
+    tag_black = {
+        str(item).strip() for item in (tag_blacklist or []) if str(item).strip()
+    }
+    post_black = {
+        str(item).strip() for item in (post_blacklist or []) if str(item).strip()
+    }
+    grouped: Dict[str, tuple[int | None, list[IndexedThread]]] = {}
+    indexed_ids: set[str] = set()
+    tag_order: Dict[str, int] = {}
+    for forum in forums:
+        for index, tag in enumerate(getattr(forum, "available_tags", []) or []):
+            name = str(getattr(tag, "name", "")).strip()
+            if name:
+                tag_order.setdefault(name, index)
+        forum_id = _parse_int(getattr(forum, "id", None))
+        for thread in threads_by_forum.get(forum_id or 0, []):
+            thread_id = str(getattr(thread, "id", "")).strip()
+            if thread_id and thread_id in post_black:
+                continue
+            tags = list(getattr(thread, "applied_tags", []) or [])
+            if not tags:
+                continue
+            rendered_this_thread = False
+            for tag in tags:
+                tag_id = str(getattr(tag, "id", "")).strip()
+                tag_name = str(getattr(tag, "name", "")).strip()
+                if not tag_name or tag_id in tag_black or tag_name in tag_black:
+                    continue
+                grouped.setdefault(tag_name, (tag_order.get(tag_name), []))[1].append(
+                    IndexedThread(thread=thread, forum=forum)
+                )
+                rendered_this_thread = True
+            if rendered_this_thread and thread_id:
+                indexed_ids.add(thread_id)
+
+    blocks = [f"{HEADER}\n\n{INTRO}".rstrip()]
+    for tag_name, (_, items) in sorted(grouped.items(), key=_tag_group_sort_key):
+        lines = [f"## {tag_name}", ""]
+        seen: set[str] = set()
+        for item in sorted(items, key=_thread_sort_key):
+            tid = str(getattr(item.thread, "id", "")).strip()
+            if tid and tid in seen:
+                continue
+            seen.add(tid)
+            lines.append(f"{BULLET} {_thread_mention(item.thread)}")
+        if len(lines) > 2:
+            blocks.append("\n".join(lines).rstrip())
+
+    messages: list[str] = []
+    current = ""
+    for block in blocks:
+        candidate = block if not current else f"{current}\n\n{block}"
+        if current and len(candidate) > threshold:
+            messages.append(current)
+            current = block
+        else:
+            current = candidate
+    if current:
+        messages.append(current)
+    return messages, len(indexed_ids), len(grouped)
+
+
+async def _config(key: str, default: str | None = None) -> str | None:
+    return await recruitment.get_config_value_async(key, default)
+
+
+async def _resolve_category(
+    bot: discord.Client, category_id: int | None
+) -> tuple[object | None, str | None]:
+    if category_id is None:
+        return None, "missing_source_category"
+    channel = bot.get_channel(category_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(category_id)
+        except discord.NotFound:
+            return None, "missing_source_category"
+        except discord.Forbidden:
+            return None, "discord_permission_issue"
+        except discord.HTTPException:
+            return None, "discord_fetch_issue"
+    if not (
+        isinstance(channel, discord.CategoryChannel)
+        or getattr(channel, "type", None) == discord.ChannelType.category
+        or hasattr(channel, "channels")
+    ):
+        return None, "invalid_category_type"
+    return channel, None
+
+
+def _extract_message_slots(state: Mapping[str, str]) -> list[tuple[int, int]]:
+    slots = []
+    for key, value in state.items():
+        if key.startswith(STATE_MESSAGE_PREFIX):
+            slot = _parse_int(key.rsplit("_", 1)[-1])
+            mid = _parse_int(value)
+            if slot and mid:
+                slots.append((slot, mid))
+    return sorted(slots)
+
+
+async def refresh_guides_help_index(
+    bot: discord.Client, *, force: bool = False, actor: str = "scheduler"
+) -> GuidesHelpIndexResult:
+    await bot.wait_until_ready()
+    if not feature_flags.is_enabled(FEATURE_KEY):
+        log.info("guides help index skipped: disabled")
+        await runtime_helpers.send_log_message(
+            "📘 Guides help index — skipped • reason=feature_disabled"
+        )
+        return GuidesHelpIndexResult(status="disabled", reason="feature_disabled")
+
+    source_id = _parse_int(await _config(CONFIG_SOURCE_CATEGORY_ID))
+    target_id = _parse_int(await _config(CONFIG_TARGET_CHANNEL_ID))
+    if source_id is None:
+        return GuidesHelpIndexResult(status="error", reason="missing_source_category")
+    if target_id is None:
+        return GuidesHelpIndexResult(status="error", reason="missing_target_channel")
+
+    category, category_error = await _resolve_category(bot, source_id)
+    if category_error:
+        await runtime_helpers.send_log_message(
+            f"❌ Guides help index — error • reason={category_error}"
+        )
+        return GuidesHelpIndexResult(status="error", reason=category_error)
+    target, target_error = await runtime_helpers.resolve_configured_text_channel(
+        bot,
+        channel_id=target_id,
+        logger=log,
+        context="guides help index",
+        invalid_reason="invalid_target_channel_type",
+    )
+    if target_error:
+        reason = (
+            "missing_target_channel"
+            if target_error in {"missing_channel", "not_found"}
+            else target_error
+        )
+        await runtime_helpers.send_log_message(
+            f"❌ Guides help index — error • reason={reason}"
+        )
+        return GuidesHelpIndexResult(status="error", reason=reason)
+
+    try:
+        state = await server_map_state.fetch_state()
+    except Exception:
+        log.exception("failed to read Config worksheet for guides help index state")
+        return GuidesHelpIndexResult(status="error", reason="config_fetch_failed")
+    refresh_days = _parse_int(await _config(CONFIG_REFRESH_DAYS, "1")) or 1
+    last_run_raw = state.get(STATE_LAST_RUN_AT)
+    now = dt.datetime.now(dt.timezone.utc)
+    if not force and not should_refresh(
+        _parse_timestamp(last_run_raw), refresh_days, now=now
+    ):
+        log.info("guides help index skipped: interval not elapsed")
+        return GuidesHelpIndexResult(
+            status="skipped", reason="interval_not_elapsed", last_run=last_run_raw
+        )
+
+    forum_black = _parse_csv(await _config(CONFIG_FORUM_BLACKLIST, ""))
+    tag_black = _parse_csv(await _config(CONFIG_TAG_BLACKLIST, ""))
+    post_black = _parse_csv(await _config(CONFIG_POST_BLACKLIST, ""))
+    forums = discover_forum_channels(category, blacklist=forum_black)
+    if not forums:
+        return GuidesHelpIndexResult(
+            status="error", reason="no_readable_forum_channels"
+        )
+
+    threads_by_forum: dict[int, list[object]] = {}
+    readable = 0
+    for forum in forums:
+        fid = _parse_int(getattr(forum, "id", None))
+        if fid is None:
+            continue
+        try:
+            threads, _ = await _collect_forum_threads(forum)
+        except (discord.Forbidden, discord.HTTPException) as exc:
+            log.warning(
+                "guides help index forum fetch failed: forum=%s error=%s",
+                channel_label(getattr(forum, "guild", None), fid),
+                exc,
+            )
+            continue
+        readable += 1
+        threads_by_forum[fid] = threads
+    if readable == 0:
+        return GuidesHelpIndexResult(
+            status="error", reason="discord_fetch_permission_issue"
+        )
+
+    bodies, indexed_posts, tag_groups = build_index_messages(
+        forums, threads_by_forum, tag_blacklist=tag_black, post_blacklist=post_black
+    )
+    stored_slots = _extract_message_slots(state)
+    fetched = []
+    for _, message_id in stored_slots:
+        try:
+            fetched.append(await target.fetch_message(message_id))
+        except (discord.NotFound, discord.HTTPException):
+            continue
+    updated = []
+    for index, body in enumerate(bodies):
+        existing = fetched[index] if index < len(fetched) else None
+        if existing is None:
+            try:
+                updated.append(await target.send(body))
+            except discord.HTTPException:
+                log.exception(
+                    "failed to send guides help index block",
+                    extra={"channel": target_id},
+                )
+                await runtime_helpers.send_log_message(
+                    "❌ Guides help index — error • reason=message_send_failed"
+                )
+                return GuidesHelpIndexResult(
+                    status="error", reason="message_send_failed"
+                )
+        else:
+            try:
+                if (getattr(existing, "content", "") or "").strip() != body.strip():
+                    await existing.edit(content=body)
+            except discord.HTTPException:
+                log.exception(
+                    "failed to edit guides help index message",
+                    extra={"message_id": getattr(existing, "id", None)},
+                )
+                await runtime_helpers.send_log_message(
+                    "❌ Guides help index — error • reason=message_edit_failed"
+                )
+                return GuidesHelpIndexResult(
+                    status="error", reason="message_edit_failed"
+                )
+            updated.append(existing)
+    stale_deleted = 0
+    for extra in fetched[len(updated) :]:
+        try:
+            await extra.delete()
+            stale_deleted += 1
+        except discord.HTTPException:
+            log.debug("failed to delete stale guides help index message", exc_info=True)
+    if updated:
+        try:
+            if not getattr(updated[0], "pinned", False):
+                await updated[0].pin()
+        except Exception:
+            log.debug("failed to pin guides help index primary message", exc_info=True)
+    entries = {
+        f"{STATE_MESSAGE_PREFIX}{idx}": str(msg.id)
+        for idx, msg in enumerate(updated, start=1)
+    }
+    for slot in range(
+        len(updated) + 1, max((slot for slot, _ in stored_slots), default=0) + 1
+    ):
+        entries[f"{STATE_MESSAGE_PREFIX}{slot}"] = ""
+    entries[STATE_LAST_RUN_AT] = _now_iso(now)
+    try:
+        await server_map_state.update_state(entries)
+    except Exception:
+        log.exception("failed to persist guides help index state")
+        await runtime_helpers.send_log_message(
+            "❌ Guides help index — error • reason=state_update_failed"
+        )
+        return GuidesHelpIndexResult(status="error", reason="state_update_failed")
+    await runtime_helpers.send_log_message(
+        "✅ Guides help index updated — "
+        f"cmd={'cron' if actor == 'scheduler' else 'guideshelpindex'} • forums={readable} • tags={tag_groups} "
+        f"• posts={indexed_posts} • messages={len(updated)} • cleaned={stale_deleted}"
+    )
+    return GuidesHelpIndexResult(
+        status="ok",
+        message_count=len(updated),
+        indexed_posts=indexed_posts,
+        tag_groups=tag_groups,
+        stale_deleted=stale_deleted,
+    )
+
+
+def schedule_guides_help_index_job(runtime: "Runtime") -> None:
+    job = runtime.scheduler.every(
+        hours=24,
+        jitter="small",
+        tag="guides_help_index",
+        name="guides_help_index_refresh",
+    )
+
+    async def runner() -> None:
+        try:
+            await refresh_guides_help_index(runtime.bot, actor="scheduler")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("scheduled guides help index refresh failed")
+
+    job.do(runner)

--- a/tests/housekeeping/test_guides_help_index.py
+++ b/tests/housekeeping/test_guides_help_index.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from modules.housekeeping import guides_help_index as ghi
+
+
+class AsyncIter:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def __aiter__(self):
+        self._it = iter(self.items)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class Message:
+    def __init__(self, id, content="old", pinned=False, pin_fails=False):
+        self.id = id
+        self.content = content
+        self.pinned = pinned
+        self.pin_fails = pin_fails
+        self.deleted = False
+        self.edited = []
+
+    async def edit(self, *, content):
+        self.content = content
+        self.edited.append(content)
+
+    async def delete(self):
+        self.deleted = True
+
+    async def pin(self):
+        if self.pin_fails:
+            raise ghi.discord.HTTPException(response=None, message="nope")
+        self.pinned = True
+
+
+class Target:
+    def __init__(self, messages=None):
+        self.messages = {m.id: m for m in (messages or [])}
+        self.sent = []
+        self.id = 60
+        self.guild = SimpleNamespace(name="guild")
+
+    async def fetch_message(self, mid):
+        if mid not in self.messages:
+            raise ghi.discord.NotFound(response=None, message="missing")
+        return self.messages[mid]
+
+    async def send(self, content):
+        m = Message(1000 + len(self.sent), content)
+        self.sent.append(m)
+        return m
+
+
+class Bot:
+    def __init__(self, channels):
+        self.channels = channels
+
+    async def wait_until_ready(self):
+        pass
+
+    def get_channel(self, cid):
+        return self.channels.get(cid)
+
+    async def fetch_channel(self, cid):
+        return self.channels.get(cid)
+
+
+def tag(id, name, position=0):
+    return SimpleNamespace(id=id, name=name, position=position)
+
+
+def thread(id, name, tags, created=0):
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        applied_tags=tags,
+        mention=f"<#T{id}>",
+        created_at=datetime.fromtimestamp(created, timezone.utc),
+    )
+
+
+def forum(id, name, tags, threads=(), pos=0, archived=()):
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        available_tags=list(tags),
+        threads=list(threads),
+        position=pos,
+        archived_threads=lambda limit=None: AsyncIter(archived),
+    )
+
+
+async def _noop(*args, **kwargs):
+    pass
+
+
+async def _ret(v):
+    return v
+
+
+def test_discover_forum_channels_from_category_and_blacklist():
+    f1 = forum(1, "f1", [])
+    f2 = forum(2, "f2", [])
+    cat = SimpleNamespace(channels=[f2, SimpleNamespace(id=3), f1])
+    assert [f.id for f in ghi.discover_forum_channels(cat, blacklist={"2"})] == [1]
+
+
+def test_build_ignores_untagged_and_groups_tagged_posts():
+    a = tag(10, "Missions", 0)
+    f = forum(1, "forum", [a], [thread(11, "x", []), thread(12, "y", [a])])
+    messages, posts, groups = ghi.build_index_messages([f], {1: f.threads})
+    assert posts == 1 and groups == 1
+    assert "## Missions" in messages[0] and "<#T12>" in messages[0]
+    assert "<#T11>" not in messages[0]
+
+
+def test_build_multi_tag_thread_appears_under_each_group():
+    a = tag(10, "Missions", 0)
+    b = tag(11, "Faction Wars", 1)
+    f = forum(1, "forum", [a, b], [thread(12, "y", [a, b])])
+    body = "\n".join(ghi.build_index_messages([f], {1: f.threads})[0])
+    assert "## Missions" in body and "## Faction Wars" in body
+    assert body.count("<#T12>") == 2
+
+
+def test_tag_groups_follow_available_tags_order_without_position():
+    a = SimpleNamespace(id=10, name="Missions")
+    b = SimpleNamespace(id=11, name="Faction Wars")
+    f = forum(1, "forum", [b, a], [thread(12, "mission", [a]), thread(13, "war", [b])])
+
+    body = "\n".join(ghi.build_index_messages([f], {1: f.threads})[0])
+
+    assert body.index("## Faction Wars") < body.index("## Missions")
+
+
+def test_tag_and_post_blacklists_hide_content():
+    a = tag(10, "Missions", 0)
+    b = tag(11, "Faction Wars", 1)
+    f = forum(1, "forum", [a, b], [thread(12, "y", [a]), thread(13, "z", [b])])
+    messages, posts, groups = ghi.build_index_messages(
+        [f], {1: f.threads}, tag_blacklist={"Faction Wars"}, post_blacklist={"12"}
+    )
+    body = "\n".join(messages)
+    assert posts == 0 and groups == 0
+    assert "Missions" not in body and "Faction Wars" not in body
+
+
+def test_output_splits_when_threshold_exceeded():
+    a = tag(10, "Missions", 0)
+    b = tag(11, "Faction Wars", 1)
+    f = forum(1, "forum", [a, b], [thread(12, "long", [a]), thread(13, "long2", [b])])
+    messages, _, _ = ghi.build_index_messages([f], {1: f.threads}, threshold=90)
+    assert len(messages) > 1
+
+
+def test_archived_tagged_posts_are_indexed():
+    a = tag(10, "Missions", 0)
+    archived = thread(14, "archived", [a])
+    f = forum(1, "forum", [a], [], archived=[archived])
+
+    async def run():
+        threads, _ = await ghi._collect_forum_threads(f)
+        messages, posts, groups = ghi.build_index_messages([f], {1: threads})
+        assert posts == 1 and groups == 1
+        assert "<#T14>" in messages[0]
+
+    asyncio.run(run())
+
+
+def test_scheduler_interval():
+    now = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    assert not ghi.should_refresh(now - timedelta(hours=12), 1, now=now)
+    assert ghi.should_refresh(now - timedelta(days=2), 1, now=now)
+
+
+def test_disabled_skips(monkeypatch):
+    async def run():
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: False)
+        monkeypatch.setattr(
+            ghi.runtime_helpers, "send_log_message", lambda msg: _noop()
+        )
+        result = await ghi.refresh_guides_help_index(Bot({}), force=True)
+        assert result.status == "disabled" and result.reason == "feature_disabled"
+
+    asyncio.run(run())
+
+
+def test_missing_source_and_target_config(monkeypatch):
+    async def run():
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return None
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        assert (
+            await ghi.refresh_guides_help_index(Bot({}), force=True)
+        ).reason == "missing_source_category"
+
+        async def cfg2(key, default=None):
+            return "1" if key == ghi.CONFIG_SOURCE_CATEGORY_ID else None
+
+        monkeypatch.setattr(ghi, "_config", cfg2)
+        assert (
+            await ghi.refresh_guides_help_index(
+                Bot({1: SimpleNamespace(id=1, channels=[])}), force=True
+            )
+        ).reason == "missing_target_channel"
+
+    asyncio.run(run())
+
+
+def test_refresh_edits_reuses_deletes_and_pin_nonfatal(monkeypatch):
+    async def run():
+        a = tag(10, "Missions", 0)
+        f = forum(1, "forum", [a], [thread(12, "y", [a])])
+        target = Target([Message(201, "old", pin_fails=True), Message(202, "stale")])
+        bot = Bot({50: SimpleNamespace(id=50, channels=[f]), 60: target})
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return {
+                ghi.CONFIG_SOURCE_CATEGORY_ID: "50",
+                ghi.CONFIG_TARGET_CHANNEL_ID: "60",
+                ghi.CONFIG_REFRESH_DAYS: "1",
+            }.get(key, default)
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((target, None)),
+        )
+        monkeypatch.setattr(
+            ghi.runtime_helpers, "send_log_message", lambda msg: _noop()
+        )
+        monkeypatch.setattr(
+            ghi.server_map_state,
+            "fetch_state",
+            lambda: _ret(
+                {
+                    ghi.STATE_MESSAGE_PREFIX + "1": "201",
+                    ghi.STATE_MESSAGE_PREFIX + "2": "202",
+                }
+            ),
+        )
+        saved = {}
+
+        async def save(entries):
+            saved.update(entries)
+
+        monkeypatch.setattr(ghi.server_map_state, "update_state", save)
+        result = await ghi.refresh_guides_help_index(bot, force=True, actor="command")
+        assert result.status == "ok"
+        assert target.messages[201].edited and target.messages[202].deleted
+        assert saved[ghi.STATE_MESSAGE_PREFIX + "1"] == "201"
+        assert saved[ghi.STATE_MESSAGE_PREFIX + "2"] == ""
+
+    asyncio.run(run())
+
+
+def test_message_lifecycle_failures_return_clear_reasons(monkeypatch):
+    async def run():
+        a = tag(10, "Missions", 0)
+        f = forum(1, "forum", [a], [thread(12, "y", [a])])
+        bot = Bot({50: SimpleNamespace(id=50, channels=[f])})
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return {
+                ghi.CONFIG_SOURCE_CATEGORY_ID: "50",
+                ghi.CONFIG_TARGET_CHANNEL_ID: "60",
+                ghi.CONFIG_REFRESH_DAYS: "1",
+            }.get(key, default)
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        monkeypatch.setattr(
+            ghi.runtime_helpers, "send_log_message", lambda msg: _noop()
+        )
+        monkeypatch.setattr(ghi.server_map_state, "fetch_state", lambda: _ret({}))
+        monkeypatch.setattr(
+            ghi.server_map_state, "update_state", lambda entries: _noop()
+        )
+
+        class SendFailTarget(Target):
+            async def send(self, content):
+                raise ghi.discord.HTTPException(
+                    response=SimpleNamespace(status=500, reason="boom"),
+                    message="boom",
+                )
+
+        send_fail = SendFailTarget([])
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((send_fail, None)),
+        )
+        assert (
+            await ghi.refresh_guides_help_index(bot, force=True)
+        ).reason == "message_send_failed"
+
+        class EditFailMessage(Message):
+            async def edit(self, *, content):
+                raise ghi.discord.HTTPException(
+                    response=SimpleNamespace(status=500, reason="boom"),
+                    message="boom",
+                )
+
+        edit_fail = Target([EditFailMessage(201, "old")])
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((edit_fail, None)),
+        )
+        monkeypatch.setattr(
+            ghi.server_map_state,
+            "fetch_state",
+            lambda: _ret({ghi.STATE_MESSAGE_PREFIX + "1": "201"}),
+        )
+        assert (
+            await ghi.refresh_guides_help_index(bot, force=True)
+        ).reason == "message_edit_failed"
+
+        target = Target([])
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((target, None)),
+        )
+        monkeypatch.setattr(ghi.server_map_state, "fetch_state", lambda: _ret({}))
+
+        async def state_fail(entries):
+            raise RuntimeError("sheet unavailable")
+
+        monkeypatch.setattr(ghi.server_map_state, "update_state", state_fail)
+        assert (
+            await ghi.refresh_guides_help_index(bot, force=True)
+        ).reason == "state_update_failed"
+
+    asyncio.run(run())
+
+
+def test_manual_force_bypasses_interval(monkeypatch):
+    async def run():
+        a = tag(10, "Missions", 0)
+        f = forum(1, "forum", [a], [thread(12, "y", [a])])
+        target = Target([])
+        bot = Bot({50: SimpleNamespace(id=50, channels=[f]), 60: target})
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return {
+                ghi.CONFIG_SOURCE_CATEGORY_ID: "50",
+                ghi.CONFIG_TARGET_CHANNEL_ID: "60",
+                ghi.CONFIG_REFRESH_DAYS: "99",
+            }.get(key, default)
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((target, None)),
+        )
+        monkeypatch.setattr(
+            ghi.runtime_helpers, "send_log_message", lambda msg: _noop()
+        )
+        monkeypatch.setattr(
+            ghi.server_map_state,
+            "fetch_state",
+            lambda: _ret({ghi.STATE_LAST_RUN_AT: ghi._now_iso()}),
+        )
+        monkeypatch.setattr(
+            ghi.server_map_state, "update_state", lambda entries: _noop()
+        )
+        assert (
+            await ghi.refresh_guides_help_index(bot, force=False)
+        ).reason == "interval_not_elapsed"
+        assert (await ghi.refresh_guides_help_index(bot, force=True)).status == "ok"
+
+    asyncio.run(run())

--- a/tests/housekeeping/test_next_command.py
+++ b/tests/housekeeping/test_next_command.py
@@ -24,13 +24,24 @@ def _runtime_with_jobs(jobs):
     return _Runtime(jobs)
 
 
+def _embed_text(embeds):
+    chunks = []
+    for embed in embeds:
+        chunks.append(embed.title or "")
+        chunks.append(embed.description or "")
+        for field in embed.fields:
+            chunks.append(field.name)
+            chunks.append(field.value)
+    return "\n".join(chunks)
+
+
 def test_build_scheduler_overview_groups_components():
     runtime = _runtime_with_jobs([
         _DummyJob("onboarding_idle_watcher", "recruitment"),
         _DummyJob("cache_refresh", "default"),
     ])
 
-    message = app_admin._build_scheduler_overview(runtime, None)
+    message = _embed_text(app_admin._build_scheduler_embeds(runtime, None))
 
     assert "recruitment" in message
     assert "onboarding_idle_watcher" in message
@@ -43,7 +54,7 @@ def test_build_scheduler_overview_filters_components():
         _DummyJob("cache_refresh", "default"),
     ])
 
-    message = app_admin._build_scheduler_overview(runtime, "recruitment")
+    message = _embed_text(app_admin._build_scheduler_embeds(runtime, "recruitment"))
 
     assert "onboarding_idle_watcher" in message
     assert "cache_refresh" not in message
@@ -52,6 +63,6 @@ def test_build_scheduler_overview_filters_components():
 def test_build_scheduler_overview_handles_empty_filter():
     runtime = _runtime_with_jobs([])
 
-    message = app_admin._build_scheduler_overview(runtime, "unknown")
+    message = _embed_text(app_admin._build_scheduler_embeds(runtime, "unknown"))
 
-    assert "no jobs under unknown" in message
+    assert "No scheduled jobs under unknown." in message


### PR DESCRIPTION
### Motivation

- Provide an automated, periodically-updated index of tagged forum posts in the "Guides & Help" category so users can find resources by tag.
- Allow operators to trigger an immediate rebuild from Discord when needed and surface scheduling control to the app admin tools.
- Wire the new feature into the runtime scheduler so it can run automatically under feature-toggle control.

### Description

- Add `modules/housekeeping/guides_help_index.py` which implements index discovery, message generation (`build_index_messages`), Discord interactions (`refresh_guides_help_index`), state persistence, and a scheduler registration function `schedule_guides_help_index_job`.
- Register the guides help index job in the runtime by importing and calling `housekeeping_guides_help_index.schedule_guides_help_index_job` from `modules/common/runtime.py` via `_register_optional_scheduler` and add the job to the housekeeping job set in `cogs/app_admin.py`.
- Add an admin command group `!guideshelpindex` with a `refresh` subcommand in `cogs/app_admin.py` to force an immediate refresh and report structured results to the invoker.
- Add comprehensive unit tests at `tests/housekeeping/test_guides_help_index.py` validating discovery, message building, blacklist handling, scheduling interval, error paths, message lifecycle, and manual forcing, and update `tests/housekeeping/test_next_command.py` to consume the new embed-based scheduler output via `app_admin._build_scheduler_embeds`.

### Testing

- Ran the new unit tests `pytest tests/housekeeping/test_guides_help_index.py` and they passed.
- Ran the updated scheduler tests `pytest tests/housekeeping/test_next_command.py` and they passed.
- Ran the housekeeping test suite `pytest tests/housekeeping -q` to validate integration of the changes and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b814e7c3c832392596c67f0c20581)