### PR TITLE
Faction Wars: add stage-star tracking, completion tips, and UI for Set Stages / Mark Perfect

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -50,6 +50,10 @@ _SET_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:setprogress:"
 _PLAN_AHEAD_CUSTOM_ID_PREFIX = "progressguides:planahead:"
 _FW_STARS_CUSTOM_ID_PREFIX = "progressguides:fwstars:"
 _FW_PROGRESS_CUSTOM_ID_PREFIX = "progressguides:fwprogress:"
+_FW_SET_STAGES_CUSTOM_ID_PREFIX = "progressguides:fwsetstages:"
+_FW_MARK_PERFECT_CUSTOM_ID_PREFIX = "progressguides:fwperfect:"
+_FW_TIPS_CUSTOM_ID_PREFIX = "progressguides:fwtips:"
+_FW_STUCK_CUSTOM_ID_PREFIX = "progressguides:fwstuck:"
 _FW_GUIDE_CUSTOM_ID_PREFIX = "progressguides:fwguide:"
 _FW_CONDITIONS_CUSTOM_ID_PREFIX = "progressguides:fwconditions:"
 _HOW_TO_USE_CUSTOM_ID_PREFIX = "progressguides:howto:"
@@ -58,6 +62,7 @@ _MISSION_CATEGORIES = ("ARB", "RAM", "MAR")
 _FACTION_WARS_CATEGORIES = ("FW_N", "FW_H")
 _FW_HARD_CATEGORY = "FW_H"
 _FW_USER_COUNTERS_KEY = "PROGRESS_USER_COUNTERS_TAB"
+_FW_STAGE_STARS_KEY = "PROGRESS_FW_STAGE_STARS_TAB"
 _FW_FACTIONS_KEY = "PROGRESS_FW_FACTIONS_TAB"
 _FW_CHAMPION_GUIDES_KEY = "PROGRESS_FW_CHAMPION_GUIDES_TAB"
 _FW_HARD_STAGE_CONDITIONS_KEY = "PROGRESS_FW_HARD_STAGE_CONDITIONS_TAB"
@@ -2337,6 +2342,52 @@ async def _fw_user_counter_rows() -> tuple[str, list[dict[str, Any]]]:
     return tab, await afetch_records(sheet_id, tab)
 
 
+async def _fw_stage_star_rows() -> tuple[str, list[dict[str, Any]]]:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab = await milestones_config.arequire_value(_FW_STAGE_STARS_KEY)
+    return tab, await afetch_records(sheet_id, tab)
+
+
+def _fw_user_stage_rows(
+    rows: Sequence[Mapping[str, object]], user_id: int, category: str
+) -> list[Mapping[str, object]]:
+    user = str(user_id)
+    return [
+        row
+        for row in rows
+        if _text(row.get("user_id")) == user and _text(row.get("category")) == category
+    ]
+
+
+def _fw_stage_rows_for_faction(
+    rows: Sequence[Mapping[str, object]], faction_key: str
+) -> list[Mapping[str, object]]:
+    return [row for row in rows if _fw_faction_key(row) == faction_key]
+
+
+def _fw_stage_star_map(rows: Sequence[Mapping[str, object]]) -> dict[int, int]:
+    stage_map: dict[int, int] = {}
+    for row in rows:
+        stage = _int_or_none(row.get("stage_number"))
+        stars = _int_or_none(row.get("stars"))
+        if stage is not None and stars is not None and 1 <= stage <= 21:
+            stage_map[stage] = max(0, min(stars, 3))
+    return stage_map
+
+
+def _fw_complete_stage_star_map(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[int, int] | None:
+    stage_map = _fw_stage_star_map(rows)
+    required_stages = set(range(1, 22))
+    return stage_map if set(stage_map) == required_stages else None
+
+
+def _fw_stage_total(rows: Sequence[Mapping[str, object]]) -> int | None:
+    stage_map = _fw_complete_stage_star_map(rows)
+    return sum(stage_map.values()) if stage_map is not None else None
+
+
 def _fw_user_rows(
     rows: Sequence[Mapping[str, object]], user_id: int, category: str
 ) -> list[Mapping[str, object]]:
@@ -2366,9 +2417,23 @@ def build_faction_wars_stars_embed(
     post: ForumPost,
     fw: FactionWarsData,
     user_rows: Sequence[Mapping[str, object]],
+    stage_rows: Sequence[Mapping[str, object]] = (),
 ) -> discord.Embed:
     title = post.counter_stars_title or f"{post.label or post.category} — My Stars"
-    if not user_rows:
+    lookup = _fw_faction_lookup(fw)
+    saved = _fw_rows_by_key(user_rows)
+    staged_keys = {
+        _fw_faction_key(row)
+        for row in stage_rows
+        if _fw_faction_key(row)
+        and _fw_stage_total(
+            _fw_stage_rows_for_faction(stage_rows, _fw_faction_key(row))
+        )
+        is not None
+    }
+    display_keys = list(saved)
+    display_keys.extend(key for key in staged_keys if key not in saved)
+    if not display_keys:
         return discord.Embed(
             title=_embed_title(title),
             description=_embed_description(
@@ -2377,16 +2442,27 @@ def build_faction_wars_stars_embed(
             ),
             color=discord.Color.blurple(),
         )
-    lookup = _fw_faction_lookup(fw)
     lines = []
     total = 0
-    for row in sorted(user_rows, key=lambda r: _fw_faction_name(r).casefold())[:25]:
-        key = _fw_faction_key(row)
-        label, fallback_goal = lookup.get(key, (_fw_faction_name(row) or key, 63))
-        stars = _fw_counter_value(row)
-        goal = _fw_goal_value(row, fallback_goal)
+    for key in sorted(
+        display_keys,
+        key=lambda row_key: lookup.get(
+            row_key, (_fw_faction_name(saved.get(row_key, {})) or row_key, 63)
+        )[0].casefold(),
+    )[:25]:
+        row = saved.get(key)
+        label, fallback_goal = lookup.get(
+            key, (_fw_faction_name(row or {"faction_key": key}) or key, 63)
+        )
+        stage_total = _fw_stage_total(_fw_stage_rows_for_faction(stage_rows, key))
+        stars = (
+            stage_total
+            if stage_total is not None
+            else (_fw_counter_value(row) if row else 0)
+        )
+        goal = _fw_goal_value(row, fallback_goal) if row else fallback_goal
         total += stars
-        status = _text(row.get("status")).casefold()
+        status = _text(row.get("status") if row else "").casefold()
         icon = "✅" if status == "complete" or stars >= goal else "⏳"
         lines.append(f"- {icon} {label}: {stars}/{goal}⭐")
     description = f"Total saved stars: **{total}**\n\n" + "\n".join(lines)
@@ -2395,12 +2471,6 @@ def build_faction_wars_stars_embed(
         description=_embed_description(description),
         color=discord.Color.blurple(),
     )
-
-
-def _fw_estimated_next_stage(current_stars: int, goal_stars: int) -> int | None:
-    if goal_stars <= 0 or current_stars >= goal_stars:
-        return None
-    return min((current_stars // 3) + 1, 21)
 
 
 def _fw_row_matches_mode(row: Mapping[str, object], category: str) -> bool:
@@ -2426,72 +2496,122 @@ def _fw_boss_solver_row(
     )
 
 
-def _fw_hard_solver_hint(
+def _fw_stage_hint_lines(
     fw: FactionWarsData, category: str, faction_key: str, stage: int
-) -> str:
-    if category != _FW_HARD_CATEGORY:
-        return ""
-    solver = next(iter(_fw_solver_rows(fw, category, faction_key).get(stage, [])), None)
-    if solver is None:
-        return ""
-    parts = [
-        _strip_visible_urls(solver.get("condition")),
-        _strip_visible_urls(solver.get("solver_roles")),
-        _strip_visible_urls(solver.get("suggested_champions")),
-    ]
-    detail = " • ".join(part for part in parts if part)
-    return _limit_text(f"Stage {stage}: {detail}", 180) if detail else ""
+) -> list[str]:
+    lines: list[str] = []
+    if category == _FW_HARD_CATEGORY:
+        condition_row = _fw_condition_row(fw, category, faction_key)
+        if condition_row is not None:
+            condition = _strip_visible_urls(condition_row.get(f"stage_{stage}"))
+            if condition:
+                lines.append(f"Stage condition: {condition}")
+        for solver in _fw_solver_rows(fw, category, faction_key).get(stage, []):
+            parts = [
+                _strip_visible_urls(solver.get("condition")),
+                _strip_visible_urls(solver.get("solver_roles")),
+                _strip_visible_urls(solver.get("suggested_champions")),
+            ]
+            detail = " • ".join(part for part in parts if part)
+            if detail:
+                lines.append(f"Stage solver: {detail}")
+    boss = _fw_boss_solver_row(fw, category, faction_key, stage)
+    if boss is not None:
+        parts = [
+            _strip_visible_urls(boss.get("boss_type")),
+            _strip_visible_urls(boss.get("recommended_roles")),
+            _strip_visible_urls(boss.get("strategy_note")),
+        ]
+        detail = " • ".join(part for part in parts if part)
+        if detail:
+            lines.append(f"Boss {stage}: {detail}")
+    return lines
 
 
-def _fw_boss_solver_hint(
-    fw: FactionWarsData, category: str, faction_key: str, stage: int
-) -> str:
-    row = _fw_boss_solver_row(fw, category, faction_key, stage)
-    if row is None:
-        return ""
-    parts = [
-        _strip_visible_urls(row.get("boss_type")),
-        _strip_visible_urls(row.get("recommended_roles")),
-        _strip_visible_urls(row.get("strategy_note")),
-    ]
-    detail = " • ".join(part for part in parts if part)
-    return _limit_text(f"Boss {stage}: {detail}", 180) if detail else ""
+def build_faction_wars_stage_hints_embed(
+    post: ForumPost, fw: FactionWarsData, faction_key: str, stage: int
+) -> discord.Embed:
+    label = _fw_faction_lookup(fw).get(faction_key, (faction_key, 63))[0]
+    lines = _fw_stage_hint_lines(fw, post.category, faction_key, stage)
+    embed = discord.Embed(
+        title=_embed_title(f"{label}: Stage {stage} Help"),
+        description=_embed_description(
+            "\n".join(f"- {line}" for line in lines)
+            or "No exact hints are configured for this stage yet."
+        ),
+        color=discord.Color.blurple(),
+    )
+    return embed
 
 
-def _fw_focus_line(
-    fw: FactionWarsData, category: str, key: str, label: str, current: int, goal: int
-) -> str:
-    line = f"{label}: {current}/{goal}⭐"
-    stage = _fw_estimated_next_stage(current, goal)
-    if stage is None:
-        return line
-    hints = [
-        _fw_hard_solver_hint(fw, category, key, stage),
-        _fw_boss_solver_hint(fw, category, key, stage),
-    ]
-    hints = [hint for hint in hints if hint]
-    if hints:
-        line += "\n" + "\n".join(hints)
-    return line
+def build_faction_wars_completion_tips_embed(
+    post: ForumPost,
+    fw: FactionWarsData,
+    faction_key: str,
+    stage_rows: Sequence[Mapping[str, object]],
+) -> discord.Embed:
+    label = _fw_faction_lookup(fw).get(faction_key, (faction_key, 63))[0]
+    if not stage_rows:
+        return discord.Embed(
+            title=_embed_title(f"{label}: Completion Tips"),
+            description=(
+                "Completion tips need stage stars for this faction. Use Set Stages "
+                "to save them, or use I'm Stuck for one specific stage."
+            ),
+            color=discord.Color.blurple(),
+        )
+    stage_map = _fw_complete_stage_star_map(stage_rows)
+    if stage_map is None:
+        return discord.Embed(
+            title=_embed_title(f"{label}: Completion Tips"),
+            description=(
+                "Stage tracking is incomplete for this faction. Use Set Stages "
+                "to save all 21 stages, or use I'm Stuck for one specific stage."
+            ),
+            color=discord.Color.blurple(),
+        )
+    tips: list[str] = []
+    for stage in range(1, 22):
+        if stage_map.get(stage, 0) >= 3:
+            continue
+        for line in _fw_stage_hint_lines(fw, post.category, faction_key, stage):
+            tips.append(f"Stage {stage}: {line}")
+    return discord.Embed(
+        title=_embed_title(f"{label}: Completion Tips"),
+        description=_embed_description(
+            _limited_bullets(tips, 20, "more tip")
+            or "No exact hints are configured for incomplete stages."
+        ),
+        color=discord.Color.blurple(),
+    )
 
 
 def build_faction_wars_progress_embed(
     post: ForumPost,
     fw: FactionWarsData,
     user_rows: Sequence[Mapping[str, object]],
+    stage_rows: Sequence[Mapping[str, object]] = (),
 ) -> discord.Embed:
     lookup = _fw_faction_lookup(fw)
     saved = _fw_rows_by_key(user_rows)
     progress_rows: list[tuple[str, str, int, int]] = []
     for key, label, max_stars in _fw_faction_options(fw):
         row = saved.get(key)
-        current = _fw_counter_value(row) if row else 0
+        staged_total = _fw_stage_total(_fw_stage_rows_for_faction(stage_rows, key))
+        current = (
+            staged_total
+            if staged_total is not None
+            else (_fw_counter_value(row) if row else 0)
+        )
         goal = _fw_goal_value(row, max_stars) if row else max_stars
         progress_rows.append((key, label, current, goal))
     for key, row in saved.items():
         if key not in lookup:
             label = _fw_faction_name(row) or key
-            current = _fw_counter_value(row)
+            staged_total = _fw_stage_total(_fw_stage_rows_for_faction(stage_rows, key))
+            current = (
+                staged_total if staged_total is not None else _fw_counter_value(row)
+            )
             progress_rows.append((key, label, current, _fw_goal_value(row)))
     total = sum(current for _key, _label, current, _goal in progress_rows)
     max_total = sum(goal for _key, _label, _current, goal in progress_rows)
@@ -2501,7 +2621,7 @@ def build_faction_wars_progress_embed(
     focus = sorted(
         [r for r in progress_rows if r[2] < r[3]], key=lambda r: (r[2], r[1])
     )[:5]
-    if not user_rows and post.counter_progress_empty_description:
+    if not user_rows and not stage_rows and post.counter_progress_empty_description:
         description = post.counter_progress_empty_description
     else:
         values = {
@@ -2524,36 +2644,31 @@ def build_faction_wars_progress_embed(
         description=_embed_description(description),
         color=discord.Color.blurple(),
     )
-    embed.add_field(
-        name=_embed_title(
-            post.counter_progress_finished_field_title or "Finished factions"
+    for title, rows, empty in (
+        (
+            post.counter_progress_finished_field_title or "Finished factions",
+            finished,
+            "None yet.",
         ),
-        value=_limited_bullets(
-            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in finished], 8
+        (
+            post.counter_progress_close_field_title or "Close to finish",
+            close,
+            "None yet.",
+        ),
+        (
+            post.counter_progress_focus_field_title or "Focus factions",
+            focus,
+            "All tracked factions are complete.",
+        ),
+    ):
+        embed.add_field(
+            name=_embed_title(title),
+            value=_limited_bullets(
+                [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in rows], 8
+            )
+            or empty,
+            inline=False,
         )
-        or "None yet.",
-        inline=False,
-    )
-    embed.add_field(
-        name=_embed_title(post.counter_progress_close_field_title or "Close to finish"),
-        value=_limited_bullets(
-            [f"{label}: {current}/{goal}⭐" for _k, label, current, goal in close], 8
-        )
-        or "None yet.",
-        inline=False,
-    )
-    embed.add_field(
-        name=_embed_title(post.counter_progress_focus_field_title or "Focus factions"),
-        value=_limited_bullets(
-            [
-                _fw_focus_line(fw, post.category, key, label, current, goal)
-                for key, label, current, goal in focus
-            ],
-            8,
-        )
-        or "All tracked factions are complete.",
-        inline=False,
-    )
     if post.counter_progress_footer:
         embed.set_footer(text=_limit_text(post.counter_progress_footer, 2048))
     return embed
@@ -2796,6 +2911,9 @@ class FactionWarsFactionSelect(discord.ui.Select):
         ]
         placeholder = {
             "stars": post.counter_stars_faction_select_placeholder,
+            "setstages": "Choose a faction to set stage stars…",
+            "tips": "Choose a faction for completion tips…",
+            "stuck": "Choose a faction for stage help…",
             "guide": post.faction_guide_select_placeholder,
             "conditions": post.conditions_select_placeholder,
         }.get(kind) or "Choose a faction…"
@@ -2817,7 +2935,42 @@ class FactionWarsFactionSelect(discord.ui.Select):
                 FactionWarsStarModal(view.post, selected, label, max_stars)
             )
             return
-        if view.kind == "guide":
+        if view.kind == "setstages":
+            await interaction.response.send_modal(
+                FactionWarsStageStarsModal(view.post, selected, label)
+            )
+            return
+        if view.kind == "perfect":
+            await mark_faction_wars_perfect(
+                interaction.user.id, view.post.category, selected, label, max_stars
+            )
+            await interaction.response.edit_message(
+                embed=_progress_notice_embed(
+                    view.post, f"Marked {label} complete: {max_stars}/{max_stars}."
+                ),
+                view=view,
+            )
+            return
+        if view.kind == "stuck":
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title=_embed_title(f"{label}: Choose a Stage"),
+                    description="Choose the stage where you're stuck.",
+                    color=discord.Color.blurple(),
+                ),
+                view=FactionWarsStagePickerView(view.post, view.fw, selected),
+            )
+            return
+        if view.kind == "tips":
+            _tab, rows = await _fw_stage_star_rows()
+            user_stage_rows = _fw_stage_rows_for_faction(
+                _fw_user_stage_rows(rows, interaction.user.id, view.post.category),
+                selected,
+            )
+            embed = build_faction_wars_completion_tips_embed(
+                view.post, view.fw, selected, user_stage_rows
+            )
+        elif view.kind == "guide":
             embed = build_faction_wars_guide_embed(view.post, view.fw, selected)
         else:
             embed = build_faction_wars_conditions_embed(view.post, view.fw, selected)
@@ -2893,6 +3046,238 @@ async def upsert_faction_wars_counter(
     )
 
 
+class FactionWarsStageStarsModal(discord.ui.Modal):
+    def __init__(self, post: ForumPost, faction_key: str, faction_label: str) -> None:
+        super().__init__(title=_limit_text(f"Set {faction_label} stage stars", 45))
+        self.post = post
+        self.faction_key = faction_key
+        self.faction_label = faction_label
+        self.stage_number = discord.ui.TextInput(
+            label="Stage number", placeholder="1-21", required=True, max_length=2
+        )
+        self.stars = discord.ui.TextInput(
+            label="Stars", placeholder="0-3", required=True, max_length=1
+        )
+        self.add_item(self.stage_number)
+        self.add_item(self.stars)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        stage = _int_or_none(self.stage_number.value)
+        stars = _int_or_none(self.stars.value)
+        if (
+            stage is None
+            or not 1 <= stage <= 21
+            or stars is None
+            or not 0 <= stars <= 3
+        ):
+            await interaction.response.send_message(
+                embed=_progress_notice_embed(
+                    self.post, "Stage must be 1-21 and stars must be 0-3."
+                ),
+                ephemeral=True,
+            )
+            return
+        await upsert_faction_wars_stage_stars(
+            interaction.user.id,
+            self.post.category,
+            self.faction_key,
+            self.faction_label,
+            stage,
+            stars,
+        )
+        await interaction.response.send_message(
+            embed=_progress_notice_embed(
+                self.post,
+                f"Saved {stars}/3 stars for {self.faction_label} stage {stage}.",
+            ),
+            ephemeral=True,
+        )
+
+
+class FactionWarsStageSelect(discord.ui.Select):
+    def __init__(self, post: ForumPost, fw: FactionWarsData, faction_key: str) -> None:
+        self.post = post
+        self.fw = fw
+        self.faction_key = faction_key
+        super().__init__(
+            placeholder="Choose a stage…",
+            options=[
+                discord.SelectOption(label=f"Stage {stage}", value=str(stage))
+                for stage in range(1, 22)
+            ],
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.edit_message(
+            embed=build_faction_wars_stage_hints_embed(
+                self.post, self.fw, self.faction_key, int(self.values[0])
+            ),
+            view=self.view,
+        )
+
+
+class FactionWarsStagePickerView(discord.ui.View):
+    def __init__(self, post: ForumPost, fw: FactionWarsData, faction_key: str) -> None:
+        super().__init__(timeout=900)
+        self.add_item(FactionWarsStageSelect(post, fw, faction_key))
+
+
+async def upsert_faction_wars_stage_stars(
+    user_id: int,
+    category: str,
+    faction_key: str,
+    faction_name: str,
+    stage_number: int,
+    stars: int,
+) -> None:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab, rows = await _fw_stage_star_rows()
+    worksheet = await aget_worksheet(sheet_id, tab)
+    header = await _load_header(sheet_id, tab)
+    now = datetime.now(timezone.utc).isoformat()
+    values = {
+        "user_id": str(user_id),
+        "category": category,
+        "faction_key": faction_key,
+        "faction_name": faction_name,
+        "stage_number": str(stage_number),
+        "stars": str(stars),
+        "updated_at_utc": now,
+    }
+    found: tuple[int, Mapping[str, object]] | None = None
+    for row_number, row in enumerate(rows, start=2):
+        if (
+            _text(row.get("user_id")) == str(user_id)
+            and _text(row.get("category")) == category
+            and _fw_faction_key(row) == faction_key
+            and _int_or_none(row.get("stage_number")) == stage_number
+        ):
+            found = (row_number, row)
+            break
+    if found is None:
+        await acall_with_backoff(
+            worksheet.append_row,
+            [values.get(name, "") for name in header],
+            value_input_option="RAW",
+        )
+        return
+    row_number, existing = found
+    full_row = [values.get(name, _text(existing.get(name))) for name in header]
+    await acall_with_backoff(
+        worksheet.update,
+        f"{_column_label(0)}{row_number}:{_column_label(len(header) - 1)}{row_number}",
+        [full_row],
+        value_input_option="RAW",
+    )
+
+
+async def upsert_all_faction_wars_stage_stars(
+    user_id: int, category: str, faction_key: str, faction_name: str, stars: int
+) -> None:
+    sheet_id = get_milestones_sheet_id().strip()
+    tab, rows = await _fw_stage_star_rows()
+    worksheet = await aget_worksheet(sheet_id, tab)
+    header = await _load_header(sheet_id, tab)
+    now = datetime.now(timezone.utc).isoformat()
+    existing_by_stage: dict[int, tuple[int, Mapping[str, object]]] = {}
+    for row_number, row in enumerate(rows, start=2):
+        stage = _int_or_none(row.get("stage_number"))
+        if (
+            _text(row.get("user_id")) == str(user_id)
+            and _text(row.get("category")) == category
+            and _fw_faction_key(row) == faction_key
+            and stage is not None
+            and 1 <= stage <= 21
+        ):
+            existing_by_stage[stage] = (row_number, row)
+    for stage_number in range(1, 22):
+        values = {
+            "user_id": str(user_id),
+            "category": category,
+            "faction_key": faction_key,
+            "faction_name": faction_name,
+            "stage_number": str(stage_number),
+            "stars": str(stars),
+            "updated_at_utc": now,
+        }
+        found = existing_by_stage.get(stage_number)
+        if found is None:
+            await acall_with_backoff(
+                worksheet.append_row,
+                [values.get(name, "") for name in header],
+                value_input_option="RAW",
+            )
+            continue
+        row_number, existing = found
+        full_row = [values.get(name, _text(existing.get(name))) for name in header]
+        await acall_with_backoff(
+            worksheet.update,
+            f"{_column_label(0)}{row_number}:{_column_label(len(header) - 1)}{row_number}",
+            [full_row],
+            value_input_option="RAW",
+        )
+
+
+async def mark_faction_wars_perfect(
+    user_id: int, category: str, faction_key: str, faction_name: str, max_stars: int
+) -> None:
+    await upsert_faction_wars_counter(
+        user_id, category, faction_key, faction_name, max_stars, max_stars
+    )
+    await upsert_all_faction_wars_stage_stars(
+        user_id, category, faction_key, faction_name, 3
+    )
+
+
+class FactionWarsProgressActionButton(discord.ui.Button):
+    def __init__(self, category: str, label: str, kind: str) -> None:
+        self.category = category
+        self.kind = kind
+        prefix = (
+            _FW_TIPS_CUSTOM_ID_PREFIX if kind == "tips" else _FW_STUCK_CUSTOM_ID_PREFIX
+        )
+        super().__init__(
+            label=_button_label(label),
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"{prefix}{category}",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        data = await get_or_load_progress_guide_data()
+        post = _post_for_category(self.category, data)
+        if post is None:
+            await interaction.followup.send(
+                embed=_progress_unavailable_embed(post), ephemeral=True
+            )
+            return
+        fw = await get_or_load_faction_wars_data()
+        await interaction.followup.send(
+            embed=discord.Embed(
+                title="Choose a faction",
+                description=(
+                    "Choose a faction for completion tips."
+                    if self.kind == "tips"
+                    else "Choose a faction, then a stage."
+                ),
+                color=discord.Color.blurple(),
+            ),
+            view=FactionWarsFactionPickerView(post, fw, self.kind),
+            ephemeral=True,
+        )
+
+
+def build_faction_wars_progress_view(post: ForumPost) -> discord.ui.View:
+    view = discord.ui.View(timeout=900)
+    view.add_item(
+        FactionWarsProgressActionButton(post.category, "Completion Tips", "tips")
+    )
+    view.add_item(FactionWarsProgressActionButton(post.category, "I'm Stuck", "stuck"))
+    return view
+
+
 class FactionWarsPanelButton(discord.ui.Button):
     def __init__(self, category: str, label: str, kind: str) -> None:
         self.category = category
@@ -2900,6 +3285,8 @@ class FactionWarsPanelButton(discord.ui.Button):
         prefixes = {
             "stars": _FW_STARS_CUSTOM_ID_PREFIX,
             "progress": _FW_PROGRESS_CUSTOM_ID_PREFIX,
+            "setstages": _FW_SET_STAGES_CUSTOM_ID_PREFIX,
+            "perfect": _FW_MARK_PERFECT_CUSTOM_ID_PREFIX,
             "guide": _FW_GUIDE_CUSTOM_ID_PREFIX,
             "conditions": _FW_CONDITIONS_CUSTOM_ID_PREFIX,
         }
@@ -2934,8 +3321,14 @@ class FactionWarsPanelButton(discord.ui.Button):
             if self.kind == "stars":
                 _tab, rows = await _fw_user_counter_rows()
                 user_rows = _fw_user_rows(rows, interaction.user.id, self.category)
+                _stage_tab, stage_rows = await _fw_stage_star_rows()
+                user_stage_rows = _fw_user_stage_rows(
+                    stage_rows, interaction.user.id, self.category
+                )
                 await interaction.followup.send(
-                    embed=build_faction_wars_stars_embed(post, fw, user_rows),
+                    embed=build_faction_wars_stars_embed(
+                        post, fw, user_rows, user_stage_rows
+                    ),
                     view=FactionWarsFactionPickerView(post, fw, "stars"),
                     ephemeral=True,
                 )
@@ -2943,21 +3336,47 @@ class FactionWarsPanelButton(discord.ui.Button):
             if self.kind == "progress":
                 _tab, rows = await _fw_user_counter_rows()
                 user_rows = _fw_user_rows(rows, interaction.user.id, self.category)
+                _stage_tab, stage_rows = await _fw_stage_star_rows()
+                user_stage_rows = _fw_user_stage_rows(
+                    stage_rows, interaction.user.id, self.category
+                )
                 await interaction.followup.send(
-                    embed=build_faction_wars_progress_embed(post, fw, user_rows),
+                    embed=build_faction_wars_progress_embed(
+                        post, fw, user_rows, user_stage_rows
+                    ),
+                    view=build_faction_wars_progress_view(post),
                     ephemeral=True,
                 )
                 return
-            view_kind = "guide" if self.kind == "guide" else "conditions"
+            if self.kind == "perfect":
+                await interaction.followup.send(
+                    embed=discord.Embed(
+                        title="Choose a faction",
+                        description="Choose a faction to mark perfect (63/63).",
+                        color=discord.Color.blurple(),
+                    ),
+                    view=FactionWarsFactionPickerView(post, fw, "perfect"),
+                    ephemeral=True,
+                )
+                return
+            view_kind = (
+                "guide"
+                if self.kind == "guide"
+                else ("setstages" if self.kind == "setstages" else "conditions")
+            )
+            if view_kind == "setstages":
+                picker_title = "Set Stage Stars"
+                picker_description = "Choose a faction to save stage stars."
+            elif view_kind == "guide":
+                picker_title = post.faction_guide_title or "Choose a faction"
+                picker_description = "Choose a faction to view details."
+            else:
+                picker_title = post.conditions_title or "Choose a faction"
+                picker_description = "Choose a faction to view details."
             await interaction.followup.send(
                 embed=discord.Embed(
-                    title=_embed_title(
-                        post.faction_guide_title
-                        if view_kind == "guide"
-                        else post.conditions_title
-                    )
-                    or "Choose a faction",
-                    description="Choose a faction to view details.",
+                    title=_embed_title(picker_title),
+                    description=picker_description,
                     color=discord.Color.blurple(),
                 ),
                 view=FactionWarsFactionPickerView(post, fw, view_kind),
@@ -2977,6 +3396,8 @@ class FactionWarsPersistentView(discord.ui.View):
         super().__init__(timeout=None)
         for category in categories:
             self.add_item(FactionWarsPanelButton(category, "My Stars", "stars"))
+            self.add_item(FactionWarsPanelButton(category, "Set Stages", "setstages"))
+            self.add_item(FactionWarsPanelButton(category, "Mark Perfect", "perfect"))
             self.add_item(FactionWarsPanelButton(category, "Progress", "progress"))
             self.add_item(FactionWarsPanelButton(category, "Faction Guide", "guide"))
             if category == _FW_HARD_CATEGORY:
@@ -2993,6 +3414,8 @@ def _add_faction_wars_main_buttons(view: discord.ui.View, post: ForumPost) -> bo
             post.category, post.counter_stars_button_label or "My Stars", "stars"
         )
     )
+    view.add_item(FactionWarsPanelButton(post.category, "Set Stages", "setstages"))
+    view.add_item(FactionWarsPanelButton(post.category, "Mark Perfect", "perfect"))
     view.add_item(
         FactionWarsPanelButton(
             post.category, post.counter_progress_button_label or "Progress", "progress"

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -3288,18 +3288,20 @@ def _fw_static_data():
 def test_fw_guide_view_uses_sheet_labels_and_hard_conditions_only():
     hard = _fw_data("FW_H")
     hard_view = service.build_guide_view(hard.posts[0], hard)
-    assert [getattr(i, "label", "") for i in hard_view.children[:4]] == [
-        "Sheet My Stars",
-        "Sheet Progress",
-        "Sheet Faction Guide",
-        "Sheet Conditions",
-    ]
-    assert [getattr(i, "custom_id", "") for i in hard_view.children[:4]] == [
-        "progressguides:fwstars:FW_H",
-        "progressguides:fwprogress:FW_H",
-        "progressguides:fwguide:FW_H",
-        "progressguides:fwconditions:FW_H",
-    ]
+    hard_labels = [getattr(i, "label", "") for i in hard_view.children]
+    hard_ids = [getattr(i, "custom_id", "") for i in hard_view.children]
+    assert "Sheet My Stars" in hard_labels
+    assert "Set Stages" in hard_labels
+    assert "Mark Perfect" in hard_labels
+    assert "Sheet Progress" in hard_labels
+    assert "Sheet Faction Guide" in hard_labels
+    assert "Sheet Conditions" in hard_labels
+    assert "progressguides:fwstars:FW_H" in hard_ids
+    assert "progressguides:fwsetstages:FW_H" in hard_ids
+    assert "progressguides:fwperfect:FW_H" in hard_ids
+    assert "progressguides:fwprogress:FW_H" in hard_ids
+    assert "progressguides:fwguide:FW_H" in hard_ids
+    assert "progressguides:fwconditions:FW_H" in hard_ids
 
     normal = _fw_data("FW_N")
     normal_view = service.build_guide_view(normal.posts[0], normal)
@@ -3351,10 +3353,15 @@ def test_fw_my_stars_reads_progress_user_counters(monkeypatch):
 
     async def require_value(key):
         calls.append(("config", key))
-        return {"PROGRESS_USER_COUNTERS_TAB": "ProgressUserCounters"}[key]
+        return {
+            "PROGRESS_USER_COUNTERS_TAB": "ProgressUserCounters",
+            "PROGRESS_FW_STAGE_STARS_TAB": "ProgressUserFactionStageStars",
+        }[key]
 
     async def fetch_records(_sheet, tab):
         calls.append(("tab", tab))
+        if tab == "ProgressUserFactionStageStars":
+            return []
         return [
             {
                 "user_id": "123456",
@@ -3391,6 +3398,8 @@ def test_fw_my_stars_reads_progress_user_counters(monkeypatch):
     assert calls == [
         ("config", "PROGRESS_USER_COUNTERS_TAB"),
         ("tab", "ProgressUserCounters"),
+        ("config", "PROGRESS_FW_STAGE_STARS_TAB"),
+        ("tab", "ProgressUserFactionStageStars"),
     ]
     embed = interaction.followup.sent[0]["embed"]
     assert embed.title == "Sheet Stars Title"
@@ -3625,7 +3634,7 @@ def test_fw_progress_summary_uses_saved_user_counters():
     assert "Ogryn Tribes: 0/63" in fields["Sheet Focus"]
 
 
-def test_fw_h_progress_includes_compact_solver_hints_for_lowest_stars():
+def test_fw_progress_is_summary_only_without_solver_hints():
     post = _fw_data("FW_H").posts[0]
     embed = service.build_faction_wars_progress_embed(
         post,
@@ -3652,14 +3661,10 @@ def test_fw_h_progress_includes_compact_solver_hints_for_lowest_stars():
     assert "Sheet Finished" in [field.name for field in embed.fields]
     assert "Sheet Close" in [field.name for field in embed.fields]
     assert "Sheet Focus" in [field.name for field in embed.fields]
-    assert "⏳ Ogryn Tribes: 2/63⭐" in focus
-    assert (
-        "Tip: Stage 3, Stun application. Control. Bellower / stun set options." in focus
-    )
+    assert "Ogryn Tribes: 2/63⭐" in focus
+    assert "Stage 3" not in focus
+    assert "Tip:" not in focus
     assert "Keep waves locked" not in focus
-    assert all(
-        len(line) <= 180 for line in focus.splitlines() if line.startswith("Tip:")
-    )
 
 
 def test_fw_normal_progress_does_not_include_solver_hints():
@@ -3684,46 +3689,59 @@ def test_fw_normal_progress_does_not_include_solver_hints():
     assert "Stage 3" not in focus
 
 
-def test_fw_progress_solver_hints_match_estimated_stage_number():
+def test_fw_partial_stage_rows_do_not_override_manual_total():
     post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {"category": "FW_H", "faction_key": "orcs", "stage_number": "1", "stars": "3"},
+        {"category": "FW_H", "faction_key": "orcs", "stage_number": "2", "stars": "2"},
+    ]
     embed = service.build_faction_wars_progress_embed(
         post,
         _fw_static_data(),
         [
             {
                 "category": "FW_H",
-                "counter_key": "banner_lords",
-                "counter_label": "Banner Lords",
+                "counter_key": "orcs",
                 "current_value": "63",
                 "goal_value": "63",
-            },
-            {
-                "category": "FW_H",
-                "counter_key": "high_elves",
-                "counter_label": "High Elves",
-                "current_value": "63",
-                "goal_value": "63",
-            },
-            {
-                "category": "FW_H",
-                "counter_key": "ogryn_tribes",
-                "counter_label": "Ogryn Tribes",
-                "current_value": "63",
-                "goal_value": "63",
-            },
+            }
+        ],
+        stage_rows,
+    )
+    fields = {field.name: field.value for field in embed.fields}
+
+    assert "Orcs: 63/63⭐" in fields["Sheet Finished"]
+    assert "Orcs: 5/63⭐" not in fields["Sheet Focus"]
+
+
+def test_fw_full_stage_rows_override_manual_total():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "orcs",
+            "stage_number": str(stage),
+            "stars": "3" if stage <= 20 else "2",
+        }
+        for stage in range(1, 22)
+    ]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
             {
                 "category": "FW_H",
                 "counter_key": "orcs",
-                "counter_label": "Orcs",
-                "current_value": "12",
+                "current_value": "10",
                 "goal_value": "63",
-            },
+            }
         ],
+        stage_rows,
     )
-    focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
+    fields = {field.name: field.value for field in embed.fields}
 
-    assert "Tip: Stage 5, Turn meter control." in focus
-    assert "Stage 3" not in focus
+    assert "Orcs: 62/63⭐" in fields["Sheet Close"]
+    assert "Orcs: 10/63⭐" not in fields["Sheet Focus"]
 
 
 def test_fw_progress_does_not_show_stale_early_solver_hint_for_late_progress():
@@ -3764,7 +3782,7 @@ def test_fw_progress_does_not_show_stale_early_solver_hint_for_late_progress():
     )
     focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
 
-    assert "⏳ Orcs: 62/63⭐" in focus
+    assert "Orcs: 62/63⭐" in focus
     assert "Tip:" not in focus
     assert "Stage 5" not in focus
     assert "Turn meter control" not in focus
@@ -3908,7 +3926,7 @@ def test_fw_normal_progress_shows_matching_boss_tip_for_boss_stage_only():
 
     assert "High Elves: 18/63" in focus
     assert " — " not in focus
-    assert "\nBoss 7: Turn meter boss • Decrease speed • Control the boss" in focus
+    assert "Boss 7:" not in focus
     assert "Turn meter cuts" not in focus
     assert "Apothecary" not in focus
     assert "normal.example" not in focus
@@ -3947,8 +3965,8 @@ def test_fw_hard_progress_combines_hard_solver_and_boss_tip_without_notes():
     focus = {field.name: field.value for field in embed.fields}["Sheet Focus"]
 
     assert " — " not in focus
-    assert "\nStage 21: No revives. • Shields and control • Ragash" in focus
-    assert "\nBoss 21: Health-swap boss • Shield and control • Save cooldowns" in focus
+    assert "Stage 21:" not in focus
+    assert "Boss 21:" not in focus
     assert "Sustain pressure" not in focus
     assert "Valerie" not in focus
     assert "boss.example" not in focus
@@ -3974,3 +3992,300 @@ def test_fw_progress_does_not_fallback_to_earlier_boss_stage():
     assert "High Elves: 39/63" in focus
     assert "Boss 7:" not in focus
     assert "Boss 14:" not in focus
+
+
+def test_fw_completion_tips_requires_saved_stage_rows():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_completion_tips_embed(
+        post, _fw_static_data(), "banner_lords", []
+    )
+
+    assert embed.description == (
+        "Completion tips need stage stars for this faction. Use Set Stages to save them, "
+        "or use I'm Stuck for one specific stage."
+    )
+
+
+def test_fw_im_stuck_renders_exact_stage_hints_without_saved_progress():
+    post = _fw_data("FW_H").posts[0]
+    embed = service.build_faction_wars_stage_hints_embed(
+        post, _fw_static_data(), "banner_lords", 21
+    )
+
+    assert "Stage condition: No revives." in embed.description
+    assert (
+        "Stage solver: No revives. • Shields and control • Ragash" in embed.description
+    )
+    assert (
+        "Boss 21: Health-swap boss • Shield and control • Save cooldowns"
+        in embed.description
+    )
+    assert "Manual boss wave" not in embed.description
+    assert "Sustain pressure" not in embed.description
+    assert "Valerie" not in embed.description
+    assert "boss.example" not in embed.description
+
+
+def test_fw_partial_stage_rows_do_not_produce_completion_tips():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "banner_lords",
+            "stage_number": "21",
+            "stars": "2",
+        }
+    ]
+    embed = service.build_faction_wars_completion_tips_embed(
+        post, _fw_static_data(), "banner_lords", stage_rows
+    )
+
+    assert embed.description == (
+        "Stage tracking is incomplete for this faction. Use Set Stages to save all 21 "
+        "stages, or use I'm Stuck for one specific stage."
+    )
+
+
+def test_fw_full_stage_rows_produce_completion_tips_below_three_stars():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "banner_lords",
+            "stage_number": str(stage),
+            "stars": "2" if stage == 21 else "3",
+        }
+        for stage in range(1, 22)
+    ]
+    embed = service.build_faction_wars_completion_tips_embed(
+        post, _fw_static_data(), "banner_lords", stage_rows
+    )
+
+    assert "Stage 21: Stage condition: No revives." in embed.description
+    assert "Stage 1:" not in embed.description
+    assert "Manual boss wave" not in embed.description
+
+
+def test_fw_boss_hints_only_render_on_exact_boss_stage():
+    post = _fw_data("FW_N").posts[0]
+    boss = service.build_faction_wars_stage_hints_embed(
+        post, _fw_static_data(), "high_elves", 7
+    )
+    non_boss = service.build_faction_wars_stage_hints_embed(
+        post, _fw_static_data(), "high_elves", 8
+    )
+
+    assert (
+        "Boss 7: Turn meter boss • Decrease speed • Control the boss"
+        in boss.description
+    )
+    assert "Boss 7:" not in non_boss.description
+
+
+def test_fw_mark_perfect_upserts_all_stage_rows_as_three(monkeypatch):
+    header = [
+        "user_id",
+        "category",
+        "faction_key",
+        "faction_name",
+        "stage_number",
+        "stars",
+        "updated_at_utc",
+    ]
+    worksheet = FakeWorksheet()
+    rows = [
+        {
+            "user_id": "123456",
+            "category": "FW_H",
+            "faction_key": "banner_lords",
+            "faction_name": "Banner Lords",
+            "stage_number": "1",
+            "stars": "1",
+            "updated_at_utc": "old",
+        }
+    ]
+
+    async def stage_rows():
+        return "ProgressUserFactionStageStars", rows
+
+    async def get_ws(_sheet, _tab):
+        return worksheet
+
+    monkeypatch.setattr(service, "get_milestones_sheet_id", lambda: "sheet-id")
+    monkeypatch.setattr(service, "_fw_stage_star_rows", stage_rows)
+    monkeypatch.setattr(service, "aget_worksheet", get_ws)
+    monkeypatch.setattr(
+        service, "_load_header", lambda *_args: asyncio.sleep(0, result=header)
+    )
+    monkeypatch.setattr(
+        service,
+        "acall_with_backoff",
+        lambda func, *a, **kw: asyncio.sleep(
+            0, result=func(*a, **{k: v for k, v in kw.items() if k != "attempts"})
+        ),
+    )
+
+    asyncio.run(
+        service.upsert_all_faction_wars_stage_stars(
+            123456, "FW_H", "banner_lords", "Banner Lords", 3
+        )
+    )
+
+    assert worksheet.updates[0][0] == "A2:G2"
+    assert worksheet.updates[0][1][0][4:6] == ["1", "3"]
+    assert len(worksheet.appended) == 20
+    assert {row[0][5] for row in worksheet.appended} == {"3"}
+    assert {row[0][4] for row in worksheet.appended} == {str(i) for i in range(2, 22)}
+
+
+def test_fw_mark_perfect_with_existing_incomplete_stage_rows_makes_progress_complete():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "banner_lords",
+            "stage_number": str(stage),
+            "stars": "3",
+        }
+        for stage in range(1, 22)
+    ]
+    embed = service.build_faction_wars_progress_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "counter_label": "Banner Lords",
+                "current_value": "63",
+                "goal_value": "63",
+                "status": "complete",
+            }
+        ],
+        stage_rows,
+    )
+    fields = {field.name: field.value for field in embed.fields}
+
+    assert "Banner Lords: 63/63⭐" in fields["Sheet Finished"]
+    assert "Banner Lords" not in fields["Sheet Focus"]
+
+
+def test_fw_my_stars_uses_complete_stage_rows_over_manual_total():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "banner_lords",
+            "stage_number": str(stage),
+            "stars": "3" if stage <= 20 else "2",
+        }
+        for stage in range(1, 22)
+    ]
+    embed = service.build_faction_wars_stars_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_H",
+                "counter_key": "banner_lords",
+                "counter_label": "Banner Lords",
+                "current_value": "10",
+                "goal_value": "63",
+            }
+        ],
+        stage_rows,
+    )
+
+    assert "Banner Lords: 62/63⭐" in embed.description
+    assert "Banner Lords: 10/63⭐" not in embed.description
+
+
+def test_fw_my_stars_includes_complete_stage_faction_without_counter_row():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {
+            "category": "FW_H",
+            "faction_key": "orcs",
+            "stage_number": str(stage),
+            "stars": "3",
+        }
+        for stage in range(1, 22)
+    ]
+    embed = service.build_faction_wars_stars_embed(
+        post, _fw_static_data(), [], stage_rows
+    )
+
+    assert "Orcs: 63/63⭐" in embed.description
+    assert "Total saved stars: **63**" in embed.description
+
+
+def test_fw_my_stars_partial_stage_rows_do_not_override_manual_total():
+    post = _fw_data("FW_H").posts[0]
+    stage_rows = [
+        {"category": "FW_H", "faction_key": "orcs", "stage_number": "1", "stars": "2"}
+    ]
+    embed = service.build_faction_wars_stars_embed(
+        post,
+        _fw_static_data(),
+        [
+            {
+                "category": "FW_H",
+                "counter_key": "orcs",
+                "counter_label": "Orcs",
+                "current_value": "40",
+                "goal_value": "63",
+            }
+        ],
+        stage_rows,
+    )
+
+    assert "Orcs: 40/63⭐" in embed.description
+    assert "Orcs: 2/63⭐" not in embed.description
+
+
+def test_fw_set_stages_picker_uses_dedicated_copy(monkeypatch):
+    data = _fw_data("FW_H")
+    service.set_progress_guide_cache(data)
+    service._FW_DATA_CACHE = _fw_static_data()
+    interaction = FakeInteraction()
+
+    asyncio.run(
+        service.FactionWarsPanelButton("FW_H", "Set Stages", "setstages").callback(
+            interaction
+        )
+    )
+
+    embed = interaction.followup.sent[0]["embed"]
+    assert embed.title == "Set Stage Stars"
+    assert embed.description == "Choose a faction to save stage stars."
+    assert embed.title != data.posts[0].conditions_title
+    assert embed.description != "Choose a faction to view details."
+
+
+def test_fw_new_stage_helper_titles_use_colons_not_em_dashes():
+    post = _fw_data("FW_H").posts[0]
+    stage_help = service.build_faction_wars_stage_hints_embed(
+        post, _fw_static_data(), "banner_lords", 21
+    )
+    tips = service.build_faction_wars_completion_tips_embed(
+        post,
+        _fw_static_data(),
+        "banner_lords",
+        [
+            {
+                "category": "FW_H",
+                "faction_key": "banner_lords",
+                "stage_number": str(stage),
+                "stars": "2" if stage == 21 else "3",
+            }
+            for stage in range(1, 22)
+        ],
+    )
+    stuck_picker_title = service._embed_title("Banner Lords: Choose a Stage")
+
+    assert stage_help.title == "Banner Lords: Stage 21 Help"
+    assert tips.title == "Banner Lords: Completion Tips"
+    assert stuck_picker_title == "Banner Lords: Choose a Stage"
+    assert " — " not in stage_help.title
+    assert " — " not in tips.title
+    assert " — " not in stuck_picker_title


### PR DESCRIPTION
### Motivation
- Add per-stage star tracking for Faction Wars so users can save stage stars, get exact stage hints when "I'm Stuck", and receive completion tips that aggregate stage data to recommend next actions. 
- Provide bulk/quick actions to mark a faction perfect and to set stage stars from the UI.

### Description
- Introduces a new config key `_FW_STAGE_STARS_KEY` and functions to fetch, filter, and aggregate stage-star rows (`_fw_stage_star_rows`, `_fw_user_stage_rows`, `_fw_stage_rows_for_faction`, `_fw_stage_star_map`, `_fw_complete_stage_star_map`, `_fw_stage_total`).
- Adds new embeds and helpers to render stage-level information: `build_faction_wars_stage_hints_embed`, `build_faction_wars_completion_tips_embed`, and `_fw_stage_hint_lines`; updates star/progress embeds to prefer complete stage totals when available.
- Adds UI elements and flows: `FactionWarsStageStarsModal`, `FactionWarsStageSelect`, `FactionWarsStagePickerView`, `FactionWarsStageStarsModal` handling, `FactionWarsProgressActionButton`, `build_faction_wars_progress_view`, new custom id prefixes, and integrates "Set Stages", "Mark Perfect", and "I'm Stuck" actions into persistent and panel views.
- Implements persistence helpers `upsert_faction_wars_stage_stars`, `upsert_all_faction_wars_stage_stars`, and `mark_faction_wars_perfect` with sheet/worksheet upsert logic and timezone-stamped rows.
- Updates existing logic to merge stage-based totals with manual counter rows (stage totals take precedence when a complete set of 21 stages is present) and simplifies/hardens solver/hint rendering.
- Updates tests to cover the new behaviors, UI labels, picker flows, upsert logic, and edge cases for partial vs full stage data.

### Testing
- Ran the updated unit tests in `tests/community/test_progress_guides.py`, including new tests for stage rows, completion tips, stage hint embeds, set/mark actions, and upsert helpers, and all tests passed. 
- Executed `pytest` for the community progress guides module to validate embed text, view children/custom IDs, and worksheet interactions, and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b97e81f6c8323bbbe15409cbacd65)