### PR TITLE
Resolve source category from target guild, add diagnostics and tests

### DIFF
--- a/modules/housekeeping/guides_help_index.py
+++ b/modules/housekeeping/guides_help_index.py
@@ -263,28 +263,34 @@ async def _config(key: str, default: str | None = None) -> str | None:
     return await recruitment.get_config_value_async(key, default)
 
 
-async def _resolve_category(
-    bot: discord.Client, category_id: int | None
+def _resolve_category_from_guild(
+    guild: object, category_id: int | None
 ) -> tuple[object | None, str | None]:
     if category_id is None:
         return None, "missing_source_category"
-    channel = bot.get_channel(category_id)
-    if channel is None:
-        try:
-            channel = await bot.fetch_channel(category_id)
-        except discord.NotFound:
-            return None, "missing_source_category"
-        except discord.Forbidden:
-            return None, "discord_permission_issue"
-        except discord.HTTPException:
-            return None, "discord_fetch_issue"
-    if not (
-        isinstance(channel, discord.CategoryChannel)
-        or getattr(channel, "type", None) == discord.ChannelType.category
-        or hasattr(channel, "channels")
-    ):
+
+    categories = list(getattr(guild, "categories", []) or [])
+    for category in categories:
+        if _parse_int(getattr(category, "id", None)) == category_id:
+            return category, None
+
+    resolved = None
+    get_channel = getattr(guild, "get_channel", None)
+    if callable(get_channel):
+        resolved = get_channel(category_id)
+
+    if resolved is not None:
+        log.warning(
+            "guides help index source category resolved outside guild.categories: "
+            "source_id=%s resolved_class=%s resolved_name=%s resolved_type=%s",
+            category_id,
+            resolved.__class__.__name__,
+            getattr(resolved, "name", None),
+            getattr(resolved, "type", None),
+        )
         return None, "invalid_category_type"
-    return channel, None
+
+    return None, "missing_source_category"
 
 
 def _extract_message_slots(state: Mapping[str, str]) -> list[tuple[int, int]]:
@@ -316,12 +322,6 @@ async def refresh_guides_help_index(
     if target_id is None:
         return GuidesHelpIndexResult(status="error", reason="missing_target_channel")
 
-    category, category_error = await _resolve_category(bot, source_id)
-    if category_error:
-        await runtime_helpers.send_log_message(
-            f"❌ Guides help index — error • reason={category_error}"
-        )
-        return GuidesHelpIndexResult(status="error", reason=category_error)
     target, target_error = await runtime_helpers.resolve_configured_text_channel(
         bot,
         channel_id=target_id,
@@ -339,6 +339,15 @@ async def refresh_guides_help_index(
             f"❌ Guides help index — error • reason={reason}"
         )
         return GuidesHelpIndexResult(status="error", reason=reason)
+
+    category, category_error = _resolve_category_from_guild(
+        getattr(target, "guild", None), source_id
+    )
+    if category_error:
+        await runtime_helpers.send_log_message(
+            f"❌ Guides help index — error • reason={category_error}"
+        )
+        return GuidesHelpIndexResult(status="error", reason=category_error)
 
     try:
         state = await server_map_state.fetch_state()

--- a/tests/housekeeping/test_guides_help_index.py
+++ b/tests/housekeeping/test_guides_help_index.py
@@ -45,11 +45,11 @@ class Message:
 
 
 class Target:
-    def __init__(self, messages=None):
+    def __init__(self, messages=None, guild=None):
         self.messages = {m.id: m for m in (messages or [])}
         self.sent = []
         self.id = 60
-        self.guild = SimpleNamespace(name="guild")
+        self.guild = guild or SimpleNamespace(name="guild", categories=[])
 
     async def fetch_message(self, mid):
         if mid not in self.messages:
@@ -107,6 +107,56 @@ async def _noop(*args, **kwargs):
 
 async def _ret(v):
     return v
+
+
+def test_resolve_category_from_guild_returns_matching_guild_category():
+    source_category = SimpleNamespace(id=50, name="🆘GUIDES & HELP", channels=[])
+    other_category = SimpleNamespace(id=51, name="Other", channels=[])
+    guild = SimpleNamespace(categories=[other_category, source_category])
+
+    category, reason = ghi._resolve_category_from_guild(guild, 50)
+
+    assert category is source_category
+    assert reason is None
+
+
+def test_resolve_category_from_guild_invalid_when_get_channel_finds_non_category(
+    caplog,
+):
+    non_category = SimpleNamespace(
+        id=50,
+        name="general",
+        type=ghi.discord.ChannelType.text,
+    )
+
+    class Guild:
+        categories = []
+
+        def get_channel(self, cid):
+            return non_category if cid == 50 else None
+
+    with caplog.at_level("WARNING", logger="c1c.housekeeping.guides_help_index"):
+        category, reason = ghi._resolve_category_from_guild(Guild(), 50)
+
+    assert category is None
+    assert reason == "invalid_category_type"
+    assert "source_id=50" in caplog.text
+    assert "resolved_class=SimpleNamespace" in caplog.text
+    assert "resolved_name=general" in caplog.text
+    assert "resolved_type=text" in caplog.text
+
+
+def test_resolve_category_from_guild_missing_when_no_category_or_channel_found():
+    class Guild:
+        categories = [SimpleNamespace(id=51, name="Other", channels=[])]
+
+        def get_channel(self, cid):
+            return None
+
+    category, reason = ghi._resolve_category_from_guild(Guild(), 50)
+
+    assert category is None
+    assert reason == "missing_source_category"
 
 
 def test_discover_forum_channels_from_category_and_blacklist():
@@ -225,8 +275,12 @@ def test_refresh_edits_reuses_deletes_and_pin_nonfatal(monkeypatch):
     async def run():
         a = tag(10, "Missions", 0)
         f = forum(1, "forum", [a], [thread(12, "y", [a])])
-        target = Target([Message(201, "old", pin_fails=True), Message(202, "stale")])
-        bot = Bot({50: SimpleNamespace(id=50, channels=[f]), 60: target})
+        category = SimpleNamespace(id=50, channels=[f])
+        target = Target(
+            [Message(201, "old", pin_fails=True), Message(202, "stale")],
+            guild=SimpleNamespace(name="guild", categories=[category]),
+        )
+        bot = Bot({60: target})
         monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
 
         async def cfg(key, default=None):
@@ -274,7 +328,8 @@ def test_message_lifecycle_failures_return_clear_reasons(monkeypatch):
     async def run():
         a = tag(10, "Missions", 0)
         f = forum(1, "forum", [a], [thread(12, "y", [a])])
-        bot = Bot({50: SimpleNamespace(id=50, channels=[f])})
+        category = SimpleNamespace(id=50, channels=[f])
+        bot = Bot({})
         monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
 
         async def cfg(key, default=None):
@@ -300,7 +355,8 @@ def test_message_lifecycle_failures_return_clear_reasons(monkeypatch):
                     message="boom",
                 )
 
-        send_fail = SendFailTarget([])
+        guild = SimpleNamespace(name="guild", categories=[category])
+        send_fail = SendFailTarget([], guild=guild)
         monkeypatch.setattr(
             ghi.runtime_helpers,
             "resolve_configured_text_channel",
@@ -317,7 +373,7 @@ def test_message_lifecycle_failures_return_clear_reasons(monkeypatch):
                     message="boom",
                 )
 
-        edit_fail = Target([EditFailMessage(201, "old")])
+        edit_fail = Target([EditFailMessage(201, "old")], guild=guild)
         monkeypatch.setattr(
             ghi.runtime_helpers,
             "resolve_configured_text_channel",
@@ -332,7 +388,7 @@ def test_message_lifecycle_failures_return_clear_reasons(monkeypatch):
             await ghi.refresh_guides_help_index(bot, force=True)
         ).reason == "message_edit_failed"
 
-        target = Target([])
+        target = Target([], guild=guild)
         monkeypatch.setattr(
             ghi.runtime_helpers,
             "resolve_configured_text_channel",
@@ -355,8 +411,9 @@ def test_manual_force_bypasses_interval(monkeypatch):
     async def run():
         a = tag(10, "Missions", 0)
         f = forum(1, "forum", [a], [thread(12, "y", [a])])
-        target = Target([])
-        bot = Bot({50: SimpleNamespace(id=50, channels=[f]), 60: target})
+        category = SimpleNamespace(id=50, channels=[f])
+        target = Target([], guild=SimpleNamespace(name="guild", categories=[category]))
+        bot = Bot({60: target})
         monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
 
         async def cfg(key, default=None):
@@ -387,5 +444,95 @@ def test_manual_force_bypasses_interval(monkeypatch):
             await ghi.refresh_guides_help_index(bot, force=False)
         ).reason == "interval_not_elapsed"
         assert (await ghi.refresh_guides_help_index(bot, force=True)).status == "ok"
+
+    asyncio.run(run())
+
+
+def test_refresh_resolves_source_category_from_target_guild_categories(monkeypatch):
+    async def run():
+        a = tag(10, "Missions", 0)
+        f = forum(1, "forum", [a], [thread(12, "y", [a])])
+        source_category = SimpleNamespace(id=50, name="🆘GUIDES & HELP", channels=[f])
+        bad_old_resolver_object = SimpleNamespace(
+            id=50,
+            name="not-a-category-cache-shape",
+            type="text",
+        )
+        guild = SimpleNamespace(name="guild", categories=[source_category])
+        target = Target([], guild=guild)
+        bot = Bot({50: bad_old_resolver_object, 60: target})
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return {
+                ghi.CONFIG_SOURCE_CATEGORY_ID: "50",
+                ghi.CONFIG_TARGET_CHANNEL_ID: "60",
+                ghi.CONFIG_REFRESH_DAYS: "1",
+            }.get(key, default)
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((target, None)),
+        )
+        monkeypatch.setattr(ghi.runtime_helpers, "send_log_message", lambda msg: _noop())
+        monkeypatch.setattr(ghi.server_map_state, "fetch_state", lambda: _ret({}))
+        monkeypatch.setattr(ghi.server_map_state, "update_state", lambda entries: _noop())
+
+        result = await ghi.refresh_guides_help_index(bot, force=True, actor="command")
+
+        assert result.status == "ok"
+        assert result.indexed_posts == 1
+        assert target.sent
+
+    asyncio.run(run())
+
+
+def test_non_category_source_id_returns_invalid_category_type_with_diagnostics(
+    monkeypatch, caplog
+):
+    async def run():
+        non_category = SimpleNamespace(
+            id=50,
+            name="general",
+            type=ghi.discord.ChannelType.text,
+        )
+
+        class Guild:
+            name = "guild"
+            categories = []
+
+            def get_channel(self, cid):
+                return non_category if cid == 50 else None
+
+        target = Target([], guild=Guild())
+        bot = Bot({60: target})
+        monkeypatch.setattr(ghi.feature_flags, "is_enabled", lambda key: True)
+
+        async def cfg(key, default=None):
+            return {
+                ghi.CONFIG_SOURCE_CATEGORY_ID: "50",
+                ghi.CONFIG_TARGET_CHANNEL_ID: "60",
+            }.get(key, default)
+
+        monkeypatch.setattr(ghi, "_config", cfg)
+        monkeypatch.setattr(
+            ghi.runtime_helpers,
+            "resolve_configured_text_channel",
+            lambda *a, **k: _ret((target, None)),
+        )
+        monkeypatch.setattr(ghi.runtime_helpers, "send_log_message", lambda msg: _noop())
+
+        with caplog.at_level("WARNING", logger="c1c.housekeeping.guides_help_index"):
+            result = await ghi.refresh_guides_help_index(bot, force=True)
+
+        assert result.status == "error"
+        assert result.reason == "invalid_category_type"
+        log_text = caplog.text
+        assert "source_id=50" in log_text
+        assert "resolved_class=SimpleNamespace" in log_text
+        assert "resolved_name=general" in log_text
+        assert "resolved_type=text" in log_text
 
     asyncio.run(run())


### PR DESCRIPTION
### Motivation

- The category resolution previously relied on fetching channels via the bot which could return non-category objects or fail when channel caching shapes differed from expectations, causing ambiguous errors. 
- The goal is to resolve the configured source category more robustly from the target channel's guild (using `guild.categories`) and provide better diagnostics when a non-category object is found. 
- Tests and fixtures needed updating to exercise the new resolution code path and to assert diagnostic logging.

### Description

- Replaced the async `_resolve_category` that used `bot.get_channel`/`fetch_channel` with a synchronous `_resolve_category_from_guild(guild, category_id)` that first searches `guild.categories` and then falls back to `guild.get_channel` if present, returning structured error reasons. 
- Added a warning log with diagnostic fields when `get_channel` resolves a non-category object so operators can inspect `resolved_class`, `resolved_name`, and `resolved_type`. 
- Updated `refresh_guides_help_index` to call the new resolver with `getattr(target, "guild", None)` and handle the new error reasons. 
- Updated and added unit tests in `tests/housekeeping/test_guides_help_index.py` and modified test fixtures to supply a `guild` on `Target` objects to cover the new resolution flow and diagnostic logging.

### Testing

- Ran the unit tests in `tests/housekeeping/test_guides_help_index.py` which exercise category resolution, diagnostic logging, and the refreshed index behavior, and they all passed. 
- Existing tests for message lifecycle and blacklist/grouping behavior were updated and executed successfully. 
- New tests verifying diagnostics and resolution from `target.guild.categories` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ba6f35d0c83239bb8a52487a00ee8)