### PR TITLE
Remove FW champion fallback reads

### DIFF
--- a/modules/community/progress_guides/service.py
+++ b/modules/community/progress_guides/service.py
@@ -2706,12 +2706,16 @@ def build_faction_wars_guide_embed(
             or "No champion guide is configured for that faction yet."
         )
         return embed
+    champion_value = _text(row.get("recommended_champions"))
+    if champion_value:
+        embed.add_field(
+            name=_embed_title(
+                post.faction_guide_champions_field_title or "Recommended champions"
+            ),
+            value=_limit_text(champion_value, _FIELD_LIMIT),
+            inline=False,
+        )
     for title, key, fallback in (
-        (
-            post.faction_guide_champions_field_title,
-            "recommended_champions",
-            "Recommended champions",
-        ),
         (post.faction_guide_roles_field_title, "core_roles", "Core roles"),
         (
             post.faction_guide_accessible_field_title,

--- a/tests/community/test_progress_guides.py
+++ b/tests/community/test_progress_guides.py
@@ -3801,6 +3801,47 @@ def test_fw_faction_guide_uses_live_headers_and_sheet_field_titles():
     assert fields["Sheet Note"] == "Build control first."
 
 
+def test_fw_champion_guide_ignores_legacy_champion_columns():
+    post = _fw_data("FW_H").posts[0]
+    fw = service.FactionWarsData(
+        factions=[
+            {
+                "faction_key": "DE",
+                "name": "Dark Elves",
+                "stages": "21",
+                "stars_per_stage": "3",
+                "max_stars": "63",
+            }
+        ],
+        champion_guides=[
+            {
+                "category": "FW_H",
+                "faction_key": "DE",
+                "faction_name": "Dark Elves",
+                "recommended_champions": "",
+                "champion_1": "Should Not Appear",
+                "champion_2": "Also Should Not Appear",
+                "core_roles": "Control and revive.",
+                "accessible_options": "",
+                "planning_note": "",
+                "enabled": "TRUE",
+            }
+        ],
+        hard_stage_conditions=[],
+        hard_stage_solvers=[],
+        boss_solvers=[],
+    )
+
+    embed = service.build_faction_wars_guide_embed(post, fw, "DE")
+
+    fields = {field.name: field.value for field in embed.fields}
+    all_field_text = "\n".join(f"{field.name}\n{field.value}" for field in embed.fields)
+    assert "Should Not Appear" not in all_field_text
+    assert "Also Should Not Appear" not in all_field_text
+    assert "Sheet Champions" not in fields
+    assert fields["Sheet Roles"] == "Control and revive."
+
+
 def test_fw_conditions_uses_stage_columns_and_solver_stage_number():
     post = _fw_data("FW_H").posts[0]
     embed = service.build_faction_wars_conditions_embed(


### PR DESCRIPTION
### Motivation
- The Faction Wars champion guide still fell back to legacy `champion_1`–`champion_5` columns that were removed from the sheet, violating the sheet contract that `recommended_champions` is the single source of champion display text. 
- The change ensures the champions display uses only `recommended_champions` and that no automatic fallback or synthesis occurs from removed columns. 

### Description
- Update `build_faction_wars_guide_embed` in `modules/community/progress_guides/service.py` to populate the champions field only from `_text(row.get("recommended_champions"))` and omit the field when that value is blank. 
- Remove the previous loop usage that treated `recommended_champions` as a generic key with fallbacks and keep rendering behavior for `core_roles`, `accessible_options`, and `planning_note` unchanged. 
- Add a regression test `test_fw_champion_guide_ignores_legacy_champion_columns` in `tests/community/test_progress_guides.py` that proves legacy `champion_1`/`champion_2` values are ignored and the champions field is omitted when `recommended_champions` is blank. 
- No Google Sheets edits, no new sheet columns, no row normalizers/wrappers, and no inference or generation of champion names were added. 

### Testing
- Ran `rg -n "champion_[1-5]" modules cogs shared` and it returned no production matches. 
- Ran `pytest tests/community/test_progress_guides.py -q` and the test suite passed. 
- Ran `python -m py_compile modules/community/progress_guides/service.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bbc0e2c24832397a8691023b20f85)