### PR TITLE
Sort Guides & Help index posts alphabetically

### DIFF
--- a/modules/housekeeping/guides_help_index.py
+++ b/modules/housekeeping/guides_help_index.py
@@ -24,7 +24,6 @@ FEATURE_KEY = "GUIDES_HELP_INDEX_ENABLED"
 DEFAULT_MESSAGE_THRESHOLD = 1800
 BULLET = "🔹"
 HEADER = "# 🛠️ Guides & Help Index"
-INTRO = "Generated from tagged forum posts in 🆘GUIDES & HELP."
 
 CONFIG_SOURCE_CATEGORY_ID = "GUIDES_HELP_INDEX_SOURCE_CATEGORY_ID"
 CONFIG_TARGET_CHANNEL_ID = "GUIDES_HELP_INDEX_TARGET_CHANNEL_ID"
@@ -144,18 +143,8 @@ def _tag_group_sort_key(
     return (0, available_tag_index, tag_name.casefold())
 
 
-def _thread_sort_key(item: IndexedThread) -> tuple[int, float, str]:
-    thread = item.thread
-    created = getattr(thread, "created_at", None)
-    if isinstance(created, dt.datetime):
-        created_key = created.timestamp()
-    else:
-        created_key = 0.0
-    return (
-        _sort_key(item.forum)[0],
-        created_key,
-        str(getattr(thread, "name", "")).casefold(),
-    )
+def _thread_sort_key(item: IndexedThread) -> str:
+    return (_text(getattr(item.thread, "name", "")) or "").casefold()
 
 
 def _thread_mention(thread: object) -> str:
@@ -232,7 +221,7 @@ def build_index_messages(
             if rendered_this_thread and thread_id:
                 indexed_ids.add(thread_id)
 
-    blocks = [f"{HEADER}\n\n{INTRO}".rstrip()]
+    blocks = [HEADER]
     for tag_name, (_, items) in sorted(grouped.items(), key=_tag_group_sort_key):
         lines = [f"## {tag_name}", ""]
         seen: set[str] = set()

--- a/tests/housekeeping/test_guides_help_index.py
+++ b/tests/housekeeping/test_guides_help_index.py
@@ -194,6 +194,34 @@ def test_tag_groups_follow_available_tags_order_without_position():
     assert body.index("## Faction Wars") < body.index("## Missions")
 
 
+def test_posts_within_tag_group_are_sorted_by_name_case_insensitively():
+    a = tag(10, "Missions", 0)
+    f = forum(
+        1,
+        "forum",
+        [a],
+        [
+            thread(12, "Zulu guide", [a], created=1),
+            thread(13, "alpha guide", [a], created=3),
+            thread(14, "Bravo guide", [a], created=2),
+        ],
+    )
+
+    body = "\n".join(ghi.build_index_messages([f], {1: f.threads})[0])
+
+    assert body.index("<#T13>") < body.index("<#T14>") < body.index("<#T12>")
+
+
+def test_generated_text_omits_source_subtitle():
+    a = tag(10, "Missions", 0)
+    f = forum(1, "forum", [a], [thread(12, "guide", [a])])
+
+    body = "\n".join(ghi.build_index_messages([f], {1: f.threads})[0])
+
+    assert "Generated from tagged forum posts" not in body
+    assert body.startswith(f"{ghi.HEADER}\n\n## Missions")
+
+
 def test_tag_and_post_blacklists_hide_content():
     a = tag(10, "Missions", 0)
     b = tag(11, "Faction Wars", 1)
@@ -210,7 +238,7 @@ def test_output_splits_when_threshold_exceeded():
     a = tag(10, "Missions", 0)
     b = tag(11, "Faction Wars", 1)
     f = forum(1, "forum", [a, b], [thread(12, "long", [a]), thread(13, "long2", [b])])
-    messages, _, _ = ghi.build_index_messages([f], {1: f.threads}, threshold=90)
+    messages, _, _ = ghi.build_index_messages([f], {1: f.threads}, threshold=60)
     assert len(messages) > 1
 
 


### PR DESCRIPTION
### Motivation
- Remove the generated-source subtitle so the index begins with the title and tag groups only.
- Ensure posts within each tag group are ordered alphabetically A→Z by their visible thread/post name (case-insensitive) while preserving existing tag-group ordering and existing blacklist/pinning/splitting behavior.

### Description
- Stop emitting the subtitle by removing the `INTRO` line from the rendered header so blocks start with `HEADER` only.
- Replace the previous sort key with a stable case-insensitive thread-name key by changing `_thread_sort_key` to return the thread name `.casefold()` and sort each tag group with this key before rendering.
- Keep tag-group ordering unchanged via the existing `_tag_group_sort_key` and leave message-splitting/pinning/state logic untouched.
- Add tests `test_posts_within_tag_group_are_sorted_by_name_case_insensitively` and `test_generated_text_omits_source_subtitle`, and adjust the threshold split test to account for the shorter header.

### Testing
- Ran `pytest tests/housekeeping/test_guides_help_index.py -q` and all tests passed (no failures).
- Ran `python -m py_compile modules/housekeeping/guides_help_index.py` and compilation succeeded.
- Ran `git diff --check` and found no issues.

[approval]
[/approval]

[meta]
labels: bug, tests
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bbd0e54688323aa734bd59005801f)