### PR TITLE
Centralize scheduler jobs, remove 1-minute polling, and split startup summary

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,8 +39,9 @@ from c1c_coreops.rbac import (
     is_admin_member,
 )
 from c1c_coreops.cron_summary import emit_daily_summary
-from modules.recruitment.reporting.daily_recruiter_update import ensure_scheduler_started
-from modules.ops.startup_summary import render_startup_summary
+from modules.recruitment.reporting.daily_recruiter_update import (
+    ensure_scheduler_started,
+)
 from modules.community.fusion.reminders import collect_fusion_reminder_startup_summary
 
 logging.basicConfig(
@@ -127,7 +128,9 @@ def _interaction_diagnostics(interaction: object | None) -> dict[str, object]:
     channel = getattr(interaction, "channel", None)
     user = getattr(interaction, "user", None)
     message = getattr(interaction, "message", None)
-    interaction_type = getattr(getattr(interaction, "type", None), "name", None) or str(getattr(interaction, "type", "-"))
+    interaction_type = getattr(getattr(interaction, "type", None), "name", None) or str(
+        getattr(interaction, "type", "-")
+    )
     return {
         "interaction_type": interaction_type,
         "interaction_id": _safe_id(interaction),
@@ -141,7 +144,9 @@ def _interaction_diagnostics(interaction: object | None) -> dict[str, object]:
             data.get("name") if isinstance(data, dict) else None,
         ),
         "custom_id": _find_custom_id(data),
-        "component_type": data.get("component_type") if isinstance(data, dict) else None,
+        "component_type": (
+            data.get("component_type") if isinstance(data, dict) else None
+        ),
     }
 
 
@@ -161,6 +166,7 @@ async def _send_interaction_error_ops_message(metadata: dict[str, object]) -> No
         )
     except Exception:
         log.warning("failed to send interaction error to log channel", exc_info=True)
+
 
 INTENTS = discord.Intents.default()
 INTENTS.message_content = True
@@ -223,7 +229,9 @@ def _safe_logged_message_content(content: str) -> str:
     return _truncate_text(str(sanitized), LOG_MESSAGE_CONTENT_MAX_LEN)
 
 
-def _can_dispatch_bare_coreops(member: discord.abc.User | discord.Member | None) -> bool:
+def _can_dispatch_bare_coreops(
+    member: discord.abc.User | discord.Member | None,
+) -> bool:
     if not isinstance(member, discord.Member):
         return False
     return is_admin_member(member)
@@ -254,7 +262,11 @@ def _fmt_next_utc(job: object) -> str:
     next_run = getattr(job, "next_run", None)
     if next_run is None:
         return "not scheduled"
-    return next_run.astimezone(dt.timezone.utc).replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M UTC")
+    return (
+        next_run.astimezone(dt.timezone.utc)
+        .replace(second=0, microsecond=0)
+        .strftime("%Y-%m-%d %H:%M UTC")
+    )
 
 
 async def _maybe_capture_onboarding_answer(message: discord.Message) -> bool:
@@ -320,7 +332,9 @@ async def _enforce_guild_allow_list(
     allowed_guilds = get_allowed_guild_ids()
     allowed_sorted = sorted(allowed_guilds)
     connected_guilds = list(bot.guilds)
-    allowed_labels = [guild_label(bot, gid) for gid in allowed_sorted] if allowed_sorted else []
+    allowed_labels = (
+        [guild_label(bot, gid) for gid in allowed_sorted] if allowed_sorted else []
+    )
     connected_labels = [guild_label(bot, g.id) for g in connected_guilds]
     if not allowed_guilds:
         if log_when_empty:
@@ -368,8 +382,6 @@ async def _enforce_guild_allow_list(
     return True
 
 
-
-
 @bot.event
 async def on_ready():
     hb.note_ready()
@@ -386,11 +398,13 @@ async def on_ready():
         "CoreOps RBAC: admin_role_ids=%s staff_role_ids=%s",
         sorted(get_admin_role_ids()),
         sorted(get_staff_role_ids()),
-        )
+    )
     bot._c1c_started_mono = _STARTED_MONO
 
     allowed_guilds = sorted(get_allowed_guild_ids())
-    allowed_labels = [guild_label(bot, gid) for gid in allowed_guilds] if allowed_guilds else []
+    allowed_labels = (
+        [guild_label(bot, gid) for gid in allowed_guilds] if allowed_guilds else []
+    )
     connected_labels = [guild_label(bot, g.id) for g in list(bot.guilds)]
     allow_list_lines = [
         "✅ Guild allow-list",
@@ -427,6 +441,7 @@ async def on_ready():
         watchdog_tuple = runtime.watchdog(delay_sec=5.0)
 
         if not hasattr(bot, "_cron_summary_task"):
+
             async def _daily_summary_loop() -> None:
                 while True:
                     now = dt.datetime.now(dt.timezone.utc)
@@ -468,20 +483,23 @@ async def on_ready():
                 )
             refresh_lines.append(f"• total={preload_report.total_s:.1f}s")
         else:
-            refresh_lines = ["♻️ Refresh", f"• failed: {preload_report.error or 'unknown'}"]
+            refresh_lines = [
+                "♻️ Refresh",
+                f"• failed: {preload_report.error or 'unknown'}",
+            ]
 
     jobs = {getattr(job, "name", ""): job for job in runtime.scheduler.jobs}
     fusion_reminder_lines: list[str]
     try:
         fusion_reminder_lines = await collect_fusion_reminder_startup_summary(
             bot,
-            scheduler_started="fusion_reminders" in jobs,
+            scheduler_started=any(name.startswith("fusion_") for name in jobs),
         )
     except Exception as exc:
         log.exception("fusion reminder startup summary failed")
         fusion_reminder_lines = [
             "🧬 Fusion reminders",
-            f"• started={'yes' if 'fusion_reminders' in jobs else 'no'}",
+            f"• started={'yes' if any(name.startswith('fusion_') for name in jobs) else 'no'}",
             f"• failed={type(exc).__name__}",
         ]
     scheduler_lines = [
@@ -494,7 +512,11 @@ async def on_ready():
         f"• cleanup={_fmt_next_utc(jobs['cleanup_watcher']) if 'cleanup_watcher' in jobs else 'not scheduled'}",
         f"• housekeeping_keepalive={_fmt_next_utc(jobs['housekeeping_keepalive']) if 'housekeeping_keepalive' in jobs else 'not scheduled'}",
         f"• mirralith_overview={_fmt_next_utc(jobs['mirralith_overview']) if 'mirralith_overview' in jobs else 'not scheduled'}",
-        f"• fusion_reminders={_fmt_next_utc(jobs['fusion_reminders']) if 'fusion_reminders' in jobs else 'not scheduled'}",
+        f"• fusion_grouped_reminders={_fmt_next_utc(jobs['fusion_grouped_reminders']) if 'fusion_grouped_reminders' in jobs else 'not scheduled'}",
+        f"• fusion_announcement_refresh={_fmt_next_utc(jobs['fusion_announcement_refresh']) if 'fusion_announcement_refresh' in jobs else 'not scheduled'}",
+        f"• fusion_role_cleanup={_fmt_next_utc(jobs['fusion_role_cleanup']) if 'fusion_role_cleanup' in jobs else 'not scheduled'}",
+        f"• reset_reminders={_fmt_next_utc(jobs['reset_reminders']) if 'reset_reminders' in jobs else 'not scheduled'}",
+        f"• achievement_collector={_fmt_next_utc(jobs['achievement_collector']) if 'achievement_collector' in jobs else 'not scheduled'}",
         *fusion_reminder_lines,
     ]
     watchers_lines = [
@@ -513,7 +535,12 @@ async def on_ready():
         watchdog_lines = ["🐶 Watchdog started", "• failed: unavailable"]
     else:
         _, interval, stall, grace = watchdog_tuple
-        watchdog_lines = ["🐶 Watchdog started", f"• interval={interval}s", f"• stall={stall}s", f"• disconnect_grace={grace}s"]
+        watchdog_lines = [
+            "🐶 Watchdog started",
+            f"• interval={interval}s",
+            f"• stall={stall}s",
+            f"• disconnect_grace={grace}s",
+        ]
 
     global _startup_summary_lock
     if _startup_summary_lock is None:
@@ -523,16 +550,18 @@ async def on_ready():
             if getattr(bot, "_startup_summary_sent", False):
                 return
             bot._startup_summary_sent = True
-            summary = render_startup_summary(
-                sections={
-                    "allow_list": allow_list_lines,
-                    "watchers": watchers_lines,
-                    "scheduler": scheduler_lines,
-                    "watchdog": watchdog_lines,
-                    "refresh": refresh_lines,
-                },
+            startup_message = "\n\n".join(
+                [
+                    "✅ Woadkeeper Startup",
+                    "\n".join(allow_list_lines),
+                    "\n".join(watchers_lines),
+                    "\n".join(watchdog_lines),
+                ]
             )
-            await runtime.send_log_message(summary)
+            scheduler_message = "\n".join(["🧭 Scheduler", *scheduler_lines[1:]])
+            refresh_message = "\n".join(["♻️ Startup Refresh", *refresh_lines[1:]])
+            for message in (startup_message, scheduler_message, refresh_message):
+                await runtime.send_log_message(message)
     except Exception:
         bot._startup_summary_sent = False
         log.exception("startup summary failed", exc_info=True)
@@ -566,11 +595,18 @@ async def on_error(event: str, *_args, **_kwargs) -> None:
     if event == "on_interaction":
         interaction = _args[0] if _args else None
         extra.update(_interaction_diagnostics(interaction))
-        log.error("Unhandled exception in %s", event, exc_info=(exc_type, exc, tb), extra=extra)
+        log.error(
+            "Unhandled exception in %s",
+            event,
+            exc_info=(exc_type, exc, tb),
+            extra=extra,
+        )
         await _send_interaction_error_ops_message(extra)
         return
 
-    log.error("Unhandled exception in %s", event, exc_info=(exc_type, exc, tb), extra=extra)
+    log.error(
+        "Unhandled exception in %s", event, exc_info=(exc_type, exc, tb), extra=extra
+    )
 
 
 @bot.event
@@ -579,9 +615,11 @@ async def on_socket_response(_payload):
 
 
 try:
+
     @bot.event
     async def on_socket_raw_receive(_):
         hb.touch()
+
 except Exception:
     pass
 
@@ -703,7 +741,9 @@ async def on_command_error(ctx: commands.Context, error: Exception):
         await runtime.send_log_message(
             LogTemplates.cmd_error(
                 command=getattr(ctx.command, "name", None) or "-",
-                user=user_label(getattr(ctx, "guild", None), getattr(ctx.author, "id", None)),
+                user=user_label(
+                    getattr(ctx, "guild", None), getattr(ctx.author, "id", None)
+                ),
                 reason=human_reason(error),
             )
         )
@@ -786,7 +826,8 @@ async def main() -> None:
         for sig in (signal.SIGTERM, signal.SIGINT):
             try:
                 loop.add_signal_handler(
-                    sig, lambda s=sig: asyncio.create_task(_shutdown(f"signal:{s.name}"))
+                    sig,
+                    lambda s=sig: asyncio.create_task(_shutdown(f"signal:{s.name}")),
                 )
             except NotImplementedError:
                 log.warning("Signal handlers not supported", extra={"signal": sig.name})

--- a/app.py
+++ b/app.py
@@ -186,7 +186,9 @@ CRON_JOB_NAMES = (
     "cleanup_watcher",
     "housekeeping_keepalive",
     "mirralith_overview",
-    "fusion_reminders",
+    "fusion_grouped_reminders",
+    "fusion_announcement_refresh",
+    "fusion_role_cleanup",
 )
 
 bot = commands.Bot(

--- a/cogs/app_admin.py
+++ b/cogs/app_admin.py
@@ -20,7 +20,6 @@ from modules.housekeeping import guides_help_index
 from shared.config import get_who_we_are_channel_id
 from shared.sheets import recruitment as recruitment_sheet
 
-
 log = logging.getLogger(__name__)
 
 CACHE_REFRESH_JOBS = {
@@ -38,8 +37,18 @@ HOUSEKEEPING_JOBS = {
     "cleanup_watcher",
     "housekeeping_keepalive",
     "guides_help_index_refresh",
+    "achievement_collector",
 }
-GROUP_ORDER = ("Cache Refresh", "recruitment", "housekeeping", "other")
+COMMUNITY_JOBS = {
+    "fusion_grouped_reminders",
+    "fusion_announcement_refresh",
+    "fusion_role_cleanup",
+    "fusion_daily_reconcile",
+    "reset_reminders",
+    "reset_reminders_reconcile",
+    "shard_weekly_reminders",
+}
+GROUP_ORDER = ("Cache Refresh", "Recruitment", "Housekeeping", "Community", "Other")
 
 
 def _format_interval_label(delta: timedelta) -> str:
@@ -59,10 +68,12 @@ def _group_for_job(job_name: str) -> str:
     if job_name in CACHE_REFRESH_JOBS:
         return "Cache Refresh"
     if job_name in RECRUITMENT_JOBS:
-        return "recruitment"
+        return "Recruitment"
     if job_name in HOUSEKEEPING_JOBS:
-        return "housekeeping"
-    return "other"
+        return "Housekeeping"
+    if job_name in COMMUNITY_JOBS:
+        return "Community"
+    return "Other"
 
 
 def _display_job_name(job_name: str, group_name: str) -> str:
@@ -149,7 +160,13 @@ def _build_scheduler_embeds(runtime, component: str | None) -> list[discord.Embe
             display_name = _display_job_name(job_name, group_name)
             next_label = _format_next_run(getattr(job, "next_run", None))
             interval = getattr(job, "interval", None)
-            cadence = _format_interval_label(interval) if interval else "every ?"
+            cadence = (
+                _format_interval_label(interval)
+                if interval
+                else getattr(job, "cadence_label", None)
+                or getattr(job, "schedule_label", None)
+                or "scheduled"
+            )
             entries.append(
                 [
                     f"• {display_name}",
@@ -167,10 +184,7 @@ def _build_scheduler_embeds(runtime, component: str | None) -> list[discord.Embe
 
     for name, value in fields:
         field_len = len(name) + len(value)
-        if (
-            field_count >= 25
-            or current_len + field_len + reserve > 6000
-        ):
+        if field_count >= 25 or current_len + field_len + reserve > 6000:
             current.set_footer(text=footer_text)
             embeds.append(current)
             current = discord.Embed(title=title, colour=embed_color)
@@ -185,6 +199,7 @@ def _build_scheduler_embeds(runtime, component: str | None) -> list[discord.Embe
         embeds.append(current)
 
     return embeds
+
 
 class AppAdmin(commands.Cog):
     """Lightweight administrative utilities for bot operators."""
@@ -354,7 +369,9 @@ class AppAdmin(commands.Cog):
         help="Show upcoming scheduled jobs. Optionally filter by component.",
     )
     @admin_only()
-    async def next_jobs(self, ctx: commands.Context, component: str | None = None) -> None:
+    async def next_jobs(
+        self, ctx: commands.Context, component: str | None = None
+    ) -> None:
         runtime = runtime_helpers.get_active_runtime()
         if runtime is None:
             await ctx.reply("Scheduler unavailable.", mention_author=False)
@@ -479,7 +496,9 @@ class AppAdmin(commands.Cog):
                 )
 
         try:
-            index_message = await target_channel.send(cluster_role_map.build_index_placeholder())
+            index_message = await target_channel.send(
+                cluster_role_map.build_index_placeholder()
+            )
         except discord.HTTPException as exc:
             reason = str(exc) or "index_send_failed"
             await ctx.reply(
@@ -498,7 +517,9 @@ class AppAdmin(commands.Cog):
                 embeds = cluster_role_map.build_category_embeds(category)
                 fallback_messages = []
                 if not embeds:
-                    fallback_messages = cluster_role_map.build_category_fallback_messages(category)
+                    fallback_messages = (
+                        cluster_role_map.build_category_fallback_messages(category)
+                    )
                 if not embeds and not fallback_messages:
                     continue
                 if embeds:
@@ -546,7 +567,9 @@ class AppAdmin(commands.Cog):
             empty_reason = None
 
         try:
-            final_index = cluster_role_map.build_index_message(jump_entries, empty_reason=empty_reason)
+            final_index = cluster_role_map.build_index_message(
+                jump_entries, empty_reason=empty_reason
+            )
             await index_message.edit(content=final_index)
         except discord.HTTPException as exc:
             reason = str(exc) or "index_edit_failed"

--- a/cogs/housekeeping_achievement_collector.py
+++ b/cogs/housekeeping_achievement_collector.py
@@ -13,7 +13,6 @@ from c1c_coreops.rbac import admin_only
 from modules.common import runtime as runtime_helpers
 from modules.housekeeping.achievement_collector import (
     AchievementCollectorError,
-    AchievementCollectorScheduler,
     LeaderboardCache,
     build_leaderboard,
     effective_limit,
@@ -102,13 +101,6 @@ class AchievementCollectorCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self._cache: LeaderboardCache | None = None
-        self._scheduler = AchievementCollectorScheduler(self)
-
-    async def cog_load(self) -> None:
-        self._scheduler.start()
-
-    async def cog_unload(self) -> None:
-        self._scheduler.cancel()
 
     async def cog_command_error(self, ctx: commands.Context, error: Exception) -> None:
         if isinstance(error, commands.BadArgument):

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -231,9 +231,16 @@ async def _startup_preload(bot: commands.Bot | None = None) -> StartupPreloadRep
             quota = is_sheets_rate_limited_error(exc)
             log.exception(
                 "startup preload refresh failed",
-                extra={"bucket": name, "quota_exhausted": quota, "exception_type": type(exc).__name__, "exception_message": str(exc)},
+                extra={
+                    "bucket": name,
+                    "quota_exhausted": quota,
+                    "exception_type": type(exc).__name__,
+                    "exception_message": str(exc),
+                },
             )
-            await send_log_message(f"❌ Startup refresh failed for {name}: {'quota_exhausted' if quota else exc}")
+            await send_log_message(
+                f"❌ Startup refresh failed for {name}: {'quota_exhausted' if quota else exc}"
+            )
             if quota:
                 break
             continue
@@ -871,12 +878,77 @@ class _CronJob:
         return self._scheduler.spawn(runner(), name=task_name)
 
 
+class _DueJob:
+    """A centrally visible job whose next run is supplied by its owner."""
+
+    def __init__(
+        self,
+        scheduler: "Scheduler",
+        *,
+        next_run: datetime | None,
+        tag: str | None,
+        name: str | None,
+        component: str | None,
+        cadence_label: str,
+    ) -> None:
+        self._scheduler = scheduler
+        self.tag = tag
+        self.name = name
+        self.component = component or "default"
+        self.next_run = next_run
+        self.cadence_label = cadence_label
+        self._changed = asyncio.Event()
+
+    @property
+    def schedule_label(self) -> str:
+        return self.cadence_label
+
+    def reschedule(self, next_run: datetime | None) -> None:
+        if next_run is not None and next_run.tzinfo is None:
+            next_run = next_run.replace(tzinfo=timezone.utc)
+        self.next_run = next_run
+        self._changed.set()
+
+    async def _wait(self) -> None:
+        while True:
+            self._changed.clear()
+            if self.next_run is None:
+                await self._changed.wait()
+                continue
+            delay = (self.next_run - datetime.now(timezone.utc)).total_seconds()
+            if delay <= 0:
+                return
+            try:
+                await asyncio.wait_for(self._changed.wait(), timeout=delay)
+            except asyncio.TimeoutError:
+                return
+
+    def do(self, callback: Callable[[], Awaitable[None]]) -> asyncio.Task:
+        async def runner() -> None:
+            while True:
+                await self._wait()
+                # Clear before invoking the callback. Owners explicitly calculate
+                # the following occurrence, so stale due times cannot busy-loop.
+                self.next_run = None
+                try:
+                    await callback()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    log.exception(
+                        "due-time job error",
+                        extra={"job_name": self.name, "tag": self.tag},
+                    )
+
+        return self._scheduler.spawn(runner(), name=self.name or "due_time_job")
+
+
 class Scheduler:
     """Very small asyncio task supervisor for background jobs."""
 
     def __init__(self) -> None:
         self._tasks: list[asyncio.Task] = []
-        self._jobs: list[_RecurringJob] = []
+        self._jobs: list[Any] = []
 
     def spawn(self, coro: Awaitable, *, name: Optional[str] = None) -> asyncio.Task:
         if name is not None:
@@ -939,8 +1011,34 @@ class Scheduler:
         self._jobs.append(job)
         return job
 
+    def at(
+        self,
+        next_run: datetime | None,
+        *,
+        tag: str | None = None,
+        name: str | None = None,
+        component: str | None = None,
+        cadence_label: str = "scheduled",
+    ) -> _DueJob:
+        if name is not None:
+            for existing in self._jobs:
+                if existing.name == name:
+                    if isinstance(existing, _DueJob):
+                        existing.reschedule(next_run)
+                    return existing
+        job = _DueJob(
+            self,
+            next_run=next_run,
+            tag=tag,
+            name=name,
+            component=component,
+            cadence_label=cadence_label,
+        )
+        self._jobs.append(job)
+        return job
+
     @property
-    def jobs(self) -> list[_RecurringJob]:
+    def jobs(self) -> list[Any]:
         return list(self._jobs)
 
     async def shutdown(self) -> None:
@@ -1519,7 +1617,11 @@ class Runtime:
                 self.startup_diag_mark(login_reached=login_reached)
 
                 should_retry, detail = _is_retryable_discord_start_failure(exc)
-                retry_allowed = should_retry and not login_reached and startup_attempt < max_attempts
+                retry_allowed = (
+                    should_retry
+                    and not login_reached
+                    and startup_attempt < max_attempts
+                )
 
                 _startup_phase_log(
                     "discord login",
@@ -1691,19 +1793,8 @@ class Runtime:
         )
         cleanup_logger.info(registration_summary)
 
-        async def registration_notice_runner() -> None:
-            try:
-                await send_log_message(f"🧹 {registration_summary}")
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                cleanup_logger.exception(
-                    "cleanup watcher registration notice failed; recurring cleanup remains scheduled"
-                )
-
-        self.scheduler.spawn(
-            registration_notice_runner(), name="cleanup_registration_notice"
-        )
+        # Registration is included in the final Scheduler startup message;
+        # avoid a routine Discord notice while startup is still in progress.
         successes.append(
             (
                 SimpleNamespace(
@@ -1765,7 +1856,9 @@ class Runtime:
         from modules.housekeeping import keepalive as housekeeping_keepalive
         from modules.housekeeping import mirralith_overview as housekeeping_mirralith
         from modules.housekeeping import c1c_ad as housekeeping_c1c_ad
-        from modules.housekeeping import guides_help_index as housekeeping_guides_help_index
+        from modules.housekeeping import (
+            guides_help_index as housekeeping_guides_help_index,
+        )
         from modules.recruitment import clan_ads as recruitment_clan_ads
         from modules.common import feature_flags
         from shared.sheets import recruitment as recruitment_sheets
@@ -1775,6 +1868,10 @@ class Runtime:
         from modules.community.shard_tracker.scheduler import schedule_shard_jobs
         from modules.community.reset_reminders.scheduler import (
             schedule_reset_reminder_jobs,
+        )
+        from modules.housekeeping.achievement_collector import (
+            parse_schedule,
+            resolve_config,
         )
 
         toggles = shared_config.features
@@ -1796,6 +1893,47 @@ class Runtime:
                 cadence_label=cadence,
             )
             successes.append((spec, job))
+
+        # Achievement Collector commands live in their cog, while scheduling is
+        # owned here so operational views have one complete source of truth.
+        collector_cog = self.bot.get_cog("AchievementCollectorCog")
+        if collector_cog is not None:
+            try:
+                collector_config = await resolve_config()
+                collector_next = parse_schedule(
+                    collector_config.schedule_rrule,
+                    collector_config.schedule_time_utc,
+                )
+            except Exception:
+                log.exception("achievement collector schedule configuration failed")
+            else:
+                collector_job = self.scheduler.at(
+                    collector_next,
+                    tag="housekeeping",
+                    component="housekeeping",
+                    name="achievement_collector",
+                    cadence_label="scheduled",
+                )
+
+                async def achievement_collector_runner() -> None:
+                    try:
+                        config = await resolve_config()
+                        await collector_cog.publish_scheduled(config)
+                    finally:
+                        try:
+                            config = await resolve_config()
+                            collector_job.reschedule(
+                                parse_schedule(
+                                    config.schedule_rrule, config.schedule_time_utc
+                                )
+                            )
+                        except Exception:
+                            log.exception("achievement collector reschedule failed")
+                            collector_job.reschedule(
+                                datetime.now(timezone.utc) + timedelta(hours=1)
+                            )
+
+                collector_job.do(achievement_collector_runner)
 
         await self._register_cleanup_scheduler(
             toggles=toggles,
@@ -1849,7 +1987,9 @@ class Runtime:
                     exc=exc,
                 )
             else:
-                log.exception("C1C ad refresh interval lookup failed; skipping schedule")
+                log.exception(
+                    "C1C ad refresh interval lookup failed; skipping schedule"
+                )
 
         if c1c_refresh_days and c1c_refresh_days > 0:
             c1c_ad_job = self.scheduler.every(
@@ -1933,8 +2073,10 @@ class Runtime:
         if toggles.housekeeping_enabled:
             keepalive_logger = logging.getLogger("c1c.housekeeping.keepalive")
             try:
-                keepalive_config = await housekeeping_keepalive.resolve_keepalive_config_async(
-                    keepalive_logger
+                keepalive_config = (
+                    await housekeeping_keepalive.resolve_keepalive_config_async(
+                        keepalive_logger
+                    )
                 )
             except Exception as exc:
                 keepalive_config = None

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -2,62 +2,111 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Awaitable, Callable
 
-from modules.community.fusion.announcement_refresh import process_fusion_announcement_refreshes
-from modules.community.fusion import logs as fusion_logs
-from modules.community.fusion.reminders import process_fusion_reminders
+from modules.community.fusion.announcement_refresh import (
+    process_fusion_announcement_refreshes,
+)
+from modules.community.fusion.reminders import (
+    _load_grouped_sent_keys,
+    _next_grouped_due,
+    _parse_grouped_post_time_utc,
+    process_fusion_reminders,
+)
 from modules.community.fusion.role_cleanup import process_ended_fusion_role_cleanup
+from shared.sheets import fusion as fusion_sheets
 
 if TYPE_CHECKING:
     from modules.common.runtime import Runtime
 
 log = logging.getLogger("c1c.community.fusion.scheduler")
-_NOT_READY_LOG_INTERVAL_SEC = 300.0
-_last_not_ready_log_at: dt.datetime | None = None
 
 
-def _should_log_not_ready(now: dt.datetime) -> bool:
-    global _last_not_ready_log_at
-    if _last_not_ready_log_at is None:
-        _last_not_ready_log_at = now
-        return True
-    if (now - _last_not_ready_log_at).total_seconds() >= _NOT_READY_LOG_INTERVAL_SEC:
-        _last_not_ready_log_at = now
-        return True
-    return False
+def _next_daily(now: dt.datetime, *, hour: int = 0, minute: int = 15) -> dt.datetime:
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    return candidate if candidate > now else candidate + dt.timedelta(days=1)
+
+
+async def reconcile_fusion_jobs(runtime: "Runtime") -> None:
+    """Rebuild event-driven Fusion due times from the current cached sheet data."""
+    now = dt.datetime.now(dt.timezone.utc)
+    target = await fusion_sheets.get_publishable_fusion()
+    published = await fusion_sheets.get_published_fusions()
+
+    specs: list[tuple[str, dt.datetime | None, str, Callable[[], Awaitable[None]]]] = []
+    if target is not None:
+        settings = await fusion_sheets.get_fusion_reminder_settings(now=now)
+        post_time = _parse_grouped_post_time_utc(settings.grouped_post_time_utc)
+        if settings.group_events and post_time is not None and target.end_at_utc > now:
+            sent_keys, _ = await _load_grouped_sent_keys(target)
+            if sent_keys is not None:
+                due = _next_grouped_due(
+                    now=now, post_time=post_time, sent_keys=sent_keys
+                )
+                if target.start_at_utc <= due <= target.end_at_utc:
+                    specs.append(
+                        (
+                            "fusion_grouped_reminders",
+                            due,
+                            "grouped daily",
+                            lambda: process_fusion_reminders(runtime.bot),
+                        )
+                    )
+
+    if published:
+        boundaries = [
+            value
+            for row in published
+            for value in (row.start_at_utc, row.end_at_utc)
+            if value > now
+        ]
+        refresh_due = min([_next_daily(now), *boundaries])
+        specs.append(
+            (
+                "fusion_announcement_refresh",
+                refresh_due,
+                "daily/event boundary",
+                lambda: process_fusion_announcement_refreshes(runtime.bot),
+            )
+        )
+        end_times = [row.end_at_utc for row in published if row.end_at_utc > now]
+        if end_times:
+            specs.append(
+                (
+                    "fusion_role_cleanup",
+                    min(end_times),
+                    "event end",
+                    lambda: process_ended_fusion_role_cleanup(runtime.bot),
+                )
+            )
+
+    for name, due, label, callback in specs:
+        job = runtime.scheduler.at(
+            due, tag="fusion", component="community", name=name, cadence_label=label
+        )
+
+        async def runner(job=job, callback=callback) -> None:
+            await callback()
+            await reconcile_fusion_jobs(runtime)
+
+        job.do(runner)
 
 
 def schedule_fusion_jobs(runtime: "Runtime") -> None:
-    if any(getattr(job, "name", None) == "fusion_reminders" for job in runtime.scheduler.jobs):
-        log.info("fusion scheduler already registered; skipping duplicate job")
+    """Register daily reconciliation and asynchronously discover relevant jobs."""
+    if any(
+        getattr(job, "name", None) == "fusion_daily_reconcile"
+        for job in runtime.scheduler.jobs
+    ):
         return
+    reconcile = runtime.scheduler.every(
+        hours=24, tag="fusion", name="fusion_daily_reconcile", component="community"
+    )
+    reconcile.cadence_label = "daily reconcile"
+    reconcile.do(lambda: reconcile_fusion_jobs(runtime))
+    runtime.scheduler.spawn(
+        reconcile_fusion_jobs(runtime), name="fusion_initial_reconcile"
+    )
 
-    job = runtime.scheduler.every(minutes=1.0, tag="fusion", name="fusion_reminders")
 
-    async def _runner() -> None:
-        if runtime.bot.is_closed() or not runtime.bot.is_ready():
-            now = dt.datetime.now(dt.timezone.utc)
-            if _should_log_not_ready(now):
-                log.info("fusion scheduler paused; bot not ready")
-            return
-        jobs = (
-            ("reminders", process_fusion_reminders),
-            ("announcement_refresh", process_fusion_announcement_refreshes),
-            ("role_cleanup", process_ended_fusion_role_cleanup),
-        )
-        for job_name, job_fn in jobs:
-            try:
-                await job_fn(runtime.bot)
-            except Exception as exc:
-                context = {"job_name": job_name}
-                log.exception("fusion scheduler task failed", extra=context)
-                await fusion_logs.send_ops_alert(
-                    component="scheduler",
-                    summary="fusion_scheduler_task_failed",
-                    dedupe_key=f"fusion:scheduler:{job_name}",
-                    error=exc,
-                    fields=context,
-                )
-
-    job.do(_runner)
+__all__ = ["schedule_fusion_jobs", "reconcile_fusion_jobs"]

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import logging
 from typing import TYPE_CHECKING, Awaitable, Callable
@@ -66,7 +67,7 @@ async def reconcile_fusion_jobs(
                 )
                 if timing is not None:
                     event_boundaries.extend(value for value in timing if value > now)
-        refresh_due = min(event_boundaries) if event_boundaries else _next_daily(now)
+        refresh_due = min([_next_daily(now), *event_boundaries])
         specs.append(
             (
                 "fusion_announcement_refresh",
@@ -98,11 +99,20 @@ async def reconcile_fusion_jobs(
         )
 
         async def runner(job=job, callback=callback, name=name) -> None:
-            await callback()
-            await reconcile_fusion_jobs(
-                runtime,
-                include_cleanup_catchup=name != "fusion_role_cleanup",
-            )
+            try:
+                await callback()
+                await reconcile_fusion_jobs(
+                    runtime,
+                    include_cleanup_catchup=name != "fusion_role_cleanup",
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # _DueJob clears next_run before invoking us. Unexpected owner
+                # failures must leave a safe retry armed rather than silently
+                # disabling the job until the daily reconciliation pass.
+                job.reschedule(dt.datetime.now(dt.timezone.utc) + _DUE_JOB_RETRY_DELAY)
+                raise
             if name == "fusion_grouped_reminders":
                 completed_at = dt.datetime.now(dt.timezone.utc)
                 next_due = job.next_run

--- a/modules/community/fusion/scheduler.py
+++ b/modules/community/fusion/scheduler.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from modules.common.runtime import Runtime
 
 log = logging.getLogger("c1c.community.fusion.scheduler")
+_DUE_JOB_RETRY_DELAY = dt.timedelta(minutes=15)
 
 
 def _next_daily(now: dt.datetime, *, hour: int = 0, minute: int = 15) -> dt.datetime:
@@ -27,7 +28,9 @@ def _next_daily(now: dt.datetime, *, hour: int = 0, minute: int = 15) -> dt.date
     return candidate if candidate > now else candidate + dt.timedelta(days=1)
 
 
-async def reconcile_fusion_jobs(runtime: "Runtime") -> None:
+async def reconcile_fusion_jobs(
+    runtime: "Runtime", *, include_cleanup_catchup: bool = True
+) -> None:
     """Rebuild event-driven Fusion due times from the current cached sheet data."""
     now = dt.datetime.now(dt.timezone.utc)
     target = await fusion_sheets.get_publishable_fusion()
@@ -54,13 +57,16 @@ async def reconcile_fusion_jobs(runtime: "Runtime") -> None:
                     )
 
     if published:
-        boundaries = [
-            value
-            for row in published
-            for value in (row.start_at_utc, row.end_at_utc)
-            if value > now
-        ]
-        refresh_due = min([_next_daily(now), *boundaries])
+        event_boundaries: list[dt.datetime] = []
+        for row in published:
+            events = await fusion_sheets.get_fusion_events(row.fusion_id)
+            for event in events:
+                timing = fusion_sheets.get_valid_event_timing(
+                    event, for_helper="fusion_announcement_refresh_scheduler"
+                )
+                if timing is not None:
+                    event_boundaries.extend(value for value in timing if value > now)
+        refresh_due = min(event_boundaries) if event_boundaries else _next_daily(now)
         specs.append(
             (
                 "fusion_announcement_refresh",
@@ -69,12 +75,18 @@ async def reconcile_fusion_jobs(runtime: "Runtime") -> None:
                 lambda: process_fusion_announcement_refreshes(runtime.bot),
             )
         )
-        end_times = [row.end_at_utc for row in published if row.end_at_utc > now]
-        if end_times:
+        ended = [row for row in published if row.end_at_utc <= now]
+        future_end_times = [row.end_at_utc for row in published if row.end_at_utc > now]
+        cleanup_due = (
+            now
+            if ended and include_cleanup_catchup
+            else (min(future_end_times) if future_end_times else None)
+        )
+        if cleanup_due is not None:
             specs.append(
                 (
                     "fusion_role_cleanup",
-                    min(end_times),
+                    cleanup_due,
                     "event end",
                     lambda: process_ended_fusion_role_cleanup(runtime.bot),
                 )
@@ -85,9 +97,17 @@ async def reconcile_fusion_jobs(runtime: "Runtime") -> None:
             due, tag="fusion", component="community", name=name, cadence_label=label
         )
 
-        async def runner(job=job, callback=callback) -> None:
+        async def runner(job=job, callback=callback, name=name) -> None:
             await callback()
-            await reconcile_fusion_jobs(runtime)
+            await reconcile_fusion_jobs(
+                runtime,
+                include_cleanup_catchup=name != "fusion_role_cleanup",
+            )
+            if name == "fusion_grouped_reminders":
+                completed_at = dt.datetime.now(dt.timezone.utc)
+                next_due = job.next_run
+                if next_due is not None and next_due <= completed_at:
+                    job.reschedule(completed_at + _DUE_JOB_RETRY_DELAY)
 
         job.do(runner)
 

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -49,8 +49,17 @@ _LOAD_FAILURE_ALERT_COOLDOWN_SEC = 1800.0
 _LOAD_FAILURE_ALERT_THRESHOLD = 3
 _LOAD_RETRY_ATTEMPTS = 2
 _LOAD_RETRY_BACKOFF_SEC = 0.5
-_load_failure_state: dict[str, Any] = {"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False}
-_last_successful_load: dict[str, Any] = {"tab_name": None, "header_map": None, "records": None}
+_load_failure_state: dict[str, Any] = {
+    "key": None,
+    "last_alert": 0.0,
+    "failures": 0,
+    "alert_sent": False,
+}
+_last_successful_load: dict[str, Any] = {
+    "tab_name": None,
+    "header_map": None,
+    "records": None,
+}
 _next_sheet_load_after_utc: dt.datetime | None = None
 _PROCESS_LOCK = asyncio.Lock()
 _REQUIRED_COLUMNS: tuple[str, ...] = (
@@ -114,7 +123,9 @@ def _replace_cached_record(
     replaced = False
     for record in records:
         if record.row_number == row_number:
-            updated.append(_ResetReminderRecord(row_number=row_number, reminder=reminder))
+            updated.append(
+                _ResetReminderRecord(row_number=row_number, reminder=reminder)
+            )
             replaced = True
         else:
             updated.append(record)
@@ -228,7 +239,9 @@ def _resolve_header_map(header: list[Any]) -> dict[str, int]:
     return indices
 
 
-async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord]]:
+async def _load_reset_reminder_records(
+    *, active_only: bool
+) -> tuple[str, dict[str, int], list[_ResetReminderRecord]]:
     stage = "config_load"
     started = time.monotonic()
     tab_name = "unknown"
@@ -236,7 +249,10 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
         tab_name = await _tab_name()
         sheet_id = _sheet_id()
         stage = "sheet_fetch"
-        log.info("reset reminder sheet load started", extra={"tab": tab_name, "active_only": active_only})
+        log.info(
+            "reset reminder sheet load started",
+            extra={"tab": tab_name, "active_only": active_only},
+        )
         matrix = await afetch_values(sheet_id, tab_name)
         if not matrix:
             return tab_name, {}, []
@@ -266,7 +282,9 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                 reset_id=_cell(row, header_map["reset_id"]),
                 label=_cell(row, header_map["label"]),
                 status=status,
-                reference_date_utc=_parse_dt(_cell(row, header_map["reference_date_utc"])),
+                reference_date_utc=_parse_dt(
+                    _cell(row, header_map["reference_date_utc"])
+                ),
                 cycle_days=cycle_days,
                 lead_minutes=lead_minutes,
                 role_id=role_id,
@@ -277,12 +295,20 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                 embed_footer=_cell(row, header_map["embed_footer"]),
                 button_label_opt_in=_cell(row, header_map["button_label_opt_in"]),
                 button_label_opt_out=_cell(row, header_map["button_label_opt_out"]),
-                last_sent_for_reset_utc=_parse_dt_optional(_cell(row, header_map["last_sent_for_reset_utc"])),
-                next_scheduled_post_utc=_parse_dt_optional(_cell(row, header_map["next_scheduled_post_utc"])),
-                last_message_id=_parse_optional_int(_cell(row, header_map["last_message_id"])),
+                last_sent_for_reset_utc=_parse_dt_optional(
+                    _cell(row, header_map["last_sent_for_reset_utc"])
+                ),
+                next_scheduled_post_utc=_parse_dt_optional(
+                    _cell(row, header_map["next_scheduled_post_utc"])
+                ),
+                last_message_id=_parse_optional_int(
+                    _cell(row, header_map["last_message_id"])
+                ),
                 emoji_name_or_id=_cell(row, header_map["emojinameorid"]),
             )
-            records.append(_ResetReminderRecord(row_number=row_number, reminder=reminder))
+            records.append(
+                _ResetReminderRecord(row_number=row_number, reminder=reminder)
+            )
         except Exception as exc:
             reason = type(exc).__name__
             invalid_rows.append(
@@ -292,10 +318,17 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                     "reason": reason,
                 }
             )
-            log.exception("invalid reset reminder row skipped", extra={"tab": tab_name, "row_number": row_number})
+            log.exception(
+                "invalid reset reminder row skipped",
+                extra={"tab": tab_name, "row_number": row_number},
+            )
             continue
 
-    valid_active_count = len(records) if active_only else sum(1 for r in records if r.reminder.status.lower() == "active")
+    valid_active_count = (
+        len(records)
+        if active_only
+        else sum(1 for r in records if r.reminder.status.lower() == "active")
+    )
     log.info(
         "reset reminder rows loaded",
         extra={
@@ -319,12 +352,16 @@ async def _load_reset_reminder_records(*, active_only: bool) -> tuple[str, dict[
                     f"⚠️ Reset reminders — invalid active rows skipped • tab={tab_name} • count={len(invalid_rows)} • {detail}"
                 )
             except Exception:
-                log.warning("failed to send reset reminder invalid-row ops alert", exc_info=True)
+                log.warning(
+                    "failed to send reset reminder invalid-row ops alert", exc_info=True
+                )
 
     return tab_name, header_map, records
 
 
-def _next_reset_description(base_description: str, reset_time_utc: dt.datetime | None) -> str:
+def _next_reset_description(
+    base_description: str, reset_time_utc: dt.datetime | None
+) -> str:
     if reset_time_utc is None:
         return base_description
     unix_seconds = int(reset_time_utc.astimezone(dt.timezone.utc).timestamp())
@@ -338,7 +375,9 @@ def _reset_reminder_footer(
     reset_time_utc: dt.datetime,
     cycle_days: int,
 ) -> str:
-    following_cycle_reset_time = reset_time_utc.astimezone(dt.timezone.utc) + dt.timedelta(days=cycle_days)
+    following_cycle_reset_time = reset_time_utc.astimezone(
+        dt.timezone.utc
+    ) + dt.timedelta(days=cycle_days)
     following_cycle_text = (
         "Following cycle reset: "
         f"{following_cycle_reset_time.strftime('%Y-%m-%d %H:%M UTC')}"
@@ -354,7 +393,9 @@ def _custom_emoji_id(value: str) -> int | None:
     return int(match.group(2))
 
 
-def _resolve_custom_emoji(target: discord.abc.Messageable | None, value: str | None) -> discord.Emoji | None:
+def _resolve_custom_emoji(
+    target: discord.abc.Messageable | None, value: str | None
+) -> discord.Emoji | None:
     text = str(value or "").strip()
     if not text:
         return None
@@ -387,11 +428,15 @@ def _is_direct_image_url(value: str) -> bool:
 
 
 def _reset_image_filename(reminder: ResetReminder, extension: str) -> str:
-    safe_reset_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", reminder.reset_id or "reset_reminder").strip("._")
+    safe_reset_id = re.sub(
+        r"[^A-Za-z0-9_.-]+", "_", reminder.reset_id or "reset_reminder"
+    ).strip("._")
     return f"{safe_reset_id or 'reset_reminder'}_icon.{extension}"
 
 
-async def _download_image_url_to_file(url: str, *, reminder: ResetReminder) -> discord.File | None:
+async def _download_image_url_to_file(
+    url: str, *, reminder: ResetReminder
+) -> discord.File | None:
     timeout = aiohttp.ClientTimeout(total=_RESET_IMAGE_DOWNLOAD_TIMEOUT_SEC)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -399,16 +444,29 @@ async def _download_image_url_to_file(url: str, *, reminder: ResetReminder) -> d
                 if response.status < 200 or response.status >= 300:
                     log.warning(
                         "reset reminder image URL download failed",
-                        extra={"reset_id": reminder.reset_id, "image_value": url, "status": response.status},
+                        extra={
+                            "reset_id": reminder.reset_id,
+                            "image_value": url,
+                            "status": response.status,
+                        },
                     )
                     return None
 
-                content_type = str(response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+                content_type = (
+                    str(response.headers.get("Content-Type") or "")
+                    .split(";", 1)[0]
+                    .strip()
+                    .lower()
+                )
                 extension = _SUPPORTED_IMAGE_CONTENT_TYPES.get(content_type)
                 if extension is None:
                     log.warning(
                         "reset reminder image URL rejected; non-image or unsupported content type",
-                        extra={"reset_id": reminder.reset_id, "image_value": url, "content_type": content_type},
+                        extra={
+                            "reset_id": reminder.reset_id,
+                            "image_value": url,
+                            "content_type": content_type,
+                        },
                     )
                     return None
 
@@ -419,7 +477,9 @@ async def _download_image_url_to_file(url: str, *, reminder: ResetReminder) -> d
                         extra={"reset_id": reminder.reset_id, "image_value": url},
                     )
                     return None
-                return discord.File(io.BytesIO(raw), filename=_reset_image_filename(reminder, extension))
+                return discord.File(
+                    io.BytesIO(raw), filename=_reset_image_filename(reminder, extension)
+                )
     except Exception:
         log.warning(
             "reset reminder image URL download failed",
@@ -466,7 +526,9 @@ async def _reset_image_to_file(
         return None
 
     extension = "gif" if bool(getattr(emoji, "animated", False)) else "png"
-    return discord.File(io.BytesIO(raw), filename=_reset_image_filename(reminder, extension))
+    return discord.File(
+        io.BytesIO(raw), filename=_reset_image_filename(reminder, extension)
+    )
 
 
 def _utc_now(now: dt.datetime | None = None) -> dt.datetime:
@@ -495,11 +557,15 @@ def _next_reminder_from_anchor(
     return first_reminder_time + cycles_ahead * cycle
 
 
-def _reset_time_for_scheduled_post(reminder_time_utc: dt.datetime, lead_minutes: int) -> dt.datetime:
+def _reset_time_for_scheduled_post(
+    reminder_time_utc: dt.datetime, lead_minutes: int
+) -> dt.datetime:
     return reminder_time_utc + dt.timedelta(minutes=lead_minutes)
 
 
-def _following_reminder_time(reminder_time_utc: dt.datetime, cycle_days: int) -> dt.datetime:
+def _following_reminder_time(
+    reminder_time_utc: dt.datetime, cycle_days: int
+) -> dt.datetime:
     return reminder_time_utc + dt.timedelta(days=cycle_days)
 
 
@@ -518,12 +584,16 @@ def _advance_reminder_until_reset_future(
 
 async def register_persistent_reset_views(bot: commands.Bot) -> None:
     if not _is_feature_enabled():
-        log.info("reset reminders disabled via feature toggle; skipping persistent view registration")
+        log.info(
+            "reset reminders disabled via feature toggle; skipping persistent view registration"
+        )
         return
     try:
         _, _, records = await _load_reset_reminder_records(active_only=True)
     except Exception:
-        log.exception("failed to load reset reminders for persistent views; skipping reset reminder views")
+        log.exception(
+            "failed to load reset reminders for persistent views; skipping reset reminder views"
+        )
         return
     for record in records:
         reminder = record.reminder
@@ -555,7 +625,9 @@ async def _record_load_failure(exc: Exception) -> None:
     now = time.monotonic()
     previous_key = state.get("key")
     state["key"] = key
-    state["failures"] = (int(state.get("failures") or 0) + 1) if previous_key == key else 1
+    state["failures"] = (
+        (int(state.get("failures") or 0) + 1) if previous_key == key else 1
+    )
 
     stage = getattr(exc, "reset_reminder_stage", "unknown")
     tab = getattr(exc, "reset_reminder_tab", "unknown")
@@ -566,24 +638,35 @@ async def _record_load_failure(exc: Exception) -> None:
         "tab": tab,
         "operation": stage,
         "timeout_type": type(exc).__name__ if isinstance(exc, TimeoutError) else "",
-        "elapsed_s": round(float(elapsed), 3) if isinstance(elapsed, (int, float)) else None,
+        "elapsed_s": (
+            round(float(elapsed), 3) if isinstance(elapsed, (int, float)) else None
+        ),
         "failure_count": state["failures"],
         "exception_type": type(exc).__name__,
         "exception_message": str(exc),
     }
     if previous_key != key or int(state["failures"]) == 1:
-        log.error("failed to load reset reminders; scheduler tick skipped", extra=log_extra, exc_info=(type(exc), exc, exc.__traceback__))
+        log.error(
+            "failed to load reset reminders; scheduler tick skipped",
+            extra=log_extra,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
     else:
         log.info("repeated reset reminder load failure suppressed", extra=log_extra)
 
     last_alert = float(state.get("last_alert") or 0.0)
     should_send = int(state["failures"]) >= _LOAD_FAILURE_ALERT_THRESHOLD and (
-        not bool(state.get("alert_sent")) or previous_key != key or now - last_alert >= _LOAD_FAILURE_ALERT_COOLDOWN_SEC
+        not bool(state.get("alert_sent"))
+        or previous_key != key
+        or now - last_alert >= _LOAD_FAILURE_ALERT_COOLDOWN_SEC
     )
     if should_send:
         state["last_alert"] = now
         state["alert_sent"] = True
-        log.warning("reset reminder Discord warning sent", extra={"consecutive_failures": state["failures"]})
+        log.warning(
+            "reset reminder Discord warning sent",
+            extra={"consecutive_failures": state["failures"]},
+        )
         await _send_ops_log(
             "⚠️ Reset reminders failed to load after repeated ticks; scheduler tick skipped. "
             f"See app logs. error={type(exc).__name__} consecutive_failures={state['failures']}"
@@ -591,7 +674,10 @@ async def _record_load_failure(exc: Exception) -> None:
     else:
         log.info(
             "reset reminder Discord warning suppressed",
-            extra={"consecutive_failures": state["failures"], "threshold": _LOAD_FAILURE_ALERT_THRESHOLD},
+            extra={
+                "consecutive_failures": state["failures"],
+                "threshold": _LOAD_FAILURE_ALERT_THRESHOLD,
+            },
         )
 
 
@@ -599,14 +685,26 @@ async def _record_load_success() -> None:
     failures = int(_load_failure_state.get("failures") or 0)
     alert_sent = bool(_load_failure_state.get("alert_sent"))
     if failures > 0 and alert_sent:
-        log.info("reset reminder recovery message sent", extra={"consecutive_failures": failures})
-        await _send_ops_log(f"✅ Reset reminders loaded again after {failures} failed tick(s).")
+        log.info(
+            "reset reminder recovery message sent",
+            extra={"consecutive_failures": failures},
+        )
+        await _send_ops_log(
+            f"✅ Reset reminders loaded again after {failures} failed tick(s)."
+        )
     elif failures > 0:
-        log.info("reset reminder recovery message suppressed", extra={"consecutive_failures": failures})
-    _load_failure_state.update({"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False})
+        log.info(
+            "reset reminder recovery message suppressed",
+            extra={"consecutive_failures": failures},
+        )
+    _load_failure_state.update(
+        {"key": None, "last_alert": 0.0, "failures": 0, "alert_sent": False}
+    )
 
 
-async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) -> discord.abc.Messageable | None:
+async def _resolve_target_channel(
+    bot: commands.Bot, reminder: ResetReminder
+) -> discord.abc.Messageable | None:
     base_channel = bot.get_channel(reminder.channel_id)
     if base_channel is None:
         try:
@@ -614,7 +712,10 @@ async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) ->
         except Exception as exc:
             log.exception(
                 "reset reminder target channel fetch failed",
-                extra={"reset_id": reminder.reset_id, "channel_id": reminder.channel_id},
+                extra={
+                    "reset_id": reminder.reset_id,
+                    "channel_id": reminder.channel_id,
+                },
             )
             await _send_ops_log(
                 "⚠️ Reset reminder target fetch failed "
@@ -646,7 +747,11 @@ async def _resolve_target_channel(bot: commands.Bot, reminder: ResetReminder) ->
             return thread
         log.warning(
             "reset reminder target thread is not messageable",
-            extra={"reset_id": reminder.reset_id, "channel_id": reminder.channel_id, "thread_id": reminder.thread_id},
+            extra={
+                "reset_id": reminder.reset_id,
+                "channel_id": reminder.channel_id,
+                "thread_id": reminder.thread_id,
+            },
         )
         await _send_ops_log(
             "⚠️ Reset reminder thread is not messageable "
@@ -719,12 +824,16 @@ async def _update_row_after_send(
     )
 
 
-async def _load_reset_reminder_records_resilient(*, active_only: bool) -> tuple[str, dict[str, int], list[_ResetReminderRecord], bool]:
+async def _load_reset_reminder_records_resilient(
+    *, active_only: bool
+) -> tuple[str, dict[str, int], list[_ResetReminderRecord], bool]:
     last_exc: Exception | None = None
     for attempt in range(1, _LOAD_RETRY_ATTEMPTS + 1):
         started = time.monotonic()
         try:
-            tab_name, header_map, records = await _load_reset_reminder_records(active_only=active_only)
+            tab_name, header_map, records = await _load_reset_reminder_records(
+                active_only=active_only
+            )
         except TimeoutError as exc:
             last_exc = exc
             log.warning(
@@ -742,10 +851,15 @@ async def _load_reset_reminder_records_resilient(*, active_only: bool) -> tuple[
             break
         except Exception:
             raise
-        _last_successful_load.update({"tab_name": tab_name, "header_map": header_map, "records": records})
+        _last_successful_load.update(
+            {"tab_name": tab_name, "header_map": header_map, "records": records}
+        )
         log.info(
             "reset reminder sheet load succeeded",
-            extra={"attempt": attempt, "load_duration_ms": round((time.monotonic() - started) * 1000, 1)},
+            extra={
+                "attempt": attempt,
+                "load_duration_ms": round((time.monotonic() - started) * 1000, 1),
+            },
         )
         return tab_name, header_map, records, False
 
@@ -772,10 +886,14 @@ async def _load_reset_reminder_records_resilient(*, active_only: bool) -> tuple[
     raise RuntimeError("reset reminder sheet load failed")
 
 
-async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None = None) -> None:
+async def process_reset_reminders(
+    bot: commands.Bot, *, now: dt.datetime | None = None
+) -> None:
     global _next_sheet_load_after_utc
     if not _is_feature_enabled():
-        log.debug("reset reminders disabled via feature toggle; skipping scheduler tick")
+        log.debug(
+            "reset reminders disabled via feature toggle; skipping scheduler tick"
+        )
         return
     if _PROCESS_LOCK.locked():
         log.info("reset reminder processing already running; skipping overlapping tick")
@@ -818,20 +936,27 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
             )
         else:
             try:
-                tab_name, header_map, records, used_cached_rows = await _load_reset_reminder_records_resilient(active_only=True)
+                tab_name, header_map, records, used_cached_rows = (
+                    await _load_reset_reminder_records_resilient(active_only=True)
+                )
             except Exception as exc:
                 await _record_load_failure(exc)
                 return
             _set_next_sheet_load_after_from_records(records, now_utc)
 
         if used_cached_rows and not used_due_cache:
-            synthetic = TimeoutError("reset reminder sheet load failed; cached rows used")
+            synthetic = TimeoutError(
+                "reset reminder sheet load failed; cached rows used"
+            )
             setattr(synthetic, "reset_reminder_stage", "sheet_fetch")
             setattr(synthetic, "reset_reminder_tab", tab_name)
             await _record_load_failure(synthetic)
             log.info(
                 "reset reminder scheduler continuing with cached rows",
-                extra={"cached_rows": len(records), "consecutive_failed_ticks": _load_failure_state.get("failures")},
+                extra={
+                    "cached_rows": len(records),
+                    "consecutive_failed_ticks": _load_failure_state.get("failures"),
+                },
             )
         elif not used_due_cache:
             await _record_load_success()
@@ -843,13 +968,20 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
             reminder = record.reminder
 
             if reminder.cycle_days <= 0:
-                log.warning("reset reminder skipped; cycle_days must be > 0", extra={"reset_id": reminder.reset_id})
+                log.warning(
+                    "reset reminder skipped; cycle_days must be > 0",
+                    extra={"reset_id": reminder.reset_id},
+                )
                 continue
 
             if reminder.role_id <= 0 or reminder.channel_id <= 0:
                 log.warning(
                     "reset reminder skipped; missing role/channel",
-                    extra={"reset_id": reminder.reset_id, "role_id": reminder.role_id, "channel_id": reminder.channel_id},
+                    extra={
+                        "reset_id": reminder.reset_id,
+                        "role_id": reminder.role_id,
+                        "channel_id": reminder.channel_id,
+                    },
                 )
                 continue
 
@@ -882,9 +1014,14 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                     continue
 
                 reminder_time = reminder.next_scheduled_post_utc
-                reset_time = _reset_time_for_scheduled_post(reminder_time, reminder.lead_minutes)
+                reset_time = _reset_time_for_scheduled_post(
+                    reminder_time, reminder.lead_minutes
+                )
             except Exception:
-                log.exception("reset reminder skipped; failed to compute cycle", extra={"reset_id": reminder.reset_id})
+                log.exception(
+                    "reset reminder skipped; failed to compute cycle",
+                    extra={"reset_id": reminder.reset_id},
+                )
                 continue
 
             if now_utc < reminder_time:
@@ -928,11 +1065,16 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 except Exception:
                     log.exception(
                         "reset reminder next scheduled update failed",
-                        extra={"reset_id": reminder.reset_id, "row_number": record.row_number},
+                        extra={
+                            "reset_id": reminder.reset_id,
+                            "row_number": record.row_number,
+                        },
                     )
                 continue
 
-            following_reminder_time = _following_reminder_time(reminder_time, reminder.cycle_days)
+            following_reminder_time = _following_reminder_time(
+                reminder_time, reminder.cycle_days
+            )
             if reminder.last_sent_for_reset_utc == reset_time:
                 if reminder.next_scheduled_post_utc != following_reminder_time:
                     try:
@@ -955,7 +1097,10 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                     except Exception:
                         log.exception(
                             "reset reminder next scheduled update failed",
-                            extra={"reset_id": reminder.reset_id, "row_number": record.row_number},
+                            extra={
+                                "reset_id": reminder.reset_id,
+                                "row_number": record.row_number,
+                            },
                         )
                 continue
 
@@ -982,12 +1127,17 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 except Exception:
                     log.debug(
                         "failed to delete old reset reminder",
-                        extra={"reset_id": reminder.reset_id, "last_message_id": reminder.last_message_id},
+                        extra={
+                            "reset_id": reminder.reset_id,
+                            "last_message_id": reminder.last_message_id,
+                        },
                     )
 
             embed = discord.Embed(
                 title=reminder.embed_title or reminder.label,
-                description=_next_reset_description(reminder.embed_description, reset_time),
+                description=_next_reset_description(
+                    reminder.embed_description, reset_time
+                ),
                 color=get_embed_colour("community"),
             )
             embed.set_footer(
@@ -1036,7 +1186,9 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 )
                 continue
 
-            following_reminder_time = _following_reminder_time(reminder_time, reminder.cycle_days)
+            following_reminder_time = _following_reminder_time(
+                reminder_time, reminder.cycle_days
+            )
             records = _record_reset_reminder_discord_send_in_memory(
                 records,
                 record,
@@ -1073,20 +1225,62 @@ async def process_reset_reminders(bot: commands.Bot, *, now: dt.datetime | None 
                 )
 
 
-def schedule_reset_reminder_jobs(runtime: "Runtime") -> None:
-    if not _is_feature_enabled():
-        log.info("reset reminders disabled via feature toggle; scheduler job not registered")
-        return
-    if any(getattr(job, "name", None) == "reset_reminders" for job in runtime.scheduler.jobs):
-        log.info("reset reminder scheduler already registered; skipping duplicate job")
-        return
+def _earliest_cached_due() -> dt.datetime | None:
+    records = _last_successful_load.get("records")
+    if not isinstance(records, list):
+        return None
+    values = [
+        record.reminder.next_scheduled_post_utc
+        for record in records
+        if record.reminder.next_scheduled_post_utc is not None
+    ]
+    return min(values) if values else None
 
-    job = runtime.scheduler.every(minutes=1.0, tag="community", name="reset_reminders")
+
+async def reconcile_reset_reminder_jobs(runtime: "Runtime") -> None:
+    """Load active rows, fill missing due values, and arm the earliest due job."""
+    global _next_sheet_load_after_utc
+    _next_sheet_load_after_utc = None
+    await process_reset_reminders(runtime.bot)
+    due = _earliest_cached_due()
+    job = runtime.scheduler.at(
+        due,
+        tag="community",
+        component="community",
+        name="reset_reminders",
+        cadence_label="next reset reminder",
+    )
 
     async def _runner() -> None:
         await process_reset_reminders(runtime.bot)
+        job.reschedule(_earliest_cached_due())
 
     job.do(_runner)
+
+
+def schedule_reset_reminder_jobs(runtime: "Runtime") -> None:
+    if not _is_feature_enabled():
+        log.info(
+            "reset reminders disabled via feature toggle; scheduler job not registered"
+        )
+        return
+    if any(
+        getattr(job, "name", None) == "reset_reminders_reconcile"
+        for job in runtime.scheduler.jobs
+    ):
+        log.info("reset reminder scheduler already registered; skipping duplicate job")
+        return
+    reconcile = runtime.scheduler.every(
+        hours=24,
+        tag="community",
+        component="community",
+        name="reset_reminders_reconcile",
+    )
+    reconcile.cadence_label = "daily reconcile"
+    reconcile.do(lambda: reconcile_reset_reminder_jobs(runtime))
+    runtime.scheduler.spawn(
+        reconcile_reset_reminder_jobs(runtime), name="reset_reminders_initial_reconcile"
+    )
 
 
 __all__ = [
@@ -1095,6 +1289,7 @@ __all__ = [
     "process_reset_reminders",
     "register_persistent_reset_views",
     "schedule_reset_reminder_jobs",
+    "reconcile_reset_reminder_jobs",
     "_load_failure_state",
     "_last_successful_load",
 ]

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -1253,7 +1253,16 @@ async def reconcile_reset_reminder_jobs(runtime: "Runtime") -> None:
     )
 
     async def _runner() -> None:
-        await process_reset_reminders(runtime.bot)
+        try:
+            await process_reset_reminders(runtime.bot)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # _DueJob clears next_run before invoking the owner. Preserve a
+            # bounded retry when an unexpected failure bypasses normal cache
+            # reconciliation instead of leaving this job silently disarmed.
+            job.reschedule(_utc_now() + _DUE_JOB_RETRY_DELAY)
+            raise
         now_utc = _utc_now()
         next_due = _earliest_cached_due()
         if next_due is not None and next_due <= now_utc:

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -49,6 +49,7 @@ _LOAD_FAILURE_ALERT_COOLDOWN_SEC = 1800.0
 _LOAD_FAILURE_ALERT_THRESHOLD = 3
 _LOAD_RETRY_ATTEMPTS = 2
 _LOAD_RETRY_BACKOFF_SEC = 0.5
+_DUE_JOB_RETRY_DELAY = dt.timedelta(minutes=15)
 _load_failure_state: dict[str, Any] = {
     "key": None,
     "last_alert": 0.0,
@@ -1253,7 +1254,11 @@ async def reconcile_reset_reminder_jobs(runtime: "Runtime") -> None:
 
     async def _runner() -> None:
         await process_reset_reminders(runtime.bot)
-        job.reschedule(_earliest_cached_due())
+        now_utc = _utc_now()
+        next_due = _earliest_cached_due()
+        if next_due is not None and next_due <= now_utc:
+            next_due = now_utc + _DUE_JOB_RETRY_DELAY
+        job.reschedule(next_due)
 
     job.do(_runner)
 

--- a/modules/housekeeping/achievement_collector.py
+++ b/modules/housekeeping/achievement_collector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import datetime as dt
 import logging
 import os
@@ -327,40 +326,8 @@ async def resolve_messageable(bot: discord.Client, channel_id: int) -> Any | Non
     return channel if hasattr(channel, "send") else None
 
 
-class AchievementCollectorScheduler:
-    def __init__(self, cog: Any) -> None:
-        self.cog = cog
-        self.task: asyncio.Task[None] | None = None
-        self.last_post_key: str | None = None
-
-    def start(self) -> None:
-        if self.task is None or self.task.done():
-            self.task = asyncio.create_task(self._run(), name="achievement_collector_scheduler")
-
-    def cancel(self) -> None:
-        if self.task is not None:
-            self.task.cancel()
-
-    async def _run(self) -> None:
-        await self.cog.bot.wait_until_ready()
-        while not self.cog.bot.is_closed():
-            try:
-                config = await resolve_config()
-                next_run = parse_schedule(config.schedule_rrule, config.schedule_time_utc)
-                await asyncio.sleep(max(0.0, (next_run - dt.datetime.now(dt.timezone.utc)).total_seconds()))
-                post_key = next_run.strftime("%Y-%m-%dT%H:%MZ")
-                if post_key != self.last_post_key:
-                    self.last_post_key = post_key
-                    await self.cog.publish_scheduled(config)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                log.exception("achievement collector scheduler failed; retrying after backoff")
-                await asyncio.sleep(3600)
-
-
 __all__ = [
-    "AchievementCollectorConfig", "AchievementCollectorError", "AchievementCollectorScheduler",
+    "AchievementCollectorConfig", "AchievementCollectorError",
     "LeaderboardCache", "LeaderboardEntry", "NON_RAID_RANK_COPY", "build_leaderboard",
     "effective_limit", "leaderboard_embed", "load_active_role_ids", "member_has_role",
     "non_raid_rank_embed", "parse_schedule", "rank_embed", "resolve_config",

--- a/tests/cogs/test_achievement_collector.py
+++ b/tests/cogs/test_achievement_collector.py
@@ -172,7 +172,7 @@ def test_preview_publish_rank_routing_embeds_allowed_mentions_and_cache(monkeypa
     monkeypatch.setenv("RAID_ROLE_ID", str(raid.id))
     current=Channel(); publish_ch=Channel(); bot=SimpleNamespace(get_channel=lambda cid: publish_ch, fetch_channel=None, wait_until_ready=lambda: None, is_closed=lambda: True)
     cog = AchievementCollectorCog(bot)
-    cog._scheduler.start = lambda: None
+    assert not hasattr(cog, "_scheduler")
     async def fake_config(): return cfg(channel_id=555, default_limit=5, max_limit=5, min_count=1)
     builds = {"n":0}
     async def fake_build(g, c):

--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -1,5 +1,3 @@
-import asyncio
-import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -24,6 +22,9 @@ class _FakeScheduler:
         self.jobs.append(job)
         return job
 
+    def spawn(self, coro, **_kwargs):
+        coro.close()
+
 
 def test_schedule_fusion_jobs_is_idempotent() -> None:
     runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
@@ -32,10 +33,11 @@ def test_schedule_fusion_jobs_is_idempotent() -> None:
     fusion_scheduler.schedule_fusion_jobs(runtime)
 
     assert len(runtime.scheduler.jobs) == 1
-    assert runtime.scheduler.jobs[0].name == "fusion_reminders"
+    assert runtime.scheduler.jobs[0].name == "fusion_daily_reconcile"
+    assert runtime.scheduler.jobs[0].name != "fusion_reminders"
 
 
-def test_fusion_scheduler_pauses_when_bot_not_ready(
+def test_fusion_scheduler_registers_daily_reconciliation(
     monkeypatch,
     caplog,
 ) -> None:
@@ -47,18 +49,10 @@ def test_fusion_scheduler_pauses_when_bot_not_ready(
     refresh = AsyncMock()
     cleanup = AsyncMock()
     monkeypatch.setattr(fusion_scheduler, "process_fusion_reminders", reminders)
-    monkeypatch.setattr(fusion_scheduler, "process_fusion_announcement_refreshes", refresh)
+    monkeypatch.setattr(
+        fusion_scheduler, "process_fusion_announcement_refreshes", refresh
+    )
     monkeypatch.setattr(fusion_scheduler, "process_ended_fusion_role_cleanup", cleanup)
-    monkeypatch.setattr(fusion_scheduler, "_last_not_ready_log_at", None)
-
     fusion_scheduler.schedule_fusion_jobs(runtime)
-    runner = runtime.scheduler.jobs[0]._runner
-    assert runner is not None
-
-    caplog.set_level(logging.INFO, logger="c1c.community.fusion.scheduler")
-    asyncio.run(runner())
-
-    reminders.assert_not_awaited()
-    refresh.assert_not_awaited()
-    cleanup.assert_not_awaited()
-    assert "fusion scheduler paused; bot not ready" in caplog.text
+    assert runtime.scheduler.jobs[0].name == "fusion_daily_reconcile"
+    assert runtime.scheduler.jobs[0].cadence_label == "daily reconcile"

--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -1,3 +1,5 @@
+import asyncio
+import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -5,12 +7,16 @@ from modules.community.fusion import scheduler as fusion_scheduler
 
 
 class _FakeJob:
-    def __init__(self, *, name: str) -> None:
+    def __init__(self, *, name: str, next_run=None) -> None:
         self.name = name
+        self.next_run = next_run
         self._runner = None
 
     def do(self, runner):
         self._runner = runner
+
+    def reschedule(self, next_run):
+        self.next_run = next_run
 
 
 class _FakeScheduler:
@@ -24,6 +30,47 @@ class _FakeScheduler:
 
     def spawn(self, coro, **_kwargs):
         coro.close()
+
+    def at(self, next_run, **kwargs):
+        name = kwargs["name"]
+        existing = next((job for job in self.jobs if job.name == name), None)
+        if existing is not None:
+            existing.reschedule(next_run)
+            return existing
+        job = _FakeJob(name=name, next_run=next_run)
+        self.jobs.append(job)
+        return job
+
+
+def _runtime():
+    return SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+
+
+def _fusion(now, *, fusion_id="fusion", start_delta=-1, end_delta=1):
+    return SimpleNamespace(
+        fusion_id=fusion_id,
+        start_at_utc=now + dt.timedelta(hours=start_delta),
+        end_at_utc=now + dt.timedelta(hours=end_delta),
+    )
+
+
+def _patch_fusion_data(monkeypatch, *, target=None, published=(), events=None):
+    async def get_target():
+        return target
+
+    async def get_published():
+        return list(published)
+
+    async def get_events(_fusion_id):
+        return list(events or [])
+
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets, "get_publishable_fusion", get_target
+    )
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets, "get_published_fusions", get_published
+    )
+    monkeypatch.setattr(fusion_scheduler.fusion_sheets, "get_fusion_events", get_events)
 
 
 def test_schedule_fusion_jobs_is_idempotent() -> None:
@@ -56,3 +103,84 @@ def test_fusion_scheduler_registers_daily_reconciliation(
     fusion_scheduler.schedule_fusion_jobs(runtime)
     assert runtime.scheduler.jobs[0].name == "fusion_daily_reconcile"
     assert runtime.scheduler.jobs[0].cadence_label == "daily reconcile"
+
+
+def test_grouped_overdue_catchup_backs_off_when_still_due(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    target = _fusion(now)
+    runtime = _runtime()
+    _patch_fusion_data(monkeypatch, target=target)
+
+    async def settings(**_kwargs):
+        return SimpleNamespace(group_events=True, grouped_post_time_utc="00:00")
+
+    async def sent_keys(_target):
+        return set(), True
+
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets, "get_fusion_reminder_settings", settings
+    )
+    monkeypatch.setattr(fusion_scheduler, "_load_grouped_sent_keys", sent_keys)
+    monkeypatch.setattr(
+        fusion_scheduler,
+        "_next_grouped_due",
+        lambda **_kwargs: dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=1),
+    )
+    process = AsyncMock()
+    monkeypatch.setattr(fusion_scheduler, "process_fusion_reminders", process)
+
+    asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
+    job = next(
+        job for job in runtime.scheduler.jobs if job.name == "fusion_grouped_reminders"
+    )
+    assert job.next_run <= dt.datetime.now(dt.timezone.utc)
+    asyncio.run(job._runner())
+
+    process.assert_awaited_once()
+    assert job.next_run >= dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+        minutes=14, seconds=59
+    )
+
+
+def test_cleanup_catches_up_ended_then_schedules_future_end(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    ended = _fusion(now, fusion_id="ended", start_delta=-2, end_delta=-1)
+    future = _fusion(now, fusion_id="future", end_delta=2)
+    runtime = _runtime()
+    _patch_fusion_data(monkeypatch, published=(ended, future))
+    cleanup = AsyncMock()
+    monkeypatch.setattr(fusion_scheduler, "process_ended_fusion_role_cleanup", cleanup)
+
+    asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
+    job = next(
+        job for job in runtime.scheduler.jobs if job.name == "fusion_role_cleanup"
+    )
+    assert job.next_run <= dt.datetime.now(dt.timezone.utc)
+    asyncio.run(job._runner())
+
+    cleanup.assert_awaited_once()
+    assert job.next_run == future.end_at_utc
+
+
+def test_announcement_refresh_uses_event_boundaries(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    parent = _fusion(now, start_delta=-24, end_delta=24)
+    event_start = now + dt.timedelta(hours=2)
+    event_end = now + dt.timedelta(hours=3)
+    event = SimpleNamespace()
+    runtime = _runtime()
+    _patch_fusion_data(monkeypatch, published=(parent,), events=(event,))
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets,
+        "get_valid_event_timing",
+        lambda _event, **_kwargs: (event_start, event_end),
+    )
+
+    asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
+    job = next(
+        job
+        for job in runtime.scheduler.jobs
+        if job.name == "fusion_announcement_refresh"
+    )
+    assert job.next_run == event_start
+    assert job.next_run not in {parent.start_at_utc, parent.end_at_utc}

--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -3,6 +3,8 @@ import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 from modules.community.fusion import scheduler as fusion_scheduler
 
 
@@ -184,3 +186,62 @@ def test_announcement_refresh_uses_event_boundaries(monkeypatch) -> None:
     )
     assert job.next_run == event_start
     assert job.next_run not in {parent.start_at_utc, parent.end_at_utc}
+
+
+def test_announcement_refresh_keeps_earlier_daily_refresh(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    parent = _fusion(now, start_delta=-24, end_delta=72)
+    event = SimpleNamespace()
+    event_start = now + dt.timedelta(days=2)
+    event_end = event_start + dt.timedelta(hours=1)
+    runtime = _runtime()
+    _patch_fusion_data(monkeypatch, published=(parent,), events=(event,))
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets,
+        "get_valid_event_timing",
+        lambda _event, **_kwargs: (event_start, event_end),
+    )
+
+    asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
+    job = next(
+        job
+        for job in runtime.scheduler.jobs
+        if job.name == "fusion_announcement_refresh"
+    )
+    assert job.next_run == fusion_scheduler._next_daily(now)
+
+
+def test_grouped_callback_failure_rearms_due_job(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    target = _fusion(now)
+    runtime = _runtime()
+    _patch_fusion_data(monkeypatch, target=target)
+
+    async def settings(**_kwargs):
+        return SimpleNamespace(group_events=True, grouped_post_time_utc="00:00")
+
+    async def sent_keys(_target):
+        return set(), True
+
+    monkeypatch.setattr(
+        fusion_scheduler.fusion_sheets, "get_fusion_reminder_settings", settings
+    )
+    monkeypatch.setattr(fusion_scheduler, "_load_grouped_sent_keys", sent_keys)
+    monkeypatch.setattr(fusion_scheduler, "_next_grouped_due", lambda **_kwargs: now)
+    monkeypatch.setattr(
+        fusion_scheduler,
+        "process_fusion_reminders",
+        AsyncMock(side_effect=RuntimeError("unexpected")),
+    )
+
+    asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
+    job = next(
+        job for job in runtime.scheduler.jobs if job.name == "fusion_grouped_reminders"
+    )
+    with pytest.raises(RuntimeError, match="unexpected"):
+        asyncio.run(job._runner())
+
+    assert job.next_run is not None
+    assert job.next_run >= dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+        minutes=14, seconds=59
+    )

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -10,12 +10,16 @@ from modules.community.reset_reminders import scheduler
 
 
 class _FakeJob:
-    def __init__(self, *, name: str) -> None:
+    def __init__(self, *, name: str, next_run=None) -> None:
         self.name = name
+        self.next_run = next_run
         self._runner = None
 
     def do(self, runner):
         self._runner = runner
+
+    def reschedule(self, next_run):
+        self.next_run = next_run
 
 
 class _FakeScheduler:
@@ -29,6 +33,16 @@ class _FakeScheduler:
 
     def spawn(self, coro, **_kwargs):
         coro.close()
+
+    def at(self, next_run, **kwargs):
+        name = kwargs["name"]
+        existing = next((job for job in self.jobs if job.name == name), None)
+        if existing is not None:
+            existing.reschedule(next_run)
+            return existing
+        job = _FakeJob(name=name, next_run=next_run)
+        self.jobs.append(job)
+        return job
 
 
 class _DummyMessage:
@@ -473,6 +487,38 @@ def _make_reset_reminder(**overrides):
     }
     values.update(overrides)
     return scheduler.ResetReminder(**values)
+
+
+def test_due_job_catches_up_once_then_backs_off_if_target_remains_missing(
+    monkeypatch,
+) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    reminder = _make_reset_reminder(
+        next_scheduled_post_utc=now - dt.timedelta(minutes=5)
+    )
+    scheduler._last_successful_load["records"] = [
+        scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    ]
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    process = 0
+
+    async def _no_op(_bot):
+        nonlocal process
+        process += 1
+
+    monkeypatch.setattr(scheduler, "process_reset_reminders", _no_op)
+
+    asyncio.run(scheduler.reconcile_reset_reminder_jobs(runtime))
+    job = next(job for job in runtime.scheduler.jobs if job.name == "reset_reminders")
+    assert job.next_run <= dt.datetime.now(dt.timezone.utc)
+    asyncio.run(job._runner())
+
+    # Reconcile/load and one immediate due attempt; a missing target or send
+    # failure leaves the cached timestamp overdue, but cannot hot-loop.
+    assert process == 2
+    assert job.next_run >= dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+        minutes=14, seconds=59
+    )
 
 
 def _run_reset_process(monkeypatch, reminder, now):

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -521,6 +521,34 @@ def test_due_job_catches_up_once_then_backs_off_if_target_remains_missing(
     )
 
 
+def test_due_job_callback_failure_rearms_instead_of_disarming(monkeypatch) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    reminder = _make_reset_reminder(next_scheduled_post_utc=now)
+    scheduler._last_successful_load["records"] = [
+        scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
+    ]
+    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    calls = 0
+
+    async def _process(_bot):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(scheduler, "process_reset_reminders", _process)
+    asyncio.run(scheduler.reconcile_reset_reminder_jobs(runtime))
+    job = next(job for job in runtime.scheduler.jobs if job.name == "reset_reminders")
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        asyncio.run(job._runner())
+
+    assert job.next_run is not None
+    assert job.next_run >= dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+        minutes=14, seconds=59
+    )
+
+
 def _run_reset_process(monkeypatch, reminder, now):
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     channel = _DummyChannel()

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -27,6 +27,9 @@ class _FakeScheduler:
         self.jobs.append(job)
         return job
 
+    def spawn(self, coro, **_kwargs):
+        coro.close()
+
 
 class _DummyMessage:
     def __init__(self, message_id: int) -> None:
@@ -46,14 +49,18 @@ class _DummyChannel:
         assert message_id == 111
         return self.last_message
 
-    async def send(self, *, content=None, files=None, embed=None, view=None, allowed_mentions=None):
-        self.sent.append({
-            "content": content,
-            "files": files or [],
-            "embed": embed,
-            "view": view,
-            "allowed_mentions": allowed_mentions,
-        })
+    async def send(
+        self, *, content=None, files=None, embed=None, view=None, allowed_mentions=None
+    ):
+        self.sent.append(
+            {
+                "content": content,
+                "files": files or [],
+                "embed": embed,
+                "view": view,
+                "allowed_mentions": allowed_mentions,
+            }
+        )
         return _DummyMessage(222)
 
 
@@ -98,7 +105,7 @@ def test_schedule_reset_jobs_is_idempotent(monkeypatch) -> None:
     scheduler.schedule_reset_reminder_jobs(runtime)
 
     assert len(runtime.scheduler.jobs) == 1
-    assert runtime.scheduler.jobs[0].name == "reset_reminders"
+    assert runtime.scheduler.jobs[0].name == "reset_reminders_reconcile"
 
 
 def test_schedule_reset_jobs_not_registered_when_disabled(monkeypatch) -> None:
@@ -113,7 +120,7 @@ def test_schedule_reset_jobs_registered_when_enabled(monkeypatch) -> None:
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
     scheduler.schedule_reset_reminder_jobs(runtime)
     assert len(runtime.scheduler.jobs) == 1
-    assert runtime.scheduler.jobs[0].name == "reset_reminders"
+    assert runtime.scheduler.jobs[0].name == "reset_reminders_reconcile"
 
 
 def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> None:
@@ -141,7 +148,15 @@ def test_process_reset_reminder_sends_once_and_updates_sheet(monkeypatch) -> Non
     updates = []
 
     async def _load(*, active_only: bool):
-        return "ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]
+        return (
+            "ResetTab",
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
+            [record],
+        )
 
     async def _update(**kwargs):
         updates.append(kwargs)
@@ -202,10 +217,23 @@ def test_process_reset_reminder_dedupes_by_last_sent(monkeypatch) -> None:
         "_load_reset_reminder_records",
         lambda *, active_only: asyncio.sleep(
             0,
-            result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]),
+            result=(
+                "ResetTab",
+                {
+                    "last_sent_for_reset_utc": 14,
+                    "next_scheduled_post_utc": 15,
+                    "last_message_id": 16,
+                },
+                [record],
+            ),
         ),
     )
-    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_target_channel",
+        lambda *_args: asyncio.sleep(0, result=channel),
+    )
+
     async def _update(**kwargs):
         updates.append(kwargs)
 
@@ -256,16 +284,29 @@ def test_process_reset_reminder_delete_failure_does_not_block_send(monkeypatch) 
         "_load_reset_reminder_records",
         lambda *, active_only: asyncio.sleep(
             0,
-            result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]),
+            result=(
+                "ResetTab",
+                {
+                    "last_sent_for_reset_utc": 14,
+                    "next_scheduled_post_utc": 15,
+                    "last_message_id": 16,
+                },
+                [record],
+            ),
         ),
     )
+
     async def _update(**kwargs):
         updates.append(kwargs)
 
     monkeypatch.setattr(scheduler, "_update_row_after_send", _update)
     monkeypatch.setattr(scheduler, "_update_next_scheduled_post", _update)
     channel = _DeleteFailChannel()
-    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_target_channel",
+        lambda *_args: asyncio.sleep(0, result=channel),
+    )
     bot = _DummyBot(channel)
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
     assert len(channel.sent) == 1
@@ -275,15 +316,76 @@ def test_process_reset_reminder_delete_failure_does_not_block_send(monkeypatch) 
 def test_invalid_rows_skipped_without_crash(monkeypatch) -> None:
     async def _fetch_values(_sheet_id, _tab):
         return [
-            ["reset_id", "label", "status", "reference_date_utc", "cycle_days", "lead_minutes", "role_id", "channel_id", "thread_id", "embed_title", "embed_description", "embed_footer", "button_label_opt_in", "button_label_opt_out", "last_sent_for_reset_utc", "next_scheduled_post_utc", "last_message_id", "EmojiNameOrId"],
-            ["doom", "Doom", "active", "not-a-date", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", "", "", ""],
-            ["grim", "Grim", "active", "2026-01-01T00:00:00Z", "30", "60", "1", "2", "", "", "", "", "Opt in", "Opt out", "", "", "", ""],
+            [
+                "reset_id",
+                "label",
+                "status",
+                "reference_date_utc",
+                "cycle_days",
+                "lead_minutes",
+                "role_id",
+                "channel_id",
+                "thread_id",
+                "embed_title",
+                "embed_description",
+                "embed_footer",
+                "button_label_opt_in",
+                "button_label_opt_out",
+                "last_sent_for_reset_utc",
+                "next_scheduled_post_utc",
+                "last_message_id",
+                "EmojiNameOrId",
+            ],
+            [
+                "doom",
+                "Doom",
+                "active",
+                "not-a-date",
+                "30",
+                "60",
+                "1",
+                "2",
+                "",
+                "",
+                "",
+                "",
+                "Opt in",
+                "Opt out",
+                "",
+                "",
+                "",
+                "",
+            ],
+            [
+                "grim",
+                "Grim",
+                "active",
+                "2026-01-01T00:00:00Z",
+                "30",
+                "60",
+                "1",
+                "2",
+                "",
+                "",
+                "",
+                "",
+                "Opt in",
+                "Opt out",
+                "",
+                "",
+                "",
+                "",
+            ],
         ]
 
     monkeypatch.setattr(scheduler, "afetch_values", _fetch_values)
-    monkeypatch.setattr(scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab"))
+    monkeypatch.setattr(
+        scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab")
+    )
     monkeypatch.setattr(scheduler, "_sheet_id", lambda: "sheet")
-    tab, header, records = asyncio.run(scheduler._load_reset_reminder_records(active_only=True))
+    tab, header, records = asyncio.run(
+        scheduler._load_reset_reminder_records(active_only=True)
+    )
     assert tab == "ResetTab"
     assert "reset_id" in header
     assert len(records) == 1
@@ -335,7 +437,9 @@ def test_register_persistent_views_active_rows(monkeypatch) -> None:
     monkeypatch.setattr(
         scheduler,
         "_load_reset_reminder_records",
-        lambda *, active_only: asyncio.sleep(0, result=("ResetTab", {"reset_id": 0}, [record])),
+        lambda *, active_only: asyncio.sleep(
+            0, result=("ResetTab", {"reset_id": 0}, [record])
+        ),
     )
 
     bot = _Bot()
@@ -379,7 +483,11 @@ def _run_reset_process(monkeypatch, reminder, now):
     async def _load(*, active_only: bool):
         return (
             "ResetTab",
-            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             [record],
         )
 
@@ -414,7 +522,11 @@ def test_next_scheduled_post_written_from_reference_minus_lead(monkeypatch) -> N
     assert updates == [
         {
             "tab_name": "ResetTab",
-            "header_map": {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            "header_map": {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             "row_number": 7,
             "reminder_time": dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
         }
@@ -423,17 +535,23 @@ def test_next_scheduled_post_written_from_reference_minus_lead(monkeypatch) -> N
 
 def test_lead_zero_at_reset_time_is_stale_and_advances(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=0, next_scheduled_post_utc=reference)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference, lead_minutes=0, next_scheduled_post_utc=reference
+    )
 
     channel, updates = _run_reset_process(monkeypatch, reminder, reference)
 
     assert channel.sent == []
-    assert updates[-1]["reminder_time"] == dt.datetime(2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc)
+    assert updates[-1]["reminder_time"] == dt.datetime(
+        2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc
+    )
 
 
 def test_lead_zero_after_reset_time_is_stale_and_advances(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=0, next_scheduled_post_utc=reference)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference, lead_minutes=0, next_scheduled_post_utc=reference
+    )
 
     channel, updates = _run_reset_process(
         monkeypatch,
@@ -442,13 +560,19 @@ def test_lead_zero_after_reset_time_is_stale_and_advances(monkeypatch) -> None:
     )
 
     assert channel.sent == []
-    assert updates[-1]["reminder_time"] == dt.datetime(2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc)
+    assert updates[-1]["reminder_time"] == dt.datetime(
+        2026, 6, 26, 10, 0, tzinfo=dt.timezone.utc
+    )
 
 
 def test_positive_lead_posts_before_reset_time(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
     reminder_time = dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=reminder_time)
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=reminder_time,
+    )
 
     channel, updates = _run_reset_process(
         monkeypatch,
@@ -458,17 +582,27 @@ def test_positive_lead_posts_before_reset_time(monkeypatch) -> None:
 
     assert len(channel.sent) == 1
     assert updates[-1]["reset_time"] == reference
-    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(
+        2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc
+    )
 
 
 def test_successful_post_updates_last_sent_and_next_scheduled(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+    )
 
-    _channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    _channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert updates[-1]["reset_time"] == reference
-    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(
+        2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc
+    )
     assert updates[-1]["message_id"] == 222
 
 
@@ -482,7 +616,9 @@ def test_same_last_sent_suppresses_duplicate(monkeypatch) -> None:
         next_scheduled_post_utc=following,
     )
 
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent == []
     assert updates == []
@@ -497,7 +633,9 @@ def test_older_last_sent_does_not_suppress_current_reset(monkeypatch) -> None:
         next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
     )
 
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert len(channel.sent) == 1
     assert updates[-1]["reset_time"] == reference
@@ -505,12 +643,20 @@ def test_older_last_sent_does_not_suppress_current_reset(monkeypatch) -> None:
 
 def test_empty_thread_id_posts_to_channel_id(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, thread_id=None, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        thread_id=None,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+    )
 
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert len(channel.sent) == 1
     assert updates[-1]["reset_time"] == reference
+
 
 def test_next_scheduled_post_present_future_does_not_send(monkeypatch) -> None:
     reference = dt.datetime(2026, 6, 8, 7, 30, tzinfo=dt.timezone.utc)
@@ -523,13 +669,17 @@ def test_next_scheduled_post_present_future_does_not_send(monkeypatch) -> None:
         next_scheduled_post_utc=scheduled,
     )
 
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 7, 8, 3, 29, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 7, 8, 3, 29, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent == []
     assert updates == []
 
 
-def test_next_scheduled_post_present_due_displays_derived_reset_time(monkeypatch) -> None:
+def test_next_scheduled_post_present_due_displays_derived_reset_time(
+    monkeypatch,
+) -> None:
     reference = dt.datetime(2026, 6, 8, 7, 30, tzinfo=dt.timezone.utc)
     scheduled = dt.datetime(2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc)
     reset_time = dt.datetime(2026, 7, 8, 7, 30, tzinfo=dt.timezone.utc)
@@ -544,13 +694,22 @@ def test_next_scheduled_post_present_due_displays_derived_reset_time(monkeypatch
     channel, updates = _run_reset_process(monkeypatch, reminder, scheduled)
 
     assert len(channel.sent) == 1
-    assert f"<t:{int(reset_time.timestamp())}:F>" in channel.sent[0]["embed"].description
-    assert f"<t:{int(reference.timestamp())}:F>" not in channel.sent[0]["embed"].description
+    assert (
+        f"<t:{int(reset_time.timestamp())}:F>" in channel.sent[0]["embed"].description
+    )
+    assert (
+        f"<t:{int(reference.timestamp())}:F>"
+        not in channel.sent[0]["embed"].description
+    )
     assert updates[-1]["reset_time"] == reset_time
-    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc)
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(
+        2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc
+    )
 
 
-def test_next_scheduled_post_blank_computes_from_anchor_and_does_not_send_stale(monkeypatch) -> None:
+def test_next_scheduled_post_blank_computes_from_anchor_and_does_not_send_stale(
+    monkeypatch,
+) -> None:
     reference = dt.datetime(2026, 6, 8, 7, 30, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(
         reset_id="doom_tower",
@@ -560,13 +719,19 @@ def test_next_scheduled_post_blank_computes_from_anchor_and_does_not_send_stale(
         next_scheduled_post_utc=None,
     )
 
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 7, 1, 12, 0, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 7, 1, 12, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent == []
     assert updates == [
         {
             "tab_name": "ResetTab",
-            "header_map": {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            "header_map": {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             "row_number": 7,
             "reminder_time": dt.datetime(2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc),
         }
@@ -590,7 +755,11 @@ def test_blank_next_scheduled_cached_tick_does_not_rewrite(monkeypatch) -> None:
         load_calls["count"] += 1
         return (
             "ResetTab",
-            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             [record],
         )
 
@@ -604,11 +773,15 @@ def test_blank_next_scheduled_cached_tick_does_not_rewrite(monkeypatch) -> None:
 
     bot = _DummyBot(_DummyChannel())
     asyncio.run(scheduler.process_reset_reminders(bot, now=now))
-    asyncio.run(scheduler.process_reset_reminders(bot, now=now + dt.timedelta(minutes=1)))
+    asyncio.run(
+        scheduler.process_reset_reminders(bot, now=now + dt.timedelta(minutes=1))
+    )
 
     assert load_calls["count"] == 1
     assert len(updates) == 1
-    assert updates[0]["reminder_time"] == dt.datetime(2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc)
+    assert updates[0]["reminder_time"] == dt.datetime(
+        2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc
+    )
 
 
 def test_due_reminder_cached_tick_does_not_resend(monkeypatch) -> None:
@@ -632,7 +805,11 @@ def test_due_reminder_cached_tick_does_not_resend(monkeypatch) -> None:
         load_calls["count"] += 1
         return (
             "ResetTab",
-            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             [record],
         )
 
@@ -650,7 +827,11 @@ def test_due_reminder_cached_tick_does_not_resend(monkeypatch) -> None:
 
     bot = _DummyBot(channel)
     asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time))
-    asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time + dt.timedelta(minutes=1)))
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            bot, now=reminder_time + dt.timedelta(minutes=1)
+        )
+    )
 
     assert load_calls["count"] == 1
     assert len(channel.sent) == 1
@@ -658,11 +839,15 @@ def test_due_reminder_cached_tick_does_not_resend(monkeypatch) -> None:
     assert updates[0]["reset_time"] == reset_time
     cached = scheduler._last_successful_load["records"][0].reminder
     assert cached.last_sent_for_reset_utc == reset_time
-    assert cached.next_scheduled_post_utc == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+    assert cached.next_scheduled_post_utc == dt.datetime(
+        2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc
+    )
     assert cached.last_message_id == 222
 
 
-def test_due_reminder_sheet_update_failure_still_suppresses_cached_resend(monkeypatch) -> None:
+def test_due_reminder_sheet_update_failure_still_suppresses_cached_resend(
+    monkeypatch,
+) -> None:
     reminder_time = dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
     reset_time = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(
@@ -684,7 +869,11 @@ def test_due_reminder_sheet_update_failure_still_suppresses_cached_resend(monkey
         load_calls["count"] += 1
         return (
             "ResetTab",
-            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             [record],
         )
 
@@ -706,14 +895,20 @@ def test_due_reminder_sheet_update_failure_still_suppresses_cached_resend(monkey
 
     bot = _DummyBot(channel)
     asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time))
-    asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time + dt.timedelta(minutes=1)))
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            bot, now=reminder_time + dt.timedelta(minutes=1)
+        )
+    )
 
     assert load_calls["count"] == 1
     assert len(channel.sent) == 1
     assert update_attempts["count"] == 1
     cached = scheduler._last_successful_load["records"][0].reminder
     assert cached.last_sent_for_reset_utc == reset_time
-    assert cached.next_scheduled_post_utc == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+    assert cached.next_scheduled_post_utc == dt.datetime(
+        2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc
+    )
     assert cached.last_message_id == 222
     assert ops_logs and "posted but sheet update failed" in ops_logs[0]
 
@@ -736,7 +931,11 @@ def test_same_last_sent_cached_tick_advances_once(monkeypatch) -> None:
         load_calls["count"] += 1
         return (
             "ResetTab",
-            {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16},
+            {
+                "last_sent_for_reset_utc": 14,
+                "next_scheduled_post_utc": 15,
+                "last_message_id": 16,
+            },
             [record],
         )
 
@@ -750,14 +949,22 @@ def test_same_last_sent_cached_tick_advances_once(monkeypatch) -> None:
 
     bot = _DummyBot(_DummyChannel())
     asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time))
-    asyncio.run(scheduler.process_reset_reminders(bot, now=reminder_time + dt.timedelta(minutes=1)))
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            bot, now=reminder_time + dt.timedelta(minutes=1)
+        )
+    )
 
     assert load_calls["count"] == 1
     assert len(updates) == 1
-    assert updates[0]["reminder_time"] == dt.datetime(2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc)
+    assert updates[0]["reminder_time"] == dt.datetime(
+        2026, 6, 26, 9, 0, tzinfo=dt.timezone.utc
+    )
 
 
-def test_next_scheduled_post_due_but_reset_past_skips_and_advances(monkeypatch, caplog) -> None:
+def test_next_scheduled_post_due_but_reset_past_skips_and_advances(
+    monkeypatch, caplog
+) -> None:
     reference = dt.datetime(2026, 6, 8, 7, 30, tzinfo=dt.timezone.utc)
     scheduled = dt.datetime(2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(
@@ -769,14 +976,20 @@ def test_next_scheduled_post_due_but_reset_past_skips_and_advances(monkeypatch, 
     )
 
     caplog.set_level("WARNING", logger="c1c.community.reset_reminders.scheduler")
-    channel, updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 7, 8, 7, 30, tzinfo=dt.timezone.utc))
+    channel, updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 7, 8, 7, 30, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent == []
-    assert updates[-1]["reminder_time"] == dt.datetime(2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc)
+    assert updates[-1]["reminder_time"] == dt.datetime(
+        2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc
+    )
     assert "stale reset reminder skipped; next scheduled post advanced" in caplog.text
 
 
-def test_doom_tower_regression_uses_next_scheduled_post_not_reference_date(monkeypatch) -> None:
+def test_doom_tower_regression_uses_next_scheduled_post_not_reference_date(
+    monkeypatch,
+) -> None:
     reference = dt.datetime(2026, 6, 8, 7, 30, tzinfo=dt.timezone.utc)
     scheduled = dt.datetime(2026, 7, 8, 3, 30, tzinfo=dt.timezone.utc)
     reset_time = dt.datetime(2026, 7, 8, 7, 30, tzinfo=dt.timezone.utc)
@@ -796,10 +1009,14 @@ def test_doom_tower_regression_uses_next_scheduled_post_not_reference_date(monke
     assert embed.timestamp is None
     assert f"<t:{int(reset_time.timestamp())}:R>" in embed.description
     assert embed.footer.text == "footer • Following cycle reset: 2026-08-07 07:30 UTC"
-    assert updates[-1]["next_scheduled_post"] == dt.datetime(2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc)
+    assert updates[-1]["next_scheduled_post"] == dt.datetime(
+        2026, 8, 7, 3, 30, tzinfo=dt.timezone.utc
+    )
 
 
-def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(monkeypatch) -> None:
+def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(
+    monkeypatch,
+) -> None:
     now = dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc)
     sent_logs = []
     outcomes = [TimeoutError(), TimeoutError(), ("ResetTab", {}, [])]
@@ -819,7 +1036,11 @@ def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(monkey
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
     monkeypatch.setattr(scheduler, "_load_reset_reminder_records", _load)
     monkeypatch.setattr(scheduler, "_send_ops_log", _send)
-    monkeypatch.setattr(scheduler, "_load_failure_state", {"key": None, "last_alert": 0.0, "failures": 0})
+    monkeypatch.setattr(
+        scheduler,
+        "_load_failure_state",
+        {"key": None, "last_alert": 0.0, "failures": 0},
+    )
     monkeypatch.setattr(scheduler, "time", SimpleNamespace(monotonic=lambda: 100.0))
 
     bot = _DummyBot(_DummyChannel())
@@ -832,8 +1053,10 @@ def test_reset_reminder_load_timeout_ops_log_is_rate_limited_and_recovers(monkey
     assert sent_logs == []
 
 
-def test_reset_reminder_scheduler_runner_continues_after_timeout(monkeypatch) -> None:
-    runtime = SimpleNamespace(bot=_DummyBot(_DummyChannel()), scheduler=_FakeScheduler())
+def test_reset_reminder_scheduler_runner_reconciles_daily(monkeypatch) -> None:
+    runtime = SimpleNamespace(
+        bot=_DummyBot(_DummyChannel()), scheduler=_FakeScheduler()
+    )
     calls = {"count": 0}
 
     async def _process(_bot):
@@ -843,6 +1066,11 @@ def test_reset_reminder_scheduler_runner_continues_after_timeout(monkeypatch) ->
     monkeypatch.setattr(scheduler, "process_reset_reminders", _process)
 
     scheduler.schedule_reset_reminder_jobs(runtime)
+
+    async def _reconcile(_runtime):
+        calls["count"] += 1
+
+    monkeypatch.setattr(scheduler, "reconcile_reset_reminder_jobs", _reconcile)
     asyncio.run(runtime.scheduler.jobs[0]._runner())
     asyncio.run(runtime.scheduler.jobs[0]._runner())
 
@@ -913,7 +1141,9 @@ def test_missing_emoji_name_or_id_column_is_schema_error(monkeypatch) -> None:
         ]
 
     monkeypatch.setattr(scheduler, "afetch_values", _fetch_values)
-    monkeypatch.setattr(scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab"))
+    monkeypatch.setattr(
+        scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab")
+    )
     monkeypatch.setattr(scheduler, "_sheet_id", lambda: "sheet")
     with pytest.raises(RuntimeError, match="emojinameorid"):
         asyncio.run(scheduler._load_reset_reminder_records(active_only=True))
@@ -965,10 +1195,14 @@ def test_exact_emoji_name_or_id_sheet_header_is_parsed(monkeypatch) -> None:
         ]
 
     monkeypatch.setattr(scheduler, "afetch_values", _fetch_values)
-    monkeypatch.setattr(scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab"))
+    monkeypatch.setattr(
+        scheduler, "_tab_name", lambda: asyncio.sleep(0, result="ResetTab")
+    )
     monkeypatch.setattr(scheduler, "_sheet_id", lambda: "sheet")
 
-    _tab, header, records = asyncio.run(scheduler._load_reset_reminder_records(active_only=True))
+    _tab, header, records = asyncio.run(
+        scheduler._load_reset_reminder_records(active_only=True)
+    )
 
     assert "emojinameorid" in header
     assert records[0].reminder.emoji_name_or_id == "doom_tower_icon"
@@ -976,17 +1210,33 @@ def test_exact_emoji_name_or_id_sheet_header_is_parsed(monkeypatch) -> None:
 
 def test_empty_emoji_name_or_id_keeps_message_content_unchanged(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id=" ")
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id=" ",
+    )
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
     assert channel.sent[0]["content"] == "<@&999>"
     assert channel.sent[0]["files"] == []
 
 
 def test_numeric_emoji_id_resolves_into_standalone_file(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id=" 1413557246297637025 ")
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id=" 1413557246297637025 ",
+    )
     channel = _GuildChannel([_FakeEmoji(1413557246297637025, "doom_tower_icon")])
-    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_target_channel",
+        lambda *_args: asyncio.sleep(0, result=channel),
+    )
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
     monkeypatch.setattr(
@@ -994,12 +1244,29 @@ def test_numeric_emoji_id_resolves_into_standalone_file(monkeypatch) -> None:
         "_load_reset_reminder_records",
         lambda *, active_only: asyncio.sleep(
             0,
-            result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]),
+            result=(
+                "ResetTab",
+                {
+                    "last_sent_for_reset_utc": 14,
+                    "next_scheduled_post_utc": 15,
+                    "last_message_id": 16,
+                },
+                [record],
+            ),
         ),
     )
-    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0))
-    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0))
-    asyncio.run(scheduler.process_reset_reminders(_DummyBot(channel), now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)))
+    monkeypatch.setattr(
+        scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0)
+    )
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            _DummyBot(channel),
+            now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        )
+    )
     assert channel.sent[0]["content"] == "<@&999>"
     assert len(channel.sent[0]["files"]) == 1
     assert channel.sent[0]["files"][0].filename == "cursed_city_icon.png"
@@ -1007,9 +1274,18 @@ def test_numeric_emoji_id_resolves_into_standalone_file(monkeypatch) -> None:
 
 def test_emoji_name_resolves_to_file_and_is_not_embed_thumbnail(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id="doom_tower_icon")
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id="doom_tower_icon",
+    )
     channel = _GuildChannel([_FakeEmoji(12345, "doom_tower_icon")])
-    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_target_channel",
+        lambda *_args: asyncio.sleep(0, result=channel),
+    )
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
     monkeypatch.setattr(
@@ -1017,12 +1293,29 @@ def test_emoji_name_resolves_to_file_and_is_not_embed_thumbnail(monkeypatch) -> 
         "_load_reset_reminder_records",
         lambda *, active_only: asyncio.sleep(
             0,
-            result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]),
+            result=(
+                "ResetTab",
+                {
+                    "last_sent_for_reset_utc": 14,
+                    "next_scheduled_post_utc": 15,
+                    "last_message_id": 16,
+                },
+                [record],
+            ),
         ),
     )
-    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0))
-    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0))
-    asyncio.run(scheduler.process_reset_reminders(_DummyBot(channel), now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)))
+    monkeypatch.setattr(
+        scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0)
+    )
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            _DummyBot(channel),
+            now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        )
+    )
     sent = channel.sent[0]
     assert sent["content"] == "<@&999>"
     assert len(sent["files"]) == 1
@@ -1044,7 +1337,9 @@ def test_direct_image_url_resolves_into_standalone_file(monkeypatch) -> None:
         return discord.File(io.BytesIO(b"png"), filename="direct_reset_icon.png")
 
     monkeypatch.setattr(scheduler, "_download_image_url_to_file", _download)
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     sent = channel.sent[0]
     assert sent["content"] == "<@&999>"
@@ -1053,7 +1348,9 @@ def test_direct_image_url_resolves_into_standalone_file(monkeypatch) -> None:
     assert sent["embed"].thumbnail.url is None
 
 
-def test_direct_image_url_rejects_non_image_content_type_and_sends_without_file(monkeypatch, caplog) -> None:
+def test_direct_image_url_rejects_non_image_content_type_and_sends_without_file(
+    monkeypatch, caplog
+) -> None:
     class _Content:
         async def read(self, _limit: int) -> bytes:
             return b"not an image"
@@ -1081,9 +1378,15 @@ def test_direct_image_url_rejects_non_image_content_type_and_sends_without_file(
             return None
 
     monkeypatch.setattr(scheduler.aiohttp, "ClientSession", lambda timeout: _Session())
-    reminder = _make_reset_reminder(lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id="https://cdn.example.invalid/not-image")
+    reminder = _make_reset_reminder(
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id="https://cdn.example.invalid/not-image",
+    )
 
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent[0]["content"] == "<@&999>"
     assert channel.sent[0]["files"] == []
@@ -1092,33 +1395,56 @@ def test_direct_image_url_rejects_non_image_content_type_and_sends_without_file(
 
 def test_missing_emoji_logs_warning_and_posts_without_icon(monkeypatch, caplog) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id="missing_icon")
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id="missing_icon",
+    )
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
     assert channel.sent[0]["content"] == "<@&999>"
     assert channel.sent[0]["files"] == []
     assert "reset reminder image emoji could not be resolved" in caplog.text
 
 
-def test_embed_includes_current_cycle_reset_timestamps_inside_description(monkeypatch) -> None:
+def test_embed_includes_current_cycle_reset_timestamps_inside_description(
+    monkeypatch,
+) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), embed_description="Reset incoming")
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        embed_description="Reset incoming",
+    )
     channel, _updates = _run_reset_process(
         monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 5, tzinfo=dt.timezone.utc)
     )
     unix_seconds = int(reference.timestamp())
     desc = channel.sent[0]["embed"].description
-    assert desc == f"Reset incoming\n\nCurrent cycle resets at: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
+    assert (
+        desc
+        == f"Reset incoming\n\nCurrent cycle resets at: <t:{unix_seconds}:F>\nTime left: <t:{unix_seconds}:R>"
+    )
     assert f"<t:{unix_seconds}:R>" not in channel.sent[0]["content"]
 
 
 def test_description_uses_reset_time_not_reminder_time(monkeypatch) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=120, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=120,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc),
+    )
     channel, _updates = _run_reset_process(
         monkeypatch, reminder, dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc)
     )
     reset_ts = int(reference.timestamp())
-    reminder_ts = int(dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc).timestamp())
+    reminder_ts = int(
+        dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.timezone.utc).timestamp()
+    )
     desc = channel.sent[0]["embed"].description
     assert f"<t:{reset_ts}:F>" in desc
     assert f"<t:{reminder_ts}:F>" not in desc
@@ -1126,36 +1452,70 @@ def test_description_uses_reset_time_not_reminder_time(monkeypatch) -> None:
 
 def test_emoji_resolution_ignores_unrelated_bot_guilds(monkeypatch, caplog) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id="shared_icon")
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id="shared_icon",
+    )
     channel = _GuildChannel([])
     bot = _DummyBot(channel)
     bot.guilds = [SimpleNamespace(emojis=[_FakeEmoji(54321, "shared_icon")])]
     record = scheduler._ResetReminderRecord(row_number=7, reminder=reminder)
 
-    monkeypatch.setattr(scheduler, "_resolve_target_channel", lambda *_args: asyncio.sleep(0, result=channel))
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_target_channel",
+        lambda *_args: asyncio.sleep(0, result=channel),
+    )
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: True)
     monkeypatch.setattr(
         scheduler,
         "_load_reset_reminder_records",
         lambda *, active_only: asyncio.sleep(
             0,
-            result=("ResetTab", {"last_sent_for_reset_utc": 14, "next_scheduled_post_utc": 15, "last_message_id": 16}, [record]),
+            result=(
+                "ResetTab",
+                {
+                    "last_sent_for_reset_utc": 14,
+                    "next_scheduled_post_utc": 15,
+                    "last_message_id": 16,
+                },
+                [record],
+            ),
         ),
     )
-    monkeypatch.setattr(scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0))
-    monkeypatch.setattr(scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0))
+    monkeypatch.setattr(
+        scheduler, "_update_next_scheduled_post", lambda **kwargs: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        scheduler, "_update_row_after_send", lambda **kwargs: asyncio.sleep(0)
+    )
 
-    asyncio.run(scheduler.process_reset_reminders(bot, now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)))
+    asyncio.run(
+        scheduler.process_reset_reminders(
+            bot, now=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+        )
+    )
 
     assert channel.sent[0]["content"] == "<@&999>"
     assert channel.sent[0]["files"] == []
     assert "reset reminder image emoji could not be resolved" in caplog.text
 
 
-def test_configured_emoji_with_missing_target_guild_logs_warning(monkeypatch, caplog) -> None:
+def test_configured_emoji_with_missing_target_guild_logs_warning(
+    monkeypatch, caplog
+) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
-    reminder = _make_reset_reminder(reference_date_utc=reference, lead_minutes=60, next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc), emoji_name_or_id="doom_tower_icon")
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    reminder = _make_reset_reminder(
+        reference_date_utc=reference,
+        lead_minutes=60,
+        next_scheduled_post_utc=dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc),
+        emoji_name_or_id="doom_tower_icon",
+    )
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     assert channel.sent[0]["content"] == "<@&999>"
     assert "target guild unavailable" in caplog.text
@@ -1171,14 +1531,21 @@ def test_footer_uses_following_cycle_reset_without_embed_timestamp(monkeypatch) 
         embed_footer="Configured footer",
     )
 
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     embed = channel.sent[0]["embed"]
     assert embed.timestamp is None
-    assert embed.footer.text == "Configured footer • Following cycle reset: 2026-06-12 10:00 UTC"
+    assert (
+        embed.footer.text
+        == "Configured footer • Following cycle reset: 2026-06-12 10:00 UTC"
+    )
 
 
-def test_footer_uses_following_cycle_reset_when_configured_footer_blank(monkeypatch) -> None:
+def test_footer_uses_following_cycle_reset_when_configured_footer_blank(
+    monkeypatch,
+) -> None:
     reference = dt.datetime(2026, 5, 29, 10, 0, tzinfo=dt.timezone.utc)
     reminder = _make_reset_reminder(
         reference_date_utc=reference,
@@ -1188,7 +1555,9 @@ def test_footer_uses_following_cycle_reset_when_configured_footer_blank(monkeypa
         embed_footer="",
     )
 
-    channel, _updates = _run_reset_process(monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc))
+    channel, _updates = _run_reset_process(
+        monkeypatch, reminder, dt.datetime(2026, 5, 29, 9, 0, tzinfo=dt.timezone.utc)
+    )
 
     embed = channel.sent[0]["embed"]
     assert embed.timestamp is None

--- a/tests/housekeeping/test_next_command.py
+++ b/tests/housekeeping/test_next_command.py
@@ -12,6 +12,14 @@ class _DummyJob:
         self.tag = None
 
 
+class _DueJob:
+    name = "achievement_collector"
+    component = "housekeeping"
+    next_run = datetime(2026, 7, 20, 9, 30, tzinfo=timezone.utc)
+    tag = "housekeeping"
+    cadence_label = "scheduled"
+
+
 def _runtime_with_jobs(jobs):
     class _Scheduler:
         def __init__(self, jobs):
@@ -36,23 +44,27 @@ def _embed_text(embeds):
 
 
 def test_build_scheduler_overview_groups_components():
-    runtime = _runtime_with_jobs([
-        _DummyJob("onboarding_idle_watcher", "recruitment"),
-        _DummyJob("cache_refresh", "default"),
-    ])
+    runtime = _runtime_with_jobs(
+        [
+            _DummyJob("onboarding_idle_watcher", "recruitment"),
+            _DummyJob("cache_refresh", "default"),
+        ]
+    )
 
     message = _embed_text(app_admin._build_scheduler_embeds(runtime, None))
 
-    assert "recruitment" in message
+    assert "Recruitment" in message
     assert "onboarding_idle_watcher" in message
     assert "cache_refresh" in message
 
 
 def test_build_scheduler_overview_filters_components():
-    runtime = _runtime_with_jobs([
-        _DummyJob("onboarding_idle_watcher", "recruitment"),
-        _DummyJob("cache_refresh", "default"),
-    ])
+    runtime = _runtime_with_jobs(
+        [
+            _DummyJob("onboarding_idle_watcher", "recruitment"),
+            _DummyJob("cache_refresh", "default"),
+        ]
+    )
 
     message = _embed_text(app_admin._build_scheduler_embeds(runtime, "recruitment"))
 
@@ -66,3 +78,14 @@ def test_build_scheduler_overview_handles_empty_filter():
     message = _embed_text(app_admin._build_scheduler_embeds(runtime, "unknown"))
 
     assert "No scheduled jobs under unknown." in message
+
+
+def test_build_scheduler_overview_formats_due_job_without_unknown_interval():
+    message = _embed_text(
+        app_admin._build_scheduler_embeds(_runtime_with_jobs([_DueJob()]), None)
+    )
+
+    assert "Housekeeping" in message
+    assert "achievement_collector" in message
+    assert "next: 2026-07-20 09:30 UTC (scheduled)" in message
+    assert "every ?" not in message


### PR DESCRIPTION
### Motivation
- Reduce noisy 1-minute polling jobs and provide a single, visible scheduling source-of-truth for operational tooling. 
- Make Achievement Collector use the central runtime scheduler so `!next` and ops views show accurate next runs. 
- Make Fusion and Reset Reminders event/due-driven with daily reconciliation to avoid unnecessary minute-level wakeups and noisy startup notices.

### Description
- Add a centrally visible due-time job type (`_DueJob`) and `Scheduler.at(...)` in `modules/common/runtime.py` to allow owners to supply and reschedule `next_run` and expose readable cadence labels. 
- Remove the private `AchievementCollectorScheduler` and stop creating tasks from the cog; register `achievement_collector` from `Runtime._register_ready_schedulers_inner` using existing `parse_schedule`/`resolve_config` and keep manual preview/publish/rank commands unchanged. 
- Replace Fusion minute polling with event-driven due jobs and a daily reconcile flow in `modules/community/fusion/scheduler.py` that registers `fusion_daily_reconcile` and discovers `fusion_grouped_reminders`, `fusion_announcement_refresh`, and `fusion_role_cleanup` as due-time jobs. 
- Replace Reset Reminders minute polling with a reconcile-driven approach in `modules/community/reset_reminders/scheduler.py` that computes/writes missing `next_scheduled_post_utc`, schedules the earliest due reminder via `Scheduler.at`, and reschedules after processing; add a daily reconciliation job. 
- Improve `!next` grouping and formatting in `cogs/app_admin.py` so jobs are placed into Cache Refresh, Recruitment, Housekeeping, Community, and Other, and due-time jobs show readable cadence (e.g. `scheduled`/`daily reconcile`) instead of `every ?`. 
- Split the startup summary in `app.py` into three grouped Discord log messages: `Woadkeeper Startup`, `Scheduler` (grouped next runs), and `Startup Refresh`, and suppress routine pre-summary registration notices so the final summary is the canonical startup report.

### Testing
- Ran focused scheduler/unit tests: `pytest -q tests/housekeeping/test_next_command.py tests/cogs/test_achievement_collector.py tests/community/test_fusion_scheduler.py tests/community/test_reset_reminder_scheduler.py tests/modules/ops/test_startup_summary.py --disable-warnings` and these feature-focused tests passed (80 tests across the targeted suites). 
- Linted and formatted changed files (`ruff` and `black`) and addressed style issues; `ruff` checks and formatting were applied to affected files. 
- Verified `git diff --check` produced no whitespace/error diagnostics and committed the change. 
- Ran the full test suite; it reached five unrelated pre-existing failures in shard/config isolation, CoreOps env-embed compatibility, and a docs index audit, which are outside the scope of this scheduler-focused change and did not affect the scheduler tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c98f32dd883239d3be4d0b8ab2a65)