### PR TITLE
Add RealmWalker role audit and restore visitor join dates

### DIFF
--- a/cogs/housekeeping_realmwalker.py
+++ b/cogs/housekeeping_realmwalker.py
@@ -12,6 +12,11 @@ from modules.housekeeping import realmwalker
 
 log = logging.getLogger("c1c.housekeeping.realmwalker.cog")
 
+MEMBER_LOAD_ERROR = (
+    "The full member list could not be loaded, so the RealmWalker audit was aborted. "
+    "No roles were changed."
+)
+
 
 class RealmWalkerAuditCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
@@ -63,9 +68,15 @@ class RealmWalkerAuditCog(commands.Cog):
             members = [member async for member in guild.fetch_members(limit=None)]
         except Exception:
             log.warning(
-                "RealmWalker member fetch failed; using guild cache", exc_info=True
+                "RealmWalker audit aborted; full member fetch failed", exc_info=True
             )
-            members = list(guild.members)
+            await ctx.send(
+                embed=realmwalker.build_embeds(
+                    realmwalker.RealmWalkerAuditResult(), error=MEMBER_LOAD_ERROR
+                )[0],
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            return
         result = realmwalker.scan_members(members, config)
         if action.lower() == "fix":
             fixed = await realmwalker.fix_issues(

--- a/cogs/housekeeping_realmwalker.py
+++ b/cogs/housekeeping_realmwalker.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.common.embeds import get_embed_colour
+from modules.housekeeping import realmwalker
+
+log = logging.getLogger("c1c.housekeeping.realmwalker.cog")
+
+
+class RealmWalkerAuditCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational", section="housekeeping", access_tier="admin"
+    )
+    @commands.group(name="audit", invoke_without_command=True)
+    @commands.guild_only()
+    @admin_only()
+    async def audit_group(self, ctx: commands.Context) -> None:
+        embed = discord.Embed(
+            title="🧹 Housekeeping Audit",
+            description="Usage: `!audit realmwalker [fix]`",
+            colour=get_embed_colour("admin"),
+        )
+        await ctx.send(embed=embed)
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational", section="housekeeping", access_tier="admin"
+    )
+    @audit_group.command(name="realmwalker")
+    @commands.guild_only()
+    @admin_only()
+    async def audit_realmwalker(self, ctx: commands.Context, action: str = "") -> None:
+        if action and action.lower() != "fix":
+            await ctx.send(
+                embed=realmwalker.build_embeds(
+                    realmwalker.RealmWalkerAuditResult(),
+                    error="Usage: `!audit realmwalker [fix]`",
+                )[0]
+            )
+            return
+        config, error = await realmwalker.resolve_config()
+        if config is None:
+            log.warning("RealmWalker audit config invalid", extra={"reason": error})
+            await ctx.send(
+                embed=realmwalker.build_embeds(
+                    realmwalker.RealmWalkerAuditResult(), error=error
+                )[0]
+            )
+            return
+        guild = ctx.guild
+        assert guild is not None
+        try:
+            members = [member async for member in guild.fetch_members(limit=None)]
+        except Exception:
+            log.warning(
+                "RealmWalker member fetch failed; using guild cache", exc_info=True
+            )
+            members = list(guild.members)
+        result = realmwalker.scan_members(members, config)
+        if action.lower() == "fix":
+            fixed = await realmwalker.fix_issues(
+                result.issues, guild.get_role(config.access_role_id)
+            )
+            fixed.checked = result.checked
+            result = fixed
+        for embed in realmwalker.build_embeds(result, fixing=action.lower() == "fix"):
+            await ctx.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RealmWalkerAuditCog(bot))

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1218,6 +1218,7 @@ class Runtime:
         from cogs import housekeeping_achievement_collector
         from cogs import housekeeping_wandering_souls
         from cogs import housekeeping_c1c_ad
+        from cogs import housekeeping_realmwalker
         from cogs import recruitment_clan_ads
         from modules.housekeeping import cleanup as housekeeping_cleanup_commands
         from modules.onboarding import ops_check as onboarding_ops_check
@@ -1267,6 +1268,9 @@ class Runtime:
 
         await housekeeping_c1c_ad.setup(self.bot)
         log.info("modules: c1c_ad command registered")
+
+        await housekeeping_realmwalker.setup(self.bot)
+        log.info("modules: RealmWalker audit command registered")
 
         await recruitment_clan_ads.setup(self.bot)
         log.info("modules: clan_ads command registered")

--- a/modules/housekeeping/__init__.py
+++ b/modules/housekeeping/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "mirralith_overview",
     "achievements",
     "role_audit",
+    "realmwalker",
 ]

--- a/modules/housekeeping/realmwalker.py
+++ b/modules/housekeeping/realmwalker.py
@@ -1,0 +1,193 @@
+"""Config-driven RealmWalker access auditing and repair helpers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import discord
+
+from modules.common.embeds import get_embed_colour
+from shared.sheets import recruitment
+
+log = logging.getLogger("c1c.housekeeping.realmwalker")
+
+ACCESS_ROLE_KEY = "REALMWALKER_ACCESS_ROLE_ID"
+GAME_ROLES_KEY = "REALMWALKER_GAME_ROLE_IDS"
+FIX_REASON = "Housekeeping RealmWalker access audit"
+
+
+@dataclass(frozen=True, slots=True)
+class RealmWalkerConfig:
+    access_role_id: int
+    game_role_ids: frozenset[int]
+
+
+@dataclass(frozen=True, slots=True)
+class RealmWalkerIssue:
+    member: discord.Member
+    matched_game_roles: tuple[discord.Role, ...]
+
+
+@dataclass(slots=True)
+class RealmWalkerAuditResult:
+    checked: int = 0
+    issues: list[RealmWalkerIssue] = field(default_factory=list)
+    fixed: list[RealmWalkerIssue] = field(default_factory=list)
+    skipped: list[RealmWalkerIssue] = field(default_factory=list)
+    failures: list[tuple[RealmWalkerIssue, str]] = field(default_factory=list)
+
+
+def _parse_role_id(value: str | None) -> int | None:
+    try:
+        role_id = int((value or "").strip())
+    except (TypeError, ValueError):
+        return None
+    return role_id if role_id > 0 else None
+
+
+async def resolve_config() -> tuple[RealmWalkerConfig | None, str | None]:
+    """Resolve and validate RealmWalker role IDs from the existing Config tab."""
+    access_value = await recruitment.get_config_value_async(ACCESS_ROLE_KEY, None)
+    games_value = await recruitment.get_config_value_async(GAME_ROLES_KEY, None)
+    access_id = _parse_role_id(access_value)
+    game_ids: set[int] = set()
+    invalid_games: list[str] = []
+    for item in (games_value or "").split(","):
+        item = item.strip()
+        if not item:
+            continue
+        role_id = _parse_role_id(item)
+        if role_id is None:
+            invalid_games.append(item)
+        else:
+            game_ids.add(role_id)
+    if access_id is None or not game_ids or invalid_games:
+        details = []
+        if access_id is None:
+            details.append(f"{ACCESS_ROLE_KEY} is missing or invalid")
+        if not game_ids:
+            details.append(f"{GAME_ROLES_KEY} has no valid role IDs")
+        if invalid_games:
+            details.append(f"{GAME_ROLES_KEY} contains invalid values")
+        return None, "; ".join(details)
+    return RealmWalkerConfig(access_id, frozenset(game_ids)), None
+
+
+def scan_members(
+    members: Sequence[discord.Member], config: RealmWalkerConfig
+) -> RealmWalkerAuditResult:
+    """Find humans with configured game roles but without the access role."""
+    result = RealmWalkerAuditResult()
+    for member in members:
+        if getattr(member, "bot", False):
+            continue
+        result.checked += 1
+        roles = tuple(
+            role
+            for role in getattr(member, "roles", ())
+            if getattr(role, "id", None) in config.game_role_ids
+        )
+        role_ids = {getattr(role, "id", None) for role in getattr(member, "roles", ())}
+        if roles and config.access_role_id not in role_ids:
+            result.issues.append(RealmWalkerIssue(member, roles))
+    return result
+
+
+async def fix_issues(
+    issues: Sequence[RealmWalkerIssue], access_role: discord.Role | None
+) -> RealmWalkerAuditResult:
+    """Add the access role independently for each issue, retaining all existing roles."""
+    result = RealmWalkerAuditResult(issues=list(issues))
+    for issue in issues:
+        if access_role is None:
+            result.skipped.append(issue)
+            continue
+        try:
+            await issue.member.add_roles(access_role, reason=FIX_REASON)
+        except discord.Forbidden:
+            result.failures.append((issue, "missing permission or role hierarchy"))
+        except discord.HTTPException as exc:
+            result.failures.append((issue, f"Discord API error: {exc}"))
+        else:
+            result.fixed.append(issue)
+    return result
+
+
+def format_issue(issue: RealmWalkerIssue) -> str:
+    member = issue.member
+    mention = getattr(member, "mention", None) or str(getattr(member, "id", "unknown"))
+    name = (
+        getattr(member, "display_name", None)
+        or getattr(member, "name", None)
+        or "unknown"
+    )
+    roles = ", ".join(
+        getattr(role, "name", "unknown") for role in issue.matched_game_roles
+    )
+    return f"• {mention} – {name} – game roles: {roles}"
+
+
+def build_embeds(
+    result: RealmWalkerAuditResult, *, fixing: bool = False, error: str | None = None
+) -> list[discord.Embed]:
+    """Render bounded, mention-safe manual command output."""
+    if error:
+        sections = ["**Configuration warning**", error]
+    elif fixing:
+        sections = [
+            "**Fixed members**",
+            *([format_issue(item) for item in result.fixed] or ["• None"]),
+            "",
+            "**Skipped members**",
+            *([format_issue(item) for item in result.skipped] or ["• None"]),
+            "",
+            "**Failures**",
+            *(
+                [f"{format_issue(item)} – {reason}" for item, reason in result.failures]
+                or ["• None"]
+            ),
+        ]
+    elif result.issues:
+        sections = ["**Missing RealmWalker access**", *map(format_issue, result.issues)]
+    else:
+        sections = ["✅ No RealmWalker access issues found."]
+
+    chunks: list[str] = []
+    current = ""
+    for line in sections:
+        candidate = f"{current}\n{line}".strip()
+        if current and len(candidate) > 3800:
+            chunks.append(current)
+            current = line
+        else:
+            current = candidate
+    chunks.append(current)
+    embeds = []
+    for index, chunk in enumerate(chunks, 1):
+        title = "🧹 RealmWalker Access Audit"
+        if len(chunks) > 1:
+            title += f" ({index}/{len(chunks)})"
+        embed = discord.Embed(
+            title=title, description=chunk, colour=get_embed_colour("admin")
+        )
+        affected = len(result.issues)
+        footer = f"Checked: {result.checked} members • Affected: {affected}"
+        if fixing:
+            footer += f" • Fixed: {len(result.fixed)} • Skipped: {len(result.skipped)} • Failed: {len(result.failures)}"
+        embed.set_footer(text=footer)
+        embeds.append(embed)
+    return embeds
+
+
+__all__ = [
+    "RealmWalkerAuditResult",
+    "RealmWalkerConfig",
+    "RealmWalkerIssue",
+    "build_embeds",
+    "fix_issues",
+    "format_issue",
+    "resolve_config",
+    "scan_members",
+]

--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -237,10 +237,17 @@ async def _audit_guild(
         )
         return None
 
+    full_members_loaded = True
     try:
         members = [member async for member in guild.fetch_members(limit=None)]
     except Exception:
+        full_members_loaded = False
         members = list(getattr(guild, "members", []))
+        log.warning(
+            "role audit full member fetch failed; RealmWalker scan skipped",
+            exc_info=True,
+            extra={"guild_id": getattr(guild, "id", None)},
+        )
 
     tickets = await fetch_ticket_threads(
         bot,
@@ -278,7 +285,9 @@ async def _audit_guild(
         action_failed_or_skipped=[],
     )
 
-    if realmwalker_config is not None:
+    if realmwalker_config is not None and not full_members_loaded:
+        result.realmwalker_warning = "RealmWalker audit was skipped because the full member list could not be loaded."
+    elif realmwalker_config is not None:
         access_role = guild.get_role(realmwalker_config.access_role_id)
         missing_game_ids = sorted(
             role_id

--- a/modules/housekeeping/role_audit.py
+++ b/modules/housekeeping/role_audit.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Scheduled audit for roles and visitor ticket hygiene."""
+
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
@@ -11,6 +11,7 @@ import discord
 from discord.ext import commands
 
 from modules.community.fusion import role_cleanup as fusion_role_cleanup
+from modules.housekeeping import realmwalker
 from modules.common.embeds import get_embed_colour
 from modules.common.tickets import TicketThread, fetch_ticket_threads
 from shared.config import (
@@ -51,10 +52,18 @@ class AuditResult:
     wanderers_with_clans: list[tuple[discord.Member, list[discord.Role]]] | None = None
     visitors_no_ticket: list[discord.Member] | None = None
     visitors_closed_only: list[tuple[discord.Member, list[TicketThread]]] | None = None
-    visitors_extra_roles: list[tuple[discord.Member, list[discord.Role], list[TicketThread]]] | None = None
+    visitors_extra_roles: (
+        list[tuple[discord.Member, list[discord.Role], list[TicketThread]]] | None
+    ) = None
     members_only_everyone: list[discord.Member] | None = None
-    fusion_role_cleanup: list[fusion_role_cleanup.FusionRoleCleanupSummary] | None = None
-    proposed_role_mutations: list[tuple[discord.Member, list[discord.Role], list[discord.Role]]] | None = None
+    realmwalker_issues: list[realmwalker.RealmWalkerIssue] | None = None
+    realmwalker_warning: str | None = None
+    fusion_role_cleanup: list[fusion_role_cleanup.FusionRoleCleanupSummary] | None = (
+        None
+    )
+    proposed_role_mutations: (
+        list[tuple[discord.Member, list[discord.Role], list[discord.Role]]] | None
+    ) = None
     action_roles_removed: list[str] | None = None
     action_roles_added: list[str] | None = None
     action_users_kicked: list[str] | None = None
@@ -66,7 +75,11 @@ def _member_roles(member: discord.Member) -> set[int]:
 
 
 def _classify_roles(
-    member_roles: set[int], *, raid_role_id: int, wanderer_role_id: int, clan_role_ids: set[int]
+    member_roles: set[int],
+    *,
+    raid_role_id: int,
+    wanderer_role_id: int,
+    clan_role_ids: set[int],
 ) -> str:
     has_raid = raid_role_id in member_roles
     has_wanderer = wanderer_role_id in member_roles
@@ -82,7 +95,10 @@ def _classify_roles(
 
 
 def _extra_roles(member: discord.Member, visitor_role_id: int) -> list[discord.Role]:
-    visitor_and_everyone = {visitor_role_id, getattr(getattr(member, "guild", None), "id", -1)}
+    visitor_and_everyone = {
+        visitor_role_id,
+        getattr(getattr(member, "guild", None), "id", -1),
+    }
     extras: list[discord.Role] = []
     for role in getattr(member, "roles", []):
         if getattr(role, "id", 0) in visitor_and_everyone:
@@ -143,7 +159,10 @@ async def _apply_role_changes(
     scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
     if dry_run or actor_normalized in scheduled_actors:
         return True, None
-    before_roles = [getattr(role, "name", str(getattr(role, "id", "unknown"))) for role in getattr(member, "roles", [])]
+    before_roles = [
+        getattr(role, "name", str(getattr(role, "id", "unknown")))
+        for role in getattr(member, "roles", [])
+    ]
     try:
         if remove:
             await member.remove_roles(*remove, reason=ROLE_AUDIT_REASON)
@@ -162,17 +181,25 @@ async def _apply_role_changes(
             extra={"member_id": getattr(member, "id", None), "error": str(exc)},
         )
         return False, str(exc)
-    after_roles = [getattr(role, "name", str(getattr(role, "id", "unknown"))) for role in getattr(member, "roles", [])]
+    after_roles = [
+        getattr(role, "name", str(getattr(role, "id", "unknown")))
+        for role in getattr(member, "roles", [])
+    ]
     log.info(
         "role audit mutation applied",
         extra={
             "actor": actor,
             "member_id": getattr(member, "id", None),
-            "member_name": getattr(member, "display_name", None) or getattr(member, "name", None),
+            "member_name": getattr(member, "display_name", None)
+            or getattr(member, "name", None),
             "before_roles": before_roles,
             "after_roles": after_roles,
-            "remove_roles": [getattr(r, "name", str(getattr(r, "id", "unknown"))) for r in remove],
-            "add_roles": [getattr(r, "name", str(getattr(r, "id", "unknown"))) for r in add],
+            "remove_roles": [
+                getattr(r, "name", str(getattr(r, "id", "unknown"))) for r in remove
+            ],
+            "add_roles": [
+                getattr(r, "name", str(getattr(r, "id", "unknown"))) for r in add
+            ],
             "reason": ROLE_AUDIT_REASON,
             "success": True,
         },
@@ -192,6 +219,8 @@ async def _audit_guild(
     wanderer_role_name: str,
     actor: str = "manual",
     dry_run: bool = True,
+    realmwalker_config: realmwalker.RealmWalkerConfig | None = None,
+    realmwalker_warning: str | None = None,
 ) -> AuditResult | None:
     raid_role = guild.get_role(raid_role_id)
     wanderer_role = guild.get_role(wanderer_role_id)
@@ -225,7 +254,11 @@ async def _audit_guild(
         for member_id in ticket.member_ids:
             ticket_map.setdefault(int(member_id), []).append(ticket)
 
-    clan_lookup = {role.id: role for role in getattr(guild, "roles", []) if role.id in clan_role_ids}
+    clan_lookup = {
+        role.id: role
+        for role in getattr(guild, "roles", [])
+        if role.id in clan_role_ids
+    }
 
     result = AuditResult(
         checked=len(members),
@@ -236,12 +269,38 @@ async def _audit_guild(
         visitors_closed_only=[],
         visitors_extra_roles=[],
         members_only_everyone=[],
+        realmwalker_issues=[],
+        realmwalker_warning=realmwalker_warning,
         proposed_role_mutations=[],
         action_roles_removed=[],
         action_roles_added=[],
         action_users_kicked=[],
         action_failed_or_skipped=[],
     )
+
+    if realmwalker_config is not None:
+        access_role = guild.get_role(realmwalker_config.access_role_id)
+        missing_game_ids = sorted(
+            role_id
+            for role_id in realmwalker_config.game_role_ids
+            if guild.get_role(role_id) is None
+        )
+        if access_role is None or missing_game_ids:
+            result.realmwalker_warning = (
+                "RealmWalker audit roles could not be resolved in this guild."
+            )
+            log.warning(
+                "RealmWalker audit role config unresolved",
+                extra={
+                    "guild_id": getattr(guild, "id", None),
+                    "access_role_found": access_role is not None,
+                    "missing_game_role_count": len(missing_game_ids),
+                },
+            )
+        else:
+            result.realmwalker_issues.extend(
+                realmwalker.scan_members(members, realmwalker_config).issues
+            )
 
     for member in members:
         member_roles = _member_roles(member)
@@ -255,7 +314,9 @@ async def _audit_guild(
             clan_role_ids=clan_role_ids,
         )
         if classification == "stray":
-            result.proposed_role_mutations.append((member, [raid_role], [wanderer_role]))
+            result.proposed_role_mutations.append(
+                (member, [raid_role], [wanderer_role])
+            )
             changed, error = await _apply_role_changes(
                 member,
                 actor=actor,
@@ -299,7 +360,11 @@ async def _audit_guild(
             continue
 
         if classification == "wander_with_clan":
-            clan_roles = [clan_lookup[role_id] for role_id in member_roles & clan_role_ids if role_id in clan_lookup]
+            clan_roles = [
+                clan_lookup[role_id]
+                for role_id in member_roles & clan_role_ids
+                if role_id in clan_lookup
+            ]
             result.wanderers_with_clans.append((member, clan_roles))
 
         if visitor_role_id not in member_roles:
@@ -331,6 +396,16 @@ def _format_joined_date(member: discord.abc.User) -> str:
     if not joined_at:
         return "unknown"
     return joined_at.strftime("%Y-%m-%d")
+
+
+def _format_joined_with_age(member: discord.abc.User) -> str:
+    joined_at = getattr(member, "joined_at", None)
+    if not joined_at:
+        return "joined unknown"
+    if joined_at.tzinfo is None:
+        joined_at = joined_at.replace(tzinfo=timezone.utc)
+    days = max(0, (datetime.now(timezone.utc).date() - joined_at.date()).days)
+    return f"joined {joined_at.strftime('%Y-%m-%d')} ({days}d ago)"
 
 
 def _build_fusion_cleanup_lines(
@@ -381,7 +456,9 @@ def _build_report_sections(
         for member, clan_roles in (summary.wanderers_with_clans or [])
     ]
     if manual_lines:
-        detected_sections.append(("2) Manual review – Wandering Souls with clan tags", manual_lines))
+        detected_sections.append(
+            ("2) Manual review – Wandering Souls with clan tags", manual_lines)
+        )
 
     visitor_no_ticket = [
         f"• {_format_member(member)} – joined {_format_joined_date(member)} – no ticket found"
@@ -395,7 +472,9 @@ def _build_report_sections(
         for member, tickets in (summary.visitors_closed_only or [])
     ]
     if visitor_closed_only:
-        detected_sections.append(("4) Visitors with only closed tickets", visitor_closed_only))
+        detected_sections.append(
+            ("4) Visitors with only closed tickets", visitor_closed_only)
+        )
 
     visitor_extra_roles = [
         f"• {_format_member(member)} – Roles: {_format_roles(roles)} – Tickets: {_format_ticket_links(tickets)}"
@@ -405,15 +484,31 @@ def _build_report_sections(
         detected_sections.append(("5) Visitors with extra roles", visitor_extra_roles))
 
     only_everyone_lines = [
-        f"• {_format_member_with_username(member)}"
+        f"• {_format_member_with_username(member)} – {_format_joined_with_age(member)}"
         for member in (summary.members_only_everyone or [])
     ]
     if only_everyone_lines:
-        detected_sections.append(("6) Members with only @everyone", only_everyone_lines))
+        detected_sections.append(
+            ("6) Members with only @everyone", only_everyone_lines)
+        )
+
+    realmwalker_lines = [
+        realmwalker.format_issue(issue) for issue in (summary.realmwalker_issues or [])
+    ]
+    if realmwalker_lines:
+        realmwalker_lines.append("")
+        realmwalker_lines.append(
+            "Run `!audit realmwalker fix` to add RealmWalker to these members."
+        )
+        detected_sections.append(("7) Missing RealmWalker access", realmwalker_lines))
+    if summary.realmwalker_warning:
+        detected_sections.append(
+            ("RealmWalker audit warning", [f"• {summary.realmwalker_warning}"])
+        )
 
     fusion_lines = _build_fusion_cleanup_lines(summary.fusion_role_cleanup or [])
     if fusion_lines:
-        detected_sections.append(("7) Fusion role cleanup", fusion_lines))
+        detected_sections.append(("8) Fusion role cleanup", fusion_lines))
 
     if summary.action_roles_removed:
         action_sections.append(("6) Roles removed", summary.action_roles_removed))
@@ -422,7 +517,9 @@ def _build_report_sections(
     if summary.action_users_kicked:
         action_sections.append(("8) Users kicked", summary.action_users_kicked))
     if summary.action_failed_or_skipped:
-        action_sections.append(("9) Failed / skipped actions", summary.action_failed_or_skipped))
+        action_sections.append(
+            ("9) Failed / skipped actions", summary.action_failed_or_skipped)
+        )
 
     return detected_sections, action_sections
 
@@ -430,7 +527,9 @@ def _build_report_sections(
 _SAFE_DESCRIPTION_LIMIT = 3800
 
 
-def _section_blocks(sections: Sequence[tuple[str, list[str]]], *, heading: str) -> list[list[str]]:
+def _section_blocks(
+    sections: Sequence[tuple[str, list[str]]], *, heading: str
+) -> list[list[str]]:
     if not sections:
         return []
     blocks: list[list[str]] = [["━━━━━━━━━━━━", heading, "━━━━━━━━━━━━", ""]]
@@ -544,23 +643,44 @@ async def run_role_and_visitor_audit(
     clan_role_ids = get_clan_role_ids()
     dest_id, dest_source = resolve_audit_destination()
 
-    if not all((raid_role_id, wanderer_role_id, visitor_role_id, clan_role_ids, dest_id)):
+    if not all(
+        (raid_role_id, wanderer_role_id, visitor_role_id, clan_role_ids, dest_id)
+    ):
         return False, "config-missing"
 
     if not (get_welcome_channel_id() or get_promo_channel_id()):
         return False, "ticket-channels-missing"
 
     allowed = get_allowed_guild_ids()
-    target_guilds = [guild for guild in bot.guilds if not allowed or guild.id in allowed]
+    target_guilds = [
+        guild for guild in bot.guilds if not allowed or guild.id in allowed
+    ]
     if not target_guilds:
         return False, "no-guilds"
+
+    try:
+        realmwalker_config, realmwalker_warning = await realmwalker.resolve_config()
+    except Exception as exc:
+        realmwalker_config = None
+        realmwalker_warning = "RealmWalker audit config could not be loaded."
+        log.warning(
+            "RealmWalker audit config lookup failed",
+            exc_info=True,
+            extra={"error": str(exc)},
+        )
+    if realmwalker_warning:
+        log.warning(
+            "RealmWalker audit config invalid", extra={"reason": realmwalker_warning}
+        )
 
     raid_role_name = "Raid"
     wanderer_role_name = "Wandering Souls"
     actor_normalized = (actor or "").strip().lower()
     scheduled_actors = {"scheduled", "background", "cron", "startup", "ready"}
     try:
-        fusion_cleanup_summaries = await fusion_role_cleanup.load_unreported_role_cleanup_summaries()
+        fusion_cleanup_summaries = (
+            await fusion_role_cleanup.load_unreported_role_cleanup_summaries()
+        )
     except Exception as exc:
         log.warning(
             "failed to load fusion role cleanup summaries",
@@ -572,7 +692,9 @@ async def run_role_and_visitor_audit(
             },
             exc_info=True,
         )
-        fusion_cleanup_summaries = fusion_role_cleanup.get_recent_role_cleanup_summaries()
+        fusion_cleanup_summaries = (
+            fusion_role_cleanup.get_recent_role_cleanup_summaries()
+        )
     aggregated = AuditResult(
         checked=0,
         auto_fixed_strays=[],
@@ -582,6 +704,8 @@ async def run_role_and_visitor_audit(
         visitors_closed_only=[],
         visitors_extra_roles=[],
         members_only_everyone=[],
+        realmwalker_issues=[],
+        realmwalker_warning=realmwalker_warning,
         fusion_role_cleanup=fusion_cleanup_summaries,
         proposed_role_mutations=[],
         action_roles_removed=[],
@@ -609,6 +733,8 @@ async def run_role_and_visitor_audit(
             wanderer_role_name=wanderer_role_name,
             actor=actor,
             dry_run=dry_run,
+            realmwalker_config=realmwalker_config,
+            realmwalker_warning=realmwalker_warning,
         )
         if result is None:
             continue
@@ -621,17 +747,24 @@ async def run_role_and_visitor_audit(
         aggregated.visitors_closed_only.extend(result.visitors_closed_only or [])
         aggregated.visitors_extra_roles.extend(result.visitors_extra_roles or [])
         aggregated.members_only_everyone.extend(result.members_only_everyone or [])
+        aggregated.realmwalker_issues.extend(result.realmwalker_issues or [])
+        if result.realmwalker_warning:
+            aggregated.realmwalker_warning = result.realmwalker_warning
         aggregated.proposed_role_mutations.extend(result.proposed_role_mutations or [])
         aggregated.action_roles_removed.extend(result.action_roles_removed or [])
         aggregated.action_roles_added.extend(result.action_roles_added or [])
         aggregated.action_users_kicked.extend(result.action_users_kicked or [])
-        aggregated.action_failed_or_skipped.extend(result.action_failed_or_skipped or [])
+        aggregated.action_failed_or_skipped.extend(
+            result.action_failed_or_skipped or []
+        )
 
     if aggregated.checked == 0:
         return False, "no-members"
 
     proposed_adds = len(aggregated.auto_fixed_strays or [])
-    proposed_removes = len(aggregated.auto_fixed_strays or []) + len(aggregated.auto_fixed_wanderers or [])
+    proposed_removes = len(aggregated.auto_fixed_strays or []) + len(
+        aggregated.auto_fixed_wanderers or []
+    )
     if dry_run or actor_normalized in scheduled_actors:
         log.info(
             "role audit mutations skipped",
@@ -647,7 +780,10 @@ async def run_role_and_visitor_audit(
                 "proposed_remove_count": proposed_removes,
             },
         )
-    elif len(aggregated.proposed_role_mutations or []) > max_mutations and not allow_over_cap:
+    elif (
+        len(aggregated.proposed_role_mutations or []) > max_mutations
+        and not allow_over_cap
+    ):
         log.warning(
             "role audit apply aborted due to mutation cap",
             extra={
@@ -696,7 +832,9 @@ async def run_role_and_visitor_audit(
         return False, f"send:{type(exc).__name__}"
     if actor_normalized == "scheduled":
         try:
-            await fusion_role_cleanup.mark_role_cleanup_summaries_reported(fusion_cleanup_summaries)
+            await fusion_role_cleanup.mark_role_cleanup_summaries_reported(
+                fusion_cleanup_summaries
+            )
         except Exception as exc:
             log.warning(
                 "failed to mark fusion role cleanup summaries reported",
@@ -724,7 +862,9 @@ async def preview_role_audit_mutations(
     visitor_role_id = get_visitor_role_id()
     clan_role_ids = get_clan_role_ids()
     allowed = get_allowed_guild_ids()
-    target_guilds = [guild for guild in bot.guilds if not allowed or guild.id in allowed]
+    target_guilds = [
+        guild for guild in bot.guilds if not allowed or guild.id in allowed
+    ]
     combined = AuditResult(
         checked=0,
         auto_fixed_strays=[],

--- a/tests/housekeeping/test_realmwalker.py
+++ b/tests/housekeeping/test_realmwalker.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import discord
 
 from modules.housekeeping import realmwalker, role_audit
+from cogs.housekeeping_realmwalker import MEMBER_LOAD_ERROR, RealmWalkerAuditCog
 
 
 class Member(SimpleNamespace):
@@ -110,3 +111,136 @@ def test_daily_config_warning_renders_without_crashing():
         summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
     )
     assert "RealmWalker audit warning" in (embed.description or "")
+
+
+def test_manual_fix_aborts_with_embed_when_full_member_load_fails(monkeypatch):
+    cached = member(1, [role(20, "WoW")])
+    add_called = False
+
+    async def add_roles(*_args, **_kwargs):
+        nonlocal add_called
+        add_called = True
+
+    cached.add_roles = add_roles
+
+    async def failing_members():
+        raise RuntimeError("member fetch failed")
+        yield  # pragma: no cover
+
+    guild = SimpleNamespace(
+        members=[cached],
+        fetch_members=lambda **_kwargs: failing_members(),
+        get_role=lambda _role_id: role(10, "RealmWalker"),
+    )
+    sent = []
+
+    async def send(**kwargs):
+        sent.append(kwargs)
+
+    ctx = SimpleNamespace(guild=guild, send=send)
+
+    async def config():
+        return realmwalker.RealmWalkerConfig(10, frozenset({20})), None
+
+    monkeypatch.setattr(realmwalker, "resolve_config", config)
+    cog = RealmWalkerAuditCog(SimpleNamespace())
+    asyncio.run(RealmWalkerAuditCog.audit_realmwalker.callback(cog, ctx, "fix"))
+
+    assert add_called is False
+    assert len(sent) == 1
+    assert MEMBER_LOAD_ERROR in (sent[0]["embed"].description or "")
+    assert "No roles were changed" in (sent[0]["embed"].description or "")
+
+
+def test_manual_report_aborts_instead_of_claiming_clean_on_member_load_failure(
+    monkeypatch,
+):
+    async def failing_members():
+        raise RuntimeError("member fetch failed")
+        yield  # pragma: no cover
+
+    guild = SimpleNamespace(
+        members=[], fetch_members=lambda **_kwargs: failing_members()
+    )
+    sent = []
+
+    async def send(**kwargs):
+        sent.append(kwargs)
+
+    async def config():
+        return realmwalker.RealmWalkerConfig(10, frozenset({20})), None
+
+    monkeypatch.setattr(realmwalker, "resolve_config", config)
+    cog = RealmWalkerAuditCog(SimpleNamespace())
+    ctx = SimpleNamespace(guild=guild, send=send)
+    asyncio.run(RealmWalkerAuditCog.audit_realmwalker.callback(cog, ctx, ""))
+
+    description = sent[0]["embed"].description or ""
+    assert MEMBER_LOAD_ERROR in description
+    assert "No RealmWalker access issues found" not in description
+
+
+def test_config_resolution_still_uses_recruitment_config_helper(monkeypatch):
+    calls = []
+
+    async def get_config(key, default=None):
+        calls.append((key, default))
+        return "10" if key == realmwalker.ACCESS_ROLE_KEY else "20,21"
+
+    monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
+    config, error = asyncio.run(realmwalker.resolve_config())
+    assert error is None
+    assert config == realmwalker.RealmWalkerConfig(10, frozenset({20, 21}))
+    assert [key for key, _ in calls] == [
+        "REALMWALKER_ACCESS_ROLE_ID",
+        "REALMWALKER_GAME_ROLE_IDS",
+    ]
+
+
+def test_daily_realmwalker_scan_warns_instead_of_using_partial_cache(monkeypatch):
+    roles = {
+        role_id: role(role_id, name)
+        for role_id, name in (
+            (1, "Raid"),
+            (2, "Wandering Souls"),
+            (3, "Visitor"),
+            (10, "RealmWalker"),
+            (20, "WoW"),
+        )
+    }
+    cached = member(1, [roles[20]])
+
+    async def failing_members():
+        raise RuntimeError("member fetch failed")
+        yield  # pragma: no cover
+
+    guild = SimpleNamespace(
+        id=100,
+        members=[cached],
+        roles=list(roles.values()),
+        fetch_members=lambda **_kwargs: failing_members(),
+        get_role=lambda role_id: roles.get(role_id),
+    )
+    cached.guild = guild
+
+    async def no_tickets(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(role_audit, "fetch_ticket_threads", no_tickets)
+    result = asyncio.run(
+        role_audit._audit_guild(
+            SimpleNamespace(),
+            guild,
+            raid_role_id=1,
+            wanderer_role_id=2,
+            visitor_role_id=3,
+            clan_role_ids={99},
+            raid_role_name="Raid",
+            wanderer_role_name="Wandering Souls",
+            realmwalker_config=realmwalker.RealmWalkerConfig(10, frozenset({20})),
+        )
+    )
+
+    assert result is not None
+    assert result.realmwalker_issues == []
+    assert "full member list could not be loaded" in (result.realmwalker_warning or "")

--- a/tests/housekeeping/test_realmwalker.py
+++ b/tests/housekeeping/test_realmwalker.py
@@ -1,0 +1,112 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord
+
+from modules.housekeeping import realmwalker, role_audit
+
+
+class Member(SimpleNamespace):
+    @property
+    def mention(self):
+        return f"<@{self.id}>"
+
+
+def role(role_id, name):
+    return SimpleNamespace(id=role_id, name=name)
+
+
+def member(member_id, roles, *, bot=False):
+    return Member(
+        id=member_id,
+        name=f"user{member_id}",
+        display_name=f"User {member_id}",
+        roles=roles,
+        bot=bot,
+    )
+
+
+def test_scan_flags_only_humans_with_games_and_missing_access_once():
+    access = role(10, "RealmWalker")
+    game_a = role(20, "ArcRaiders")
+    game_b = role(21, "WoW")
+    other = role(30, "Other")
+    config = realmwalker.RealmWalkerConfig(10, frozenset({20, 21}))
+    flagged = member(1, [game_a, game_b])
+    result = realmwalker.scan_members(
+        [
+            flagged,
+            member(2, [game_a, access]),
+            member(3, [access]),
+            member(4, [other]),
+            member(5, [game_a], bot=True),
+        ],
+        config,
+    )
+    assert result.checked == 4
+    assert len(result.issues) == 1
+    assert result.issues[0].member is flagged
+    assert [item.name for item in result.issues[0].matched_game_roles] == [
+        "ArcRaiders",
+        "WoW",
+    ]
+
+
+def test_fix_adds_access_without_removing_games_and_continues_after_failures(
+    monkeypatch,
+):
+    access = role(10, "RealmWalker")
+    game = role(20, "WoW")
+    good = member(1, [game])
+    forbidden = member(2, [game])
+    http_error = member(3, [game])
+
+    async def add_good(added, **_kwargs):
+        good.roles.append(added)
+
+    async def add_forbidden(*_args, **_kwargs):
+        raise discord.Forbidden(
+            SimpleNamespace(status=403, reason="Forbidden"), "hierarchy"
+        )
+
+    async def add_http(*_args, **_kwargs):
+        raise discord.HTTPException(
+            SimpleNamespace(status=500, reason="Error"), "failure"
+        )
+
+    good.add_roles = add_good
+    forbidden.add_roles = add_forbidden
+    http_error.add_roles = add_http
+    issues = realmwalker.scan_members(
+        [good, forbidden, http_error],
+        realmwalker.RealmWalkerConfig(10, frozenset({20})),
+    ).issues
+    result = asyncio.run(realmwalker.fix_issues(issues, access))
+    assert result.fixed[0].member is good
+    assert len(result.failures) == 2
+    assert game in good.roles and access in good.roles
+
+
+def test_daily_section_reports_mismatch_and_fix_hint_without_mutation():
+    game = role(20, "WoW")
+    affected = member(1, [game])
+    issue = realmwalker.RealmWalkerIssue(affected, (game,))
+    summary = role_audit.AuditResult(checked=1, realmwalker_issues=[issue])
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+    text = embed.description or ""
+    assert "Missing RealmWalker access" in text
+    assert "<@1> – User 1 – game roles: WoW" in text
+    assert "!audit realmwalker fix" in text
+    assert not hasattr(affected, "add_roles")
+
+
+def test_daily_config_warning_renders_without_crashing():
+    summary = role_audit.AuditResult(
+        checked=1, realmwalker_warning="Config is invalid."
+    )
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+    assert "RealmWalker audit warning" in (embed.description or "")

--- a/tests/housekeeping/test_role_audit.py
+++ b/tests/housekeeping/test_role_audit.py
@@ -18,7 +18,9 @@ def test_classify_roles_covers_stray_and_wander_cases():
     clan_roles = {10, 11}
 
     assert (
-        role_audit._classify_roles({1}, raid_role_id=1, wanderer_role_id=2, clan_role_ids=clan_roles)
+        role_audit._classify_roles(
+            {1}, raid_role_id=1, wanderer_role_id=2, clan_role_ids=clan_roles
+        )
         == "stray"
     )
     assert (
@@ -42,7 +44,12 @@ def test_classify_roles_covers_stray_and_wander_cases():
 
 
 def test_render_report_formats_all_sections():
-    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    member = DummyMember(
+        id=1,
+        name="tester",
+        roles=[],
+        joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
     clan_role = DummyRole(id=10, name="ClanTag")
     ticket = SimpleNamespace(name="W0001-test", url="https://discord.com/channels/1/2")
 
@@ -87,7 +94,12 @@ def test_render_report_uses_unknown_join_date_when_missing():
 
 
 def test_render_report_apply_mode_includes_actions_and_failures():
-    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    member = DummyMember(
+        id=1,
+        name="tester",
+        roles=[],
+        joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
     summary = role_audit.AuditResult(
         checked=2,
         auto_fixed_strays=[member],
@@ -114,8 +126,15 @@ def test_render_report_apply_mode_includes_actions_and_failures():
 
 
 def test_render_report_dry_run_wording_and_footer():
-    member = DummyMember(id=1, name="tester", roles=[], joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc))
-    summary = role_audit.AuditResult(checked=9, auto_fixed_strays=[member], auto_fixed_wanderers=[member])
+    member = DummyMember(
+        id=1,
+        name="tester",
+        roles=[],
+        joined_at=datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
+    summary = role_audit.AuditResult(
+        checked=9, auto_fixed_strays=[member], auto_fixed_wanderers=[member]
+    )
     embed = role_audit._render_report(
         summary=summary,
         raid_role_name="raid",
@@ -133,7 +152,15 @@ def test_render_report_dry_run_wording_and_footer():
 def test_only_everyone_section_includes_non_bot_member():
     guild = SimpleNamespace(id=100)
     everyone = DummyRole(id=100, name="@everyone")
-    member = DummyMember(id=1, name="roleless", display_name="Role Less", guild=guild, roles=[everyone], bot=False)
+    member = DummyMember(
+        id=1,
+        name="roleless",
+        display_name="Role Less",
+        guild=guild,
+        roles=[everyone],
+        bot=False,
+        joined_at=datetime.now(timezone.utc),
+    )
     summary = role_audit.AuditResult(checked=1, members_only_everyone=[member])
 
     embed = role_audit._render_report(
@@ -144,6 +171,20 @@ def test_only_everyone_section_includes_non_bot_member():
     assert "Members with only @everyone" in description
     assert "<@1>" in description
     assert "Role Less" in description
+    assert (
+        datetime.now(timezone.utc).strftime("joined %Y-%m-%d (0d ago)") in description
+    )
+
+
+def test_only_everyone_section_unknown_join_date():
+    member = DummyMember(
+        id=1, name="roleless", display_name="Role Less", joined_at=None
+    )
+    summary = role_audit.AuditResult(checked=1, members_only_everyone=[member])
+    embed = role_audit._render_report(
+        summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"
+    )
+    assert "<@1> – Role Less – joined unknown" in (embed.description or "")
 
 
 def test_only_everyone_helper_excludes_members_with_other_roles_and_bots():
@@ -173,7 +214,9 @@ def test_render_report_large_roleless_set_splits_without_omitting_members():
         )
         for idx in range(1, 220)
     ]
-    summary = role_audit.AuditResult(checked=len(members), members_only_everyone=members)
+    summary = role_audit.AuditResult(
+        checked=len(members), members_only_everyone=members
+    )
 
     embeds = role_audit._render_report_embeds(
         summary=summary, raid_role_name="Raid", wanderer_role_name="Wandering Souls"


### PR DESCRIPTION
### Motivation
- Add an admin-gated, config-driven audit and repair flow to ensure members with game roles have RealmWalker access and make this check visible in the existing daily Role & Visitor Audit without automatic mutation.
- Restore lost server join-date information in the daily “Members with only @everyone” section so audit output includes both absolute date and relative age.
- Keep the implementation strictly housekeeping-focused: no Google Sheets writes, no hard-coded role IDs/names, and all outputs use existing embed formatting and admin gating patterns.

### Description
- Add `modules/housekeeping/realmwalker.py` providing `resolve_config`, `scan_members`, `fix_issues`, a small result model, and `build_embeds` for bounded, mention-safe embed rendering when reporting or applying fixes.
- Add `cogs/housekeeping_realmwalker.py` which registers admin commands `!audit realmwalker` (dry-run) and `!audit realmwalker fix` (repair) that load members, reuse the shared helpers, disable mentions, and report per-member results while capturing `Forbidden`/`HTTPException` failures.
- Integrate the scan into the existing daily `Role & Visitor Audit` by extending `modules/housekeeping/role_audit.py` to optionally resolve RealmWalker config asynchronously, collect `realmwalker_issues` per-guild, log config problems as warnings, and add a "Missing RealmWalker access" detected section with the hint to run `!audit realmwalker fix` (report-only from the scheduled job).
- Restore join-date rendering by adding `_format_joined_with_age` and updating the "Members with only @everyone" lines to include `joined YYYY-MM-DD (Nd ago)` with `0d ago` for same-day and `joined unknown` when `joined_at` is unavailable; updated output splitting and embed footer logic reused from existing audit patterns.
- Expose the new housekeeping module in `modules/housekeeping/__init__.py` and ensure the cog is loaded in runtime startup; no intents, OAuth scopes, or Sheets schema changes were made.

### Testing
- Ran focused unit tests: `python -m pytest -q tests/housekeeping/test_realmwalker.py tests/housekeeping/test_role_audit.py` — 15 tests passed.
- Static/format checks: `python -m ruff check ...` and `python -m compileall ...` completed without issues, and `git diff --check` passed.
- Full test run (`python -m pytest -q`) was attempted but interrupted by unrelated existing failures in other areas (shard tracker / docs indexing / onboarding tests); the focused feature tests and linters for changed files passed.

[meta]
labels: enhancement, comp:roles, comp:commands, tests
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cadc793fc8323ad474bb5e4b9f91b)