### PR TITLE
Fail closed and alert on feature-toggle load failures

### DIFF
--- a/modules/common/feature_flags.py
+++ b/modules/common/feature_flags.py
@@ -139,7 +139,7 @@ def _extract_column(row: Mapping[str, object], column_name: str) -> str:
     return ""
 
 
-async def refresh() -> None:
+async def _refresh() -> None:
     """Refresh feature toggles from Sheets (fail-closed)."""
 
     global _FEATURE_VALUES, _INVALID_FEATURE_VALUES, _LOADED_AT, _ROW_COUNT
@@ -240,8 +240,9 @@ async def refresh() -> None:
                             failure_reason = "Feature toggle worksheet returned no rows; treating all features as disabled."
                             await _warn_global_once("no-rows", failure_reason)
 
-        for key in _DEFAULT_TRUE_FEATURES:
-            feature_values.setdefault(key, True)
+        if failure_reason is None:
+            for key in _DEFAULT_TRUE_FEATURES:
+                feature_values.setdefault(key, True)
 
         _FEATURE_VALUES = feature_values
         _INVALID_FEATURE_VALUES = invalid_feature_values
@@ -253,12 +254,42 @@ async def refresh() -> None:
         _GLOBAL_FAILURE_REASON = failure_reason
 
 
+async def refresh() -> None:
+    """Refresh feature toggles and convert unexpected errors to a safe state."""
+
+    global _FEATURE_VALUES, _INVALID_FEATURE_VALUES, _LOADED_AT, _ROW_COUNT
+    global _SOURCE_TAB, _DISABLED_BY_DEFAULT, _NOTES, _GLOBAL_FAILURE_REASON
+
+    try:
+        await _refresh()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        reason = f"Unexpected feature toggle refresh failure: {exc}"
+        log.exception(reason)
+        async with _LOCK:
+            _FEATURE_VALUES = {}
+            _INVALID_FEATURE_VALUES = {}
+            _LOADED_AT = datetime.now(timezone.utc)
+            _ROW_COUNT = 0
+            _SOURCE_TAB = _DEFAULT_TOGGLES_TAB
+            _DISABLED_BY_DEFAULT = True
+            _NOTES = [reason]
+            _GLOBAL_FAILURE_REASON = reason
+        await _warn_global_once("unexpected-refresh", reason)
+
+
 async def _warn_global_once(token: str, detail: str) -> None:
     if token in _GLOBAL_WARNINGS_SENT:
         return
     _GLOBAL_WARNINGS_SENT.add(token)
     log.warning(detail)
-    await _emit_admin_alert(detail)
+
+
+def global_failure_reason() -> str | None:
+    """Return why the toggle source is globally unreadable, if applicable."""
+
+    return _GLOBAL_FAILURE_REASON
 
 
 async def _warn_invalid_value_once(
@@ -328,7 +359,16 @@ def snapshot() -> Dict[str, Any]:
 
 
 def values() -> Dict[str, bool]:
+    if _GLOBAL_FAILURE_REASON:
+        return {key: False for key in _DEFAULT_TRUE_FEATURES}
     return dict(_FEATURE_VALUES)
 
 
-__all__ = ["is_enabled", "refresh", "snapshot", "status", "values"]
+__all__ = [
+    "global_failure_reason",
+    "is_enabled",
+    "refresh",
+    "snapshot",
+    "status",
+    "values",
+]

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1335,7 +1335,7 @@ class Runtime:
             for module_path, feature_keys in skipped
         )
         alert = (
-            "❌ **Feature toggles unreadable** feature toggles could not be read; "
+            "❌ **Feature toggles unreadable:** feature toggles could not be read; "
             "feature-gated modules were disabled/skipped for safety "
             f"• reason={failure_reason}\n• affected={affected}"
         )

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1306,8 +1306,8 @@ class Runtime:
 
         return self.scheduler.spawn(runner(), name=name)
 
-    async def _refresh_feature_toggles(self) -> None:
-        """Refresh the shared toggle snapshot and defer one loud failure alert."""
+    async def _refresh_feature_toggles(self) -> str | None:
+        """Refresh the shared toggle snapshot and return any global failure."""
 
         from modules.common import feature_flags as features
 
@@ -1321,24 +1321,23 @@ class Runtime:
             log.exception("feature toggle snapshot update failed")
 
         failure_reason = features.global_failure_reason()
-        if not failure_reason:
-            return
+        return failure_reason
 
-        affected = (
-            "mirralith_overview_enabled (cogs.housekeeping_mirralith)",
-            "member_panel/recruiter_panel (recruitment search and panels)",
-            "clan_profile (cogs.recruitment_clan_profile)",
-            "recruitment_welcome (cogs.recruitment_welcome)",
-            "recruitment_reports (modules.recruitment.reports)",
-            "placement_target_select (modules.placement.target_select)",
-            "feature_reservations/placement_reservations (placement reservations)",
-            "welcome_watcher_enabled/promo_watcher_enabled/resume_command_enabled (onboarding)",
-            "ops_permissions_enabled (modules.ops.permissions_ui)",
+    def _alert_feature_toggle_failure(
+        self,
+        failure_reason: str,
+        skipped: Sequence[tuple[str, Sequence[str]]],
+    ) -> None:
+        """Defer one alert describing the feature modules actually skipped."""
+
+        affected = "; ".join(
+            f"{module_path} (keys={','.join(feature_keys)})"
+            for module_path, feature_keys in skipped
         )
         alert = (
-            "❌ **Feature toggles unreadable** — feature toggles could not be read; "
+            "❌ **Feature toggles unreadable** feature toggles could not be read; "
             "feature-gated modules were disabled/skipped for safety "
-            f"• reason={failure_reason}\n• affected={'; '.join(affected)}"
+            f"• reason={failure_reason}\n• affected={affected}"
         )
         log.error(alert)
         # The helper waits for Discord readiness; defer it so extension loading
@@ -1374,10 +1373,11 @@ class Runtime:
         await coreops_cog.setup(self.bot)
         await app_admin.setup(self.bot)
 
-        await self._refresh_feature_toggles()
+        failure_reason = await self._refresh_feature_toggles()
         from modules.common import feature_flags as features
 
         toggles = shared_config.features
+        skipped_feature_modules: list[tuple[str, Sequence[str]]] = []
 
         await onboarding_pkg.setup(self.bot)
 
@@ -1386,6 +1386,10 @@ class Runtime:
             log.info("modules: mirralith_overview enabled")
         else:
             log.info("modules: mirralith_overview disabled")
+            if failure_reason:
+                skipped_feature_modules.append(
+                    ("cogs.housekeeping_mirralith", ("mirralith_overview_enabled",))
+                )
 
         await housekeeping_achievements.setup(self.bot)
         log.info("modules: achievements command registered")
@@ -1413,6 +1417,8 @@ class Runtime:
         ) -> None:
             enabled_keys = [key for key in feature_keys if features.is_enabled(key)]
             if not enabled_keys:
+                if failure_reason:
+                    skipped_feature_modules.append((module_path, feature_keys))
                 extra_info = {
                     "feature_module": module_path,
                     "feature_keys": list(feature_keys),
@@ -1505,6 +1511,10 @@ class Runtime:
             log.info("modules: clan_profile enabled")
         else:
             log.info("modules: clan_profile disabled")
+            if failure_reason:
+                skipped_feature_modules.append(
+                    ("cogs.recruitment_clan_profile", ("clan_profile",))
+                )
 
         from cogs import clanrole_management
 
@@ -1537,24 +1547,55 @@ class Runtime:
             log.info("modules: onboarding_welcome enabled")
         else:
             log.info("modules: onboarding_welcome disabled")
+            if failure_reason:
+                skipped_feature_modules.extend(
+                    (
+                        (
+                            "modules.onboarding.reaction_fallback",
+                            ("welcome_watcher_enabled",),
+                        ),
+                        (
+                            "modules.onboarding.watcher_welcome",
+                            ("welcome_watcher_enabled",),
+                        ),
+                    )
+                )
 
         if toggles.promo_watcher_enabled:
             await onboarding_promo.setup(self.bot)
             log.info("modules: onboarding_promo enabled")
         else:
             log.info("modules: onboarding_promo disabled")
+            if failure_reason:
+                skipped_feature_modules.append(
+                    (
+                        "modules.onboarding.watcher_promo",
+                        ("promo_watcher_enabled",),
+                    )
+                )
 
         if toggles.resume_command_enabled:
             await onboarding_cmd_resume.setup(self.bot)  # registers !onb resume
             log.info("modules: onboarding_resume enabled")
         else:
             log.info("modules: onboarding_resume disabled")
+            if failure_reason:
+                skipped_feature_modules.append(
+                    ("modules.onboarding.cmd_resume", ("resume_command_enabled",))
+                )
 
         if toggles.welcome_watcher_enabled or toggles.promo_watcher_enabled:
             await onboarding_cmd_finishplacement.setup(self.bot)
             log.info("modules: onboarding_finishplacement enabled")
         else:
             log.info("modules: onboarding_finishplacement disabled")
+            if failure_reason:
+                skipped_feature_modules.append(
+                    (
+                        "modules.onboarding.cmd_finishplacement",
+                        ("welcome_watcher_enabled", "promo_watcher_enabled"),
+                    )
+                )
 
         await ops_cog.setup(self.bot)
 
@@ -1563,6 +1604,9 @@ class Runtime:
             log.info("modules: ops_permissions enabled")
         else:
             log.info("modules: ops_permissions disabled")
+
+        if failure_reason:
+            self._alert_feature_toggle_failure(failure_reason, skipped_feature_modules)
 
         # === Always-on internal extensions (admin-gated debug/ops commands) ===
         ALWAYS_EXTENSIONS = ("modules.coreops.cmd_cfg",)

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -1306,6 +1306,47 @@ class Runtime:
 
         return self.scheduler.spawn(runner(), name=name)
 
+    async def _refresh_feature_toggles(self) -> None:
+        """Refresh the shared toggle snapshot and defer one loud failure alert."""
+
+        from modules.common import feature_flags as features
+
+        try:
+            await features.refresh()
+        except Exception:  # pragma: no cover - refresh is fail-closed defensively
+            log.exception("feature toggle refresh failed")
+        try:
+            shared_config.update_feature_flags_snapshot(features.values())
+        except Exception:
+            log.exception("feature toggle snapshot update failed")
+
+        failure_reason = features.global_failure_reason()
+        if not failure_reason:
+            return
+
+        affected = (
+            "mirralith_overview_enabled (cogs.housekeeping_mirralith)",
+            "member_panel/recruiter_panel (recruitment search and panels)",
+            "clan_profile (cogs.recruitment_clan_profile)",
+            "recruitment_welcome (cogs.recruitment_welcome)",
+            "recruitment_reports (modules.recruitment.reports)",
+            "placement_target_select (modules.placement.target_select)",
+            "feature_reservations/placement_reservations (placement reservations)",
+            "welcome_watcher_enabled/promo_watcher_enabled/resume_command_enabled (onboarding)",
+            "ops_permissions_enabled (modules.ops.permissions_ui)",
+        )
+        alert = (
+            "❌ **Feature toggles unreadable** — feature toggles could not be read; "
+            "feature-gated modules were disabled/skipped for safety "
+            f"• reason={failure_reason}\n• affected={'; '.join(affected)}"
+        )
+        log.error(alert)
+        # The helper waits for Discord readiness; defer it so extension loading
+        # cannot deadlock startup before the ready event is dispatched.
+        asyncio.create_task(
+            self.send_log_message(alert), name="feature_toggle_failure_alert"
+        )
+
     async def load_extensions(self) -> None:
         """Load all feature modules into the shared bot instance."""
 
@@ -1333,17 +1374,8 @@ class Runtime:
         await coreops_cog.setup(self.bot)
         await app_admin.setup(self.bot)
 
+        await self._refresh_feature_toggles()
         from modules.common import feature_flags as features
-
-        try:
-            await features.refresh()
-        except Exception:
-            log.exception("feature toggle refresh failed")
-        else:
-            try:
-                shared_config.update_feature_flags_snapshot(features.values())
-            except Exception:
-                log.exception("feature toggle snapshot update failed")
 
         toggles = shared_config.features
 

--- a/tests/common/test_feature_toggle_runtime_safety.py
+++ b/tests/common/test_feature_toggle_runtime_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 
 from modules.common import feature_flags
 from modules.common import runtime as runtime_module
@@ -46,55 +47,119 @@ def test_unexpected_refresh_error_clears_previous_true_values(monkeypatch) -> No
 
 
 class _Bot:
-    pass
+    async def load_extension(self, _extension: str) -> None:
+        return None
 
 
-def test_runtime_schedules_aggregated_discord_alert_on_toggle_failure(
-    monkeypatch,
-) -> None:
-    _reset_feature_state(monkeypatch)
+def _patch_always_loaded_setups(monkeypatch, *, ops_calls: list[str]) -> None:
+    async def noop_setup(_bot) -> None:
+        return None
+
+    async def ops_setup(_bot) -> None:
+        ops_calls.append("modules.ops.permissions_ui")
+
+    module_names = (
+        "c1c_coreops.cog",
+        "c1c_coreops.ops",
+        "cogs.app_admin",
+        "cogs.housekeeping_mirralith",
+        "cogs.housekeeping_achievements",
+        "cogs.housekeeping_achievement_collector",
+        "cogs.housekeeping_wandering_souls",
+        "cogs.housekeeping_c1c_ad",
+        "cogs.housekeeping_realmwalker",
+        "cogs.recruitment_clan_ads",
+        "cogs.clanrole_management",
+        "cogs.recruitment_open_spots",
+        "modules.housekeeping.cleanup",
+        "modules.onboarding.ops_check",
+        "modules.onboarding.reaction_fallback",
+        "modules.onboarding.watcher_welcome",
+        "modules.onboarding.watcher_promo",
+        "modules.onboarding.cmd_resume",
+        "modules.onboarding.cmd_finishplacement",
+    )
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        monkeypatch.setattr(module, "setup", noop_setup)
+    permissions = importlib.import_module("modules.ops.permissions_ui")
+    monkeypatch.setattr(permissions, "setup", ops_setup)
+    monkeypatch.setattr(runtime_module.onboarding_pkg, "setup", noop_setup)
+    monkeypatch.setattr(runtime_module, "COMMUNITY_EXTENSIONS", ())
+
+
+def _run_extension_load(
+    monkeypatch, *, failure_reason: str | None
+) -> tuple[list[str], list[str]]:
     runtime = runtime_module.Runtime(_Bot())  # type: ignore[arg-type]
     messages: list[str] = []
+    ops_calls: list[str] = []
+    _patch_always_loaded_setups(monkeypatch, ops_calls=ops_calls)
 
-    async def fake_refresh() -> None:
-        monkeypatch.setattr(
-            feature_flags, "_GLOBAL_FAILURE_REASON", "Config tab read failed"
-        )
+    async def fake_refresh() -> str | None:
+        values = None
+        if failure_reason:
+            values = {
+                "mirralith_overview_enabled": False,
+                "welcome_watcher_enabled": False,
+                "promo_watcher_enabled": False,
+                "resume_command_enabled": False,
+                "ops_permissions_enabled": False,
+            }
+        runtime_module.shared_config.update_feature_flags_snapshot(values)
+        return failure_reason
 
     async def capture(message: str) -> None:
         messages.append(message)
 
-    monkeypatch.setattr(feature_flags, "refresh", fake_refresh)
+    monkeypatch.setattr(runtime, "_refresh_feature_toggles", fake_refresh)
     monkeypatch.setattr(runtime, "send_log_message", capture)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda _key: False)
 
     async def run() -> None:
-        await runtime._refresh_feature_toggles()
+        await runtime.load_extensions()
         await asyncio.sleep(0)
 
     asyncio.run(run())
+    return messages, ops_calls
+
+
+def test_runtime_alert_reports_modules_skipped_by_feature_loader(monkeypatch) -> None:
+    messages, _ops_calls = _run_extension_load(
+        monkeypatch, failure_reason="Config tab read failed"
+    )
 
     assert len(messages) == 1
     assert "feature toggles could not be read" in messages[0]
     assert "disabled/skipped for safety" in messages[0]
     assert "Config tab read failed" in messages[0]
-    assert "member_panel" in messages[0]
+    assert (
+        "modules.recruitment.services.search (keys=member_panel,recruiter_panel)"
+        in messages[0]
+    )
+
+
+def test_runtime_alert_reports_fail_closed_finishplacement(monkeypatch) -> None:
+    messages, _ops_calls = _run_extension_load(
+        monkeypatch, failure_reason="Feature Toggles tab read failed"
+    )
+
+    assert "modules.onboarding.cmd_finishplacement" in messages[0]
+    assert "keys=welcome_watcher_enabled,promo_watcher_enabled" in messages[0]
+
+
+def test_runtime_alert_does_not_report_ops_permissions_when_setup_runs(
+    monkeypatch,
+) -> None:
+    messages, ops_calls = _run_extension_load(
+        monkeypatch, failure_reason="Feature Toggles tab read failed"
+    )
+
+    assert ops_calls == ["modules.ops.permissions_ui"]
+    assert "modules.ops.permissions_ui" not in messages[0]
 
 
 def test_runtime_does_not_alert_after_successful_refresh(monkeypatch) -> None:
-    _reset_feature_state(monkeypatch)
-    runtime = runtime_module.Runtime(_Bot())  # type: ignore[arg-type]
-    messages: list[str] = []
-
-    async def fake_refresh() -> None:
-        monkeypatch.setattr(feature_flags, "_GLOBAL_FAILURE_REASON", None)
-        monkeypatch.setattr(feature_flags, "_FEATURE_VALUES", {"member_panel": True})
-
-    async def capture(message: str) -> None:
-        messages.append(message)
-
-    monkeypatch.setattr(feature_flags, "refresh", fake_refresh)
-    monkeypatch.setattr(runtime, "send_log_message", capture)
-
-    asyncio.run(runtime._refresh_feature_toggles())
+    messages, _ops_calls = _run_extension_load(monkeypatch, failure_reason=None)
 
     assert messages == []

--- a/tests/common/test_feature_toggle_runtime_safety.py
+++ b/tests/common/test_feature_toggle_runtime_safety.py
@@ -148,6 +148,23 @@ def test_runtime_alert_reports_fail_closed_finishplacement(monkeypatch) -> None:
     assert "keys=welcome_watcher_enabled,promo_watcher_enabled" in messages[0]
 
 
+def test_runtime_alert_reports_each_explicit_shared_config_skip(monkeypatch) -> None:
+    messages, _ops_calls = _run_extension_load(
+        monkeypatch, failure_reason="Feature Toggles tab read failed"
+    )
+
+    expected_modules = (
+        "cogs.housekeeping_mirralith",
+        "modules.onboarding.reaction_fallback",
+        "modules.onboarding.watcher_welcome",
+        "modules.onboarding.watcher_promo",
+        "modules.onboarding.cmd_resume",
+        "modules.onboarding.cmd_finishplacement",
+    )
+    assert all(module_path in messages[0] for module_path in expected_modules)
+    assert "—" not in messages[0]
+
+
 def test_runtime_alert_does_not_report_ops_permissions_when_setup_runs(
     monkeypatch,
 ) -> None:

--- a/tests/common/test_feature_toggle_runtime_safety.py
+++ b/tests/common/test_feature_toggle_runtime_safety.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+
+from modules.common import feature_flags
+from modules.common import runtime as runtime_module
+
+
+def _reset_feature_state(monkeypatch) -> None:
+    monkeypatch.setattr(feature_flags, "_FEATURE_VALUES", {})
+    monkeypatch.setattr(feature_flags, "_INVALID_FEATURE_VALUES", {})
+    monkeypatch.setattr(feature_flags, "_GLOBAL_FAILURE_REASON", "uninitialized")
+    monkeypatch.setattr(feature_flags, "_GLOBAL_WARNINGS_SENT", set())
+
+
+def test_refresh_missing_sheet_id_is_fail_closed(monkeypatch) -> None:
+    _reset_feature_state(monkeypatch)
+    monkeypatch.setattr(feature_flags, "get_recruitment_sheet_id", lambda: "")
+
+    asyncio.run(feature_flags.refresh())
+
+    assert feature_flags.global_failure_reason() == (
+        "Recruitment sheet ID missing; all feature toggles disabled."
+    )
+    assert feature_flags.is_enabled("welcome_watcher_enabled") is False
+    assert all(value is False for value in feature_flags.values().values())
+
+
+def test_unexpected_refresh_error_clears_previous_true_values(monkeypatch) -> None:
+    _reset_feature_state(monkeypatch)
+    monkeypatch.setattr(
+        feature_flags, "_FEATURE_VALUES", {"welcome_watcher_enabled": True}
+    )
+    monkeypatch.setattr(feature_flags, "get_recruitment_sheet_id", lambda: "sheet")
+
+    async def fail_refresh():
+        raise RuntimeError("unexpected reader failure")
+
+    monkeypatch.setattr(feature_flags, "_refresh", fail_refresh)
+
+    asyncio.run(feature_flags.refresh())
+
+    assert "unexpected reader failure" in (feature_flags.global_failure_reason() or "")
+    assert feature_flags.is_enabled("welcome_watcher_enabled") is False
+    assert feature_flags.values()["welcome_watcher_enabled"] is False
+
+
+class _Bot:
+    pass
+
+
+def test_runtime_schedules_aggregated_discord_alert_on_toggle_failure(
+    monkeypatch,
+) -> None:
+    _reset_feature_state(monkeypatch)
+    runtime = runtime_module.Runtime(_Bot())  # type: ignore[arg-type]
+    messages: list[str] = []
+
+    async def fake_refresh() -> None:
+        monkeypatch.setattr(
+            feature_flags, "_GLOBAL_FAILURE_REASON", "Config tab read failed"
+        )
+
+    async def capture(message: str) -> None:
+        messages.append(message)
+
+    monkeypatch.setattr(feature_flags, "refresh", fake_refresh)
+    monkeypatch.setattr(runtime, "send_log_message", capture)
+
+    async def run() -> None:
+        await runtime._refresh_feature_toggles()
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert len(messages) == 1
+    assert "feature toggles could not be read" in messages[0]
+    assert "disabled/skipped for safety" in messages[0]
+    assert "Config tab read failed" in messages[0]
+    assert "member_panel" in messages[0]
+
+
+def test_runtime_does_not_alert_after_successful_refresh(monkeypatch) -> None:
+    _reset_feature_state(monkeypatch)
+    runtime = runtime_module.Runtime(_Bot())  # type: ignore[arg-type]
+    messages: list[str] = []
+
+    async def fake_refresh() -> None:
+        monkeypatch.setattr(feature_flags, "_GLOBAL_FAILURE_REASON", None)
+        monkeypatch.setattr(feature_flags, "_FEATURE_VALUES", {"member_panel": True})
+
+    async def capture(message: str) -> None:
+        messages.append(message)
+
+    monkeypatch.setattr(feature_flags, "refresh", fake_refresh)
+    monkeypatch.setattr(runtime, "send_log_message", capture)
+
+    asyncio.run(runtime._refresh_feature_toggles())
+
+    assert messages == []


### PR DESCRIPTION
### Motivation

- Prevent feature-gated modules from starting on stale or default-true toggles when the Sheets-backed toggle source is unreadable, and surface a single loud alert in the Discord logging channel when that happens.

### Description

- Split the internal toggle loader into `_refresh()` and a public `refresh()` wrapper in `modules/common/feature_flags.py` so unexpected exceptions replace stale/default-true values with an explicit fail-closed state and record a global failure reason.
- Add `global_failure_reason()` and make `values()` return a safe all-false snapshot when a global failure is present, and avoid restoring `_DEFAULT_TRUE_FEATURES` on load failures.
- Add `Runtime._refresh_feature_toggles()` in `modules/common/runtime.py` which refreshes toggles, updates the shared snapshot via `shared_config.update_feature_flags_snapshot(features.values())`, and, if toggles are unreadable, emits one aggregated Discord log-channel alert (includes `reason=` and affected feature/module names) using the existing `send_log_message` helper scheduled with `asyncio.create_task` so startup is not blocked and failures to post are non-fatal.
- Add focused tests in `tests/common/test_feature_toggle_runtime_safety.py` that cover missing sheet id, unexpected `refresh()` errors clearing previous true values, the aggregated alert is scheduled with the failure reason and an affected key, and that a successful refresh does not send the failure alert.

### Testing

- Ran focused unit tests: `pytest -q tests/common/test_feature_toggle_runtime_safety.py` (4 passed).
- Ran formatting and static checks for changed files: `ruff check`, `ruff format --check`, and `python -m compileall` (passed for modified files).
- Ran a combined smoke of related tests (`pytest -q tests/common/test_feature_toggle_runtime_safety.py tests/test_runtime_async_sheet_boundary.py tests/guardrails/test_async_sheets_guardrail.py`), where the new focused tests and guardrail tests passed but an existing async Sheets boundary guard reported 10 unrelated violations in `modules/recruitment/availability.py`.
- Commit recorded with the change set and tests above (branch clean after commit).

[meta]
labels: codex, bug, robustness, comp:config, comp:modules, observability, tests
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cc6c13f748323ad00192b7fe57817)