### PR TITLE
Use the live scheduler registry for startup reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from shared.logfmt import LogTemplates, guild_label, user_label, human_reason
 from shared.redaction import sanitize_text
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
-from modules.common.runtime import Runtime, StartupPhaseError
+from modules.common.runtime import Runtime, StartupPhaseError, scheduler_report_lines
 from modules.common import keepalive
 from modules.coreops import ready as core_ready
 from c1c_coreops.config import (
@@ -42,7 +42,6 @@ from c1c_coreops.cron_summary import emit_daily_summary
 from modules.recruitment.reporting.daily_recruiter_update import (
     ensure_scheduler_started,
 )
-from modules.community.fusion.reminders import collect_fusion_reminder_startup_summary
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -258,17 +257,6 @@ def _normalize_admin_invocation(base: str, remainder: str | None) -> str:
     if remainder:
         parts.append(remainder)
     return normalize_command_text(" ".join(parts))
-
-
-def _fmt_next_utc(job: object) -> str:
-    next_run = getattr(job, "next_run", None)
-    if next_run is None:
-        return "not scheduled"
-    return (
-        next_run.astimezone(dt.timezone.utc)
-        .replace(second=0, microsecond=0)
-        .strftime("%Y-%m-%d %H:%M UTC")
-    )
 
 
 async def _maybe_capture_onboarding_answer(message: discord.Message) -> bool:
@@ -490,37 +478,9 @@ async def on_ready():
                 f"• failed: {preload_report.error or 'unknown'}",
             ]
 
-    jobs = {getattr(job, "name", ""): job for job in runtime.scheduler.jobs}
-    fusion_reminder_lines: list[str]
-    try:
-        fusion_reminder_lines = await collect_fusion_reminder_startup_summary(
-            bot,
-            scheduler_started=any(name.startswith("fusion_") for name in jobs),
-        )
-    except Exception as exc:
-        log.exception("fusion reminder startup summary failed")
-        fusion_reminder_lines = [
-            "🧬 Fusion reminders",
-            f"• started={'yes' if any(name.startswith('fusion_') for name in jobs) else 'no'}",
-            f"• failed={type(exc).__name__}",
-        ]
-    scheduler_lines = [
-        "🧭 Scheduler",
-        "• intervals: clans=3h • templates=7d • clan_tags=7d • onboarding_questions=7d • cleanup=24h • mirralith_overview=not scheduled",
-        f"• clans={_fmt_next_utc(jobs['cache_refresh:clans']) if 'cache_refresh:clans' in jobs else 'not scheduled'}",
-        f"• templates={_fmt_next_utc(jobs['cache_refresh:templates']) if 'cache_refresh:templates' in jobs else 'not scheduled'}",
-        f"• clan_tags={_fmt_next_utc(jobs['cache_refresh:clan_tags']) if 'cache_refresh:clan_tags' in jobs else 'not scheduled'}",
-        f"• onboarding_questions={_fmt_next_utc(jobs['cache_refresh:onboarding_questions']) if 'cache_refresh:onboarding_questions' in jobs else 'not scheduled'}",
-        f"• cleanup={_fmt_next_utc(jobs['cleanup_watcher']) if 'cleanup_watcher' in jobs else 'not scheduled'}",
-        f"• housekeeping_keepalive={_fmt_next_utc(jobs['housekeeping_keepalive']) if 'housekeeping_keepalive' in jobs else 'not scheduled'}",
-        f"• mirralith_overview={_fmt_next_utc(jobs['mirralith_overview']) if 'mirralith_overview' in jobs else 'not scheduled'}",
-        f"• fusion_grouped_reminders={_fmt_next_utc(jobs['fusion_grouped_reminders']) if 'fusion_grouped_reminders' in jobs else 'not scheduled'}",
-        f"• fusion_announcement_refresh={_fmt_next_utc(jobs['fusion_announcement_refresh']) if 'fusion_announcement_refresh' in jobs else 'not scheduled'}",
-        f"• fusion_role_cleanup={_fmt_next_utc(jobs['fusion_role_cleanup']) if 'fusion_role_cleanup' in jobs else 'not scheduled'}",
-        f"• reset_reminders={_fmt_next_utc(jobs['reset_reminders']) if 'reset_reminders' in jobs else 'not scheduled'}",
-        f"• achievement_collector={_fmt_next_utc(jobs['achievement_collector']) if 'achievement_collector' in jobs else 'not scheduled'}",
-        *fusion_reminder_lines,
-    ]
+    # Reporting is intentionally a registry read.  Do not call job/config helpers
+    # here: registration already established both the live jobs and skip reasons.
+    scheduler_lines = scheduler_report_lines(runtime.scheduler)
     watchers_lines = [
         "✅ Watchers",
         "• Promo watcher — event=enabled",

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -949,6 +949,7 @@ class Scheduler:
     def __init__(self) -> None:
         self._tasks: list[asyncio.Task] = []
         self._jobs: list[Any] = []
+        self._registration_skips: dict[str, str] = {}
 
     def spawn(self, coro: Awaitable, *, name: Optional[str] = None) -> asyncio.Task:
         if name is not None:
@@ -975,7 +976,16 @@ class Scheduler:
     def cron(
         self, expression: str, *, tag: str | None = None, name: str | None = None
     ) -> _CronJob:
-        return _CronJob(self, expression=expression, tag=tag, name=name)
+        if name is not None:
+            for existing in self._jobs:
+                if existing.name == name:
+                    return existing
+        job = _CronJob(self, expression=expression, tag=tag, name=name)
+        job.cadence_label = expression
+        self._jobs.append(job)
+        if name:
+            self._registration_skips.pop(name, None)
+        return job
 
     def every(
         self,
@@ -1009,6 +1019,8 @@ class Scheduler:
             component=component,
         )
         self._jobs.append(job)
+        if name:
+            self._registration_skips.pop(name, None)
         return job
 
     def at(
@@ -1035,7 +1047,19 @@ class Scheduler:
             cadence_label=cadence_label,
         )
         self._jobs.append(job)
+        if name:
+            self._registration_skips.pop(name, None)
         return job
+
+    def record_registration_skip(self, name: str, reason: str) -> None:
+        """Record why a configured job was not added to the live registry."""
+
+        if not any(getattr(job, "name", None) == name for job in self._jobs):
+            self._registration_skips.setdefault(name, reason)
+
+    @property
+    def registration_skips(self) -> dict[str, str]:
+        return dict(self._registration_skips)
 
     @property
     def jobs(self) -> list[Any]:
@@ -1057,8 +1081,53 @@ class Scheduler:
                 log.exception("scheduler task error during shutdown")
 
 
+def scheduler_report_lines(scheduler: Scheduler) -> list[str]:
+    """Render scheduler status solely from registration results and live jobs."""
+
+    lines = ["🧭 Scheduler"]
+    jobs = sorted(
+        scheduler.jobs,
+        key=lambda job: getattr(job, "name", None) or getattr(job, "tag", None) or "",
+    )
+    for job in jobs:
+        name = getattr(job, "name", None) or getattr(job, "tag", None) or "unnamed"
+        cadence = getattr(job, "cadence_label", None)
+        interval = getattr(job, "interval", None)
+        if cadence is None and isinstance(interval, timedelta):
+            seconds = interval.total_seconds()
+            if seconds % 86400 == 0:
+                cadence = f"{seconds / 86400:g}d"
+            elif seconds % 3600 == 0:
+                cadence = f"{seconds / 3600:g}h"
+            elif seconds % 60 == 0:
+                cadence = f"{seconds / 60:g}m"
+            else:
+                cadence = f"{seconds:g}s"
+        next_run = getattr(job, "next_run", None)
+        next_text = (
+            next_run.astimezone(timezone.utc)
+            .replace(second=0, microsecond=0)
+            .strftime("%Y-%m-%d %H:%M UTC")
+            if isinstance(next_run, datetime)
+            else "pending"
+        )
+        lines.append(
+            f"• {name}=registered • cadence={cadence or 'scheduled'} • next={next_text}"
+        )
+    for name, reason in sorted(scheduler.registration_skips.items()):
+        lines.append(f"• {name}=not registered • reason={reason}")
+    if len(lines) == 1:
+        lines.append("• no jobs registered")
+    return lines
+
+
 class Runtime:
     """Container object that wires the bot, health server, and scheduler."""
+
+    def _record_scheduler_skip(self, name: str, reason: str) -> None:
+        recorder = getattr(self.scheduler, "record_registration_skip", None)
+        if callable(recorder):
+            recorder(name, reason)
 
     def __init__(
         self,
@@ -1796,6 +1865,9 @@ class Runtime:
     ) -> None:
         cleanup_logger = logging.getLogger("c1c.housekeeping.cleanup")
         if not toggles.housekeeping_enabled:
+            self._record_scheduler_skip(
+                "cleanup_watcher", "global housekeeping feature toggle is disabled"
+            )
             cleanup_logger.info(
                 "housekeeping cleanup disabled via global housekeeping feature toggle"
             )
@@ -1806,6 +1878,9 @@ class Runtime:
                 cleanup_logger
             )
         except Exception as exc:
+            self._record_scheduler_skip(
+                "cleanup_watcher", f"config load failed: {type(exc).__name__}"
+            )
             if sheets_core._is_rate_limited_error(exc):
                 cleanup_logger.warning(
                     "cleanup scheduler config resolve hit Google Sheets quota/backoff; "
@@ -1818,6 +1893,9 @@ class Runtime:
             )
             return
         if cleanup_config is None or not cleanup_config.enabled:
+            self._record_scheduler_skip(
+                "cleanup_watcher", "cleanup config is missing or disabled"
+            )
             return
 
         cleanup_job = self.scheduler.every(
@@ -1917,6 +1995,9 @@ class Runtime:
             callback()
             return True
         except Exception as exc:
+            self._record_scheduler_skip(
+                scheduler_name, f"config load failed: {type(exc).__name__}"
+            )
             if sheets_core._is_rate_limited_error(exc):
                 self._log_optional_scheduler_quota_skip(
                     logger=target_logger,
@@ -1985,6 +2066,9 @@ class Runtime:
                     collector_config.schedule_time_utc,
                 )
             except Exception:
+                self._record_scheduler_skip(
+                    "achievement_collector", "schedule config load failed"
+                )
                 log.exception("achievement collector schedule configuration failed")
             else:
                 collector_job = self.scheduler.at(
@@ -2044,10 +2128,16 @@ class Runtime:
                 )
             )
         elif mirralith_cron:
+            self._record_scheduler_skip(
+                "mirralith_overview", "feature toggle is disabled"
+            )
             log.info(
                 "Mirralith overview disabled via feature toggle; skipping schedule"
             )
         else:
+            self._record_scheduler_skip(
+                "mirralith_overview", "MIRRALITH_POST_CRON is not set"
+            )
             log.info("Mirralith overview job disabled; MIRRALITH_POST_CRON is not set.")
 
         try:
@@ -2093,6 +2183,9 @@ class Runtime:
                 )
             )
         else:
+            self._record_scheduler_skip(
+                "c1c_ad", "C1C_AD_REFRESH_DAYS is not configured"
+            )
             log.info("C1C ad job disabled; C1C_AD_REFRESH_DAYS is not configured.")
 
         try:
@@ -2110,6 +2203,7 @@ class Runtime:
                 raise
 
         if not clan_ads_enabled:
+            self._record_scheduler_skip("clan_ads", "feature toggle is disabled")
             log.info("Clan ads job disabled via feature toggle.")
         else:
             try:
@@ -2146,6 +2240,9 @@ class Runtime:
                     )
                 )
             else:
+                self._record_scheduler_skip(
+                    "clan_ads", "scheduler interval is not configured"
+                )
                 log.info(
                     "Clan ads job disabled; clan_ad_post_interval_hours is not configured."
                 )
@@ -2193,10 +2290,18 @@ class Runtime:
                     )
                 )
             else:
+                self._record_scheduler_skip(
+                    "housekeeping_keepalive",
+                    "required config is missing, invalid, or disabled",
+                )
                 log.info(
                     "thread keepalive not scheduled; required sheet Config is missing, invalid, or disabled"
                 )
         else:
+            self._record_scheduler_skip(
+                "housekeeping_keepalive",
+                "global housekeeping feature toggle is disabled",
+            )
             log.info("housekeeping keepalive disabled via feature toggle")
 
         self._register_optional_scheduler(

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -2149,6 +2149,9 @@ class Runtime:
             )
         except Exception as exc:
             c1c_refresh_days = None
+            self._record_scheduler_skip(
+                "c1c_ad", f"config read failed: {type(exc).__name__}"
+            )
             if sheets_core._is_rate_limited_error(exc):
                 self._log_optional_scheduler_quota_skip(
                     logger=log,
@@ -2191,6 +2194,9 @@ class Runtime:
         try:
             clan_ads_enabled = feature_flags.is_enabled("clan_ads")
         except Exception as exc:
+            self._record_scheduler_skip(
+                "clan_ads", f"feature toggle read failed: {type(exc).__name__}"
+            )
             if sheets_core._is_rate_limited_error(exc):
                 self._log_optional_scheduler_quota_skip(
                     logger=log,
@@ -2209,6 +2215,9 @@ class Runtime:
             try:
                 clan_ads_config = await recruitment_clan_ads.load_config(force=True)
             except Exception as exc:
+                self._record_scheduler_skip(
+                    "clan_ads", f"config load failed: {type(exc).__name__}"
+                )
                 if sheets_core._is_rate_limited_error(exc):
                     self._log_optional_scheduler_quota_skip(
                         logger=log,
@@ -2257,6 +2266,10 @@ class Runtime:
                 )
             except Exception as exc:
                 keepalive_config = None
+                self._record_scheduler_skip(
+                    "housekeeping_keepalive",
+                    f"config load failed: {type(exc).__name__}",
+                )
                 if sheets_core._is_rate_limited_error(exc):
                     keepalive_logger.warning(
                         "thread keepalive config resolve hit Google Sheets quota/backoff; "

--- a/modules/community/reset_reminders/scheduler.py
+++ b/modules/community/reset_reminders/scheduler.py
@@ -1274,6 +1274,9 @@ async def reconcile_reset_reminder_jobs(runtime: "Runtime") -> None:
 
 def schedule_reset_reminder_jobs(runtime: "Runtime") -> None:
     if not _is_feature_enabled():
+        record_skip = getattr(runtime, "_record_scheduler_skip", None)
+        if callable(record_skip):
+            record_skip("reset_reminders", "feature toggle is disabled")
         log.info(
             "reset reminders disabled via feature toggle; scheduler job not registered"
         )

--- a/tests/community/test_reset_reminder_scheduler.py
+++ b/tests/community/test_reset_reminder_scheduler.py
@@ -123,10 +123,16 @@ def test_schedule_reset_jobs_is_idempotent(monkeypatch) -> None:
 
 
 def test_schedule_reset_jobs_not_registered_when_disabled(monkeypatch) -> None:
-    runtime = SimpleNamespace(bot=SimpleNamespace(), scheduler=_FakeScheduler())
+    skipped = []
+    runtime = SimpleNamespace(
+        bot=SimpleNamespace(),
+        scheduler=_FakeScheduler(),
+        _record_scheduler_skip=lambda name, reason: skipped.append((name, reason)),
+    )
     monkeypatch.setattr(scheduler, "_is_feature_enabled", lambda: False)
     scheduler.schedule_reset_reminder_jobs(runtime)
     assert runtime.scheduler.jobs == []
+    assert skipped == [("reset_reminders", "feature toggle is disabled")]
 
 
 def test_schedule_reset_jobs_registered_when_enabled(monkeypatch) -> None:

--- a/tests/modules/housekeeping/test_cleanup.py
+++ b/tests/modules/housekeeping/test_cleanup.py
@@ -1440,9 +1440,7 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(
     assert rt.scheduler.calls == [
         {"hours": 6.0, "tag": "cleanup", "name": "cleanup_watcher"}
     ]
-    assert [task["name"] for task in rt.scheduler.spawned] == [
-        "cleanup_registration_notice",
-    ]
+    assert rt.scheduler.spawned == []
     assert "cleanup_startup_validation" not in [
         task["name"] for task in rt.scheduler.spawned
     ]
@@ -1463,12 +1461,8 @@ def test_cleanup_schedules_only_when_global_and_cleanup_toggles_enabled(
         "writeback": True,
     }
 
-    registration_notice = rt.scheduler.spawned[0]["coro"]
-    asyncio.run(registration_notice)
     assert sent_logs == [
         "🧹 cleanup watcher tick: startup_validation=false writeback=true",
-        "🧹 cleanup watcher scheduled: every=6h dry_run=true "
-        "tab=CleanupRows next_run=2026-06-26T12:00:00Z",
     ]
 
 

--- a/tests/shared/test_runtime_scheduler.py
+++ b/tests/shared/test_runtime_scheduler.py
@@ -74,6 +74,44 @@ def test_scheduler_config_failure_is_not_registered_or_executed() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("job_name", "failure_reason", "generic_reason"),
+    [
+        (
+            "c1c_ad",
+            "config read failed: RuntimeError",
+            "C1C_AD_REFRESH_DAYS is not configured",
+        ),
+        (
+            "clan_ads",
+            "feature toggle read failed: RuntimeError",
+            "feature toggle is disabled",
+        ),
+        (
+            "clan_ads",
+            "config load failed: RuntimeError",
+            "scheduler interval is not configured",
+        ),
+        (
+            "housekeeping_keepalive",
+            "config load failed: RuntimeError",
+            "required config is missing, invalid, or disabled",
+        ),
+    ],
+)
+def test_scheduler_report_preserves_failure_before_normalized_fallback(
+    job_name: str, failure_reason: str, generic_reason: str
+) -> None:
+    scheduler = runtime.Scheduler()
+
+    scheduler.record_registration_skip(job_name, failure_reason)
+    scheduler.record_registration_skip(job_name, generic_reason)
+
+    report = "\n".join(runtime.scheduler_report_lines(scheduler))
+    assert failure_reason in report
+    assert generic_reason not in report
+
+
 def test_scheduler_job_exception_does_not_cancel(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/shared/test_runtime_scheduler.py
+++ b/tests/shared/test_runtime_scheduler.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from datetime import datetime, timezone
 
 import pytest
 
@@ -11,6 +12,66 @@ os.environ.setdefault("RECRUITMENT_SHEET_ID", "sheet-id")
 
 
 from modules.common import runtime
+
+
+def test_scheduler_report_uses_live_registered_jobs() -> None:
+    scheduler = runtime.Scheduler()
+    job = scheduler.every(hours=3, name="cache_refresh:clans", tag="cache")
+    job.next_run = datetime(2026, 7, 20, 3, tzinfo=timezone.utc)
+
+    assert runtime.scheduler_report_lines(scheduler) == [
+        "🧭 Scheduler",
+        "• cache_refresh:clans=registered • cadence=3h • next=2026-07-20 03:00 UTC",
+    ]
+
+
+def test_scheduler_report_does_not_execute_job_runner() -> None:
+    scheduler = runtime.Scheduler()
+    scheduler.every(minutes=15, name="safe_report")
+    calls = 0
+
+    async def runner() -> None:
+        nonlocal calls
+        calls += 1
+
+    # The callback is deliberately never passed to ``do``: reporting only
+    # inspects the live registration object.
+    lines = runtime.scheduler_report_lines(scheduler)
+
+    assert calls == 0
+    assert "safe_report=registered" in lines[1]
+
+
+def test_scheduler_report_includes_actual_skip_reason() -> None:
+    scheduler = runtime.Scheduler()
+    scheduler.record_registration_skip("optional_job", "feature toggle is disabled")
+
+    assert runtime.scheduler_report_lines(scheduler)[1] == (
+        "• optional_job=not registered • reason=feature toggle is disabled"
+    )
+
+
+def test_scheduler_config_failure_is_not_registered_or_executed() -> None:
+    scheduler = runtime.Scheduler()
+    calls = 0
+
+    def load_config() -> None:
+        nonlocal calls
+        calls += 1
+        raise ValueError("invalid cadence")
+
+    try:
+        load_config()
+    except ValueError as exc:
+        scheduler.record_registration_skip(
+            "broken_job", f"config load failed: {type(exc).__name__}"
+        )
+
+    assert calls == 1
+    assert scheduler.jobs == []
+    assert runtime.scheduler_report_lines(scheduler)[1] == (
+        "• broken_job=not registered • reason=config load failed: ValueError"
+    )
 
 
 def test_scheduler_job_exception_does_not_cancel(
@@ -40,7 +101,9 @@ def test_scheduler_job_exception_does_not_cancel(
         await scheduler.shutdown()
 
         assert attempt["count"] >= 2
-        assert any("recurring job error" in record.getMessage() for record in caplog.records)
+        assert any(
+            "recurring job error" in record.getMessage() for record in caplog.records
+        )
 
     asyncio.run(runner())
 


### PR DESCRIPTION
### Motivation
- Startup scheduler reporting was built by exercising dry-run/diagnostic paths and config helpers, which can execute (or imply) scheduled job logic and produce misleading "full dry run" output.
- Operations and admins need the startup summary to reflect the actual runtime scheduler registry as the single source of truth, including real skip/disabled reasons.
- Keep scheduler runtime behavior unchanged while removing any reporting-side job execution or simulated runs.

### Description
- Add registration-skip tracking to the scheduler so registration code can record why a configured job was not added (`record_registration_skip` / `registration_skips`) and surface that reason in reports.
- Add `scheduler_report_lines(runtime.scheduler)` that renders scheduler state from live registered jobs (name, cadence, next run) and recorded skip reasons without invoking job runners or loading configs.
- Replace the startup scheduler summary generation to call `scheduler_report_lines` instead of running diagnostic or dry-run helpers; this prevents any hidden job/config execution during reporting.
- Instrument key registration paths to record clear skip reasons when configs, feature toggles, or sheet reads prevent registration, while explicitly avoiding any changes to Google Sheets, sheet schema, or unrelated scheduler refactors.

### Testing
- Ran format and lint checks: `ruff format --check app.py modules/common/runtime.py tests/shared/test_runtime_scheduler.py tests/modules/housekeeping/test_cleanup.py` and `ruff check ...`, which passed.
- Ran focused unit tests: `pytest -q tests/shared/test_runtime_scheduler.py tests/modules/housekeeping/test_cleanup.py tests/housekeeping/test_next_command.py`, all tests passed.
- Executed additional scheduler-related test suites: `pytest -q tests/community/test_fusion_scheduler.py tests/community/test_shard_scheduler.py tests/community/test_reset_reminder_scheduler.py` and cache-scheduler tests, which passed.
- Verified repo checks: `git diff --check` and workspace status reports show no outstanding issues.

[meta]
labels: codex, bug, comp:scheduler, observability, tests
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cd8003db8832398331dbc12472f85)