### PR TITLE
Fix RealmWalker audit role-list parsing

### DIFF
--- a/modules/housekeeping/realmwalker.py
+++ b/modules/housekeeping/realmwalker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Sequence
 
@@ -48,6 +49,7 @@ class RealmWalkerAuditResult:
 
 
 def _parse_role_id(value: str | None) -> int | None:
+    """Parse one role ID without normalizing away list separators."""
     try:
         role_id = int((value or "").strip())
     except (TypeError, ValueError):
@@ -55,22 +57,27 @@ def _parse_role_id(value: str | None) -> int | None:
     return role_id if role_id > 0 else None
 
 
+def _parse_role_ids(value: str | None) -> tuple[set[int], list[str]]:
+    """Parse role IDs separated by commas or whitespace."""
+    role_ids: set[int] = set()
+    invalid: list[str] = []
+    for item in re.split(r"[,\s]+", value or ""):
+        if not item:
+            continue
+        role_id = _parse_role_id(item)
+        if role_id is None:
+            invalid.append(item)
+        else:
+            role_ids.add(role_id)
+    return role_ids, invalid
+
+
 async def resolve_config() -> tuple[RealmWalkerConfig | None, str | None]:
     """Resolve and validate RealmWalker role IDs from the existing Config tab."""
     access_value = await recruitment.get_config_value_async(ACCESS_ROLE_KEY, None)
     games_value = await recruitment.get_config_value_async(GAME_ROLES_KEY, None)
     access_id = _parse_role_id(access_value)
-    game_ids: set[int] = set()
-    invalid_games: list[str] = []
-    for item in (games_value or "").split(","):
-        item = item.strip()
-        if not item:
-            continue
-        role_id = _parse_role_id(item)
-        if role_id is None:
-            invalid_games.append(item)
-        else:
-            game_ids.add(role_id)
+    game_ids, invalid_games = _parse_role_ids(games_value)
     if access_id is None or not game_ids or invalid_games:
         details = []
         if access_id is None:

--- a/tests/housekeeping/test_realmwalker.py
+++ b/tests/housekeeping/test_realmwalker.py
@@ -215,9 +215,7 @@ def test_manual_fix_does_not_mutate_when_role_config_is_invalid(monkeypatch):
 
     affected.add_roles = add_roles
     guild = SimpleNamespace(
-        get_role=lambda role_id: role(10, "RealmWalker")
-        if role_id == 10
-        else None
+        get_role=lambda role_id: role(10, "RealmWalker") if role_id == 10 else None
     )
     sent = []
 
@@ -288,6 +286,110 @@ def test_config_resolution_still_uses_recruitment_config_helper(monkeypatch):
         "REALMWALKER_ACCESS_ROLE_ID",
         "REALMWALKER_GAME_ROLE_IDS",
     ]
+
+
+def test_config_resolution_parses_comma_separated_game_role_ids(monkeypatch):
+    game_ids = (
+        1448269393082454076,
+        1447924607842652232,
+        1447919520751681548,
+    )
+
+    async def get_config(key, default=None):
+        if key == realmwalker.ACCESS_ROLE_KEY:
+            return "1298349996374229045"
+        return ",".join(str(role_id) for role_id in game_ids)
+
+    monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
+    config, error = asyncio.run(realmwalker.resolve_config())
+
+    assert error is None
+    assert config is not None
+    assert config.access_role_id == 1298349996374229045
+    assert config.game_role_ids == frozenset(game_ids)
+
+
+def test_config_resolution_tolerates_whitespace_and_newlines(monkeypatch):
+    async def get_config(key, default=None):
+        if key == realmwalker.ACCESS_ROLE_KEY:
+            return "10"
+        return " 20,  21 ,\n22\n 23 "
+
+    monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
+    config, error = asyncio.run(realmwalker.resolve_config())
+
+    assert error is None
+    assert config == realmwalker.RealmWalkerConfig(
+        access_role_id=10, game_role_ids=frozenset({20, 21, 22, 23})
+    )
+
+
+def test_unresolved_game_role_ids_are_reported_individually():
+    access_id = 1298349996374229045
+    game_ids = frozenset({1448269393082454076, 1447924607842652232})
+    guild = SimpleNamespace(
+        get_role=lambda role_id: (
+            role(access_id, "RealmWalker") if role_id == access_id else None
+        )
+    )
+
+    resolved, error = realmwalker.resolve_guild_roles(
+        guild, realmwalker.RealmWalkerConfig(access_id, game_ids)
+    )
+
+    assert resolved is None
+    assert error is not None
+    assert "`1448269393082454076`" in error
+    assert "`1447924607842652232`" in error
+    assert "`, `" in error
+    assert "14482693930824540761447924607842652232" not in error
+
+
+def test_access_role_config_rejects_a_role_id_list(monkeypatch):
+    async def get_config(key, default=None):
+        return "10,11" if key == realmwalker.ACCESS_ROLE_KEY else "20,21"
+
+    monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
+    config, error = asyncio.run(realmwalker.resolve_config())
+
+    assert config is None
+    assert error is not None
+    assert "REALMWALKER_ACCESS_ROLE_ID is missing or invalid" in error
+
+
+def test_manual_fix_aborts_before_member_mutation_for_invalid_parsed_config(
+    monkeypatch,
+):
+    add_called = False
+
+    async def add_roles(*_args, **_kwargs):
+        nonlocal add_called
+        add_called = True
+
+    affected = member(1, [role(20, "WoW")])
+    affected.add_roles = add_roles
+
+    async def get_config(key, default=None):
+        return "10" if key == realmwalker.ACCESS_ROLE_KEY else "20,not-a-role,21"
+
+    monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
+    guild = SimpleNamespace(
+        members=[affected],
+        get_role=lambda _role_id: (_ for _ in ()).throw(
+            AssertionError("role resolution must not run for invalid config")
+        ),
+    )
+    sent = []
+
+    async def send(**kwargs):
+        sent.append(kwargs)
+
+    cog = RealmWalkerAuditCog(SimpleNamespace())
+    ctx = SimpleNamespace(guild=guild, send=send)
+    asyncio.run(RealmWalkerAuditCog.audit_realmwalker.callback(cog, ctx, "fix"))
+
+    assert add_called is False
+    assert "contains invalid values" in (sent[0]["embed"].description or "")
 
 
 def test_daily_realmwalker_scan_warns_instead_of_using_partial_cache(monkeypatch):

--- a/tests/housekeeping/test_realmwalker.py
+++ b/tests/housekeeping/test_realmwalker.py
@@ -293,11 +293,15 @@ def test_config_resolution_parses_comma_separated_game_role_ids(monkeypatch):
         1448269393082454076,
         1447924607842652232,
         1447919520751681548,
+        1298349996374229045,
+        1447924492776116316,
+        1447924956519469067,
+        1447924705892892733,
     )
 
     async def get_config(key, default=None):
         if key == realmwalker.ACCESS_ROLE_KEY:
-            return "1298349996374229045"
+            return "1450000000000000000"
         return ",".join(str(role_id) for role_id in game_ids)
 
     monkeypatch.setattr(realmwalker.recruitment, "get_config_value_async", get_config)
@@ -305,7 +309,7 @@ def test_config_resolution_parses_comma_separated_game_role_ids(monkeypatch):
 
     assert error is None
     assert config is not None
-    assert config.access_role_id == 1298349996374229045
+    assert config.access_role_id == 1450000000000000000
     assert config.game_role_ids == frozenset(game_ids)
 
 

--- a/tests/shared/sheets/test_config_columns.py
+++ b/tests/shared/sheets/test_config_columns.py
@@ -13,6 +13,19 @@ def test_recruitment_config_parser_uses_only_key_and_value_columns():
     assert parsed.get("reports_tab") is None
 
 
+def test_recruitment_config_parser_preserves_comma_separated_role_ids():
+    role_ids = (
+        "1448269393082454076,1447924607842652232,"
+        "1447919520751681548,1298349996374229045"
+    )
+
+    parsed = recruitment._parse_config_records(
+        [{"Key": "REALMWALKER_GAME_ROLE_IDS", "Value": role_ids}]
+    )
+
+    assert parsed["realmwalker_game_role_ids"] == role_ids
+
+
 def test_config_service_keeps_runtime_payload_to_key_value_columns():
     rows = [
         {


### PR DESCRIPTION
### Motivation
- The RealmWalker audit treated `REALMWALKER_GAME_ROLE_IDS` as a single glued number when commas were stripped, causing role resolution failures.  
- `REALMWALKER_ACCESS_ROLE_ID` must remain a single positive role ID and not accept list-shaped values.  
- Maintain the existing safety behavior to abort before mutating member roles if the config does not validate.

### Description
- Add `_parse_role_ids` that splits `REALMWALKER_GAME_ROLE_IDS` on commas and any whitespace and returns parsed IDs and any invalid tokens.  
- Keep `_parse_role_id` strict so `REALMWALKER_ACCESS_ROLE_ID` is parsed only as a single positive integer.  
- Update `resolve_config` to use `_parse_role_ids` for game roles and to return a clear validation message when the access role is missing, no game IDs are valid, or invalid tokens are present.  
- Ensure `resolve_guild_roles` reports unresolved game role IDs individually (e.g., `` `123`, `456` ``) and preserves the pre-mutation abort behavior.  
- Add tests covering comma-separated live-style IDs, tolerance for whitespace/newlines, individual unresolved-ID reporting, rejection of a list in the access-role field, and abort-before-mutation on invalid config.

### Testing
- Ran `python -m pytest tests/housekeeping/test_realmwalker.py -q` and all tests in that file passed.  
- Ran `python -m ruff check modules/housekeeping/realmwalker.py tests/housekeeping/test_realmwalker.py` and `python -m ruff format --check modules/housekeeping/realmwalker.py tests/housekeeping/test_realmwalker.py`, both succeeded.  
- Ran `git diff --check` and repository checks reported no issues.

[meta]
labels: bug, comp:roles, comp:config, tests
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ceb152eac8323a2905cf8ab388169)