### PR TITLE
PR 3: Clean repository hygiene artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Python bytecode and interpreter caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Test, lint, type-check, and coverage caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Packaging and build output
+build/
+dist/
+*.egg-info/
+
+# Local temporary and log output
+tmp/
+temp/
+logs/
+*.log
+*.tmp

--- a/AUDIT/Repo-Hygiene.md
+++ b/AUDIT/Repo-Hygiene.md
@@ -1,0 +1,26 @@
+# Repository Hygiene Audit
+
+## Cleaned
+
+The tracked and untracked files were inspected for generated Python bytecode,
+tool caches, build and distribution output, temporary files, and logs. No
+generated artifacts matching those categories were present or tracked, so no
+generated files required removal.
+
+## Ignored
+
+The repository now ignores Python bytecode and interpreter caches; pytest,
+Ruff, mypy, and coverage output; packaging and build output; and local
+temporary and log output.
+
+## Intentionally Not Touched
+
+No application code, runtime or scheduler logic, Google Sheets integration,
+imports, commands, modules, files, or functions were changed or renamed.
+
+The existing `member_panel.py` and `member_panel_legacy.py` files were not
+changed or deleted. Member panel cleanup is deferred to a separate, safe PR.
+
+---
+
+Doc last updated: 2026-07-19 (v0.9.8.2)


### PR DESCRIPTION
### Motivation
- Prevent generated Python/tooling artifacts from being tracked again and record a small hygiene audit while making no behavioral changes.

### Description
- Add a repository `.gitignore` for Python bytecode, test/lint/type-check/coverage caches, build/dist output, and local temporary/log files, and add `AUDIT/Repo-Hygiene.md` documenting what was inspected, ignored, and intentionally not touched.

### Testing
- Ran `git diff --check` which passed, and ran `python -m compileall -q app.py modules shared cogs packages` which completed (it emitted a pre-existing `return`-in-`finally` SyntaxWarning at `app.py:356` but did not fail).

[meta]
labels: maintenance, AUDIT, codex
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cf347589c8323a00fef9ead025630)