### PR TITLE
Hotfix: Route welcome template loading through async Sheets facade

### DIFF
--- a/modules/recruitment/welcome.py
+++ b/modules/recruitment/welcome.py
@@ -6,7 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import discord
 from discord.abc import Messageable
@@ -27,7 +27,7 @@ from shared.config import (
     get_refresh_timezone,
     get_welcome_general_channel_id,
 )
-from shared.sheets import recruitment as sheets
+from shared.sheets import async_facade as sheets
 
 try:  # Python 3.9+ optional zoneinfo
     from zoneinfo import ZoneInfo
@@ -198,7 +198,7 @@ def _build_template(row: Mapping[str, Any]) -> Optional[WelcomeTemplate]:
 
 
 async def _load_templates() -> tuple[dict[str, WelcomeTemplate], Optional[WelcomeTemplate]]:
-    rows = sheets.get_cached_welcome_templates()
+    rows = await sheets.get_cached_welcome_templates()
     templates: dict[str, WelcomeTemplate] = {}
     default_row: WelcomeTemplate | None = None
     alt_default: WelcomeTemplate | None = None

--- a/tests/guardrails/test_async_sheets_guardrail.py
+++ b/tests/guardrails/test_async_sheets_guardrail.py
@@ -16,6 +16,7 @@ FORBIDDEN_HELPERS = {
     "call_with_backoff",
     "_retry_with_backoff",
     "get_config_value",
+    "get_cached_welcome_templates",
     "_config_lookup",
     "_load_config",
     "get_clans_tab_name",
@@ -160,6 +161,19 @@ def test_async_facade_alias_is_the_only_allowed_sheets_alias() -> None:
 
     assert _forbidden_call_name(async_call, async_aliases) is None
     assert _forbidden_call_name(core_call, core_aliases) == "fetch_records"
+
+
+def test_guardrail_detects_sync_cached_welcome_template_loader() -> None:
+    tree = ast.parse(
+        "from shared.sheets import recruitment as sheets\n"
+        "async def command():\n"
+        "    return sheets.get_cached_welcome_templates()\n"
+    )
+    aliases = _import_aliases(tree)
+    command = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+    call = next(n for n in ast.walk(command) if isinstance(n, ast.Call))
+
+    assert _forbidden_call_name(call, aliases) == "get_cached_welcome_templates"
 
 
 def test_whoweare_regression_uses_async_role_map_tab_lookup() -> None:

--- a/tests/recruitment/test_welcome_command.py
+++ b/tests/recruitment/test_welcome_command.py
@@ -6,6 +6,7 @@ import pytest
 
 from cogs.recruitment_welcome import WelcomeBridge
 from modules.recruitment import welcome as welcome_module
+from shared.sheets import recruitment as recruitment_sheets
 
 
 class FakeChannel:
@@ -133,10 +134,11 @@ def test_welcome_happy_path_posts_embed(monkeypatch, stub_logs):
         message = FakeMessage(mentions=[recruit])
         ctx = FakeContext(bot=bot, guild=guild, channel=FakeChannel(555), author=author, message=message)
 
+        template_loader = AsyncMock(return_value=_template_rows())
         monkeypatch.setattr(
             welcome_module.sheets,
             "get_cached_welcome_templates",
-            Mock(return_value=_template_rows()),
+            template_loader,
         )
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: 999)
 
@@ -154,10 +156,61 @@ def test_welcome_happy_path_posts_embed(monkeypatch, stub_logs):
 
         assert len(general_channel.sent) == 1
         assert recruit.mention in general_channel.sent[0]["content"]
+        template_loader.assert_awaited_once_with()
         await asyncio.sleep(0)
 
     asyncio.run(scenario())
     stub_logs.assert_called_once()
+
+
+def test_welcome_does_not_call_sync_template_loader(monkeypatch):
+    async def scenario():
+        clan_channel = FakeChannel(123)
+        bot = FakeBot(channels=[clan_channel])
+        guild = FakeGuild(42, channels=[clan_channel])
+        ctx = FakeContext(
+            bot=bot,
+            guild=guild,
+            channel=clan_channel,
+            author=FakeMember(7),
+            message=FakeMessage(),
+        )
+        async_loader = AsyncMock(return_value=_template_rows())
+        sync_loader = Mock(side_effect=AssertionError("sync loader called in event loop"))
+        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", async_loader)
+        monkeypatch.setattr(recruitment_sheets, "get_cached_welcome_templates", sync_loader)
+        monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: None)
+
+        await welcome_module.WelcomeCommandService(bot).post_welcome(ctx, "C1CM")
+
+        async_loader.assert_awaited_once_with()
+        sync_loader.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+def test_welcome_template_load_failure_keeps_existing_response(monkeypatch):
+    async def scenario():
+        channel = FakeChannel(123)
+        bot = FakeBot(channels=[channel])
+        ctx = FakeContext(
+            bot=bot,
+            guild=FakeGuild(42, channels=[channel]),
+            channel=channel,
+            author=FakeMember(7),
+            message=FakeMessage(),
+        )
+        loader = AsyncMock(side_effect=RuntimeError("sheet unavailable"))
+        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", loader)
+
+        await welcome_module.WelcomeCommandService(bot).post_welcome(ctx, "C1CM")
+
+        loader.assert_awaited_once_with()
+        assert ctx.replies == [
+            "⚠️ Failed to load welcome templates. Try again after the next refresh."
+        ]
+
+    asyncio.run(scenario())
 
 
 def test_default_merge_uses_c1c_row(monkeypatch):
@@ -172,7 +225,11 @@ def test_default_merge_uses_c1c_row(monkeypatch):
         message = FakeMessage()
         ctx = FakeContext(bot=bot, guild=guild, channel=clan_channel, author=author, message=message)
 
-        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", Mock(return_value=rows))
+        monkeypatch.setattr(
+            welcome_module.sheets,
+            "get_cached_welcome_templates",
+            AsyncMock(return_value=rows),
+        )
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: None)
 
         bridge = WelcomeBridge(bot)
@@ -198,7 +255,11 @@ def test_ping_respects_toggle(monkeypatch):
         message = FakeMessage(mentions=[recruit])
         ctx = FakeContext(bot=bot, guild=guild, channel=clan_channel, author=author, message=message)
 
-        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", Mock(return_value=rows))
+        monkeypatch.setattr(
+            welcome_module.sheets,
+            "get_cached_welcome_templates",
+            AsyncMock(return_value=rows),
+        )
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: None)
 
         bridge = WelcomeBridge(bot)
@@ -228,7 +289,11 @@ def test_target_channel_routing(monkeypatch):
         message = FakeMessage()
         ctx = FakeContext(bot=bot, guild=guild, channel=fallback_channel, author=author, message=message)
 
-        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", Mock(return_value=rows))
+        monkeypatch.setattr(
+            welcome_module.sheets,
+            "get_cached_welcome_templates",
+            AsyncMock(return_value=rows),
+        )
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: None)
 
         bridge = WelcomeBridge(bot)
@@ -251,7 +316,11 @@ def test_missing_or_inactive_rows(monkeypatch):
         message = FakeMessage()
         ctx = FakeContext(bot=bot, guild=guild, channel=clan_channel, author=author, message=message)
 
-        monkeypatch.setattr(welcome_module.sheets, "get_cached_welcome_templates", Mock(return_value=rows))
+        monkeypatch.setattr(
+            welcome_module.sheets,
+            "get_cached_welcome_templates",
+            AsyncMock(return_value=rows),
+        )
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: None)
 
         bridge = WelcomeBridge(bot)


### PR DESCRIPTION
### Motivation
- Prevent synchronous Google Sheets helpers from being called inside Discord async runtime to avoid `_retry_with_backoff` event-loop errors. 
- Ensure welcome templates are loaded via the async facade so cached reads remain synchronous-to-cache but any live sheet access runs off the event loop. 

### Description
- Import the async Sheets facade in `modules/recruitment/welcome.py` and await `get_cached_welcome_templates()` inside `_load_templates()` instead of calling the sync recruitment helper. 
- Update tests in `tests/recruitment/test_welcome_command.py` to monkeypatch an `AsyncMock` loader, assert the async loader is awaited, assert the sync recruitment loader is not called, and verify the existing failure response is preserved. 
- Extend the async-sheets guardrail in `tests/guardrails/test_async_sheets_guardrail.py` to treat `get_cached_welcome_templates` as a forbidden sync helper in async functions and add a regression test. 
- Preserve all existing template normalization, merge, cache semantics, and do not modify Google Sheets schema or `_retry_with_backoff` behavior. 

### Testing
- Ran `python -m pytest tests/recruitment/test_welcome_command.py tests/guardrails/test_async_sheets_guardrail.py` and observed `13 passed`. 
- Ran `python -m ruff check modules/recruitment/welcome.py tests/recruitment/test_welcome_command.py tests/guardrails/test_async_sheets_guardrail.py` (passed). 
- Ran `git diff --check` (passed). 
- Ran `python -m pytest tests/recruitment tests/guardrails/test_async_sheets_guardrail.py` which produced `158 passed` with one unrelated failure from a reservations test that attempts service-account initialization in this environment. 

[meta]
labels: bug, codex, comp:commands, comp:data-sheets
milestone: Harmonize v1.0
[/meta]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cfa6528fc8323967188528033d998)