### PR TITLE
Harden CI port-import guardrail and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Verification
+
+Tests:
+<!-- List commands run, or explain why tests were not needed. -->
+
+Docs:
+<!-- List docs updated, or use: Docs: Not needed, runtime/CI-only change. -->
+
+Doc last updated: 2026-07-19 (v0.9.8.2)

--- a/.github/workflows/11-guardrails-suite.yml
+++ b/.github/workflows/11-guardrails-suite.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
       - name: Forbidden imports check (get_port path)
         run: |
           chmod +x scripts/ci/check_forbidden_imports.sh

--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -38,7 +38,7 @@ Every audit and CI check validates against this document.
 - **C-08 Single-Message Panels:** Interactive panels (like clan panels) update in place; avoid message spam.
 - **C-09 No Legacy Paths:** No imports from removed legacy paths (e.g., top-level `recruitment/`, deprecated shared CoreOps shims, `shared/utils/coreops_*`).
 - **C-10 Config Access:** Runtime config is accessed via the common config accessor (not scattered utility readers).
-- **C-11 Forbidden Ports Import:** Import the runtime port helper from `shared.ports`. Using the old `shared.config` import for `get_port` fails guardrails (`scripts/ci/check_forbidden_imports.sh`, workflow `11-guardrails-suite`).
+- **C-11 Forbidden Ports Import:** Import the runtime port helper from `shared.ports`. Using `shared.config` or `config.runtime` for `get_port` fails guardrails (`scripts/ci/check_forbidden_imports.sh`, workflow `11-guardrails-suite`).
 - **C-12 No Order Targets:** Onboarding rules and evaluators must reference question IDs (no order-number or sheet-position logic).
 - **C-13 Render Free-Tier Constraints**
   - No continuous background polling.

--- a/scripts/ci/check_forbidden_imports.sh
+++ b/scripts/ci/check_forbidden_imports.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 shopt -s globstar nullglob
 
-echo "🔍 Guardrail: scanning for forbidden imports (shared.config → get_port)..."
+echo "🔍 Guardrail: scanning for forbidden get_port imports..."
 
 if ! command -v rg >/dev/null 2>&1; then
   echo "❌ Guardrail dependency missing: install ripgrep (rg)."
@@ -16,13 +16,14 @@ fi
 set +e
 matches=$(rg -n --hidden --no-ignore \
   -g '!AUDIT/**' \
+  -g '!tests/**' \
   -g '!**/.git/**' \
   -g '!**/node_modules/**' \
   -g '!**/.venv/**' \
   -g '!**/venv/**' \
   -g '!**/dist/**' \
   -g '!**/build/**' \
-  "(from\\s+shared\\.config\\s+import[^\\n]*\\bget_port\\b|shared\\.config\\.get_port)")
+  "(from\\s+(shared\\.config|config\\.runtime)\\s+import[^\\n]*\\bget_port\\b|(shared\\.config|config\\.runtime)\\.get_port)")
 rg_status=$?
 set -e
 

--- a/scripts/ci/guardrails_suite.py
+++ b/scripts/ci/guardrails_suite.py
@@ -431,24 +431,30 @@ def check_c11(category: CategoryResult) -> None:
         except (OSError, SyntaxError):
             continue
 
-        runtime_aliases: set[str] = set()
+        forbidden_module_aliases: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
-                if node.module == "config.runtime":
+                if node.module in {"config.runtime", "shared.config"}:
                     for alias in node.names:
                         if alias.name == "get_port":
                             hits.append(f"{rel}:{node.lineno}")
                 elif node.module == "config":
-                    runtime_aliases.update(
+                    forbidden_module_aliases.update(
                         alias.asname or alias.name
                         for alias in node.names
                         if alias.name == "runtime"
                     )
+                elif node.module == "shared":
+                    forbidden_module_aliases.update(
+                        alias.asname or alias.name
+                        for alias in node.names
+                        if alias.name == "config"
+                    )
             elif isinstance(node, ast.Import):
-                runtime_aliases.update(
+                forbidden_module_aliases.update(
                     alias.asname or alias.name
                     for alias in node.names
-                    if alias.name == "config.runtime"
+                    if alias.name in {"config.runtime", "shared.config"}
                 )
 
         for node in ast.walk(tree):
@@ -457,13 +463,20 @@ def check_c11(category: CategoryResult) -> None:
             if node.func.attr != "get_port":
                 continue
             owner = node.func.value
-            if isinstance(owner, ast.Name) and owner.id in runtime_aliases:
+            if isinstance(owner, ast.Name) and owner.id in forbidden_module_aliases:
                 hits.append(f"{rel}:{node.lineno}")
             elif (
                 isinstance(owner, ast.Attribute)
                 and owner.attr == "runtime"
                 and isinstance(owner.value, ast.Name)
                 and owner.value.id == "config"
+            ):
+                hits.append(f"{rel}:{node.lineno}")
+            elif (
+                isinstance(owner, ast.Attribute)
+                and owner.attr == "config"
+                and isinstance(owner.value, ast.Name)
+                and owner.value.id == "shared"
             ):
                 hits.append(f"{rel}:{node.lineno}")
 

--- a/tests/config/test_guardrails_suite.py
+++ b/tests/config/test_guardrails_suite.py
@@ -190,6 +190,14 @@ def test_c11_allows_shared_ports_and_rejects_config_runtime(
         "from config.runtime import get_port\nPORT = get_port()\n",
         encoding="utf-8",
     )
+    (package / "forbidden_shared.py").write_text(
+        "import shared.config\nPORT = shared.config.get_port()\n",
+        encoding="utf-8",
+    )
+    (package / "forbidden_shared_direct.py").write_text(
+        "from shared.config import get_port\nPORT = get_port()\n",
+        encoding="utf-8",
+    )
 
     category = guardrails_suite.CategoryResult("c11")
     guardrails_suite.check_c11(category)
@@ -198,6 +206,8 @@ def test_c11_allows_shared_ports_and_rejects_config_runtime(
     assert category.violations[0].files == [
         "modules/example/forbidden.py:2",
         "modules/example/forbidden_direct.py:1",
+        "modules/example/forbidden_shared.py:2",
+        "modules/example/forbidden_shared_direct.py:1",
     ]
 
 


### PR DESCRIPTION
### Motivation
- Reduce noisy/false guardrail failures by installing the missing ripgrep dependency and making the forbidden-get_port check robust to multiple deprecated import forms.  
- Standardize PR expectations so future PRs always include literal `Tests:` and `Docs:` declarations to satisfy guardrail G-09.  
- Keep guardrail C-10/C-11 semantics meaningful while avoiding false negatives from alternate import forms.

### Description
- Install `ripgrep` in the guardrails workflow before running the forbidden-import check by updating `.github/workflows/11-guardrails-suite.yml`.  
- Extend the shell checker `scripts/ci/check_forbidden_imports.sh` to detect `shared.config` and `config.runtime` usages of `get_port` and to ignore `tests/` during scanning.  
- Strengthen the AST-based C-11 check in `scripts/ci/guardrails_suite.py` to detect direct imports, module imports, attribute calls, and aliases for both `shared.config` and `config.runtime`, while continuing to allow `from shared.ports import get_port`.  
- Add regression tests in `tests/config/test_guardrails_suite.py` covering `shared.ports` (allowed) and the forbidden forms (rejected).  
- Update `docs/guardrails/RepositoryGuardrails.md` to document the C-11 wording parity with automation.  
- Add a concise PR template `.github/pull_request_template.md` that requires the literal `Tests:` and `Docs:` sections and provides the approved CI-only wording example.

### Testing
- Ran `scripts/ci/check_forbidden_imports.sh` and verified it rejects a probe containing `from shared.config import get_port` and accepts `from shared.ports import get_port`. (pass)  
- Executed `PYENV_VERSION=3.11.15 python -m pytest -q tests/config/test_guardrails_suite.py` and observed the guardrail tests covering C-11 pass. (pass)  
- Ran the guardrails suite runner `python -m scripts.ci.guardrails_suite --pr 0 --status-file /tmp/guardrails-status --summary /tmp/guardrails-summary.md --base-ref HEAD` to verify integration; the runner completed and C-11 behaved as expected while reporting existing, unrelated repo-wide guardrail debt. (runner completed; C-11 passed)  
- Performed `git diff --check` and basic local commit verification; no runtime code, Sheets config, permission scopes, intents, or schema were changed. (pass)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d289b0b648323acdffee313695110)