### PR TITLE
Tighten CI guardrail metadata and C-11 coverage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Verification
+
+Tests:
+<!-- List the commands run, or briefly explain why tests were not needed. -->
+
+Docs:
+<!-- List docs updated, or use: Docs: Not needed, runtime/CI-only change. -->
+
+Doc last updated: 2026-07-19 (v0.9.8.2)

--- a/tests/config/test_forbidden_imports_script.py
+++ b/tests/config/test_forbidden_imports_script.py
@@ -43,6 +43,8 @@ def test_forbidden_import_check_falls_back_and_allows_shared_ports(tmp_path: Pat
 def test_forbidden_import_check_fallback_rejects_deprecated_paths(tmp_path: Path) -> None:
     result = _run_without_ripgrep(
         tmp_path,
+        "import config.runtime\n"
+        "CONFIG_PORT = config.runtime.get_port()\n"
         "from config.runtime import get_port\n"
         "import shared.config\n"
         "PORT = shared.config.get_port()\n",
@@ -50,5 +52,6 @@ def test_forbidden_import_check_fallback_rejects_deprecated_paths(tmp_path: Path
 
     assert result.returncode == 1
     assert "Forbidden import path detected" in result.stdout
-    assert "example.py:1" in result.stdout
+    assert "example.py:2" in result.stdout
     assert "example.py:3" in result.stdout
+    assert "example.py:5" in result.stdout

--- a/tests/config/test_guardrails_suite.py
+++ b/tests/config/test_guardrails_suite.py
@@ -197,6 +197,10 @@ def test_c11_allows_shared_ports_and_rejects_config_runtime(
         "PORT = runtime_config.get_port()\n",
         encoding="utf-8",
     )
+    (package / "forbidden_qualified.py").write_text(
+        "import config.runtime\nPORT = config.runtime.get_port()\n",
+        encoding="utf-8",
+    )
     (package / "forbidden_direct.py").write_text(
         "from config.runtime import get_port\nPORT = get_port()\n",
         encoding="utf-8",
@@ -217,6 +221,7 @@ def test_c11_allows_shared_ports_and_rejects_config_runtime(
     assert category.violations[0].files == [
         "modules/example/forbidden.py:2",
         "modules/example/forbidden_direct.py:1",
+        "modules/example/forbidden_qualified.py:2",
         "modules/example/forbidden_shared.py:2",
         "modules/example/forbidden_shared_direct.py:1",
     ]


### PR DESCRIPTION
### Motivation
- Prevent noisy/false failures from guardrails by making the forbidden-import check portable and the PR metadata expectations explicit. 
- Ensure C-11 remains meaningful by allowing the approved `from shared.ports import get_port` while still rejecting deprecated `config.runtime`/`shared.config` usages.
- Keep runtime behavior and sheet/config logic untouched and limit changes to CI/guardrail metadata and tests.

### Description
- Add a concise PR template at `.github/pull_request_template.md` that requires literal `Tests:` and `Docs:` declarations and documents the common CI-only exception wording. 
- Extend the portable forbidden-import regression test in `tests/config/test_forbidden_imports_script.py` to assert the `grep` fallback path and to detect qualified `config.runtime.get_port()` usage. 
- Expand the C-11 unit test in `tests/config/test_guardrails_suite.py` to cover qualified, direct, and aliased forbidden imports while explicitly verifying that `from shared.ports import get_port` remains allowed. 
- No runtime code, Sheets, tabs, config keys, or feature logic were modified.

### Testing
- Ran `pytest -q tests/config/test_forbidden_imports_script.py tests/config/test_guardrails_suite.py`, which passed locally (test subset: 18 passed). 
- Executed the portable script `scripts/ci/check_forbidden_imports.sh` to validate ripgrep fallback behavior, which returned the expected results. 
- Verified `git diff --check` and committed changes (`Tighten CI guardrail metadata`) with no diff issues. 
- Ran a repository guardrails suite invocation without PR context; the changed C-11 check passed but the full repo scan reported unrelated historical violations (expected when running outside CI PR context). 
- Attempted full `pytest -q` under local interpreter but noted missing runtime test dependencies (e.g., `discord`, `aiohttp`, `Pillow`) that the CI job installs; full-suite validation is expected to run in CI where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d3b5bbe408323a15dc525b1a29344)