### PR TITLE
Remove D-10 repository guardrail

### DIFF
--- a/docs/guardrails/RepositoryGuardrails.md
+++ b/docs/guardrails/RepositoryGuardrails.md
@@ -97,18 +97,6 @@ Every audit and CI check validates against this document.
     • `tests/config/**` (config-loading behaviour)
 
   Docs-only and CI-only changes do not trigger this rule. Runtime changes must include tests; PR-body declarations are not used as a substitute.
-- **D-10 User-Facing Behaviour = Mandatory Doc Updates:**
-  If a PR changes commands, help text, onboarding questions, summary formatting, watcher
-  schedules, feature toggles, or any user-visible flow, the PR **must** update the relevant
-  SSoT docs:
-    • `docs/ops/CommandMatrix.md`
-    • `docs/modules/<Module>.md`
-    • `docs/ops/Config.md`
-    • `docs/_meta/DocStyle.md` (if formatting changed)
-    • `docs/Architecture.md` (if data flows changed)
-    • `CHANGELOG.md`
-  No new docs may be created unless an ADR authorises it.
-
 ---
 
 ## **5) Governance & Workflow**

--- a/scripts/ci/guardrails_suite.py
+++ b/scripts/ci/guardrails_suite.py
@@ -732,14 +732,6 @@ def check_d09(category: CategoryResult, changed_files: List[str]) -> None:
     category.add(Violation("D-09", "error", "Runtime changes require tests", changed_files))
 
 
-def check_d10(category: CategoryResult, changed_files: List[str]) -> None:
-    user_flow_change = any(f.startswith("cogs/") or f.startswith("modules/") for f in changed_files)
-    docs_changed = any(f.startswith("docs/") for f in changed_files)
-    if not user_flow_change or docs_changed:
-        return
-    category.add(Violation("D-10", "error", "User-facing changes require docs", changed_files))
-
-
 def _parity_violation(parity_status: Optional[str]) -> tuple[List[Violation], Optional[str]]:
     if parity_status is None:
         return [], "ENV parity status unavailable"
@@ -981,17 +973,6 @@ def _build_guardrail_checks() -> List[GuardrailCheck]:
                 "Runtime changes require tests",
                 lambda ctx: _collect_category_violations(
                     ctx, "d09", check_d09, ctx.changed_files
-                ),
-            ),
-        ),
-        GuardrailCheck(
-            "D-10",
-            "User-facing changes require docs",
-            _build_pr_only_check(
-                "D-10",
-                "User-facing changes require docs",
-                lambda ctx: _collect_category_violations(
-                    ctx, "d10", check_d10, ctx.changed_files
                 ),
             ),
         ),
@@ -1286,7 +1267,7 @@ def _run_guardrail_checks(context: GuardrailContext) -> List[CheckResult]:
 # violations elsewhere in the repository remain visible to dedicated audits
 # without blocking an unrelated change.
 PR_GLOBAL_CHECKS = {"D-03", "D-04", "D-08"}
-PR_DIFF_AWARE_CHECKS = {"S-07", "D-06", "D-09", "D-10", "G-06"}
+PR_DIFF_AWARE_CHECKS = {"S-07", "D-06", "D-09", "G-06"}
 
 
 def _violation_path_is_changed(entry: str, changed_files: set[str]) -> bool:

--- a/tests/config/test_guardrails_suite.py
+++ b/tests/config/test_guardrails_suite.py
@@ -63,28 +63,28 @@ def test_pr_body_metadata_is_not_a_guardrail() -> None:
     assert "G-09" not in codes
 
 
-def test_d09_and_d10_ignore_pr_body_metadata() -> None:
+def test_d09_ignores_pr_body_metadata() -> None:
     tests_category = guardrails_suite.CategoryResult("Docs (D)")
-    docs_category = guardrails_suite.CategoryResult("Docs (D)")
 
     guardrails_suite.check_d09(tests_category, ["modules/example.py"])
-    guardrails_suite.check_d10(docs_category, ["modules/example.py"])
 
     assert tests_category.status == "fail"
     assert tests_category.violations[0].message == "Runtime changes require tests"
-    assert docs_category.status == "fail"
-    assert docs_category.violations[0].message == "User-facing changes require docs"
 
 
 def test_ci_only_change_needs_no_pr_body_metadata() -> None:
     tests_category = guardrails_suite.CategoryResult("Docs (D)")
-    docs_category = guardrails_suite.CategoryResult("Docs (D)")
 
     guardrails_suite.check_d09(tests_category, [".github/workflows/test.yml"])
-    guardrails_suite.check_d10(docs_category, [".github/workflows/test.yml"])
 
     assert tests_category.status == "pass"
-    assert docs_category.status == "pass"
+
+
+def test_d10_is_not_an_automated_guardrail() -> None:
+    codes = {check.code for check in guardrails_suite.CHECKS}
+
+    assert "D-10" not in codes
+    assert "D-10" not in guardrails_suite.PR_DIFF_AWARE_CHECKS
 
 
 def test_f04_uses_feature_registry_and_accessor(tmp_path: Path, monkeypatch: object) -> None:


### PR DESCRIPTION
### Motivation

- D-10 ("User-facing changes require docs") blocks routine runtime PRs by forcing documentation edits for user-visible changes and must be removed entirely rather than weakened or replaced.

### Description

- Remove the `check_d10` implementation and its `GuardrailCheck` registration from `scripts/ci/guardrails_suite.py` and drop `D-10` from `PR_DIFF_AWARE_CHECKS`.
- Remove the D-10 rule text from the Documentation section of `docs/guardrails/RepositoryGuardrails.md` so the spec no longer requires this mandatory-docs check.
- Update tests in `tests/config/test_guardrails_suite.py` to stop exercising `check_d10` and instead assert that `D-10` is not present among automated checks or in `PR_DIFF_AWARE_CHECKS`.
- Files changed: `scripts/ci/guardrails_suite.py`, `docs/guardrails/RepositoryGuardrails.md`, `tests/config/test_guardrails_suite.py`.

### Testing

- Ran `pytest -q tests/config/test_guardrails_suite.py tests/config/test_guardrails_summary.py tests/scripts/ci/test_render_guardrails_comment.py`; the test suites completed successfully (all tests passed).
- Rendered the guardrails summary via the existing `render_guardrails_comment` helper in a short Python invocation and confirmed the generated Guardrails Summary does not contain `D-10` and lists the remaining checks (rendered checks count validated).
- Searched for residual `D-10`/`check_d10` references (negative test coverage remains) and confirmed no active guardrail implementation or registration remains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d461b958083239a836b721dd99cee)