### PR TITLE
docs: clarify active member panel implementation

### DIFF
--- a/docs/modules/Recruitment.md
+++ b/docs/modules/Recruitment.md
@@ -114,6 +114,12 @@ ledger stays synchronized and the 🧭 placement log captures before/after value
 for `E`, `AF`, `AH`, and `AI`.
 
 ### Recruiter & member search surfaces
+- Despite its filename, `modules/recruitment/views/member_panel_legacy.py` is
+  the currently active member-panel implementation: `cogs/recruitment_member.py`
+  wires `!clansearch` to its controller, the recruitment views package re-exports
+  its controller and state, and the member clan-search tests exercise it. It is
+  retained intentionally and must not be deleted or renamed until a separate,
+  behavior-preserving migration PR rewires the command path and tests.
 - `!clanmatch` (recruiter view) and `!clansearch` (member view) both render as
 two persistent messages inside the recruiter thread: one for filters, one for
 results. When filters change, the module edits both messages in-place. Results
@@ -173,4 +179,4 @@ event loop.
 - [`docs/adr/ADR-0017-Reservations-Placement-Schema.md`](../adr/ADR-0017-Reservations-Placement-Schema.md)
 - [`docs/adr/ADR-0018_DailyRecruiterUpdate.md`](../adr/ADR-0018_DailyRecruiterUpdate.md)
 
-Doc last updated: 2025-12-04 (v0.9.8.2)
+Doc last updated: 2026-07-19 (v0.9.8.2)

--- a/modules/recruitment/views/member_panel_legacy.py
+++ b/modules/recruitment/views/member_panel_legacy.py
@@ -1,4 +1,9 @@
-"""Legacy member search panel restored for ``!clansearch``."""
+"""Active member search panel implementation for ``!clansearch``.
+
+Despite the ``_legacy`` filename, this module is the live implementation and is
+retained intentionally. Any cleanup must happen in a separate,
+behavior-preserving migration PR that first rewires the command path and tests.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
### Motivation
- Clarify that despite its filename `modules/recruitment/views/member_panel_legacy.py` this module is the live `!clansearch` implementation and must not be deleted or renamed without first performing a behavior-preserving migration that rewires the command path and tests.

### Description
- Added a module-level docstring to `modules/recruitment/views/member_panel_legacy.py` explaining that the `_legacy` file is intentionally retained as the active implementation, and added the same ownership/migration note to `docs/modules/Recruitment.md` while updating that doc's footer date.

### Testing
- Ran `git diff --check` and `python -m py_compile modules/recruitment/views/member_panel_legacy.py` which passed, and attempted `python -m pytest tests/recruitment/test_member_clansearch.py -q` but test collection was blocked in this environment by a missing import (`help_metadata` from `c1c_coreops.helpers`), so the test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d4d1ce62c83239487efe7e95320f4)