### PR TITLE
Bound and shard the pytest workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,51 +2,104 @@ name: 02 - tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  tests:
+  collection:
+    name: Collect tests
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install deps
+      - name: Install dependencies
         run: |
-          pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest pytest-asyncio aiohttp yarl
-      - name: Run tests
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          python -m pip install pytest pytest-asyncio pytest-timeout aiohttp yarl
+      - name: Collect tests
+        run: python -m pytest --collect-only -q
+
+  test-shards:
+    name: Tests / ${{ matrix.name }}
+    needs: collection
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: config-core-shared
+            paths: tests/config tests/coreops tests/docs tests/guardrails tests/scripts tests/common tests/integration tests/shared
+          - name: recruitment-placement
+            paths: tests/recruitment tests/placement
+          - name: onboarding-welcome
+            paths: tests/onboarding tests/welcome
+          - name: community-housekeeping
+            paths: tests/community tests/housekeeping tests/modules tests/cogs tests/test_*.py
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          python -m pip install pytest pytest-asyncio pytest-timeout aiohttp yarl
+      - name: Run ${{ matrix.name }} tests
         id: pytest
         continue-on-error: true
         run: |
           set -o pipefail
-          pytest -q 2>&1 | tee pytest.out
-      - name: Build tests summary
+          python -m pytest ${{ matrix.paths }} \
+            --maxfail=25 \
+            --durations=20 \
+            --timeout=180 \
+            --timeout-method=thread \
+            2>&1 | tee pytest-${{ matrix.name }}.out
+      - name: Upload ${{ matrix.name }} pytest output
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-${{ matrix.name }}
+          path: pytest-${{ matrix.name }}.out
+          if-no-files-found: warn
+      - name: Fail on test failures
+        if: steps.pytest.outcome != 'success'
+        run: exit 1
+
+  test-summary:
+    name: Test summary
+    if: always()
+    needs: [collection, test-shards]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Build test summary
         env:
-          STEP_OUTCOME: ${{ steps.pytest.outcome }}
+          COLLECTION_RESULT: ${{ needs.collection.result }}
+          SHARD_RESULT: ${{ needs.test-shards.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "${STEP_OUTCOME}" = "success" ]; then
-            MESSAGE="All tests passed.";
-          elif [ "${STEP_OUTCOME}" = "skipped" ]; then
-            MESSAGE="Test suite skipped.";
-          elif [ "${STEP_OUTCOME}" = "cancelled" ]; then
-            MESSAGE="Test run was cancelled.";
-          else
-            MESSAGE="Test failures detected. Review pytest.out for details.";
-          fi
-          python scripts/ci/write_summary.py \
-            --title "Test Suite" \
-            --status "${STEP_OUTCOME}" \
-            --message "${MESSAGE}" \
-            --detail "Command: pytest -q" \
-            --detail "Log: pytest.out" \
-            --output tests-summary.md
-      - name: Post tests summary comment
+          {
+            echo '## Test workflow summary'
+            echo
+            echo "- Collection result: **${COLLECTION_RESULT}**"
+            echo "- Shard result: **${SHARD_RESULT}**"
+            echo '- Shards: `config-core-shared`, `recruitment-placement`, `onboarding-welcome`, `community-housekeeping`'
+            echo "- Uploaded logs: open [this workflow run](${RUN_URL}) and download the \`pytest-<shard>\` artifacts."
+          } > tests-summary.md
+      - name: Post test summary comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -86,6 +139,3 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fail on test failures
-        if: steps.pytest.outcome == 'failure'
-        run: exit 1


### PR DESCRIPTION
### Motivation

- Prevent a single unbounded `pytest -q` run from hanging CI and make failing areas obvious by splitting tests into named shards.  
- Ensure newer pushes cancel in-progress runs for the same PR/branch so CI capacity is not wasted.  
- Keep failures blocking and visible while bounding runtime with per-job and per-test timeouts.  

### Description

- Add workflow-level `concurrency` with `cancel-in-progress: true` so newer pushes cancel superseded runs.  
- Add a `collection` job with `timeout-minutes: 8` that installs `pytest-timeout` and runs `python -m pytest --collect-only -q`, and fail if collection fails.  
- Replace the single full `pytest -q` run with a `test-shards` matrix (four named shards) using `strategy.fail-fast: false` and per-shard `timeout-minutes: 30`.  
- Run each shard with `python -m pytest <paths> --maxfail=25 --durations=20 --timeout=180 --timeout-method=thread`, upload `pytest-<shard>.out` as an artifact, and keep an explicit failing step when the shard outcome is not `success`.  
- Add a `test-summary` job that posts a single PR comment (marker `<!-- tests-summary -->`) summarizing collection result, shard result, shard names, and where to download uploaded logs.  
- Do not change runtime code or tests; only `.github/workflows/test.yml` was modified.  

### Testing

- Successfully validated YAML and shard count with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml')"` which parsed and found four shards.  
- Ran `git diff --check` and confirmed only `.github/workflows/test.yml` was changed.  
- Confirmed the new workflow installs `pytest-timeout` and that the collection command is `python -m pytest --collect-only -q` (collection is gated and will fail the job if collection fails).  
- Note: `actionlint` was unavailable in the environment (warning), and an earlier local Python YAML check failed because `pyyaml` was not installed, but the Ruby/YAML validation above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d513450f88323b4b20fe50b0204a8)