### PR TITLE
Stabilize sheet-backed test fixtures

### DIFF
--- a/tests/community/shard_tracker/test_data.py
+++ b/tests/community/shard_tracker/test_data.py
@@ -27,6 +27,15 @@ def _patch_runtime_config(
         }
     )
     monkeypatch.setattr(shard_data, "runtime_config", stub)
+    if tab:
+        resolver = AsyncMock(return_value=tab)
+    else:
+        resolver = AsyncMock(
+            side_effect=shard_data.milestones_config.MilestonesConfigValueBlank(
+                "SHARD_MERCY_TAB is blank", key="SHARD_MERCY_TAB"
+            )
+        )
+    monkeypatch.setattr(shard_data.milestones_config, "arequire_value", resolver)
 
 
 def test_get_config_prefers_env_channel_id(monkeypatch):

--- a/tests/onboarding/test_idle_watcher.py
+++ b/tests/onboarding/test_idle_watcher.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -87,14 +88,22 @@ def test_idle_watcher_posts_first_reminder(monkeypatch):
         return thread
 
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
-    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(3.1)])
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aload_all",
+        AsyncMock(return_value=[_row(3.1)]),
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(),
+    )
     monkeypatch.setattr(idle_watcher, "get_recruitment_coordinator_role_ids", lambda: set())
     monkeypatch.setattr(
         idle_watcher,
@@ -123,16 +132,28 @@ def test_idle_watcher_skips_when_completed_at_present(monkeypatch):
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "load_all",
-        lambda: [_row(8.0, completed=False, completed_at="2025-01-01T10:00:00+00:00")],
+        "aload_all",
+        AsyncMock(
+            return_value=[
+                _row(
+                    8.0,
+                    completed=False,
+                    completed_at="2025-01-01T10:00:00+00:00",
+                )
+            ]
+        ),
     )
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(),
+    )
 
     asyncio.run(idle_watcher.run_idle_scan(bot, now=_fixed_now()))
 
@@ -149,14 +170,22 @@ def test_idle_watcher_posts_warning(monkeypatch):
         return thread
 
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
-    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(24.5)])
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aload_all",
+        AsyncMock(return_value=[_row(24.5)]),
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(),
+    )
     monkeypatch.setattr(idle_watcher, "get_recruitment_coordinator_role_ids", lambda: {42})
     monkeypatch.setattr(
         idle_watcher,
@@ -184,14 +213,22 @@ def test_idle_watcher_autoclose_welcome(monkeypatch):
         return thread
 
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
-    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(36.5)])
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aload_all",
+        AsyncMock(return_value=[_row(36.5)]),
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda thread_id, **_: releases.append(thread_id))
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(side_effect=lambda thread_id, **_: releases.append(thread_id)),
+    )
     monkeypatch.setattr(idle_watcher, "get_recruitment_coordinator_role_ids", lambda: {7})
     monkeypatch.setattr(
         idle_watcher,
@@ -220,14 +257,22 @@ def test_idle_watcher_autoclose_promo(monkeypatch):
         return thread
 
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
-    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(36.5, thread_id=888)])
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aload_all",
+        AsyncMock(return_value=[_row(36.5, thread_id=888)]),
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("promo.r"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(),
+    )
     monkeypatch.setattr(idle_watcher, "get_recruitment_coordinator_role_ids", lambda: {9})
     monkeypatch.setattr(
         idle_watcher,
@@ -254,14 +299,22 @@ def test_idle_watcher_skips_closed_ticket(monkeypatch):
         return thread
 
     monkeypatch.setattr(idle_watcher, "_resolve_thread", _resolve)
-    monkeypatch.setattr(idle_watcher.onboarding_sessions, "load_all", lambda: [_row(6.0)])
     monkeypatch.setattr(
         idle_watcher.onboarding_sessions,
-        "update_existing",
-        lambda thread_id, payload: saves.append(payload),
+        "aload_all",
+        AsyncMock(return_value=[_row(6.0)]),
+    )
+    monkeypatch.setattr(
+        idle_watcher.onboarding_sessions,
+        "aupdate_existing",
+        AsyncMock(side_effect=lambda thread_id, payload: saves.append(payload)),
     )
     monkeypatch.setattr(welcome_flow, "resolve_onboarding_flow", lambda t: welcome_flow.FlowResolution("welcome"))
-    monkeypatch.setattr(idle_watcher.reservation_jobs, "release_reservations_for_thread", lambda *_, **__: None)
+    monkeypatch.setattr(
+        idle_watcher.reservation_jobs,
+        "release_reservations_for_thread",
+        AsyncMock(),
+    )
 
     asyncio.run(idle_watcher.run_idle_scan(bot, now=_fixed_now()))
 

--- a/tests/onboarding/test_promo_close_clan_prompt.py
+++ b/tests/onboarding/test_promo_close_clan_prompt.py
@@ -95,8 +95,14 @@ def _setup_watcher(monkeypatch):
     monkeypatch.setattr("modules.onboarding.watcher_promo.get_promo_channel_id", lambda: 123)
     monkeypatch.setattr("modules.onboarding.watcher_promo.get_ticket_tool_bot_id", lambda: 555)
     monkeypatch.setattr("modules.onboarding.watcher_promo.thread_scopes.is_promo_parent", lambda *_: True)
-    monkeypatch.setattr("modules.onboarding.watcher_promo.onboarding_sessions.get_by_thread_id", lambda *_: None)
-    monkeypatch.setattr("modules.onboarding.watcher_promo.onboarding_sessions.mark_completed", lambda *_: True)
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.onboarding_sessions.aget_by_thread_id",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "modules.onboarding.watcher_promo.onboarding_sessions.amark_completed",
+        AsyncMock(return_value=True),
+    )
     monkeypatch.setattr("modules.onboarding.watcher_promo.discord.Thread", DummyThread)
     return PromoTicketWatcher(bot=DummyBot())
 

--- a/tests/recruitment/test_reservations_sheet.py
+++ b/tests/recruitment/test_reservations_sheet.py
@@ -115,7 +115,12 @@ def test_load_reservation_ledger_rejects_bad_header(monkeypatch):
         return matrix
 
     monkeypatch.setattr(reservations, "_fetch_reservations_matrix", fake_fetch)
-    monkeypatch.setattr(reservations.recruitment, "get_reservations_tab_name", lambda: "RESERVATIONS_TAB")
+    async def fake_tab_name():
+        return "RESERVATIONS_TAB"
+
+    monkeypatch.setattr(
+        reservations.recruitment, "get_reservations_tab_name_async", fake_tab_name
+    )
 
     with pytest.raises(reservations.ReservationSchemaError):
         asyncio.run(reservations.load_reservation_ledger())

--- a/tests/shared/sheets/test_feature_refresh.py
+++ b/tests/shared/sheets/test_feature_refresh.py
@@ -68,7 +68,7 @@ def test_clan_ad_buckets_use_config_pointers(monkeypatch) -> None:
     requested_keys = []
     fetched_tabs = []
 
-    def fake_config_value(key, default=None, *, force=False):
+    async def fake_config_value(key, default=None, *, force=False):
         requested_keys.append((key, force))
         return {
             "clan_ad_messages_tab": "AdMessages",
@@ -79,7 +79,9 @@ def test_clan_ad_buckets_use_config_pointers(monkeypatch) -> None:
         fetched_tabs.append((sheet_id, tab_name))
         return [["header"], ["row"]]
 
-    monkeypatch.setattr("shared.sheets.recruitment.get_config_value", fake_config_value)
+    monkeypatch.setattr(
+        "shared.sheets.recruitment.get_config_value_async", fake_config_value
+    )
     monkeypatch.setattr(
         "shared.sheets.recruitment.get_recruitment_sheet_id", lambda: "sheet123"
     )
@@ -102,9 +104,11 @@ def test_missing_config_pointer_is_readable_failure(monkeypatch) -> None:
         return None
 
     monkeypatch.setattr(cache_service.asyncio, "sleep", no_sleep)
+    async def missing_config(key, default=None, *, force=False):
+        return default
+
     monkeypatch.setattr(
-        "shared.sheets.recruitment.get_config_value",
-        lambda key, default=None, *, force=False: default,
+        "shared.sheets.recruitment.get_config_value_async", missing_config
     )
     feature_refresh.register_cache_buckets()
 
@@ -124,9 +128,11 @@ def test_bad_tab_name_is_readable_failure(monkeypatch) -> None:
         raise RuntimeError("not found")
 
     monkeypatch.setattr(cache_service.asyncio, "sleep", no_sleep)
+    async def bogus_config(key, default=None, *, force=False):
+        return "BogusTab"
+
     monkeypatch.setattr(
-        "shared.sheets.recruitment.get_config_value",
-        lambda key, default=None, *, force=False: "BogusTab",
+        "shared.sheets.recruitment.get_config_value_async", bogus_config
     )
     monkeypatch.setattr(
         "shared.sheets.recruitment.get_recruitment_sheet_id", lambda: "sheet123"


### PR DESCRIPTION
### Motivation

- Tests were intermittently loading real sheet/env configuration and Google service account credentials, causing failures and long retries when running unit tests.
- The goal is to keep runtime behavior unchanged while making tests deterministic by fixing fixtures and async mocks at the sheet/config lookup boundaries.

### Description

- Replace synchronous test patches with async-compatible mocks for onboarding and reservation helpers by using `aload_all`/`aupdate_existing` and `AsyncMock` in `tests/onboarding/*` to avoid calling real Sheets APIs.
- Mock the async reservations tab resolver by setting `get_reservations_tab_name_async` in `tests/recruitment/test_reservations_sheet.py` so `load_reservation_ledger()` does not attempt real credential loading.
- Isolate shard-tracker config tests by stubbing `milestones_config.arequire_value` to return a controlled tab or raise a blank-value `MilestonesConfigValueBlank` when appropriate in `tests/community/shard_tracker/test_data.py`.
- Make feature-refresh tests use async recruitment config lookups by patching `get_config_value_async` and stubbing `afetch_values` where needed so `refresh_now()` is bounded and does not reach real Sheets or service-account code in `tests/shared/sheets/test_feature_refresh.py`.
- Update promo-close tests to use `aget_by_thread_id` / `amark_completed` async mocks in `tests/onboarding/test_promo_close_clan_prompt.py` to prevent sheet reads during close-handling logic.
- Changes are limited to test code and fixtures; no runtime modules, recruitment runtime logic, Google Sheets production code, or `modules/recruitment/availability.py` were modified.

### Testing

- Ran `python -m pytest --collect-only -q` and collection succeeded.
- Ran `python -m pytest tests/recruitment/test_reservations_sheet.py -q` and the targeted tests passed.
- Ran `python -m pytest tests/onboarding/test_idle_watcher.py tests/onboarding/test_promo_close_clan_prompt.py -q` and those tests passed.
- Ran `python -m pytest tests/community/shard_tracker/test_data.py -q` and `python -m pytest tests/shared/sheets/test_feature_refresh.py -q` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d568371988323b87c2a84a10ec344)