### PR TITLE
test: refresh async config and fusion fixtures

### DIFF
--- a/tests/config/test_merge_onboarding.py
+++ b/tests/config/test_merge_onboarding.py
@@ -67,14 +67,20 @@ def test_amerge_onboarding_config_early_uses_async_loader(monkeypatch):
         return "milestone-sheet", {"SHARD_MERCY_TAB": "Mercy"}
 
     def _sync_loader():
-        raise AssertionError("sync onboarding Config loader must not run in async runtime")
+        raise AssertionError(
+            "sync onboarding Config loader must not run in async runtime"
+        )
 
     monkeypatch.setitem(
         sys.modules,
         "shared.sheets.onboarding",
-        types.SimpleNamespace(_aload_config=_aload_config, _read_onboarding_config=_sync_loader),
+        types.SimpleNamespace(
+            _aload_config=_aload_config, _read_onboarding_config=_sync_loader
+        ),
     )
-    monkeypatch.setattr(config, "_aload_milestones_config_values", _aload_milestones_config_values)
+    monkeypatch.setattr(
+        config, "_aload_milestones_config_values", _aload_milestones_config_values
+    )
 
     merged = asyncio.run(config.amerge_onboarding_config_early())
 
@@ -98,8 +104,10 @@ def test_amerge_onboarding_config_early_executes_real_async_sheet_loaders(monkey
     monkeypatch.setenv("MILESTONES_CONFIG_TAB", "MilestonesConfigTab")
     config._CONFIG["MILESTONES_SHEET_ID"] = "milestone-sheet-XYZ"
 
-    onboarding_sheets._CONFIG_CACHE = None
-    onboarding_sheets._CONFIG_CACHE_TS = 0.0
+    monkeypatch.setattr(onboarding_sheets, "_CONFIG_CACHE", None)
+    monkeypatch.setattr(onboarding_sheets, "_CONFIG_CACHE_TS", 0.0)
+    monkeypatch.setattr(onboarding_sheets, "_sheet_id", lambda: "onboard-sheet-XYZ")
+    monkeypatch.setattr(milestones_config, "_sheet_id", lambda: "milestone-sheet-XYZ")
 
     calls = []
 
@@ -122,10 +130,16 @@ def test_amerge_onboarding_config_early_executes_real_async_sheet_loaders(monkey
         ]
 
     def _sync_fetch_records(*args, **kwargs):
-        raise AssertionError("sync Sheets fetch_records must not run during async startup preload")
+        raise AssertionError(
+            "sync Sheets fetch_records must not run during async startup preload"
+        )
 
-    monkeypatch.setattr(onboarding_sheets, "afetch_records", _fake_onboarding_afetch_records)
-    monkeypatch.setattr(milestones_config.async_core, "afetch_records", _fake_milestones_afetch_records)
+    monkeypatch.setattr(
+        onboarding_sheets, "afetch_records", _fake_onboarding_afetch_records
+    )
+    monkeypatch.setattr(
+        milestones_config.async_core, "afetch_records", _fake_milestones_afetch_records
+    )
     monkeypatch.setattr(sheets_core, "fetch_records", _sync_fetch_records)
 
     merged = asyncio.run(config.amerge_onboarding_config_early())

--- a/tests/coreops/test_cog_reload_async.py
+++ b/tests/coreops/test_cog_reload_async.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+from c1c_coreops import cog as coreops_cog
 from c1c_coreops.cog import CoreOpsCog
-from shared import config as shared_config
 
 
 class _Context:
@@ -28,8 +28,11 @@ def test_coreops_reload_surfaces_use_async_config_reload(monkeypatch) -> None:
         calls.append("async_reload")
         return {}
 
-    monkeypatch.setattr(shared_config, "reload_config", sync_reload_forbidden)
-    monkeypatch.setattr(shared_config, "areload_config", async_reload)
+    config_module = SimpleNamespace(
+        reload_config=sync_reload_forbidden,
+        areload_config=async_reload,
+    )
+    monkeypatch.setattr(coreops_cog, "_ensure_config_module", lambda: config_module)
 
     cog = object.__new__(CoreOpsCog)
 

--- a/tests/coreops/test_env_embed_chunking.py
+++ b/tests/coreops/test_env_embed_chunking.py
@@ -5,8 +5,10 @@ from discord.ext import commands
 
 from c1c_coreops.cog import (
     CoreOpsCog,
+    _EMBED_TOTAL_CHAR_LIMIT,
     _EnvEntry,
-    _MAX_EMBED_LENGTH,
+    _EnvRenderMeta,
+    _FIELD_CHAR_LIMIT,
     _chunk_field_lines,
     _embed_length,
 )
@@ -103,23 +105,21 @@ def test_env_embeds_chunk_large_fields(monkeypatch):
 
     timestamp = dt.datetime.now(dt.timezone.utc)
 
+    render_meta = _EnvRenderMeta(
+        bot_name="Bot", env="test", version="v1", timestamp=timestamp
+    )
     embeds, warnings, warning_keys = cog._build_env_embeds(
-        bot_name="Bot",
-        env="test",
-        version="v1",
-        guild_name="Guild",
         entries=entries,
         sheet_sections=[],
-        footer_text="footer",
-        timestamp=timestamp,
+        render_meta=render_meta,
     )
 
     assert not warnings
     assert not warning_keys
     assert len(embeds) >= 4
     assert any("Channels (" in field.name for embed in embeds for field in embed.fields)
-    for page, embed in enumerate(embeds, start=1):
-        assert f"Page {page}/{len(embeds)}" in embed.title
-        assert _embed_length(embed) <= _MAX_EMBED_LENGTH
+    for embed in embeds:
+        assert embed.title.startswith("Bot — env: test —")
+        assert _embed_length(embed) <= _EMBED_TOTAL_CHAR_LIMIT
         for field in embed.fields:
-            assert len(str(field.value)) <= 900
+            assert len(str(field.value)) <= _FIELD_CHAR_LIMIT

--- a/tests/shared/sheets/test_fusion.py
+++ b/tests/shared/sheets/test_fusion.py
@@ -8,7 +8,9 @@ import pytest
 from shared.sheets import fusion
 
 
-def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_fusions_reads_fusion_prefixed_needed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
         return [
             {
@@ -28,7 +30,7 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
         ]
 
     monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion"))
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
 
     rows = asyncio.run(fusion._load_fusions())
@@ -40,9 +42,9 @@ def test_load_fusions_reads_fusion_prefixed_needed(monkeypatch: pytest.MonkeyPat
     assert rows[0].start_at_utc == dt.datetime(2026, 4, 8, tzinfo=dt.timezone.utc)
 
 
-
-
-def test_load_fusions_reads_needed_total_alias_for_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_fusions_reads_needed_total_alias_for_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _fake_fetch_records(_sheet_id: str, _tab_name: str):
         return [
             {
@@ -62,7 +64,7 @@ def test_load_fusions_reads_needed_total_alias_for_fragment(monkeypatch: pytest.
         ]
 
     monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion"))
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
 
     rows = asyncio.run(fusion._load_fusions())
@@ -71,6 +73,7 @@ def test_load_fusions_reads_needed_total_alias_for_fragment(monkeypatch: pytest.
     assert rows[0].fusion_type == "fragment"
     assert rows[0].needed == 100
     assert rows[0].available == 135
+
 
 def _event(
     *,
@@ -115,7 +118,9 @@ def test_load_fusion_events_accepts_legacy_start_end_column_names(
         ]
 
     monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion Events")
+    monkeypatch.setattr(
+        fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion Events")
+    )
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
 
     rows = asyncio.run(fusion._load_fusion_events())
@@ -173,7 +178,9 @@ def test_get_fusion_events_matches_fusion_id_casefold_and_whitespace(
             sort_order=1,
         ),
     )
-    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(
+        fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events")
+    )
     monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=rows))
 
     result = asyncio.run(fusion.get_fusion_events("anomalus_titan_event_2026_04"))
@@ -296,7 +303,9 @@ def test_get_upcoming_events_uses_validated_timestamps_for_sorting(
     assert [row.event_id for row in result] == ["naive-earlier", "aware"]
 
 
-def test_transition_fusion_to_ended_updates_status_once(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_transition_fusion_to_ended_updates_status_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     worksheet = AsyncMock()
 
     async def _afetch_values(_sheet_id: str, _tab_name: str):
@@ -308,19 +317,25 @@ def test_transition_fusion_to_ended_updates_status_once(monkeypatch: pytest.Monk
     async def _acall_with_backoff(fn, *args, **kwargs):
         return await fn(*args, **kwargs)
 
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion"))
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
     monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
     monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
-    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(
+        fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events")
+    )
     monkeypatch.setattr(fusion.cache, "refresh_now", AsyncMock())
 
     changed = asyncio.run(fusion.transition_fusion_to_ended("f-1"))
 
     assert changed is True
-    worksheet.update.assert_awaited_once_with("B2", [["ended"]], value_input_option="RAW")
-    fusion.cache.refresh_now.assert_awaited_once_with("fusion", actor="fusion_status_ended")
+    worksheet.update.assert_awaited_once_with(
+        "B2", [["ended"]], value_input_option="RAW"
+    )
+    fusion.cache.refresh_now.assert_awaited_once_with(
+        "fusion", actor="fusion_status_ended"
+    )
 
 
 def test_transition_fusion_to_ended_is_noop_when_already_ended(
@@ -334,11 +349,13 @@ def test_transition_fusion_to_ended_is_noop_when_already_ended(
             ["f-1", "ended"],
         ]
 
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion"))
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
     monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
-    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(
+        fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events")
+    )
     monkeypatch.setattr(fusion.cache, "refresh_now", AsyncMock())
 
     changed = asyncio.run(fusion.transition_fusion_to_ended("f-1"))
@@ -371,16 +388,22 @@ def _fusion_row(*, fusion_id: str, fusion_type: str, status: str) -> fusion.Fusi
     )
 
 
-def test_get_publishable_fusion_includes_fragment_draft(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_publishable_fusion_includes_fragment_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     rows = (
         _fusion_row(fusion_id="hybrid-active", fusion_type="hybrid", status="active"),
         _fusion_row(fusion_id="fragment-draft", fusion_type="fragment", status="draft"),
     )
-    monkeypatch.setattr(fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events"))
+    monkeypatch.setattr(
+        fusion, "register_cache_buckets", lambda: ("fusion", "fusion_events")
+    )
     monkeypatch.setattr(fusion, "_cached_rows", AsyncMock(return_value=rows))
 
     result = asyncio.run(
-        fusion.get_publishable_fusion(include_draft=True, tracker_kind="fusion", prefer_draft=True)
+        fusion.get_publishable_fusion(
+            include_draft=True, tracker_kind="fusion", prefer_draft=True
+        )
     )
 
     assert result is not None
@@ -399,7 +422,9 @@ def test_get_publishable_fusion_includes_fragment_draft(monkeypatch: pytest.Monk
         ("titan event", "titan"),
     ],
 )
-def test_tracker_kind_maps_supported_fusion_types(fusion_type: str, expected: str) -> None:
+def test_tracker_kind_maps_supported_fusion_types(
+    fusion_type: str, expected: str
+) -> None:
     row = _fusion_row(fusion_id="f-1", fusion_type=fusion_type, status="draft")
     assert fusion._tracker_kind(row) == expected
 
@@ -425,7 +450,7 @@ def test_load_fusions_normalizes_fragment_fusion_type_case(
         ]
 
     monkeypatch.setattr(fusion, "afetch_records", _fake_fetch_records)
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda _key: "Fusion")
+    monkeypatch.setattr(fusion, "_resolve_tab_name", AsyncMock(return_value="Fusion"))
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
 
     rows = asyncio.run(fusion._load_fusions())
@@ -434,8 +459,20 @@ def test_load_fusions_normalizes_fragment_fusion_type_case(
     assert rows[0].fusion_type == "fragment"
 
 
-def test_upsert_user_event_progress_returns_insert_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
-    matrix = [["fusion_id", "user_id", "event_id", "milestone_key", "status", "updated_at_utc", "partial_amount"]]
+def test_upsert_user_event_progress_returns_insert_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    matrix = [
+        [
+            "fusion_id",
+            "user_id",
+            "event_id",
+            "milestone_key",
+            "status",
+            "updated_at_utc",
+            "partial_amount",
+        ]
+    ]
 
     class _Worksheet:
         async def append_row(self, *_args, **_kwargs):
@@ -454,7 +491,9 @@ def test_upsert_user_event_progress_returns_insert_diagnostics(monkeypatch: pyte
             matrix.append(args[0])
         return None
 
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "User Progress")
+    monkeypatch.setattr(
+        fusion, "_resolve_tab_name", AsyncMock(return_value="User Progress")
+    )
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
     monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
@@ -478,15 +517,43 @@ def test_upsert_user_event_progress_returns_insert_diagnostics(monkeypatch: pyte
     assert appended[0][4] == "done"
 
 
-def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_user_traditional_progress_resolves_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _afetch_values(_sheet_id: str, tab_name: str):
         assert tab_name == "fusion_traditional_user_prog"
         return [
-            ["user_id", "fusion_id", "epics_ascended", "rares_owned", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "target_ready", "updated_at_utc"],
-            ["42", "f-1", "3", "14", "12", "8", "2", "2", "yes", "2026-07-01T00:00:00+00:00"],
+            [
+                "user_id",
+                "fusion_id",
+                "epics_ascended",
+                "rares_owned",
+                "rares_level_40",
+                "rares_ascended",
+                "epics_fused",
+                "epics_level_50",
+                "target_ready",
+                "updated_at_utc",
+            ],
+            [
+                "42",
+                "f-1",
+                "3",
+                "14",
+                "12",
+                "8",
+                "2",
+                "2",
+                "yes",
+                "2026-07-01T00:00:00+00:00",
+            ],
         ]
 
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "fusion_traditional_user_prog")
+    monkeypatch.setattr(
+        fusion,
+        "_resolve_tab_name",
+        AsyncMock(return_value="fusion_traditional_user_prog"),
+    )
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
 
@@ -501,14 +568,38 @@ def test_get_user_traditional_progress_resolves_headers(monkeypatch: pytest.Monk
     assert row.target_ready is True
 
 
-def test_traditional_progress_resolves_human_readable_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_traditional_progress_resolves_human_readable_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _resolve_tab_name(_key: str) -> str:
         return "fusion_traditional_user_prog"
 
     async def _afetch_values(_sheet_id: str, _tab_name: str):
         return [
-            ["User ID", "Fusion ID", "Epics fully ascended", "Rares owned", "Rares level 40", "Rares fully ascended", "Epics fused", "Epics level 50", "Target ready", "Updated At UTC"],
-            ["42", "f-1", "4", "16", "16", "16", "4", "4", "TRUE", "2026-07-01T00:00:00+00:00"],
+            [
+                "User ID",
+                "Fusion ID",
+                "Epics fully ascended",
+                "Rares owned",
+                "Rares level 40",
+                "Rares fully ascended",
+                "Epics fused",
+                "Epics level 50",
+                "Target ready",
+                "Updated At UTC",
+            ],
+            [
+                "42",
+                "f-1",
+                "4",
+                "16",
+                "16",
+                "16",
+                "4",
+                "4",
+                "TRUE",
+                "2026-07-01T00:00:00+00:00",
+            ],
         ]
 
     monkeypatch.setattr(fusion, "_resolve_tab_name", _resolve_tab_name)
@@ -522,28 +613,55 @@ def test_traditional_progress_resolves_human_readable_headers(monkeypatch: pytes
     assert row.target_ready is True
 
 
-def test_upsert_user_traditional_progress_updates_existing_row_by_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_upsert_user_traditional_progress_updates_existing_row_by_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     worksheet = AsyncMock()
 
     async def _afetch_values(_sheet_id: str, _tab_name: str):
         return [
-            ["user_id", "fusion_id", "epics_ascended", "rares_owned", "rares_level_40", "rares_ascended", "epics_fused", "epics_level_50", "target_ready", "updated_at_utc"],
+            [
+                "user_id",
+                "fusion_id",
+                "epics_ascended",
+                "rares_owned",
+                "rares_level_40",
+                "rares_ascended",
+                "epics_fused",
+                "epics_level_50",
+                "target_ready",
+                "updated_at_utc",
+            ],
             ["42", "f-1", "1", "4", "4", "4", "1", "1", "FALSE", "old"],
         ]
 
     async def _acall_with_backoff(fn, *args, **kwargs):
         return await fn(*args, **kwargs)
 
-    monkeypatch.setattr(fusion, "_resolve_tab_name", lambda key: "fusion_traditional_user_prog")
+    monkeypatch.setattr(
+        fusion,
+        "_resolve_tab_name",
+        AsyncMock(return_value="fusion_traditional_user_prog"),
+    )
     monkeypatch.setattr(fusion, "_sheet_id", lambda: "sheet-id")
     monkeypatch.setattr(fusion, "afetch_values", _afetch_values)
     monkeypatch.setattr(fusion, "aget_worksheet", AsyncMock(return_value=worksheet))
     monkeypatch.setattr(fusion, "acall_with_backoff", _acall_with_backoff)
 
-    row = asyncio.run(fusion.upsert_user_traditional_progress(
-        "f-1", "42", rares_owned=9, rares_level_40=8, rares_ascended=8, epics_fused=2,
-        epics_level_50=2, epics_ascended=4, target_ready=True, updated_at=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
-    ))
+    row = asyncio.run(
+        fusion.upsert_user_traditional_progress(
+            "f-1",
+            "42",
+            rares_owned=9,
+            rares_level_40=8,
+            rares_ascended=8,
+            epics_fused=2,
+            epics_level_50=2,
+            epics_ascended=4,
+            target_ready=True,
+            updated_at=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
+        )
+    )
 
     assert row.rares_owned == 9
     assert row.epics_ascended == 4

--- a/tests/shared/sheets/test_fusion_reminder_schema.py
+++ b/tests/shared/sheets/test_fusion_reminder_schema.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -12,7 +13,9 @@ class _Worksheet:
         self.updated: list[tuple[str, list[list[str]]]] = []
         self.appended: list[list[str]] = []
 
-    def update(self, cell: str, values: list[list[str]], value_input_option: str = "RAW") -> None:
+    def update(
+        self, cell: str, values: list[list[str]], value_input_option: str = "RAW"
+    ) -> None:
         self.updated.append((cell, values))
 
     def append_row(self, values: list[str], value_input_option: str = "RAW") -> None:
@@ -22,9 +25,16 @@ class _Worksheet:
 def _install_config(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
     for key, value in mapping.items():
         monkeypatch.setitem(config_module._CONFIG, key, value)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "_resolve_tab_name",
+        AsyncMock(side_effect=lambda key: mapping[key]),
+    )
 
 
-def test_get_sent_reminder_keys_uses_configured_tab_and_columns(monkeypatch: pytest.MonkeyPatch):
+def test_get_sent_reminder_keys_uses_configured_tab_and_columns(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -32,6 +42,7 @@ def test_get_sent_reminder_keys_uses_configured_tab_and_columns(monkeypatch: pyt
         },
     )
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
     async def _afetch_values(sheet_id: str, tab_name: str):
         assert sheet_id == "sheet-1"
         assert tab_name == "Reminder Ledger"
@@ -48,7 +59,9 @@ def test_get_sent_reminder_keys_uses_configured_tab_and_columns(monkeypatch: pyt
     assert sent == {("e-1", "start")}
 
 
-def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeypatch: pytest.MonkeyPatch):
+def test_mark_reminder_sent_updates_existing_row_with_configured_columns(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -57,6 +70,7 @@ def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeyp
     )
     worksheet = _Worksheet()
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
+
     async def _afetch_values(sheet_id: str, tab_name: str):
         assert sheet_id == "sheet-1"
         assert tab_name == "Reminder Ledger"
@@ -89,7 +103,9 @@ def test_mark_reminder_sent_updates_existing_row_with_configured_columns(monkeyp
     assert worksheet.updated[0][0] == "D2"
 
 
-def test_get_sent_reminder_keys_requires_required_headers(monkeypatch: pytest.MonkeyPatch):
+def test_get_sent_reminder_keys_requires_required_headers(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -109,7 +125,9 @@ def test_get_sent_reminder_keys_requires_required_headers(monkeypatch: pytest.Mo
         asyncio.run(fusion_sheets.get_sent_reminder_keys("f-1"))
 
 
-def test_get_sent_reminder_keys_does_not_require_sent_at_header(monkeypatch: pytest.MonkeyPatch):
+def test_get_sent_reminder_keys_does_not_require_sent_at_header(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -133,7 +151,9 @@ def test_get_sent_reminder_keys_does_not_require_sent_at_header(monkeypatch: pyt
     assert sent == {("e-1", "start")}
 
 
-def test_get_last_reminder_sent_at_reads_grouped_marker(monkeypatch: pytest.MonkeyPatch):
+def test_get_last_reminder_sent_at_reads_grouped_marker(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -148,9 +168,24 @@ def test_get_last_reminder_sent_at_reads_grouped_marker(monkeypatch: pytest.Monk
         return [
             ["fusion_id", "event_id", "reminder_type", "sent_at_utc"],
             ["f-1", "e-old", "start", "2026-04-09T01:00:00+00:00"],
-            ["f-1", "grouped_daily:2026-04-09", "grouped_daily", "2026-04-09T12:00:00+00:00"],
-            ["f-1", "grouped_daily:2026-04-10", "grouped_daily", "2026-04-10T12:00:00+00:00"],
-            ["f-2", "grouped_daily:2026-04-11", "grouped_daily", "2026-04-11T12:00:00+00:00"],
+            [
+                "f-1",
+                "grouped_daily:2026-04-09",
+                "grouped_daily",
+                "2026-04-09T12:00:00+00:00",
+            ],
+            [
+                "f-1",
+                "grouped_daily:2026-04-10",
+                "grouped_daily",
+                "2026-04-10T12:00:00+00:00",
+            ],
+            [
+                "f-2",
+                "grouped_daily:2026-04-11",
+                "grouped_daily",
+                "2026-04-11T12:00:00+00:00",
+            ],
         ]
 
     monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
@@ -162,7 +197,9 @@ def test_get_last_reminder_sent_at_reads_grouped_marker(monkeypatch: pytest.Monk
     assert sent_at == dt.datetime(2026, 4, 10, 12, tzinfo=dt.timezone.utc)
 
 
-def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.MonkeyPatch):
+def test_get_fusion_reminder_settings_reads_configured_tab(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -208,7 +245,9 @@ def test_get_fusion_reminder_settings_reads_configured_tab(monkeypatch: pytest.M
     assert settings.settings_value_header == "value"
 
 
-def test_get_fusion_reminder_settings_reads_setting_key_and_local_sheet_time(monkeypatch: pytest.MonkeyPatch):
+def test_get_fusion_reminder_settings_reads_setting_key_and_local_sheet_time(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(
         monkeypatch,
         {
@@ -246,8 +285,12 @@ def test_get_fusion_reminder_settings_reads_setting_key_and_local_sheet_time(mon
     assert settings.settings_raw_types["grouped_daily_post_time"] == "float"
 
 
-def test_get_fusion_reminder_settings_requires_production_headers(monkeypatch: pytest.MonkeyPatch):
-    _install_config(monkeypatch, {"FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings"})
+def test_get_fusion_reminder_settings_requires_production_headers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_config(
+        monkeypatch, {"FUSION_REMINDER_SETTINGS_TAB": "FusionReminderSettings"}
+    )
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
     async def _afetch_values(sheet_id: str, tab_name: str):
@@ -275,24 +318,30 @@ def test_fusion_reminder_bool_parser_accepts_sheet_true_false_values():
     assert fusion_sheets._parse_bool("") is False
 
 
-def test_load_fusion_events_reads_optional_embed_copy_columns(monkeypatch: pytest.MonkeyPatch):
+def test_load_fusion_events_reads_optional_embed_copy_columns(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_config(monkeypatch, {"FUSION_EVENT_TAB": "FusionEvents"})
+
     async def _afetch_records(_sheet_id: str, tab_name: str):
         assert tab_name == "FusionEvents"
-        return [{
-            "fusion_id": "f-1",
-            "event_id": "e-1",
-            "event_name": "Event 1",
-            "event_type": "tournament",
-            "category": "arena",
-            "start_at_utc": "2026-01-01T00:00:00+00:00",
-            "end_at_utc": "2026-01-01T01:00:00+00:00",
-            "reward_amount": "10",
-            "reward_type": "fragments",
-            "embed_title": "{event_label}",
-            "embed_description": "Begins {starts_in}",
-            "embed_footer": "Footer",
-        }]
+        return [
+            {
+                "fusion_id": "f-1",
+                "event_id": "e-1",
+                "event_name": "Event 1",
+                "event_type": "tournament",
+                "category": "arena",
+                "start_at_utc": "2026-01-01T00:00:00+00:00",
+                "end_at_utc": "2026-01-01T01:00:00+00:00",
+                "reward_amount": "10",
+                "reward_type": "fragments",
+                "embed_title": "{event_label}",
+                "embed_description": "Begins {starts_in}",
+                "embed_footer": "Footer",
+            }
+        ]
+
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
     monkeypatch.setattr(fusion_sheets, "afetch_records", _afetch_records)
     rows = asyncio.run(fusion_sheets._load_fusion_events())

--- a/tests/shared/sheets/test_fusion_user_event_progress_schema.py
+++ b/tests/shared/sheets/test_fusion_user_event_progress_schema.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -12,7 +13,9 @@ class _Worksheet:
         self.updated: list[tuple[str, list[list[str]]]] = []
         self.appended: list[list[str]] = []
 
-    def update(self, cell: str, values: list[list[str]], value_input_option: str = "RAW") -> None:
+    def update(
+        self, cell: str, values: list[list[str]], value_input_option: str = "RAW"
+    ) -> None:
         self.updated.append((cell, values))
 
     def append_row(self, values: list[str], value_input_option: str = "RAW") -> None:
@@ -22,6 +25,11 @@ class _Worksheet:
 def _install_config(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
     for key, value in mapping.items():
         monkeypatch.setitem(config_module._CONFIG, key, value)
+    monkeypatch.setattr(
+        fusion_sheets,
+        "_resolve_tab_name",
+        AsyncMock(side_effect=lambda key: mapping[key]),
+    )
 
 
 def _install_progress_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -33,7 +41,9 @@ def _install_progress_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_get_user_event_progress_uses_configured_tab_and_columns(monkeypatch: pytest.MonkeyPatch):
+def test_get_user_event_progress_uses_configured_tab_and_columns(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_progress_config(monkeypatch)
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
@@ -41,31 +51,63 @@ def test_get_user_event_progress_uses_configured_tab_and_columns(monkeypatch: py
         assert sheet_id == "sheet-1"
         assert tab_name == "Progress Ledger"
         return [
-            ["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"],
-            ["f-1", "42", "e-1", "done", "2026-01-01T00:00:00+00:00"],
-            ["f-1", "42", "e-2", "done_bonus", "2026-01-01T00:00:00+00:00"],
-            ["f-1", "42", "e-3", "unknown", "2026-01-01T00:00:00+00:00"],
-            ["f-2", "42", "e-9", "done", "2026-01-01T00:00:00+00:00"],
+            [
+                "FusionKey",
+                "UserKey",
+                "EventKey",
+                "Milestone Key",
+                "Status",
+                "partial_amount",
+                "UpdatedAt",
+            ],
+            ["f-1", "42", "e-1", "", "done", "", "2026-01-01T00:00:00+00:00"],
+            ["f-1", "42", "e-2", "", "done_bonus", "", "2026-01-01T00:00:00+00:00"],
+            ["f-1", "42", "e-3", "", "unknown", "", "2026-01-01T00:00:00+00:00"],
+            ["f-2", "42", "e-9", "", "done", "", "2026-01-01T00:00:00+00:00"],
         ]
 
     monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
 
     progress = asyncio.run(fusion_sheets.get_user_event_progress("f-1", "42"))
 
-    assert progress == {"e-1": "done", "e-2": "done_bonus", "e-3": "not_started"}
+    assert progress == {
+        "progress": {"e-1": "done", "e-2": "done_bonus", "e-3": "not_started"},
+        "partials": {"e-1": 0.0, "e-2": 0.0, "e-3": 0.0},
+    }
 
 
-def test_upsert_user_event_progress_updates_existing_row(monkeypatch: pytest.MonkeyPatch):
+def test_upsert_user_event_progress_updates_existing_row(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_progress_config(monkeypatch)
     worksheet = _Worksheet()
+    fetch_count = 0
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
     async def _afetch_values(sheet_id: str, tab_name: str):
+        nonlocal fetch_count
+        fetch_count += 1
         assert sheet_id == "sheet-1"
         assert tab_name == "Progress Ledger"
         return [
-            ["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"],
-            ["f-1", "42", "e-1", "not_started", ""],
+            [
+                "FusionKey",
+                "UserKey",
+                "EventKey",
+                "Milestone Key",
+                "Status",
+                "partial_amount",
+                "UpdatedAt",
+            ],
+            [
+                "f-1",
+                "42",
+                "e-1",
+                "",
+                "done" if fetch_count > 1 else "not_started",
+                "",
+                "2026-01-01T12:00:00+00:00" if fetch_count > 1 else "",
+            ],
         ]
 
     async def _aget_worksheet(_sheet_id: str, _tab_name: str):
@@ -90,18 +132,38 @@ def test_upsert_user_event_progress_updates_existing_row(monkeypatch: pytest.Mon
 
     assert worksheet.updated
     assert not worksheet.appended
-    assert [cell for cell, _values in worksheet.updated] == ["D2", "E2"]
+    assert [cell for cell, _values in worksheet.updated] == ["E2", "G2", "F2"]
 
 
-def test_upsert_user_event_progress_appends_when_missing(monkeypatch: pytest.MonkeyPatch):
+def test_upsert_user_event_progress_appends_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_progress_config(monkeypatch)
     worksheet = _Worksheet()
+    fetch_count = 0
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
     async def _afetch_values(sheet_id: str, tab_name: str):
+        nonlocal fetch_count
+        fetch_count += 1
         assert sheet_id == "sheet-1"
         assert tab_name == "Progress Ledger"
-        return [["FusionKey", "UserKey", "EventKey", "Status", "UpdatedAt"]]
+        rows = [
+            [
+                "FusionKey",
+                "UserKey",
+                "EventKey",
+                "Milestone Key",
+                "Status",
+                "partial_amount",
+                "UpdatedAt",
+            ]
+        ]
+        if fetch_count > 1:
+            rows.append(
+                ["f-1", "42", "e-2", "", "done_bonus", "", "2026-01-01T12:00:00+00:00"]
+            )
+        return rows
 
     async def _aget_worksheet(_sheet_id: str, _tab_name: str):
         return worksheet
@@ -125,17 +187,27 @@ def test_upsert_user_event_progress_appends_when_missing(monkeypatch: pytest.Mon
 
     assert not worksheet.updated
     assert worksheet.appended
-    assert worksheet.appended[0][0:4] == ["f-1", "42", "e-2", "done_bonus"]
+    assert worksheet.appended[0][0:5] == ["f-1", "42", "e-2", "", "done_bonus"]
 
 
-def test_get_user_event_progress_requires_expected_headers(monkeypatch: pytest.MonkeyPatch):
+def test_get_user_event_progress_requires_expected_headers(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_progress_config(monkeypatch)
     monkeypatch.setattr(fusion_sheets, "_sheet_id", lambda: "sheet-1")
 
     async def _afetch_values(_sheet_id: str, _tab_name: str):
         return [
-            ["BadFusion", "UserKey", "EventKey", "Status", "UpdatedAt"],
-            ["f-1", "42", "e-1", "done", "2026-01-01T00:00:00+00:00"],
+            [
+                "BadFusion",
+                "UserKey",
+                "EventKey",
+                "Milestone Key",
+                "Status",
+                "partial_amount",
+                "UpdatedAt",
+            ],
+            ["f-1", "42", "e-1", "", "done", "", "2026-01-01T00:00:00+00:00"],
         ]
 
     monkeypatch.setattr(fusion_sheets, "afetch_values", _afetch_values)
@@ -144,7 +216,9 @@ def test_get_user_event_progress_requires_expected_headers(monkeypatch: pytest.M
         asyncio.run(fusion_sheets.get_user_event_progress("f-1", "42"))
 
 
-def test_upsert_user_event_progress_rejects_non_canonical_status(monkeypatch: pytest.MonkeyPatch):
+def test_upsert_user_event_progress_rejects_non_canonical_status(
+    monkeypatch: pytest.MonkeyPatch,
+):
     _install_progress_config(monkeypatch)
 
     with pytest.raises(ValueError, match="Invalid fusion progress status"):

--- a/tests/shared/test_onboarding_clan_tags.py
+++ b/tests/shared/test_onboarding_clan_tags.py
@@ -49,7 +49,13 @@ def test_load_clan_tags_async_reads_column_b(monkeypatch) -> None:
 
     async def runner() -> None:
         monkeypatch.setattr(onboarding, "_sheet_id", lambda: "sheet-id", raising=False)
-        monkeypatch.setattr(onboarding, "_clanlist_tab", lambda: "ClanList", raising=False)
+
+        async def fake_aclanlist_tab() -> str:
+            return "ClanList"
+
+        monkeypatch.setattr(
+            onboarding, "_aclanlist_tab", fake_aclanlist_tab, raising=True
+        )
         monkeypatch.setattr(onboarding, "afetch_values", fake_afetch, raising=True)
 
         tags = await onboarding._load_clan_tags_async()


### PR DESCRIPTION
### Motivation

- Tests in the config/core/shared shard were failing because they used stale synchronous or string-returning mocks for code paths that are now asynchronous; the intent is to make test fixtures awaitable so tests exercise the async resolvers correctly. 
- Keep all changes test-only so runtime behaviour, Google Sheets production logic, and forbidden modules remain untouched. 
- Align fixtures with current sheet schema (milestone key / partial amount) and the CoreOps embed/render API so save verification and diagnostics behave as expected under async flows. 

### Description

- Replaced stale sync/string mocks for tab/config resolvers with awaitable fixtures using `AsyncMock` for `_resolve_tab_name` and related resolvers in fusion tests and reminder/progress schema tests. 
- Updated onboarding tests to clear/patch `_CONFIG_CACHE` and `_CONFIG_CACHE_TS` via `monkeypatch.setattr` and to supply the test `_sheet_id` so async onboarding/milestones loaders exercise the intended async code path. 
- Modified CoreOps tests to mock the dynamically-resolved config module via `_ensure_config_module` returning a `SimpleNamespace` with `areload_config` to ensure async reloads are invoked, and adjusted embed tests to use `_EnvRenderMeta` and the cog constants for embed/field limits. 
- Adjusted fusion user-event progress and reminder fixtures to include `Milestone Key` and `partial_amount` columns, updated expected diagnostics/verification flows, and added small test plumbing (fetch counters, expected update/append cell indices) to reflect post-write verification reads. 

### Testing

- Ran the targeted test set with `pytest -q tests/config tests/coreops tests/shared --ignore=AUDIT` and the focused list `pytest -q tests/config/test_merge_onboarding.py tests/coreops/test_cog_reload_async.py tests/coreops/test_env_embed_chunking.py tests/shared/sheets/test_fusion.py tests/shared/sheets/test_fusion_reminder_schema.py tests/shared/sheets/test_fusion_user_event_progress_schema.py`; the targeted tests passed locally. 
- Ran `black` on the modified test files to ensure formatting parity and applied reformatting to test-only files. 
- Verified static/quick checks with `black --check` and `git diff --check` on the change set and addressed issues until checks passed. 
- All changes are confined to tests only and no runtime modules, Google Sheets production logic, intents, OAuth scopes, or sheet IDs were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d5c78a7c483239de4407a71706794)