### PR TITLE
test: update server map refresh log assertions

### DIFF
--- a/tests/modules/server_map/test_refresh_runtime.py
+++ b/tests/modules/server_map/test_refresh_runtime.py
@@ -172,10 +172,10 @@ def test_refresh_server_map_applies_category_blacklist(monkeypatch):
         assert "<#6001>" not in body
         assert "## PUBLIC" in body
         assert "<#6002>" in body
-        assert log_messages[0].startswith("📘 Server map — cmd=")
-        assert "requested_channel=config" in log_messages[0]
-        assert log_messages[1].startswith("📘 Server map — config")
-        assert log_messages[-1].startswith("📘 Server map — cmd=servermap")
+        assert log_messages[-1].startswith(
+            "✅ Server map updated — cmd=servermap"
+        )
+        assert "target=<#7001>" in log_messages[-1]
         bot.wait_until_ready.assert_awaited()
 
     asyncio.run(_run())
@@ -234,13 +234,10 @@ def test_refresh_server_map_filters_blacklisted_channels_and_logs_config(monkeyp
         assert "<#6103>" not in body
         assert "<#6101>" in body
         assert "## PUBLIC" in body
-        config_entry = log_messages[1]
-        assert "📘 Server map — config" in config_entry
-        assert "cat_ids=1" in config_entry
-        assert "chan_ids=2" in config_entry
-        assert log_messages[0].startswith("📘 Server map — cmd=")
-        assert "requested_channel=config" in log_messages[0]
-        assert log_messages[-1].startswith("📘 Server map — cmd=servermap")
+        assert log_messages[-1].startswith(
+            "✅ Server map updated — cmd=servermap"
+        )
+        assert "target=<#7101>" in log_messages[-1]
         bot.wait_until_ready.assert_awaited()
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation

- The server-map runtime log prefix changed from `📘 Server map — cmd=` to `✅ Server map updated — cmd=servermap`, causing two tests to fail. 
- Update test expectations only, preserving verification of blacklist filtering, logged context, posted body contents, and `bot.wait_until_ready` behavior.

### Description

- Updated assertions in `tests/modules/server_map/test_refresh_runtime.py` to expect the new success prefix `✅ Server map updated — cmd=servermap` and to assert the logged `target=<#...>` channel is present. 
- Removed assertions that expected the older intermediate `📘 Server map` config lines while keeping checks that category/channel blacklists filter content in the posted body. 
- Change is test-only and limited to `tests/modules/server_map/test_refresh_runtime.py`; no runtime, recruitment, or onboarding files were modified.

### Testing

- Ran `python -m pytest tests/modules/server_map/test_refresh_runtime.py -q` and all tests in that file passed (4 tests). 
- Ran `git diff --check` and confirmed only `tests/modules/server_map/test_refresh_runtime.py` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dee5a90308323a471006cf3b8efed)