### PR TITLE
Runtime safety: remove sync sheet fallback from recruitment availability async path

### DIFF
--- a/modules/recruitment/availability.py
+++ b/modules/recruitment/availability.py
@@ -343,71 +343,19 @@ def _resolve_availability_headers() -> AvailabilityHeaderResolution:
 
 
 async def _aresolve_availability_headers() -> AvailabilityHeaderResolution:
-    async def _load_async_header() -> tuple[str, list[Any], dict[str, str]]:
-        tab = await recruitment.get_clans_tab_name_async()
-        row = list(await recruitment.aget_clan_header_row(force=False))
-        configured: dict[str, str] = {}
-        for field in AVAILABILITY_FIELDS:
-            config_key = f"clans_header_{field}"
-            value = await recruitment.get_config_value_async(
-                config_key, None, force=False
-            )
-            configured[field] = str(value).strip() if value is not None else ""
-        return tab, row, configured
-
-    async def _load_cached_header_with_async_config() -> (
-        tuple[str, list[Any], dict[str, str]]
-    ):
-        tab = await recruitment.get_clans_tab_name_async()
-        try:
-            row = list(recruitment.get_clan_header_row(force=False))
-        except TypeError:
-            row = list(recruitment.get_clan_header_row())
-        configured: dict[str, str] = {}
-        for field in AVAILABILITY_FIELDS:
-            config_key = f"clans_header_{field}"
-            value = await recruitment.get_config_value_async(
-                config_key, None, force=False
-            )
-            configured[field] = str(value).strip() if value is not None else ""
-        return tab, row, configured
-
-    def _load_sync_for_thread() -> tuple[str, list[Any], dict[str, str]]:
-        tab = recruitment.get_clans_tab_name()
-        try:
-            row = list(recruitment.get_clan_header_row(force=False))
-        except TypeError:
-            row = list(recruitment.get_clan_header_row())
-        configured: dict[str, str] = {}
-        for field in AVAILABILITY_FIELDS:
-            config_key = f"clans_header_{field}"
-            try:
-                value = recruitment.get_config_value(config_key, None, force=False)
-            except TypeError:
-                value = recruitment.get_config_value(config_key, None)
-            configured[field] = str(value).strip() if value is not None else ""
-        return tab, row, configured
-
     sheet_id = recruitment.get_recruitment_sheet_id()
     used_cached_header = bool(
         getattr(recruitment, "clan_header_cache_ready", lambda: False)()
     )
     summary = _QUOTA_SUMMARY.get()
 
-    try:
-        if used_cached_header:
-            tab_name, header_row, configured_headers = (
-                await _load_cached_header_with_async_config()
-            )
-        else:
-            tab_name, header_row, configured_headers = await _load_async_header()
-    except Exception:
-        # Compatibility path for callers/tests that only provide sync helpers.
-        # Run it off the event loop so sync Sheets retry/backoff cannot execute
-        # in the Discord event loop.
-        tab_name, header_row, configured_headers = await asyncio.to_thread(
-            _load_sync_for_thread
-        )
+    tab_name = await recruitment.get_clans_tab_name_async()
+    header_row = list(await recruitment.aget_clan_header_row(force=False))
+    configured_headers: dict[str, str] = {}
+    for field in AVAILABILITY_FIELDS:
+        config_key = f"clans_header_{field}"
+        value = await recruitment.get_config_value_async(config_key, None, force=False)
+        configured_headers[field] = str(value).strip() if value is not None else ""
 
     if summary is not None:
         summary.used_cached_header = used_cached_header
@@ -507,25 +455,10 @@ async def _afind_availability_clan_row(
     normalized_target = _normalize_tag(clan_tag)
     used_cached_row = bool(getattr(recruitment, "clan_cache_ready", lambda: False)())
 
-    def _sync_find_for_thread() -> tuple[int, list[str]] | None:
-        try:
-            return recruitment.find_clan_row(clan_tag, force=False)
-        except TypeError:
-            return recruitment.find_clan_row(clan_tag)
-
-    if used_cached_row:
-        try:
-            try:
-                clan_rows = recruitment.fetch_clans(force=False)
-            except TypeError:
-                clan_rows = recruitment.fetch_clans()
-        except Exception:
-            clan_rows = []
-    else:
-        try:
-            clan_rows = await recruitment.afetch_clans(force=False)
-        except Exception:
-            clan_rows = []
+    try:
+        clan_rows = await recruitment.afetch_clans(force=False)
+    except Exception:
+        clan_rows = []
 
     summary = _QUOTA_SUMMARY.get()
     if summary is not None:
@@ -542,12 +475,7 @@ async def _afind_availability_clan_row(
         if _normalize_tag(tag_value) == normalized_target:
             return idx + headers.header_row_index + 1, list(row)
 
-    if used_cached_row:
-        return _sync_find_for_thread()
-
-    # Compatibility fallback for sync-only test doubles/legacy callers, without
-    # running sync Sheets retry/backoff in the event loop.
-    return await asyncio.to_thread(_sync_find_for_thread)
+    return await recruitment.afind_clan_row(clan_tag, force=False)
 
 
 async def aresolve_configured_clan_tag(clan_tag: str) -> str:

--- a/tests/recruitment/test_availability_recompute.py
+++ b/tests/recruitment/test_availability_recompute.py
@@ -50,6 +50,36 @@ def _default_recruitment_config(monkeypatch):
     header[36] = "Clan Tag"
     monkeypatch.setattr(availability.recruitment, "get_clan_header_row", lambda: header)
 
+    async def get_clans_tab_name_async():
+        return availability.recruitment.get_clans_tab_name()
+
+    async def aget_clan_header_row(*, force=False):
+        try:
+            return availability.recruitment.get_clan_header_row(force=force)
+        except TypeError:
+            return availability.recruitment.get_clan_header_row()
+
+    async def get_config_value_async(key, default=None, *, force=False):
+        return availability.recruitment.get_config_value(key, default)
+
+    async def afetch_clans(*, force=False):
+        return []
+
+    async def afind_clan_row(tag, *, force=False):
+        return availability.recruitment.find_clan_row(tag, force=force)
+
+    monkeypatch.setattr(
+        availability.recruitment, "get_clans_tab_name_async", get_clans_tab_name_async
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "aget_clan_header_row", aget_clan_header_row
+    )
+    monkeypatch.setattr(
+        availability.recruitment, "get_config_value_async", get_config_value_async
+    )
+    monkeypatch.setattr(availability.recruitment, "afetch_clans", afetch_clans)
+    monkeypatch.setattr(availability.recruitment, "afind_clan_row", afind_clan_row)
+
 
 def test_recompute_clan_availability_updates_sheet(monkeypatch):
     worksheet = StubWorksheet()
@@ -802,6 +832,57 @@ def test_availability_header_config_resolves_production_columns(monkeypatch):
         "manual_open_spots_seen": "AJ",
         "clan_tag": "AK",
     }
+
+
+def test_async_availability_resolution_never_calls_sync_sheet_helpers(monkeypatch):
+    header = [""] * 37
+    configured = {field: field for field in availability.AVAILABILITY_FIELDS}
+    for index, field in enumerate(availability.AVAILABILITY_FIELDS):
+        header[index] = field
+
+    def fail_sync(*args, **kwargs):
+        pytest.fail("async availability path called a synchronous sheet helper")
+
+    for helper in (
+        "get_clans_tab_name",
+        "get_clan_header_row",
+        "get_config_value",
+        "fetch_clans",
+        "find_clan_row",
+    ):
+        monkeypatch.setattr(availability.recruitment, helper, fail_sync)
+
+    async def get_tab():
+        return "bot_info"
+
+    async def get_header(*, force=False):
+        assert force is False
+        return header
+
+    async def get_config(key, default=None, *, force=False):
+        assert force is False
+        return configured.get(key.removeprefix("clans_header_"), default)
+
+    async def fetch_clans(*, force=False):
+        assert force is False
+        return [["#OTHER"] + [""] * 36]
+
+    async def find_clan(tag, *, force=False):
+        assert tag == "#TARGET"
+        assert force is False
+        return (8, ["#TARGET"] + [""] * 36)
+
+    monkeypatch.setattr(availability.recruitment, "get_clans_tab_name_async", get_tab)
+    monkeypatch.setattr(availability.recruitment, "aget_clan_header_row", get_header)
+    monkeypatch.setattr(availability.recruitment, "get_config_value_async", get_config)
+    monkeypatch.setattr(availability.recruitment, "afetch_clans", fetch_clans)
+    monkeypatch.setattr(availability.recruitment, "afind_clan_row", find_clan)
+
+    async def exercise():
+        headers = await availability._aresolve_availability_headers()
+        return await availability._afind_availability_clan_row("#TARGET", headers)
+
+    assert asyncio.run(exercise()) == (8, ["#TARGET"] + [""] * 36)
 
 
 def test_preflight_clan_availability_wraps_worksheet_lookup_quota(monkeypatch):


### PR DESCRIPTION
### Motivation
- Eliminate synchronous Google Sheets helper fallbacks from async availability code paths to satisfy the async sheet-boundary guardrail and avoid running blocking sheet calls on the event loop.
- Be conservative: make the minimal runtime change required while preserving existing availability behavior and sync helper compatibility for synchronous callers.
- Ensure tests exercise the async-only path and assert synchronous helpers are not invoked from async flows.

### Description
- Replaced synchronous fallback logic in `_aresolve_availability_headers()` with exclusively async helpers: `get_clans_tab_name_async()`, `aget_clan_header_row(force=False)`, and `get_config_value_async(..., force=False)`; removed `asyncio.to_thread` and sync loader code paths.
- Rewrote `_afind_availability_clan_row()` to prefer `afetch_clans(force=False)` and return via `afind_clan_row(clan_tag, force=False)` instead of calling sync `fetch_clans`/`find_clan_row` or using `asyncio.to_thread` fallbacks.
- Updated `tests/recruitment/test_availability_recompute.py` to provide async recruitment helper doubles (`get_clans_tab_name_async`, `aget_clan_header_row`, `get_config_value_async`, `afetch_clans`, `afind_clan_row`) and added `test_async_availability_resolution_never_calls_sync_sheet_helpers` to assert the async path never exercises synchronous sheet helpers and that `force=False` is respected.
- Preserved behavior: open spot math, availability column/header resolution rules, clan-tag matching, quota logging semantics (aside from unavoidable quota-tracking metadata changes tied to removing the sync fallback), cache-first semantics, and all synchronous helper functions remain intact for sync callers/tests.

### Testing
- Ran `python -m pytest tests/recruitment/test_availability_recompute.py tests/test_runtime_async_sheet_boundary.py -q` and the targeted tests passed (23 tests) after updating test doubles to async helpers.
- Attempted broader run with `--timeout` plugin args as requested but the environment lacked the pytest timeout plugin, so the timed invocation was skipped; running the broader test set without the unavailable timeout args succeeded: `python -m pytest tests/community tests/housekeeping tests/modules tests/cogs tests/test_*.py --maxfail=25 --durations=20 -q` completed successfully.
- Added an explicit regression test `test_async_availability_resolution_never_calls_sync_sheet_helpers` which passed and enforces the async sheet-boundary for `availability.py`.

No recruitment board behavior, open spot math, schema, or ticket flow changes intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e45f6ba948323810564aa90265ed7)