### PR TITLE
Apply changed-file scoping for push-to-main runs in guardrails suite

### DIFF
--- a/.github/workflows/11-guardrails-suite.yml
+++ b/.github/workflows/11-guardrails-suite.yml
@@ -44,12 +44,19 @@ jobs:
           status_file=guardrails_status.txt
           exit_code=0
           base_ref="${{ github.base_ref || 'main' }}"
+          guardrails_base="origin/$base_ref"
           git fetch origin "$base_ref" --depth=1 || exit_code=$?
+          before_sha="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" = "push" ] && \
+             [ -n "$before_sha" ] && \
+             [[ ! "$before_sha" =~ ^0+$ ]]; then
+            guardrails_base="$before_sha"
+          fi
           python -m scripts.ci.guardrails_suite \
             --pr "${{ github.event.pull_request.number || 0 }}" \
             --status-file "$status_file" \
             --summary guardrails-comment.md \
-            --base-ref "origin/$base_ref" || exit_code=$?
+            --base-ref "$guardrails_base" || exit_code=$?
           if [ -f "$status_file" ]; then
             echo "guardrails_status=$(cat "$status_file")" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/ci/guardrails_suite.py
+++ b/scripts/ci/guardrails_suite.py
@@ -1330,7 +1330,7 @@ def run_checks(
     )
 
     check_results = _run_guardrail_checks(context)
-    if pr_number > 0:
+    if pr_number > 0 or changed_files:
         check_results = _scope_results_to_pr_changes(check_results, changed_files)
     categories = _build_categories(check_results)
     violations = [violation for result in check_results for violation in result.violations]

--- a/tests/config/test_guardrails_suite.py
+++ b/tests/config/test_guardrails_suite.py
@@ -389,14 +389,21 @@ def test_non_pr_scope_ignores_unchanged_historical_violations(
     (modules_dir / "historical.py").write_text("from ..legacy import helper\n", encoding="utf-8")
     (modules_dir / "changed.py").write_text("value = 1\n", encoding="utf-8")
 
-    monkeypatch.setattr(guardrails_suite, "_git_diff_names", lambda base_ref: ["modules/changed.py"])
+    base_sha = "a" * 40
     monkeypatch.setattr(
-        guardrails_suite, "_git_diff_status", lambda base_ref: {"modules/changed.py": "M"}
+        guardrails_suite,
+        "_git_diff_names",
+        lambda base_ref: ["modules/changed.py"] if base_ref == base_sha else [],
+    )
+    monkeypatch.setattr(
+        guardrails_suite,
+        "_git_diff_status",
+        lambda base_ref: {"modules/changed.py": "M"} if base_ref == base_sha else {},
     )
     monkeypatch.setattr(guardrails_suite, "_load_feature_toggle_names", lambda: set())
 
     suite = guardrails_suite.run_checks(
-        "origin/main",
+        base_sha,
         pr_body="",
         parity_status="success",
         pr_number=0,
@@ -405,6 +412,30 @@ def test_non_pr_scope_ignores_unchanged_historical_violations(
     c03_result = next(result for result in suite.check_results if result.code == "C-03")
     assert c03_result.status == "pass"
     assert c03_result.violations == []
+
+
+def test_non_pr_scope_preserves_full_repo_scan_without_diff_context(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    _configure_roots(tmp_path, monkeypatch)
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "historical.py").write_text("from ..legacy import helper\n", encoding="utf-8")
+
+    monkeypatch.setattr(guardrails_suite, "_git_diff_names", lambda base_ref: [])
+    monkeypatch.setattr(guardrails_suite, "_git_diff_status", lambda base_ref: {})
+    monkeypatch.setattr(guardrails_suite, "_load_feature_toggle_names", lambda: set())
+
+    suite = guardrails_suite.run_checks(
+        None,
+        pr_body="",
+        parity_status="success",
+        pr_number=0,
+    )
+
+    c03_result = next(result for result in suite.check_results if result.code == "C-03")
+    assert c03_result.status == "fail"
+    assert c03_result.violations[0].files == ["modules/historical.py:1"]
 
 
 def test_non_pr_scope_keeps_violations_in_changed_files(

--- a/tests/config/test_guardrails_suite.py
+++ b/tests/config/test_guardrails_suite.py
@@ -380,6 +380,59 @@ def test_pr_scope_keeps_violations_in_changed_files(tmp_path: Path, monkeypatch:
     assert c03_result.violations[0].files == ["modules/changed.py:1"]
 
 
+def test_non_pr_scope_ignores_unchanged_historical_violations(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    _configure_roots(tmp_path, monkeypatch)
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "historical.py").write_text("from ..legacy import helper\n", encoding="utf-8")
+    (modules_dir / "changed.py").write_text("value = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(guardrails_suite, "_git_diff_names", lambda base_ref: ["modules/changed.py"])
+    monkeypatch.setattr(
+        guardrails_suite, "_git_diff_status", lambda base_ref: {"modules/changed.py": "M"}
+    )
+    monkeypatch.setattr(guardrails_suite, "_load_feature_toggle_names", lambda: set())
+
+    suite = guardrails_suite.run_checks(
+        "origin/main",
+        pr_body="",
+        parity_status="success",
+        pr_number=0,
+    )
+
+    c03_result = next(result for result in suite.check_results if result.code == "C-03")
+    assert c03_result.status == "pass"
+    assert c03_result.violations == []
+
+
+def test_non_pr_scope_keeps_violations_in_changed_files(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    _configure_roots(tmp_path, monkeypatch)
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "changed.py").write_text("from ..legacy import helper\n", encoding="utf-8")
+
+    monkeypatch.setattr(guardrails_suite, "_git_diff_names", lambda base_ref: ["modules/changed.py"])
+    monkeypatch.setattr(
+        guardrails_suite, "_git_diff_status", lambda base_ref: {"modules/changed.py": "M"}
+    )
+    monkeypatch.setattr(guardrails_suite, "_load_feature_toggle_names", lambda: set())
+
+    suite = guardrails_suite.run_checks(
+        "origin/main",
+        pr_body="",
+        parity_status="success",
+        pr_number=0,
+    )
+
+    c03_result = next(result for result in suite.check_results if result.code == "C-03")
+    assert c03_result.status == "fail"
+    assert c03_result.violations[0].files == ["modules/changed.py:1"]
+
+
 def test_run_all_checks_returns_results(tmp_path: Path, monkeypatch: object) -> None:
     _configure_roots(tmp_path, monkeypatch)
 


### PR DESCRIPTION
### Motivation
- `run_checks(...)` only applied PR-scoped changed-file filtering when `pr_number > 0`, causing push-to-main runs (`--pr 0`) to fall back to a full-repo scan and fail on historical guardrail debt even when the pushed change was clean.
- The intent is to scope automated guardrail checks to available diff context when present, while preserving existing PR behavior and full-repo fallback when no diff context exists.

### Description
- Update `run_checks(...)` in `scripts/ci/guardrails_suite.py` to call `_scope_results_to_pr_changes(...)` when a non-empty `changed_files` list is available, in addition to the existing `pr_number > 0` condition.
- Add two focused regression tests in `tests/config/test_guardrails_suite.py`: `test_non_pr_scope_ignores_unchanged_historical_violations` and `test_non_pr_scope_keeps_violations_in_changed_files` exercising non-PR (push) behavior with a provided diff context.
- Change is limited to the guardrails runner and its tests and preserves `PR_GLOBAL_CHECKS` and `PR_DIFF_AWARE_CHECKS` semantics unchanged.

### Testing
- `python -m pytest tests/config/test_guardrails_suite.py -q` — all tests passed (19 passed); pytest emitted an existing `PytestConfigWarning` about the `asyncio_mode` config option.
- `python -m scripts.ci.guardrails_suite --pr 0 --status-file /tmp/guardrails-status.txt --summary /tmp/guardrails-summary.md --base-ref origin/main` — exited with code 1 and the status file contained `fail` because this checkout lacks an `origin/main` ref so no changed-file context could be resolved and the preserved full-repo fallback reported existing historical violations; the run also emitted an existing `datetime.utcnow()` deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e8a83984883238a3c4599b351b406)