### PR TITLE
Introduce sheet-driven shared help registry with interactive access view and caching

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -21,7 +21,6 @@ from discord.ext import commands
 
 from config.runtime import (
     get_bot_name,
-    get_command_prefix,
     get_env_name,
     get_watchdog_check_sec,
     get_watchdog_disconnect_grace_sec,
@@ -55,8 +54,6 @@ from c1c_coreops.help import (
     HelpTier,
     HelpTierSection,
     build_coreops_footer,
-    build_help_detail_embed,
-    build_help_overview_embeds,
 )
 from c1c_coreops.helpers import help_metadata, tier
 from shared.redaction import sanitize_embed, sanitize_log, sanitize_text
@@ -73,6 +70,7 @@ from shared.sheets.async_core import (
     afetch_records,
 )
 from shared.sheets.recruitment import get_config_value_async, get_reports_tab_name_async
+from shared.sheets import help_commands
 import shared.sheets.core as sheets_core
 from modules.common.config_sheets import SHEET_TARGETS, SheetTarget
 
@@ -84,6 +82,7 @@ from c1c_coreops.rbac import (
     can_view_staff,
     guild_only_denied_msg,
     is_admin_member,
+    is_recruiter,
     is_staff_member,
     ops_only,
 )
@@ -91,6 +90,56 @@ from c1c_coreops.rbac import (
 UTC = dt.timezone.utc
 
 logger = logging.getLogger(__name__)
+
+
+class _HelpPagesView(discord.ui.View):
+    """Non-expiring access-group controls over a cached embed snapshot."""
+
+    def __init__(self, overview: discord.Embed, pages: Sequence[tuple[str, discord.ButtonStyle, discord.Embed]]) -> None:
+        super().__init__(timeout=None)
+        self.embeds = (overview, *(page for _, _, page in pages))
+        for index, (label, style, embed) in enumerate(pages):
+            button = discord.ui.Button(label=label, style=style, custom_id=f"woadkeeper:help:access:{index}")
+
+            async def show_page(interaction: discord.Interaction, _embed: discord.Embed = embed) -> None:
+                await interaction.response.edit_message(embed=_embed, view=self)
+
+            button.callback = show_page
+            self.add_item(button)
+
+
+_HELP_ACCESS_GROUPS = (
+    ("User", "Commands", discord.ButtonStyle.primary, {"user", "public"}),
+    ("Staff / Recruitment", "Staff Commands", discord.ButtonStyle.success, {"staff", "recruiter"}),
+    ("Admin / Operational", "Admin Commands", discord.ButtonStyle.danger, {"admin", "hidden"}),
+)
+
+
+def _help_category_fields(rows: Sequence[help_commands.HelpCommandRow]) -> list[tuple[str, str]]:
+    """Build category sections, splitting only sections that exceed field limits."""
+    categories: dict[str, list[str]] = {}
+    ordered = sorted(rows, key=lambda row: (row.sort_order is None, row.sort_order or 0, row.source_order))
+    for row in ordered:
+        label = row.usage or row.command or f"!{help_commands.normalize_lookup(row.command_key)}"
+        categories.setdefault(row.category, []).append(f"**{label}**\n{row.summary or '—'}")
+
+    fields: list[tuple[str, str]] = []
+    for category, entries in categories.items():
+        chunks: list[str] = []
+        current = ""
+        for entry in entries:
+            candidate = f"{current}\n\n{entry}" if current else entry
+            if current and len(candidate) > 1024:
+                chunks.append(current)
+                current = entry
+            else:
+                current = candidate
+        if current:
+            chunks.append(current)
+        for index, value in enumerate(chunks, start=1):
+            suffix = f" ({index})" if len(chunks) > 1 else ""
+            fields.append((f"{category}{suffix}", value[:1024]))
+    return fields
 
 
 _HELP_DIAGNOSTICS_CACHE: Dict[tuple[str, int | None], float] = {}
@@ -3725,64 +3774,93 @@ class CoreOpsCog(commands.Cog):
     async def _render_help(
         self, ctx: commands.Context, *, query: str | None
     ) -> None:
-        prefix = get_command_prefix()
         bot_version = os.getenv("BOT_VERSION", "dev")
         bot_name = get_bot_name()
         lookup = query.strip() if isinstance(query, str) else ""
-
-        diagnostics: _HelpDiagnosticsCollector | None = None
-        if self._help_diagnostics_enabled():
-            diagnostics = self._create_help_diagnostics_collector()
-
-        if not lookup:
-            tiers = await self._gather_overview_tiers(ctx, diagnostics=diagnostics)
-            if not tiers:
-                await ctx.reply(str(sanitize_text("No commands available.")))
-                await self._maybe_emit_help_diagnostics(ctx, diagnostics)
-                return
-            embeds = build_help_overview_embeds(
-                prefix=prefix,
-                overview_title="C1C-Recruitment — help",
-                overview_description=self._help_bot_description(ctx, bot_name=bot_name),
-                tiers=tiers,
-                bot_version=bot_version,
-                notes=f" • For details: {self._help_command_label(ctx, 'help')}",
-                show_empty_sections=self._show_empty_sections(),
+        rows = await help_commands.get_rows()
+        if rows is None:
+            embed = discord.Embed(
+                title=f"{bot_name} · help temporarily unavailable",
+                description="I couldn't refresh shared help just now. Please try again a little later.",
+                colour=discord.Color.orange(),
             )
-            sanitized = [sanitize_embed(embed) for embed in embeds]
-            await self._reply_with_help_embeds(ctx, sanitized)
-            await self._maybe_emit_help_diagnostics(ctx, diagnostics)
+            embed.set_footer(text=build_coreops_footer(bot_version=bot_version))
+            await ctx.reply(embed=sanitize_embed(embed))
             return
 
-        normalized_lookup = " ".join(lookup.lower().split())
-        command = self.bot.get_command(normalized_lookup)
-        if command is None and not normalized_lookup.startswith("ops "):
-            command = self.bot.get_command(f"ops {normalized_lookup}")
-        if command is None:
-            await ctx.reply(str(sanitize_text(f"Unknown command `{lookup}`.")))
-            if diagnostics is not None:
-                await self._gather_overview_tiers(ctx, diagnostics=diagnostics)
-            await self._maybe_emit_help_diagnostics(ctx, diagnostics)
-            return
-
-        if not await self._can_display_command(command, ctx):
-            await ctx.reply(str(sanitize_text("You do not have access to that command.")))
-            if diagnostics is not None:
-                await self._gather_overview_tiers(ctx, diagnostics=diagnostics)
-            await self._maybe_emit_help_diagnostics(ctx, diagnostics)
-            return
-
-        command_info = self._build_help_info(command)
-        embed = build_help_detail_embed(
-            prefix=prefix,
-            command=command_info,
-            bot_version=bot_version,
-            bot_name=bot_name,
+        visible = help_commands.visible_rows(
+            rows,
+            staff=can_view_staff(ctx),
+            recruiter=is_recruiter(ctx),
+            admin=can_view_admin(ctx),
         )
-        await self._reply_with_help_embeds(ctx, [sanitize_embed(embed)])
-        if diagnostics is not None:
-            await self._gather_overview_tiers(ctx, diagnostics=diagnostics)
-        await self._maybe_emit_help_diagnostics(ctx, diagnostics)
+        if lookup:
+            row = help_commands.find_row(visible, lookup)
+            if row is None:
+                embed = discord.Embed(
+                    title=f"{bot_name} · help",
+                    description="No visible help entry was found for that command.",
+                    colour=discord.Color.blurple(),
+                )
+            else:
+                description_parts = [
+                    text for text in (row.summary, row.details) if text
+                ]
+                embed = discord.Embed(
+                    title=row.command or f"!{help_commands.normalize_lookup(row.command_key)}",
+                    description="\n\n".join(dict.fromkeys(description_parts)) or "—",
+                    colour=discord.Color.blurple(),
+                )
+            embed.set_footer(text=build_coreops_footer(bot_version=bot_version))
+            await ctx.reply(embed=sanitize_embed(embed))
+            return
+
+        overview = discord.Embed(
+            title=f"{bot_name} · shared help",
+            description=("Welcome to Woadkeeper's shared command help. Choose a command group below, or use "
+                         f"`{self._help_command_label(ctx, 'help <command>')}` for details."),
+            colour=discord.Color.blurple(),
+        )
+        overview.set_footer(text=build_coreops_footer(bot_version=bot_version))
+        overview = sanitize_embed(overview)
+
+        pages: list[tuple[str, discord.ButtonStyle, discord.Embed]] = []
+        for title, button_label, button_style, access_levels in _HELP_ACCESS_GROUPS:
+            access_rows = [row for row in visible if row.access_level in access_levels]
+            if not access_rows:
+                continue
+            field_pages: list[list[tuple[str, str]]] = []
+            current_fields: list[tuple[str, str]] = []
+            current_size = 0
+            for field in _help_category_fields(access_rows):
+                field_size = len(field[0]) + len(field[1])
+                if current_fields and (len(current_fields) >= 25 or current_size + field_size > 5_000):
+                    field_pages.append(current_fields)
+                    current_fields, current_size = [], 0
+                current_fields.append(field)
+                current_size += field_size
+            if current_fields:
+                field_pages.append(current_fields)
+
+            for page_number, page_fields in enumerate(field_pages, start=1):
+                page_suffix = f" {page_number}" if len(field_pages) > 1 else ""
+                embed = discord.Embed(
+                    title=f"{bot_name} · help · {title}{page_suffix}",
+                    description=f"{len(access_rows)} visible command{'s' if len(access_rows) != 1 else ''}, grouped by category.",
+                    colour=discord.Color.blurple(),
+                )
+                for category, commands_text in page_fields:
+                    embed.add_field(name=category, value=commands_text, inline=False)
+                embed.set_footer(
+                    text=build_coreops_footer(
+                        bot_version=bot_version,
+                        notes=f" • For details: {self._help_command_label(ctx, 'help <command>')}",
+                    )
+                )
+                label = button_label if page_number == 1 else f"{button_label} {page_number}"
+                pages.append((label, button_style, sanitize_embed(embed)))
+        view = _HelpPagesView(overview, pages) if pages else None
+        await ctx.reply(embed=overview, view=view)
 
     async def _reply_with_help_embeds(
         self, ctx: commands.Context, embeds: Sequence[discord.Embed]

--- a/packages/c1c-coreops/tests/test_help_renderer.py
+++ b/packages/c1c-coreops/tests/test_help_renderer.py
@@ -1,5 +1,4 @@
 import asyncio
-from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterable, Mapping, Sequence
@@ -29,13 +28,12 @@ def _resolve_member(target):
 
 _ensure_src_on_path()
 
-from c1c_coreops import help as help_module
-from c1c_coreops.cog import CoreOpsCog, _HelpSectionConfig
-from cogs.recruitment_clan_profile import ClanProfileCog
-from cogs.recruitment_member import RecruitmentMember
-from cogs.recruitment_recruiter import RecruiterPanelCog
-from cogs.recruitment_welcome import WelcomeBridge
-from modules.ops.permissions_ui import PermissionsUICog
+from c1c_coreops.cog import CoreOpsCog  # noqa: E402
+from cogs.recruitment_clan_profile import ClanProfileCog  # noqa: E402
+from cogs.recruitment_member import RecruitmentMember  # noqa: E402
+from cogs.recruitment_recruiter import RecruiterPanelCog  # noqa: E402
+from cogs.recruitment_welcome import WelcomeBridge  # noqa: E402
+from modules.ops.permissions_ui import PermissionsUICog  # noqa: E402
 
 
 class DummyMember:
@@ -58,6 +56,7 @@ class HelpContext:
         self.guild = SimpleNamespace(id=1234)
         self._coreops_suppress_denials = True
         self._replies: list[discord.Embed] = []
+        self._views: list[discord.ui.View | None] = []
         self.command = None
 
     async def reply(
@@ -65,12 +64,14 @@ class HelpContext:
         *args: object,
         embed: discord.Embed | None = None,
         embeds: Sequence[discord.Embed] | None = None,
+        view: discord.ui.View | None = None,
         **_: object,
     ) -> None:
         if embed is not None:
             self._replies.append(embed)
         if embeds:
             self._replies.extend(embeds)
+        self._views.append(view)
 
 
 @pytest.fixture(autouse=True)
@@ -212,193 +213,156 @@ def _collect_text(embed: discord.Embed) -> str:
     return " \n ".join(_fields(embed).values())
 
 
-OVERVIEW_SNAPSHOT = (
-    "**C1C-Recruitment keeps the doors open and the hearths warm.**  \n"
-    "It’s how we find new clanmates, help old friends move up, and keep every hall filled with good company.\n\n"
-    "**Members** can peek at which clans have room, check what’s needed to join or dig into details about any clan across the cluster.  \n\n"
-    "**Recruiters** use it to spot open slots, match new arrivals and drop welcome notes so nobody gets lost on day one.  \n\n"
-    "_All handled right here on Discord — fast, friendly, and stitched together with that usual C1C chaos and care._ \n\n"
-    "**To learn what a command does, type like this:**  \n"
-    "`C1C-Recruitment help ping` → shows info for `C1C-Recruitment ping`"
-)
+def _sheet_rows():
+    from shared.sheets.help_commands import HelpCommandRow
+
+    return (
+        HelpCommandRow("woadkeeper", "clan", "!clan", "!clan <tag>", "Recruitment", "user", "Clan details", "Detailed clan help", 1, 0),
+        HelpCommandRow("woadkeeper", "welcome", "!welcome", "!welcome", "Recruitment", "staff", "Welcome a recruit", "Detailed welcome help", 2, 1),
+        HelpCommandRow("woadkeeper", "ops_config", "!ops config", "!ops config", "Recruitment", "admin", "Show config", "Detailed config help", 3, 2),
+    )
 
 
-def test_help_admin_view(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_help_access_views_are_sheet_driven(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
-        embeds = await _gather_help_embeds(
-            monkeypatch,
-            DummyMember(is_admin=True, is_staff=True),
-            allowlist="env,health,refresh all",
-        )
-        assert len(embeds) == 4
-        overview, admin_embed, staff_embed, user_embed = embeds
+        async def rows(): return _sheet_rows()
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            await bot.get_cog("CoreOpsCog").render_help(ctx)
+            view = ctx._views[0]
+            assert len(view.embeds) == 2
+            assert "shared help" in view.embeds[0].title
+            assert "!clan <tag>" in _collect_text(view.embeds[1])
+            assert "!welcome" not in _collect_text(view.embeds[1])
+            assert [(item.label, item.style) for item in view.children] == [("Commands", discord.ButtonStyle.primary)]
+        finally:
+            await bot.close()
+    asyncio.run(runner())
 
-        assert overview.title == "C1C-Recruitment — help"
-        assert admin_embed.title == "Admin / Operational"
-        assert staff_embed.title == "Staff"
-        assert user_embed.title == "User"
 
-        admin_text = _collect_text(admin_embed)
-        staff_text = _collect_text(staff_embed)
-        user_text = _collect_text(user_embed)
+def test_help_pages_group_access_before_category(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        async def rows():
+            return _sheet_rows()
 
-        assert "`!health`" in admin_text
-        assert "`!refresh all`" in admin_text
-        assert "`!perm`" in admin_text
-        assert "`!welcome-refresh`" in admin_text
-        assert "@Bot" not in admin_text
-        assert "`!clan`" not in admin_text
-
-        assert "`!clanmatch`" in staff_text
-        assert "`!welcome`" in staff_text
-        assert "`!ops digest`" in staff_text
-        assert "`!welcome-refresh`" not in staff_text
-        assert "`!refresh all`" not in staff_text
-
-        assert "`!clan`" in user_text
-        assert "`!clansearch`" in user_text
-        assert "help" in user_text
-        assert "ping" in user_text
-        assert "@Bot" not in user_text
-        assert "!ops" not in user_text
-
-        combined_text = " \n ".join(
-            value for embed in embeds for value in _fields(embed).values()
-        )
-        assert "!rec" not in combined_text
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        monkeypatch.setattr("c1c_coreops.cog.can_view_admin", lambda _: True)
+        monkeypatch.setattr("c1c_coreops.cog.can_view_staff", lambda _: True)
+        monkeypatch.setattr("c1c_coreops.cog.is_recruiter", lambda _: True)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember(is_admin=True, is_staff=True))
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx)
+            view = ctx._views[0]
+            assert view is not None
+            assert [embed.title for embed in view.embeds] == [
+                "C1C-Recruitment · shared help",
+                "C1C-Recruitment · help · User",
+                "C1C-Recruitment · help · Staff / Recruitment",
+                "C1C-Recruitment · help · Admin / Operational",
+            ]
+            assert [field.name for field in view.embeds[1].fields] == ["Recruitment"]
+            assert [item.label for item in view.children] == ["Commands", "Staff Commands", "Admin Commands"]
+        finally:
+            await bot.close()
 
     asyncio.run(runner())
 
 
-def test_help_staff_view(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_help_categories_are_sections_on_one_access_page(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
-        embeds = await _gather_help_embeds(
-            monkeypatch,
-            DummyMember(is_staff=True),
-            allowlist="env,health,refresh all",
-        )
-        assert len(embeds) == 3
-        titles = {embed.title: embed for embed in embeds}
-        assert "Admin / Operational" not in titles
+        from shared.sheets.help_commands import HelpCommandRow
+        async def rows():
+            return (
+                HelpCommandRow("woadkeeper", "later", "!later", "!later", "Utility", "user", "Later", "Details", 20, 0),
+                HelpCommandRow("woadkeeper", "first", "!first", "!first", "Utility", "user", "First", "Details", 10, 1),
+                HelpCommandRow("woadkeeper", "clan", "!clan", "!clan", "Clans", "user", "Clan", "Details", 30, 2),
+            )
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            await bot.get_cog("CoreOpsCog").render_help(ctx)
+            view = ctx._views[0]
+            assert len(view.embeds) == 2  # overview + one User access page
+            assert [field.name for field in view.embeds[1].fields] == ["Utility", "Clans"]
+            utility = view.embeds[1].fields[0].value
+            assert utility.index("!first") < utility.index("!later")
+        finally:
+            await bot.close()
+    asyncio.run(runner())
 
-        staff_embed = titles["Staff"]
-        user_embed = titles["User"]
 
-        staff_text = _collect_text(staff_embed)
-        user_text = _collect_text(user_embed)
+def test_recruiter_only_access_renders_recruiter_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        from shared.sheets.help_commands import HelpCommandRow
 
-        assert "`!clanmatch`" in staff_text
-        assert "`!welcome`" in staff_text
-        assert "`!ops digest`" in staff_text
-        assert "`!ops config`" not in staff_text
-        assert "`!welcome-refresh`" not in staff_text
-        assert "`!refresh all`" not in staff_text
+        async def rows():
+            return (
+                HelpCommandRow("woadkeeper", "user", "!user", "!user", "General", "user", "User", "Details", 1, 0),
+                HelpCommandRow("woadkeeper", "recruit", "!recruit", "!recruit", "Recruitment", "recruiter", "Recruit", "Details", 2, 1),
+                HelpCommandRow("woadkeeper", "staff", "!staff", "!staff", "Operations", "staff", "Staff", "Details", 3, 2),
+            )
 
-        assert "`!clan`" in user_text
-        assert "`!clansearch`" in user_text
-        assert "help" in user_text
-        assert "ping" in user_text
-        assert "@Bot" not in user_text
-        assert "!ops" not in user_text
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        monkeypatch.setattr("c1c_coreops.cog.can_view_admin", lambda _: False)
+        monkeypatch.setattr("c1c_coreops.cog.can_view_staff", lambda _: False)
+        monkeypatch.setattr("c1c_coreops.cog.is_recruiter", lambda _: True)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx)
+            view = ctx._views[0]
+            assert view is not None
+            assert [embed.title for embed in view.embeds] == [
+                "C1C-Recruitment · shared help",
+                "C1C-Recruitment · help · User",
+                "C1C-Recruitment · help · Staff / Recruitment",
+            ]
+            assert [field.name for field in view.embeds[2].fields] == ["Recruitment"]
+            assert "!recruit" in _collect_text(view.embeds[2])
+            assert "!staff" not in _collect_text(view.embeds[2])
+        finally:
+            await bot.close()
 
     asyncio.run(runner())
 
 
-def test_help_staff_view_with_empty_sections(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_help_detail_is_clean_and_uses_normalized_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
-        placeholder = _HelpSectionConfig("void", "Placeholder", ())
-        staff_config = CoreOpsCog._HELP_AUDIENCE_CONFIGS["staff"]
-        monkeypatch.setitem(
-            CoreOpsCog._HELP_AUDIENCE_CONFIGS,
-            "staff",
-            replace(staff_config, sections=(placeholder,)),
-        )
+        async def rows():
+            return _sheet_rows()
 
-        embeds = await _gather_help_embeds(
-            monkeypatch,
-            DummyMember(is_staff=True),
-            show_empty=True,
-            allowlist="env,health,refresh all",
-        )
-
-        titles = {embed.title: embed for embed in embeds}
-        assert "Staff" in titles
-        staff_embed = titles["Staff"]
-
-        fields = getattr(staff_embed, "fields", ())
-        assert fields, "expected placeholder fields for empty staff tier"
-        assert all(getattr(field, "value", "") == "Coming soon" for field in fields)
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx, query="!clan")
+            embed = ctx._replies[0]
+            assert embed.title == "!clan"
+            assert embed.description == "Clan details\n\nDetailed clan help"
+            assert list(embed.fields) == []
+        finally:
+            await bot.close()
 
     asyncio.run(runner())
 
 
-def test_help_user_view(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def runner() -> None:
-        embeds = await _gather_help_embeds(
-            monkeypatch,
-            DummyMember(),
-            allowlist="env,health,refresh all",
-        )
-        assert len(embeds) == 2
-        titles = {embed.title: embed for embed in embeds}
-        assert "Admin / Operational" not in titles
-        assert "Staff" not in titles
+def test_help_unavailable_is_an_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rows():
+        return None
 
-        user_embed = titles["User"]
-
-        user_text = _collect_text(user_embed)
-        assert "`!clan`" in user_text
-        assert "`!clansearch`" in user_text
-        assert "help" in user_text
-        assert "ping" in user_text
-        assert "@Bot" not in user_text
-        assert "!ops" not in user_text
-
-    asyncio.run(runner())
-
-
-def test_help_no_hardcoding(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def runner() -> None:
-        called = False
-
-        embeds: list[discord.Embed] = []
-
-        async def gather() -> None:
-            nonlocal called, embeds
-            bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
-
-            await bot.add_cog(CoreOpsCog(bot))
-
-            original_walk = bot.walk_commands
-
-            def _walk_commands():
-                nonlocal called
-                called = True
-                yield from original_walk()
-
-            monkeypatch.setattr(bot, "walk_commands", _walk_commands)
-
-            await bot.add_cog(PermissionsUICog(bot))
-            await bot.add_cog(RecruiterPanelCog(bot))
-            await bot.add_cog(WelcomeBridge(bot))
-            await bot.add_cog(RecruitmentMember(bot))
-            await bot.add_cog(ClanProfileCog(bot))
-
-            try:
-                ctx = HelpContext(bot, author=DummyMember(is_admin=True, is_staff=True))
-                cog = bot.get_cog("CoreOpsCog")
-                assert cog is not None
-                await cog.render_help(ctx)
-                embeds = ctx._replies
-            finally:
-                await bot.close()
-
-        await gather()
-        assert called, "walk_commands was not invoked"
-        assert embeds, "expected help embeds"
-        assert not hasattr(help_module, "HELP_COMMAND_REGISTRY")
-
-    asyncio.run(runner())
+    monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+    embed = asyncio.run(_gather_help_embeds(monkeypatch, DummyMember()))[0]
+    assert "temporarily unavailable" in (embed.title or "")
 
 
 def test_all_commands_have_brief(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -409,20 +373,9 @@ def test_all_commands_have_brief(monkeypatch: pytest.MonkeyPatch) -> None:
             for command in bot.walk_commands():
                 if getattr(command, "hidden", False):
                     continue
-                brief = getattr(command, "brief", None)
-                assert isinstance(brief, str) and brief.strip(), command.qualified_name
+                description = getattr(command, "brief", None) or getattr(command, "help", None)
+                assert isinstance(description, str) and description.strip(), command.qualified_name
         finally:
             await bot.close()
-
-    asyncio.run(runner())
-
-
-def test_overview_text_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def runner() -> None:
-        embeds = await _gather_help_embeds(
-            monkeypatch,
-            DummyMember(is_admin=True, is_staff=True),
-        )
-        assert embeds[0].description == OVERVIEW_SNAPSHOT
 
     asyncio.run(runner())

--- a/shared/sheets/cache_service.py
+++ b/shared/sheets/cache_service.py
@@ -68,8 +68,9 @@ class CacheBucket:
         "last_item_count",
         "last_trigger",
         "last_ttl_expired",
+        "retry_delay_sec",
     )
-    def __init__(self, name: str, ttl_sec: int, loader: Loader):
+    def __init__(self, name: str, ttl_sec: int, loader: Loader, *, retry_delay_sec: int = 300):
         self.name = name
         self.ttl_sec = ttl_sec
         self.loader = loader
@@ -83,6 +84,7 @@ class CacheBucket:
         self.last_item_count: Optional[int] = None
         self.last_trigger: Optional[str] = None
         self.last_ttl_expired: Optional[bool] = None
+        self.retry_delay_sec = retry_delay_sec
 
     def age_sec(self) -> Optional[int]:
         if not self.last_refresh:
@@ -98,8 +100,10 @@ class CacheService:
     def __init__(self):
         self._buckets: Dict[str, CacheBucket] = {}
 
-    def register(self, name: str, ttl_sec: int, loader: Loader) -> CacheBucket:
-        b = CacheBucket(name, ttl_sec, loader)
+    def register(
+        self, name: str, ttl_sec: int, loader: Loader, *, retry_delay_sec: int = 300
+    ) -> CacheBucket:
+        b = CacheBucket(name, ttl_sec, loader, retry_delay_sec=retry_delay_sec)
         self._buckets[name] = b
         return b
 
@@ -203,7 +207,7 @@ class CacheService:
                 first_err = _errtext(exc)
                 err_text = first_err
                 b.last_error = first_err
-                await asyncio.sleep(300)  # 5 minutes
+                await asyncio.sleep(b.retry_delay_sec)
                 try:
                     with sheets_audit.log_read(
                         component="cache_service",

--- a/shared/sheets/help_commands.py
+++ b/shared/sheets/help_commands.py
@@ -1,0 +1,214 @@
+"""Config-driven, cached source for the shared Discord help registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from shared.sheets.async_core import acall_with_backoff, aget_worksheet
+from shared.sheets import recruitment
+
+BUCKET_NAME = "helpcommands"
+CACHE_TTL_SEC = 24 * 60 * 60
+REQUIRED_HEADERS = (
+    "enabled",
+    "bot_key",
+    "command_key",
+    "command",
+    "usage",
+    "category",
+    "access_level",
+    "summary",
+    "details",
+    "sort_order",
+)
+
+
+@dataclass(frozen=True)
+class HelpCommandRow:
+    bot_key: str
+    command_key: str
+    command: str
+    usage: str
+    category: str
+    access_level: str
+    summary: str
+    details: str
+    sort_order: float | None
+    source_order: int
+
+
+def _truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _header_map(headers: Sequence[object]) -> tuple[dict[str, int], list[str]]:
+    mapped = {
+        str(header or "").strip().lower(): index
+        for index, header in enumerate(headers)
+        if str(header or "").strip()
+    }
+    return mapped, [header for header in REQUIRED_HEADERS if header not in mapped]
+
+
+def parse_rows(values: Sequence[Sequence[object]]) -> tuple[HelpCommandRow, ...]:
+    """Parse a values matrix using header names rather than column positions."""
+
+    if not values:
+        raise RuntimeError("Shared help sheet is empty.")
+    headers = values[0]
+    columns, missing = _header_map(headers)
+    if missing:
+        raise RuntimeError(
+            "Shared help sheet is missing headers: " + ", ".join(missing)
+        )
+
+    parsed: list[HelpCommandRow] = []
+    for source_order, raw_row in enumerate(values[1:]):
+
+        def value(name: str) -> str:
+            index = columns[name]
+            return str(raw_row[index] if index < len(raw_row) else "").strip()
+
+        if not _truthy(value("enabled")):
+            continue
+        raw_sort = value("sort_order")
+        try:
+            sort_order = float(raw_sort)
+        except (TypeError, ValueError):
+            sort_order = None
+        parsed.append(
+            HelpCommandRow(
+                bot_key=value("bot_key"),
+                command_key=value("command_key"),
+                command=value("command"),
+                usage=value("usage"),
+                category=value("category") or "Other",
+                access_level=value("access_level").lower() or "user",
+                summary=value("summary"),
+                details=value("details"),
+                sort_order=sort_order,
+                source_order=source_order,
+            )
+        )
+    parsed.sort(
+        key=lambda row: (
+            row.sort_order is None,
+            row.sort_order if row.sort_order is not None else 0,
+            row.source_order,
+        )
+    )
+    return tuple(parsed)
+
+
+async def _load() -> tuple[HelpCommandRow, ...]:
+    sheet_id = recruitment.get_recruitment_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("RECRUITMENT_SHEET_ID is required for shared help.")
+    tab_name = str(
+        await recruitment.get_config_value_async("HELP_COMMANDS_TAB", None) or ""
+    ).strip()
+    if not tab_name:
+        raise RuntimeError("Config key HELP_COMMANDS_TAB is required for shared help.")
+    worksheet = await aget_worksheet(sheet_id, tab_name)
+    values = await acall_with_backoff(worksheet.get_all_values)
+    return parse_rows(values or [])
+
+
+def register_cache_buckets() -> None:
+    from shared.sheets.cache_service import cache
+
+    if cache.get_bucket(BUCKET_NAME) is None:
+        # Help should fail soft immediately; a Discord request must never wait for
+        # the cache service's usual delayed retry.
+        cache.register(BUCKET_NAME, CACHE_TTL_SEC, _load, retry_delay_sec=0)
+
+
+async def get_rows() -> tuple[HelpCommandRow, ...] | None:
+    """Return fresh or stale rows; synchronously warm only a completely cold cache."""
+
+    from shared.sheets.cache_service import cache
+
+    register_cache_buckets()
+    bucket = cache.get_bucket(BUCKET_NAME)
+    assert bucket is not None
+    if bucket.value is None:
+        await cache.refresh_now(BUCKET_NAME, actor="help", trigger="runtime")
+        value = bucket.value
+    else:
+        value = await cache.get(BUCKET_NAME)
+    return value if isinstance(value, tuple) else None
+
+
+def normalize_lookup(value: object) -> str:
+    text = " ".join(str(value or "").strip().lower().split())
+    return text.lstrip("!").strip()
+
+
+def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | None:
+    needle = normalize_lookup(query)
+    for row in rows:
+        candidates = (
+            row.command_key.replace("_", " "),
+            row.command,
+            row.usage.split(" ", 1)[0],
+        )
+        if any(normalize_lookup(candidate) == needle for candidate in candidates):
+            return row
+    return None
+
+
+def visible_rows(
+    rows: Sequence[HelpCommandRow],
+    *,
+    staff: bool,
+    recruiter: bool = False,
+    admin: bool,
+) -> tuple[HelpCommandRow, ...]:
+    allowed = {"user", "public"}
+    if staff:
+        allowed.add("staff")
+    if recruiter:
+        allowed.add("recruiter")
+    if admin:
+        allowed.update({"staff", "recruiter", "admin", "hidden"})
+    return tuple(row for row in rows if row.access_level in allowed)
+
+
+def group_rows(
+    rows: Sequence[HelpCommandRow],
+) -> tuple[tuple[str, str, tuple[HelpCommandRow, ...]], ...]:
+    """Group rows by access level, then category, then numeric display order."""
+
+    access_rank = {
+        "public": 0,
+        "user": 0,
+        "recruiter": 1,
+        "staff": 2,
+        "admin": 3,
+        "hidden": 4,
+    }
+
+    def row_key(row: HelpCommandRow) -> tuple[int, str, str, bool, float, int]:
+        return (
+            access_rank.get(row.access_level, 99),
+            row.access_level,
+            row.category.casefold(),
+            row.sort_order is None,
+            row.sort_order if row.sort_order is not None else 0,
+            row.source_order,
+        )
+
+    grouped: list[tuple[str, str, tuple[HelpCommandRow, ...]]] = []
+    current_key: tuple[str, str] | None = None
+    current_rows: list[HelpCommandRow] = []
+    for row in sorted(rows, key=row_key):
+        key = (row.access_level, row.category)
+        if current_key is not None and key != current_key:
+            grouped.append((*current_key, tuple(current_rows)))
+            current_rows = []
+        current_key = key
+        current_rows.append(row)
+    if current_key is not None:
+        grouped.append((*current_key, tuple(current_rows)))
+    return tuple(grouped)

--- a/shared/sheets/runtime.py
+++ b/shared/sheets/runtime.py
@@ -15,6 +15,7 @@ def register_default_cache_buckets() -> None:
     import shared.sheets.recruitment as recruitment
     import shared.sheets.reaction_roles as reaction_roles
     import shared.sheets.feature_refresh as feature_refresh
+    import shared.sheets.help_commands as help_commands
 
     onboarding.register_cache_buckets()
     onboarding_questions.register_cache_buckets()
@@ -23,3 +24,4 @@ def register_default_cache_buckets() -> None:
     recruitment.register_cache_buckets()
     reaction_roles.register_cache_buckets()
     feature_refresh.register_cache_buckets()
+    help_commands.register_cache_buckets()

--- a/tests/shared/sheets/test_help_commands.py
+++ b/tests/shared/sheets/test_help_commands.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+
+from shared.sheets import help_commands
+from shared.sheets.cache_service import cache
+
+
+HEADERS = list(help_commands.REQUIRED_HEADERS)
+
+
+def _row(**overrides: object) -> list[object]:
+    values = {
+        "enabled": "TRUE",
+        "bot_key": "woadkeeper",
+        "command_key": "clan",
+        "command": "!clan",
+        "usage": "!clan <tag>",
+        "category": "Recruitment",
+        "access_level": "user",
+        "summary": "Clan details",
+        "details": "Shows clan details.",
+        "sort_order": "20",
+    }
+    values.update(overrides)
+    return [values[name] for name in HEADERS]
+
+
+def test_parser_resolves_reordered_headers_hides_disabled_and_sorts() -> None:
+    reordered = list(reversed(HEADERS))
+    source = [
+        reordered,
+        list(reversed(_row(command="!late", command_key="late", sort_order="30"))),
+        list(
+            reversed(
+                _row(command="!off", command_key="off", enabled="FALSE", sort_order="1")
+            )
+        ),
+        list(reversed(_row(command="!early", command_key="early", sort_order="2"))),
+        list(
+            reversed(
+                _row(command="!fallback", command_key="fallback", sort_order="bad")
+            )
+        ),
+    ]
+
+    rows = help_commands.parse_rows(source)
+
+    assert [row.command for row in rows] == ["!early", "!late", "!fallback"]
+
+
+def test_lookup_normalizes_leading_bang_and_access_filtering() -> None:
+    rows = help_commands.parse_rows(
+        [
+            HEADERS,
+            _row(),
+            _row(command="!secret", command_key="secret", access_level="admin"),
+        ]
+    )
+
+    assert help_commands.find_row(rows, "clan") == help_commands.find_row(rows, "!clan")
+    assert [
+        row.command
+        for row in help_commands.visible_rows(rows, staff=False, admin=False)
+    ] == ["!clan"]
+    assert [
+        row.command for row in help_commands.visible_rows(rows, staff=True, admin=False)
+    ] == ["!clan"]
+    assert len(help_commands.visible_rows(rows, staff=True, admin=True)) == 2
+
+
+def test_recruiter_only_visibility_uses_separate_access() -> None:
+    rows = help_commands.parse_rows(
+        [
+            HEADERS,
+            _row(command="!user", command_key="user"),
+            _row(command="!recruit", command_key="recruit", access_level="recruiter"),
+            _row(command="!staff", command_key="staff", access_level="staff"),
+        ]
+    )
+
+    visible = help_commands.visible_rows(rows, staff=False, recruiter=True, admin=False)
+
+    assert [row.command for row in visible] == ["!user", "!recruit"]
+
+
+def test_grouping_splits_access_before_dynamic_category_and_numeric_order() -> None:
+    rows = help_commands.parse_rows(
+        [
+            HEADERS,
+            _row(
+                command="!staff-late",
+                command_key="staff_late",
+                category="Zulu",
+                access_level="staff",
+                sort_order="20",
+            ),
+            _row(command="!user", command_key="user", category="Zulu", sort_order="99"),
+            _row(
+                command="!staff-early",
+                command_key="staff_early",
+                category="Zulu",
+                access_level="staff",
+                sort_order="2",
+            ),
+            _row(
+                command="!staff-alpha",
+                command_key="staff_alpha",
+                category="Alpha",
+                access_level="staff",
+                sort_order="50",
+            ),
+        ]
+    )
+
+    grouped = help_commands.group_rows(rows)
+
+    assert [(access, category) for access, category, _ in grouped] == [
+        ("user", "Zulu"),
+        ("staff", "Alpha"),
+        ("staff", "Zulu"),
+    ]
+    assert [row.command for row in grouped[-1][2]] == ["!staff-early", "!staff-late"]
+
+
+def test_loader_uses_config_selected_tab_and_one_values_read(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class Worksheet:
+        def get_all_values(self):
+            calls.append(("read", "once"))
+            return [HEADERS, _row()]
+
+    async def config(key, default):
+        assert key == "HELP_COMMANDS_TAB"
+        return "ConfiguredHelpTab"
+
+    async def worksheet(sheet_id, tab):
+        calls.append((sheet_id, tab))
+        return Worksheet()
+
+    async def direct_call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    sheet_id_calls = 0
+
+    def sheet_id():
+        nonlocal sheet_id_calls
+        sheet_id_calls += 1
+        return "sheet-id"
+
+    monkeypatch.delenv("RECRUITMENT_SHEET_ID", raising=False)
+    monkeypatch.setattr(help_commands.recruitment, "get_recruitment_sheet_id", sheet_id)
+    monkeypatch.setattr(help_commands.recruitment, "get_config_value_async", config)
+    monkeypatch.setattr(help_commands, "aget_worksheet", worksheet)
+    monkeypatch.setattr(help_commands, "acall_with_backoff", direct_call)
+
+    rows = asyncio.run(help_commands._load())
+
+    assert rows[0].command == "!clan"
+    assert sheet_id_calls == 1
+    assert calls == [("sheet-id", "ConfiguredHelpTab"), ("read", "once")]
+
+
+def test_cache_ttl_prevents_reads_and_failed_refresh_keeps_stale(monkeypatch) -> None:
+    cache._buckets.pop(help_commands.BUCKET_NAME, None)
+    reads = 0
+
+    async def loader():
+        nonlocal reads
+        reads += 1
+        if reads > 1:
+            raise RuntimeError("temporary outage")
+        return help_commands.parse_rows([HEADERS, _row()])
+
+    monkeypatch.setattr(help_commands, "_load", loader)
+    first = asyncio.run(help_commands.get_rows())
+    second = asyncio.run(help_commands.get_rows())
+    assert first == second
+    assert reads == 1
+
+    bucket = cache.get_bucket(help_commands.BUCKET_NAME)
+    assert bucket is not None
+    bucket.last_refresh = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
+    asyncio.run(cache.refresh_now(help_commands.BUCKET_NAME, actor="test"))
+    assert bucket.value == first
+    assert bucket.last_result == "fail"
+
+
+def test_manual_helpcommands_bucket_refresh_reloads_immediately(monkeypatch) -> None:
+    cache._buckets.pop(help_commands.BUCKET_NAME, None)
+    reads = 0
+
+    async def loader():
+        nonlocal reads
+        reads += 1
+        return help_commands.parse_rows([HEADERS, _row(summary=f"version {reads}")])
+
+    monkeypatch.setattr(help_commands, "_load", loader)
+    first = asyncio.run(help_commands.get_rows())
+    asyncio.run(cache.refresh_now("helpcommands", actor="admin"))
+    bucket = cache.get_bucket("helpcommands")
+
+    assert first is not None and first[0].summary == "version 1"
+    assert bucket is not None and bucket.value[0].summary == "version 2"
+    assert reads == 2


### PR DESCRIPTION
### Motivation

- Provide a central, sheet-driven shared help registry so help content can be edited via Google Sheets and surfaced consistently across bots.
- Make help output role-aware and interactive by grouping commands into access-level pages with button navigation, and ensure recruiter-specific access is supported.
- Ensure the shared help data is cached and resilient to transient sheet outages without blocking Discord requests.

### Description

- Add `shared.sheets.help_commands` implementing parsing of a header-driven sheet (`HelpCommandRow`), lookup/visibility helpers, grouping, and a cached loader integrating with the existing cache service and runtime registration.
- Add `_HelpPagesView` and `_help_category_fields` to `c1c_coreops.cog` and refactor `CoreOpsCog._render_help` to render sheet-driven embeds and a non-expiring `discord.ui.View` of access-group pages instead of the prior command-walk overview; use `help_commands.get_rows`, `visible_rows`, and `find_row` for lookups and filtering.
- Extend the cache service (`shared/sheets/cache_service.py`) to allow per-bucket `retry_delay_sec` so certain buckets (help) can retry with zero delay; wire the new option through `CacheBucket` and `CacheService.register` and use the bucket's `retry_delay_sec` on loader failure retries.
- Register the new help bucket in `shared.sheets.runtime.register_default_cache_buckets` so it is automatically initialized at startup.
- Update tests in `packages/c1c-coreops/tests/test_help_renderer.py` to exercise the new sheet-driven help view and recruiter/admin/staff filtering, and add `tests/shared/sheets/test_help_commands.py` covering parsing, grouping, loading, caching, and refresh behavior.

### Testing

- Ran the updated help renderer unit tests (`packages/c1c-coreops/tests/test_help_renderer.py`) under `pytest`; they exercise rendering of overview, access pages, detail lookups, and view/button construction and passed.
- Ran the new sheet helper unit tests (`tests/shared/sheets/test_help_commands.py`) which validate parsing, lookup/visibility, grouping, loader integration, cache TTL behavior, and manual refresh, and they passed.
- Executed full unit test suite covering modified modules with `pytest` to ensure no regressions in help-related code and cache behavior; all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f56c087d88323b59d8fa1f6a9e494)