### PR TITLE
Resolve shared-help conflicts and preserve access-group display

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -95,14 +95,23 @@ logger = logging.getLogger(__name__)
 class _HelpAccessView(discord.ui.View):
     """Non-expiring access-group controls over an already-cached snapshot."""
 
-    def __init__(self, embeds: Mapping[str, discord.Embed]) -> None:
+    def __init__(self, embeds: Mapping[str, discord.Embed], *, requester_id: int) -> None:
         super().__init__(timeout=None)
         self.embeds = dict(embeds)
+        self.requester_id = requester_id
         for item in tuple(self.children):
             if isinstance(item, discord.ui.Button) and item.custom_id:
                 access = item.custom_id.rsplit(":", 1)[-1]
                 if access not in self.embeds:
                     self.remove_item(item)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id == self.requester_id:
+            return True
+        await interaction.response.send_message(
+            "Run !help to open your own help menu.", ephemeral=True
+        )
+        return False
 
     async def _show(self, interaction: discord.Interaction, access: str) -> None:
         await interaction.response.edit_message(embed=self.embeds[access], view=self)
@@ -3834,7 +3843,10 @@ class CoreOpsCog(commands.Cog):
             colour=discord.Color.blurple(),
         )
         overview.set_footer(text=build_coreops_footer(bot_version=bot_version))
-        await ctx.reply(embed=sanitize_embed(overview), view=_HelpAccessView(access_embeds))
+        await ctx.reply(
+            embed=sanitize_embed(overview),
+            view=_HelpAccessView(access_embeds, requester_id=ctx.author.id),
+        )
 
     async def _reply_with_help_embeds(
         self, ctx: commands.Context, embeds: Sequence[discord.Embed]

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -92,30 +92,32 @@ UTC = dt.timezone.utc
 logger = logging.getLogger(__name__)
 
 
-class _HelpPagesView(discord.ui.View):
-    """Non-expiring page controls over an already-cached embed snapshot."""
+class _HelpAccessView(discord.ui.View):
+    """Non-expiring access-group controls over an already-cached snapshot."""
 
-    def __init__(self, embeds: Sequence[discord.Embed]) -> None:
+    def __init__(self, embeds: Mapping[str, discord.Embed]) -> None:
         super().__init__(timeout=None)
-        self.embeds = tuple(embeds)
-        self.index = 0
-        self._sync_buttons()
+        self.embeds = dict(embeds)
+        for item in tuple(self.children):
+            if isinstance(item, discord.ui.Button) and item.custom_id:
+                access = item.custom_id.rsplit(":", 1)[-1]
+                if access not in self.embeds:
+                    self.remove_item(item)
 
-    def _sync_buttons(self) -> None:
-        self.previous.disabled = self.index == 0
-        self.next.disabled = self.index >= len(self.embeds) - 1
+    async def _show(self, interaction: discord.Interaction, access: str) -> None:
+        await interaction.response.edit_message(embed=self.embeds[access], view=self)
 
-    @discord.ui.button(label="Previous", style=discord.ButtonStyle.secondary, custom_id="woadkeeper:help:previous")
-    async def previous(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
-        self.index = max(0, self.index - 1)
-        self._sync_buttons()
-        await interaction.response.edit_message(embed=self.embeds[self.index], view=self)
+    @discord.ui.button(label="Commands", style=discord.ButtonStyle.primary, custom_id="woadkeeper:help:user")
+    async def commands(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        await self._show(interaction, "user")
 
-    @discord.ui.button(label="Next", style=discord.ButtonStyle.secondary, custom_id="woadkeeper:help:next")
-    async def next(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
-        self.index = min(len(self.embeds) - 1, self.index + 1)
-        self._sync_buttons()
-        await interaction.response.edit_message(embed=self.embeds[self.index], view=self)
+    @discord.ui.button(label="Staff Commands", style=discord.ButtonStyle.success, custom_id="woadkeeper:help:staff")
+    async def staff_commands(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        await self._show(interaction, "staff")
+
+    @discord.ui.button(label="Admin Commands", style=discord.ButtonStyle.danger, custom_id="woadkeeper:help:admin")
+    async def admin_commands(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        await self._show(interaction, "admin")
 
 
 _HELP_DIAGNOSTICS_CACHE: Dict[tuple[str, int | None], float] = {}
@@ -3779,48 +3781,21 @@ class CoreOpsCog(commands.Cog):
                     colour=discord.Color.blurple(),
                 )
             else:
+                description_parts = [value for value in (row.summary, row.details) if value]
                 embed = discord.Embed(
                     title=row.command or f"!{help_commands.normalize_lookup(row.command_key)}",
-                    description=row.details or row.summary or "—",
+                    description="\n\n".join(dict.fromkeys(description_parts)) or "—",
                     colour=discord.Color.blurple(),
                 )
-                for label, value in (
-                    ("Command", row.command),
-                    ("Usage", row.usage),
-                    ("Category", row.category),
-                    ("Access level", row.access_level),
-                    ("Summary", row.summary),
-                    ("Details", row.details),
-                    ("Owning bot", row.bot_key),
-                ):
-                    embed.add_field(name=label, value=value or "—", inline=False)
             embed.set_footer(text=build_coreops_footer(bot_version=bot_version))
             await ctx.reply(embed=sanitize_embed(embed))
             return
 
-        embeds: list[discord.Embed] = []
-        for access_level, category, category_rows in help_commands.group_rows(visible):
-            for offset in range(0, len(category_rows), 25):
-                page_rows = category_rows[offset : offset + 25]
-                page = offset // 25 + 1
-                page_count = (len(category_rows) + 24) // 25
-                page_suffix = f" · {page}/{page_count}" if page_count > 1 else ""
-                embed = discord.Embed(
-                    title=f"{bot_name} · help · {access_level.title()} · {category}{page_suffix}",
-                    description=f"Shared command help ({len(category_rows)} command{'s' if len(category_rows) != 1 else ''}).",
-                    colour=discord.Color.blurple(),
-                )
-                for row in page_rows:
-                    label = row.usage or row.command or f"!{help_commands.normalize_lookup(row.command_key)}"
-                    embed.add_field(name=label, value=row.summary or "—", inline=False)
-                embed.set_footer(
-                    text=build_coreops_footer(
-                        bot_version=bot_version,
-                        notes=f" • For details: {self._help_command_label(ctx, 'help <command>')}",
-                    )
-                )
-                embeds.append(sanitize_embed(embed))
-        if not embeds:
+        access_categories: dict[str, dict[str, list[help_commands.HelpCommandRow]]] = {}
+        for row in visible:
+            access = "user" if row.access_level == "user" else "admin" if row.access_level == "admin" else "staff"
+            access_categories.setdefault(access, {}).setdefault(row.category, []).append(row)
+        if not access_categories:
             embed = discord.Embed(
                 title=f"{bot_name} · help",
                 description="No help entries are currently visible to you.",
@@ -3829,8 +3804,37 @@ class CoreOpsCog(commands.Cog):
             embed.set_footer(text=build_coreops_footer(bot_version=bot_version))
             await ctx.reply(embed=sanitize_embed(embed))
             return
-        view = _HelpPagesView(embeds) if len(embeds) > 1 else None
-        await ctx.reply(embed=embeds[0], view=view)
+
+        access_embeds: dict[str, discord.Embed] = {}
+        access_titles = {"user": "Commands", "staff": "Staff Commands", "admin": "Admin Commands"}
+        access_colours = {"user": discord.Color.blurple(), "staff": discord.Color.green(), "admin": discord.Color.red()}
+        for access, categories in access_categories.items():
+            embed = discord.Embed(
+                title=f"{bot_name} · {access_titles[access]}",
+                description="Choose a command below. Categories are grouped as sections.",
+                colour=access_colours[access],
+            )
+            for category, category_rows in categories.items():
+                lines = []
+                for row in category_rows:
+                    label = row.usage or row.command or f"!{help_commands.normalize_lookup(row.command_key)}"
+                    lines.append(f"**{label}** — {row.summary or '—'}")
+                embed.add_field(name=category, value="\n".join(lines), inline=False)
+            embed.set_footer(
+                text=build_coreops_footer(
+                    bot_version=bot_version,
+                    notes=f" • For details: {self._help_command_label(ctx, 'help <command>')}",
+                )
+            )
+            access_embeds[access] = sanitize_embed(embed)
+
+        overview = discord.Embed(
+            title=f"{bot_name} · help",
+            description="Select a command access group below to browse the shared help menu.",
+            colour=discord.Color.blurple(),
+        )
+        overview.set_footer(text=build_coreops_footer(bot_version=bot_version))
+        await ctx.reply(embed=sanitize_embed(overview), view=_HelpAccessView(access_embeds))
 
     async def _reply_with_help_embeds(
         self, ctx: commands.Context, embeds: Sequence[discord.Embed]

--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -95,26 +95,44 @@ logger = logging.getLogger(__name__)
 class _HelpAccessView(discord.ui.View):
     """Non-expiring access-group controls over an already-cached snapshot."""
 
-    def __init__(self, embeds: Mapping[str, discord.Embed], *, requester_id: int) -> None:
+    def __init__(
+        self,
+        embeds: Mapping[str, Sequence[discord.Embed]],
+        *,
+        requester_id: int,
+    ) -> None:
         super().__init__(timeout=None)
-        self.embeds = dict(embeds)
+        self.embeds = {access: tuple(pages) for access, pages in embeds.items()}
         self.requester_id = requester_id
+        self.access: str | None = None
+        self.page = 0
         for item in tuple(self.children):
             if isinstance(item, discord.ui.Button) and item.custom_id:
                 access = item.custom_id.rsplit(":", 1)[-1]
-                if access not in self.embeds:
+                if access in {"user", "staff", "admin"} and access not in self.embeds:
                     self.remove_item(item)
+        self._sync_page_buttons()
+
+    def _sync_page_buttons(self) -> None:
+        page_count = len(self.embeds.get(self.access or "", ()))
+        self.previous.disabled = self.access is None or self.page == 0
+        self.next.disabled = self.access is None or self.page >= page_count - 1
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id == self.requester_id:
             return True
-        await interaction.response.send_message(
-            "Run !help to open your own help menu.", ephemeral=True
+        embed = discord.Embed(
+            description="Run !help to open your own help menu.",
+            colour=discord.Color.orange(),
         )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
         return False
 
     async def _show(self, interaction: discord.Interaction, access: str) -> None:
-        await interaction.response.edit_message(embed=self.embeds[access], view=self)
+        self.access = access
+        self.page = 0
+        self._sync_page_buttons()
+        await interaction.response.edit_message(embed=self.embeds[access][0], view=self)
 
     @discord.ui.button(label="Commands", style=discord.ButtonStyle.primary, custom_id="woadkeeper:help:user")
     async def commands(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
@@ -127,6 +145,21 @@ class _HelpAccessView(discord.ui.View):
     @discord.ui.button(label="Admin Commands", style=discord.ButtonStyle.danger, custom_id="woadkeeper:help:admin")
     async def admin_commands(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
         await self._show(interaction, "admin")
+
+    @discord.ui.button(label="Previous", style=discord.ButtonStyle.secondary, custom_id="woadkeeper:help:previous")
+    async def previous(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        self.page = max(0, self.page - 1)
+        self._sync_page_buttons()
+        await interaction.response.edit_message(
+            embed=self.embeds[self.access or "user"][self.page], view=self
+        )
+
+    @discord.ui.button(label="Next", style=discord.ButtonStyle.secondary, custom_id="woadkeeper:help:next")
+    async def next(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        pages = self.embeds[self.access or "user"]
+        self.page = min(len(pages) - 1, self.page + 1)
+        self._sync_page_buttons()
+        await interaction.response.edit_message(embed=pages[self.page], view=self)
 
 
 _HELP_DIAGNOSTICS_CACHE: Dict[tuple[str, int | None], float] = {}
@@ -242,6 +275,8 @@ _ENV_FIELD_CHUNK_LIMIT = 1000
 _EMBED_TOTAL_CHAR_LIMIT = 6000
 _EMBED_FIELD_LIMIT = 25
 _MAX_EMBED_LENGTH = 4500
+_HELP_FIELD_VALUE_LIMIT = 1000
+_HELP_EMBED_CHAR_LIMIT = 5500
 _ZERO_WIDTH_SPACE = "\u200b"
 _DIGEST_SHEET_BUCKETS: Tuple[Tuple[str, str], ...] = (
     ("clans", "ClanInfo"),
@@ -257,6 +292,33 @@ _TELEMETRY_REQUIRED_KEYS: Tuple[str, ...] = (
     "last_error",
     "retries",
 )
+
+
+def _help_field_chunks(lines: Sequence[str]) -> list[str]:
+    """Pack help lines into complete field values below Discord's limit."""
+
+    chunks: list[str] = []
+    current = ""
+    for line in lines:
+        parts = textwrap.wrap(
+            line,
+            width=_HELP_FIELD_VALUE_LIMIT,
+            break_long_words=True,
+            break_on_hyphens=False,
+            replace_whitespace=False,
+            drop_whitespace=False,
+        ) or ["—"]
+        for part in parts:
+            candidate = f"{current}\n{part}" if current else part
+            if len(candidate) <= _HELP_FIELD_VALUE_LIMIT:
+                current = candidate
+                continue
+            if current:
+                chunks.append(current)
+            current = part
+    if current:
+        chunks.append(current)
+    return chunks
 _TELEMETRY_FALLBACK_KEYS: Tuple[str, ...] = (
     "name",
     "available",
@@ -3814,28 +3876,58 @@ class CoreOpsCog(commands.Cog):
             await ctx.reply(embed=sanitize_embed(embed))
             return
 
-        access_embeds: dict[str, discord.Embed] = {}
+        access_embeds: dict[str, tuple[discord.Embed, ...]] = {}
         access_titles = {"user": "Commands", "staff": "Staff Commands", "admin": "Admin Commands"}
         access_colours = {"user": discord.Color.blurple(), "staff": discord.Color.green(), "admin": discord.Color.red()}
         for access, categories in access_categories.items():
-            embed = discord.Embed(
-                title=f"{bot_name} · {access_titles[access]}",
-                description="Choose a command below. Categories are grouped as sections.",
-                colour=access_colours[access],
-            )
+            field_specs: list[tuple[str, str]] = []
             for category, category_rows in categories.items():
                 lines = []
                 for row in category_rows:
                     label = row.usage or row.command or f"!{help_commands.normalize_lookup(row.command_key)}"
                     lines.append(f"**{label}** — {row.summary or '—'}")
-                embed.add_field(name=category, value="\n".join(lines), inline=False)
-            embed.set_footer(
-                text=build_coreops_footer(
-                    bot_version=bot_version,
-                    notes=f" • For details: {self._help_command_label(ctx, 'help <command>')}",
-                )
+                for chunk_index, value in enumerate(_help_field_chunks(lines)):
+                    heading = category if chunk_index == 0 else f"{category} (continued)"
+                    field_specs.append((heading[:256], value))
+
+            title = f"{bot_name} · {access_titles[access]}"
+            description = "Choose a command below. Categories are grouped as sections."
+            pages: list[discord.Embed] = []
+            embed = discord.Embed(
+                title=title,
+                description=description,
+                colour=access_colours[access],
             )
-            access_embeds[access] = sanitize_embed(embed)
+            embed_chars = len(title) + len(description)
+            for heading, value in field_specs:
+                field_chars = len(heading) + len(value)
+                if embed.fields and (
+                    len(embed.fields) >= _EMBED_FIELD_LIMIT
+                    or embed_chars + field_chars > _HELP_EMBED_CHAR_LIMIT
+                ):
+                    pages.append(embed)
+                    embed = discord.Embed(
+                        title=title,
+                        description=description,
+                        colour=access_colours[access],
+                    )
+                    embed_chars = len(title) + len(description)
+                embed.add_field(name=heading, value=value, inline=False)
+                embed_chars += field_chars
+            pages.append(embed)
+
+            page_count = len(pages)
+            footer = build_coreops_footer(
+                bot_version=bot_version,
+                notes=f" • For details: {self._help_command_label(ctx, 'help <command>')}",
+            )
+            for page_number, page_embed in enumerate(pages, start=1):
+                if page_count > 1:
+                    page_embed.title = f"{title} · {page_number}/{page_count}"
+                page_embed.set_footer(text=footer)
+            access_embeds[access] = tuple(
+                sanitize_embed(page_embed) for page_embed in pages
+            )
 
         overview = discord.Embed(
             title=f"{bot_name} · help",

--- a/packages/c1c-coreops/tests/test_help_renderer.py
+++ b/packages/c1c-coreops/tests/test_help_renderer.py
@@ -239,7 +239,7 @@ def test_help_access_views_are_sheet_driven(monkeypatch: pytest.MonkeyPatch) -> 
             assert ctx._replies[0].title == "C1C-Recruitment · help"
             view = ctx._views[0]
             assert view is not None
-            user = view.embeds["user"]
+            user = view.embeds["user"][0]
             assert "!clan <tag>" in _collect_text(user)
             assert "!welcome" not in _collect_text(user)
         finally:
@@ -266,11 +266,15 @@ def test_help_pages_group_categories_inside_access_pages(monkeypatch: pytest.Mon
             view = ctx._views[0]
             assert view is not None
             assert set(view.embeds) == {"user", "staff", "admin"}
-            assert list(_fields(view.embeds["user"])) == ["Recruitment"]
-            assert list(_fields(view.embeds["staff"])) == ["Recruitment"]
-            assert list(_fields(view.embeds["admin"])) == ["Recruitment"]
+            assert list(_fields(view.embeds["user"][0])) == ["Recruitment"]
+            assert list(_fields(view.embeds["staff"][0])) == ["Recruitment"]
+            assert list(_fields(view.embeds["admin"][0])) == ["Recruitment"]
 
-            buttons = {button.label: button.style for button in view.children}
+            buttons = {
+                button.label: button.style
+                for button in view.children
+                if button.label in {"Commands", "Staff Commands", "Admin Commands"}
+            }
             assert buttons == {
                 "Commands": discord.ButtonStyle.primary,
                 "Staff Commands": discord.ButtonStyle.success,
@@ -300,9 +304,59 @@ def test_help_access_buttons_reject_non_owner(monkeypatch: pytest.MonkeyPatch) -
             interaction = SimpleNamespace(user=SimpleNamespace(id=999), response=response)
 
             assert await view.interaction_check(interaction) is False
-            response.send_message.assert_awaited_once_with(
-                "Run !help to open your own help menu.", ephemeral=True
+            response.send_message.assert_awaited_once()
+            kwargs = response.send_message.await_args.kwargs
+            assert kwargs["ephemeral"] is True
+            assert kwargs["embed"].description == "Run !help to open your own help menu."
+        finally:
+            await bot.close()
+
+    asyncio.run(runner())
+
+
+def test_help_long_category_splits_without_dropping_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def runner() -> None:
+        from shared.sheets.help_commands import HelpCommandRow
+
+        expected_commands = [f"!command-{index}" for index in range(70)]
+
+        async def rows():
+            return tuple(
+                HelpCommandRow(
+                    "woadkeeper",
+                    f"command_{index}",
+                    command,
+                    command,
+                    "Very Long Category",
+                    "user",
+                    f"Summary {index}: " + ("help text " * 12),
+                    "Details",
+                    index,
+                    index,
+                )
+                for index, command in enumerate(expected_commands)
             )
+
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx)
+            view = ctx._views[0]
+            assert view is not None
+            pages = view.embeds["user"]
+            assert len(pages) > 1
+            assert all(len(field.value) <= 1000 for page in pages for field in page.fields)
+            assert all(len(page.fields) <= 25 and len(page) <= 6000 for page in pages)
+            rendered = "\n".join(
+                field.value for page in pages for field in page.fields
+            )
+            missing = [command for command in expected_commands if command not in rendered]
+            assert not missing, missing
         finally:
             await bot.close()
 
@@ -333,8 +387,8 @@ def test_recruiter_only_access_renders_recruiter_page(monkeypatch: pytest.Monkey
             view = ctx._views[0]
             assert view is not None
             assert set(view.embeds) == {"user", "staff"}
-            assert "!recruit" in _collect_text(view.embeds["staff"])
-            assert "!staff" not in _collect_text(view.embeds["staff"])
+            assert "!recruit" in _collect_text(view.embeds["staff"][0])
+            assert "!staff" not in _collect_text(view.embeds["staff"][0])
         finally:
             await bot.close()
 

--- a/packages/c1c-coreops/tests/test_help_renderer.py
+++ b/packages/c1c-coreops/tests/test_help_renderer.py
@@ -2,6 +2,7 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterable, Mapping, Sequence
+from unittest.mock import AsyncMock
 
 import discord
 import pytest
@@ -275,6 +276,33 @@ def test_help_pages_group_categories_inside_access_pages(monkeypatch: pytest.Mon
                 "Staff Commands": discord.ButtonStyle.success,
                 "Admin Commands": discord.ButtonStyle.danger,
             }
+        finally:
+            await bot.close()
+
+    asyncio.run(runner())
+
+
+def test_help_access_buttons_reject_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        async def rows():
+            return _sheet_rows()
+
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx)
+            view = ctx._views[0]
+            assert view is not None
+            response = SimpleNamespace(send_message=AsyncMock())
+            interaction = SimpleNamespace(user=SimpleNamespace(id=999), response=response)
+
+            assert await view.interaction_check(interaction) is False
+            response.send_message.assert_awaited_once_with(
+                "Run !help to open your own help menu.", ephemeral=True
+            )
         finally:
             await bot.close()
 

--- a/packages/c1c-coreops/tests/test_help_renderer.py
+++ b/packages/c1c-coreops/tests/test_help_renderer.py
@@ -224,17 +224,30 @@ def _sheet_rows():
 
 
 def test_help_access_views_are_sheet_driven(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def rows():
-        return _sheet_rows()
+    async def runner() -> None:
+        async def rows():
+            return _sheet_rows()
 
-    monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
-    user = asyncio.run(_gather_help_embeds(monkeypatch, DummyMember()))[0]
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            ctx = HelpContext(bot, DummyMember())
+            cog = bot.get_cog("CoreOpsCog")
+            assert cog is not None
+            await cog.render_help(ctx)
+            assert ctx._replies[0].title == "C1C-Recruitment · help"
+            view = ctx._views[0]
+            assert view is not None
+            user = view.embeds["user"]
+            assert "!clan <tag>" in _collect_text(user)
+            assert "!welcome" not in _collect_text(user)
+        finally:
+            await bot.close()
 
-    assert "!clan <tag>" in _fields(user)
-    assert "!welcome" not in _fields(user)
+    asyncio.run(runner())
 
 
-def test_help_pages_group_access_before_category(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_help_pages_group_categories_inside_access_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
         async def rows():
             return _sheet_rows()
@@ -251,11 +264,17 @@ def test_help_pages_group_access_before_category(monkeypatch: pytest.MonkeyPatch
             await cog.render_help(ctx)
             view = ctx._views[0]
             assert view is not None
-            assert [embed.title for embed in view.embeds] == [
-                "C1C-Recruitment · help · User · Recruitment",
-                "C1C-Recruitment · help · Staff · Recruitment",
-                "C1C-Recruitment · help · Admin · Recruitment",
-            ]
+            assert set(view.embeds) == {"user", "staff", "admin"}
+            assert list(_fields(view.embeds["user"])) == ["Recruitment"]
+            assert list(_fields(view.embeds["staff"])) == ["Recruitment"]
+            assert list(_fields(view.embeds["admin"])) == ["Recruitment"]
+
+            buttons = {button.label: button.style for button in view.children}
+            assert buttons == {
+                "Commands": discord.ButtonStyle.primary,
+                "Staff Commands": discord.ButtonStyle.success,
+                "Admin Commands": discord.ButtonStyle.danger,
+            }
         finally:
             await bot.close()
 
@@ -285,9 +304,9 @@ def test_recruiter_only_access_renders_recruiter_page(monkeypatch: pytest.Monkey
             await cog.render_help(ctx)
             view = ctx._views[0]
             assert view is not None
-            titles = [embed.title for embed in view.embeds]
-            assert "C1C-Recruitment · help · Recruiter · Recruitment" in titles
-            assert not any("Staff · Operations" in title for title in titles)
+            assert set(view.embeds) == {"user", "staff"}
+            assert "!recruit" in _collect_text(view.embeds["staff"])
+            assert "!staff" not in _collect_text(view.embeds["staff"])
         finally:
             await bot.close()
 
@@ -306,10 +325,10 @@ def test_help_detail_uses_sheet_fields_and_normalized_lookup(monkeypatch: pytest
             cog = bot.get_cog("CoreOpsCog")
             assert cog is not None
             await cog.render_help(ctx, query="!clan")
-            fields = _fields(ctx._replies[0])
-            assert fields["Usage"] == "!clan <tag>"
-            assert fields["Details"] == "Detailed clan help"
-            assert fields["Owning bot"] == "woadkeeper"
+            embed = ctx._replies[0]
+            assert embed.title == "!clan"
+            assert embed.description == "Clan details\n\nDetailed clan help"
+            assert not embed.fields
         finally:
             await bot.close()
 


### PR DESCRIPTION
### Motivation
- Resolve merge conflicts after the shared-help infrastructure landed in main while keeping that Sheets-driven infrastructure intact. 
- Preserve the follow-up UX changes from the feature branch so `!help` opens an overview and then exposes permission-aware access-group navigation. 
- Keep Google Sheets, sheet accessors, and unrelated commands unchanged. 

### Description
- Replaced the old page-style view with an access-group view (`_HelpAccessView`) that exposes three access-group buttons: `Commands` (primary/blue), `Staff Commands` (success/green), and `Admin Commands` (danger/red). 
- Render `!help` as an overview embed and produce one access-level embed per visible access group where categories are fields/section headings inside that access page (no one-page-per-category unless needed). 
- Simplified `!help <command>` output to a clean embed with only the title and a description combining summary and details, and removed metadata fields. 
- Tests updated to assert the overview + access-group pages, category-as-field layout, correct button labels/styles, and metadata-free command-detail embed; shared Sheets helpers and cache runtime files were not altered. 

### Testing
- Ran `pytest -q packages/c1c-coreops/tests/test_help_renderer.py tests/shared/sheets/test_help_commands.py` and all tests passed. 
- Ran static/format checks with `python -m ruff check packages/c1c-coreops/src/c1c_coreops/cog.py packages/c1c-coreops/tests/test_help_renderer.py` and they passed. 
- Ran repository guardrails with `python -m scripts.ci.guardrails_suite --pr 1041 --base-ref HEAD --status-file <temp>/status --summary <temp>/summary` and all guardrail checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f6cb2243083239d321dc1b576f43e)