### PR TITLE
Send shared and clan welcome templates as two embeds

### DIFF
--- a/modules/recruitment/welcome.py
+++ b/modules/recruitment/welcome.py
@@ -201,28 +201,19 @@ async def _load_templates() -> tuple[dict[str, WelcomeTemplate], Optional[Welcom
     rows = await sheets.get_cached_welcome_templates()
     templates: dict[str, WelcomeTemplate] = {}
     default_row: WelcomeTemplate | None = None
-    alt_default: WelcomeTemplate | None = None
-
     for row in rows or []:
         template = _build_template(row)
         if template is None:
             continue
         key = template.tag
-        if key in {"C1C", "DEFAULT"}:
-            if key == "C1C":
-                default_row = template
-            else:
-                alt_default = template
+        if key == "C1C":
+            default_row = template
+            continue
+        if key == "DEFAULT":
             continue
         templates[key] = template
 
-    default_row = default_row or alt_default
-
-    merged: dict[str, WelcomeTemplate] = {}
-    for key, template in templates.items():
-        merged[key] = template.merged_with(default_row)
-
-    return merged, default_row
+    return templates, default_row
 
 
 def _timezone() -> timezone:
@@ -331,6 +322,52 @@ def _expand_tokens(
     return _strip_empty_role_lines(_replace_emoji_tokens(text, guild))
 
 
+def _build_welcome_embed(
+    template: WelcomeTemplate,
+    *,
+    guild: discord.Guild,
+    tag: str,
+    inviter: discord.Member | discord.User | None,
+    target: discord.Member | discord.User | None,
+    extra_body: str = "",
+    include_crest: bool = False,
+) -> discord.Embed:
+    """Build one welcome embed using only the supplied template row."""
+
+    title = _expand_tokens(
+        template.title,
+        guild=guild,
+        template=template,
+        tag=tag,
+        inviter=inviter,
+        target=target,
+    )
+    body = _expand_tokens(
+        template.body,
+        guild=guild,
+        template=template,
+        tag=tag,
+        inviter=inviter,
+        target=target,
+    )
+    footer = _expand_tokens(
+        template.footer,
+        guild=guild,
+        template=template,
+        tag=tag,
+        inviter=inviter,
+        target=target,
+    )
+    description = f"{body}\n\n{extra_body}".strip() if extra_body else body
+    embed = discord.Embed(title=title or None, description=description, colour=discord.Colour.blue())
+    embed.timestamp = datetime.now(timezone.utc)
+    if footer:
+        embed.set_footer(text=footer)
+    if include_crest and template.crest_url.strip():
+        embed.set_thumbnail(url=template.crest_url.strip())
+    return embed
+
+
 async def _log(level: str, **kv: Any) -> None:
     payload = " ".join(f"{key}={value}" for key, value in kv.items() if value is not None)
     message = f"[welcome/{level}] {payload}" if payload else f"[welcome/{level}]"
@@ -426,7 +463,21 @@ class WelcomeCommandService:
             )
             return
 
-        effective = template.merged_with(default_row)
+        if default_row is None or not default_row.active:
+            cause = "missing_cluster_row" if default_row is None else "inactive_cluster_row"
+            await _log("error", actor=getattr(ctx.author, "id", None), tag=tag, cause=cause)
+            error = discord.Embed(
+                title="Shared C1C welcome template unavailable",
+                description=(
+                    "The active **C1C** row in WelcomeTemplates is missing or unavailable. "
+                    "No welcome was posted."
+                ),
+                colour=discord.Colour.red(),
+            )
+            await ctx.reply(embed=error)
+            return
+
+        effective = template
         raw_channel_value = str(template.raw.get("TARGET_CHANNEL_ID", "") or "").strip()
         if raw_channel_value and not effective.target_channel_id:
             await _log(
@@ -474,60 +525,53 @@ class WelcomeCommandService:
             channel=summary_channel,
         )
 
-        title = _expand_tokens(
-            effective.title,
+        cluster_embed = _build_welcome_embed(
+            default_row,
             guild=ctx.guild,
-            template=effective,
-            tag=tag,
+            tag=default_row.tag,
             inviter=getattr(ctx, "author", None),
             target=target_member,
         )
-        body = _expand_tokens(
-            effective.body,
+        clan_embed = _build_welcome_embed(
+            effective,
             guild=ctx.guild,
-            template=effective,
             tag=tag,
             inviter=getattr(ctx, "author", None),
             target=target_member,
-        )
-        footer = _expand_tokens(
-            effective.footer,
-            guild=ctx.guild,
-            template=effective,
-            tag=tag,
-            inviter=getattr(ctx, "author", None),
-            target=target_member,
+            extra_body=note_text,
+            include_crest=True,
         )
 
-        if not body.strip():
+        if not (cluster_embed.description or "").strip():
             await _log("error", actor=getattr(ctx.author, "id", None), tag=tag, cause="empty_body")
-            await ctx.reply("Missing welcome text. Please check the **C1C** row in the sheet.")
+            error = discord.Embed(
+                title="Shared C1C welcome template unavailable",
+                description="The **C1C** row has no usable welcome text. No welcome was posted.",
+                colour=discord.Colour.red(),
+            )
+            await ctx.reply(embed=error)
+            if summary is not None:
+                summary.record("command", "error", "empty_cluster_body")
+                await summary.emit()
+                summary = None
+            return
+
+        if not (clan_embed.description or "").strip():
+            await _log("error", actor=getattr(ctx.author, "id", None), tag=tag, cause="empty_body")
+            await ctx.reply(f"Missing welcome text for **{tag}**. Please check WelcomeTemplates.")
             if summary is not None:
                 summary.record("command", "error", "empty_body")
                 await summary.emit()
                 summary = None
             return
 
-        description = body
-        if note_text:
-            description = f"{body}\n\n{note_text}".strip()
-
-        embed = discord.Embed(title=title or None, description=description, colour=discord.Colour.blue())
-        embed.timestamp = datetime.now(timezone.utc)
-
-        if footer:
-            embed.set_footer(text=footer)
-
-        crest_url = effective.crest_url.strip()
-        if crest_url:
-            try:
-                embed.set_thumbnail(url=crest_url)
-            except Exception:
-                await _log("warn", tag=tag, cause="crest_failed", url=crest_url)
-
         ping_content = target_member.mention if (target_member and effective.ping_user) else None
         try:
-            await channel.send(content=ping_content, embed=embed)
+            await channel.send(
+                content=ping_content,
+                embeds=[cluster_embed, clan_embed],
+                allowed_mentions=None,
+            )
         except Exception as exc:
             await _log(
                 "error",

--- a/tests/recruitment/test_welcome_command.py
+++ b/tests/recruitment/test_welcome_command.py
@@ -17,9 +17,16 @@ class FakeChannel:
     async def send(self, *args, **kwargs):
         content = kwargs.get("content")
         embed = kwargs.get("embed")
+        embeds = kwargs.get("embeds")
+        allowed_mentions = kwargs.get("allowed_mentions")
         if args:
             content = args[0]
-        payload = {"content": content, "embed": embed}
+        payload = {
+            "content": content,
+            "embed": embed,
+            "embeds": embeds,
+            "allowed_mentions": allowed_mentions,
+        }
         self.sent.append(payload)
         return SimpleNamespace(content=content, embed=embed)
 
@@ -82,9 +89,9 @@ class FakeContext:
         self.message = message
         self.replies = []
 
-    async def reply(self, content=None):
+    async def reply(self, content=None, **kwargs):
         self.replies.append(content)
-        return await self.channel.send(content=content)
+        return await self.channel.send(content=content, **kwargs)
 
     async def send(self, content=None):
         return await self.channel.send(content=content)
@@ -123,8 +130,17 @@ def _template_rows():
     ]
 
 
-def test_welcome_happy_path_posts_embed(monkeypatch, stub_logs):
+def test_welcome_happy_path_posts_two_embeds_in_one_message(monkeypatch, stub_logs):
     async def scenario():
+        rows = _template_rows()
+        rows[1].update(
+            {
+                "TAG": "C1C9",
+                "TITLE": "Welcome to {CLAN}",
+                "BODY": "Lead: {CLANLEAD}\nDeputies: {DEPUTIES}",
+                "FOOTER": "Clan footer",
+            }
+        )
         clan_channel = FakeChannel(123)
         general_channel = FakeChannel(999)
         bot = FakeBot(channels=[clan_channel, general_channel])
@@ -134,7 +150,7 @@ def test_welcome_happy_path_posts_embed(monkeypatch, stub_logs):
         message = FakeMessage(mentions=[recruit])
         ctx = FakeContext(bot=bot, guild=guild, channel=FakeChannel(555), author=author, message=message)
 
-        template_loader = AsyncMock(return_value=_template_rows())
+        template_loader = AsyncMock(return_value=rows)
         monkeypatch.setattr(
             welcome_module.sheets,
             "get_cached_welcome_templates",
@@ -143,16 +159,24 @@ def test_welcome_happy_path_posts_embed(monkeypatch, stub_logs):
         monkeypatch.setattr(welcome_module, "get_welcome_general_channel_id", lambda: 999)
 
         bridge = WelcomeBridge(bot)
-        await bridge.welcome.callback(bridge, ctx, "C1CM")  # type: ignore[misc]
+        await bridge.welcome.callback(bridge, ctx, "C1C9")  # type: ignore[misc]
 
         assert len(clan_channel.sent) == 1
         sent = clan_channel.sent[0]
         assert sent["content"] == recruit.mention
-        embed = sent["embed"]
-        assert embed.title == "Welcome <@8>"
-        assert embed.thumbnail.url == "https://example.com/crest.png"
-        assert embed.footer.text == "Footer Deputy One, Deputy Two"
-        assert "Lead Name" in embed.description
+        assert sent["allowed_mentions"] is None
+        assert len(sent["embeds"]) == 2
+        cluster_embed, clan_embed = sent["embeds"]
+        assert cluster_embed.title == "Default C1C Title"
+        assert cluster_embed.description == "Default body for C1C"
+        assert cluster_embed.footer.text == "Default footer"
+        assert "C1C Match" not in cluster_embed.description
+        assert "Lead Name" not in cluster_embed.description
+        assert clan_embed.title == "Welcome to C1C Match"
+        assert clan_embed.thumbnail.url == "https://example.com/crest.png"
+        assert clan_embed.footer.text == "Clan footer"
+        assert "Lead Name" in clan_embed.description
+        assert "Deputy One, Deputy Two" in clan_embed.description
 
         assert len(general_channel.sent) == 1
         assert recruit.mention in general_channel.sent[0]["content"]
@@ -213,17 +237,24 @@ def test_welcome_template_load_failure_keeps_existing_response(monkeypatch):
     asyncio.run(scenario())
 
 
-def test_default_merge_uses_c1c_row(monkeypatch):
+def test_clan_template_does_not_fall_back_to_c1c_row(monkeypatch):
     async def scenario():
         rows = _template_rows()
         rows[1]["BODY"] = ""
         rows[1]["FOOTER"] = ""
         clan_channel = FakeChannel(123)
+        invocation_channel = FakeChannel(555)
         bot = FakeBot(channels=[clan_channel])
         guild = FakeGuild(1, channels=[clan_channel])
         author = FakeMember(5)
         message = FakeMessage()
-        ctx = FakeContext(bot=bot, guild=guild, channel=clan_channel, author=author, message=message)
+        ctx = FakeContext(
+            bot=bot,
+            guild=guild,
+            channel=invocation_channel,
+            author=author,
+            message=message,
+        )
 
         monkeypatch.setattr(
             welcome_module.sheets,
@@ -235,10 +266,45 @@ def test_default_merge_uses_c1c_row(monkeypatch):
         bridge = WelcomeBridge(bot)
         await bridge.welcome.callback(bridge, ctx, "C1CM")  # type: ignore[misc]
 
-        sent = clan_channel.sent[0]
-        embed = sent["embed"]
-        assert embed.description == "Default body for C1C Match"
-        assert embed.footer.text == "Default footer"
+        assert not clan_channel.sent
+        assert ctx.replies == ["Missing welcome text for **C1CM**. Please check WelcomeTemplates."]
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("cluster_active", [None, "N"])
+def test_missing_or_inactive_c1c_returns_admin_embed_without_welcome(
+    monkeypatch, cluster_active
+):
+    async def scenario():
+        rows = _template_rows()
+        if cluster_active is None:
+            rows = rows[1:]
+        else:
+            rows[0]["ACTIVE"] = cluster_active
+        clan_channel = FakeChannel(123)
+        invocation_channel = FakeChannel(555)
+        bot = FakeBot(channels=[clan_channel])
+        guild = FakeGuild(1, channels=[clan_channel])
+        ctx = FakeContext(
+            bot=bot,
+            guild=guild,
+            channel=invocation_channel,
+            author=FakeMember(5),
+            message=FakeMessage(mentions=[FakeMember(6)]),
+        )
+        monkeypatch.setattr(
+            welcome_module.sheets,
+            "get_cached_welcome_templates",
+            AsyncMock(return_value=rows),
+        )
+
+        await welcome_module.WelcomeCommandService(bot).post_welcome(ctx, "C1CM")
+
+        assert not clan_channel.sent
+        error_embed = invocation_channel.sent[0]["embed"]
+        assert error_embed.title == "Shared C1C welcome template unavailable"
+        assert "No welcome was posted" in error_embed.description
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
### Motivation
- Separate the shared Cluster 101 introduction (C1C) from clan-specific text so the cluster intro can be reused across clan welcomes while keeping clan leadership/rules isolated to the clan row. 
- Preserve all existing placeholder, emoji, ping, permission, target-channel routing, logging, and general-notice behavior while changing only how the welcome is assembled and posted.

### Description
- Load templates unchanged from the configured `WELCOME_TEMPLATES_TAB` but retain the exact active `C1C` row as the cluster template and ignore any legacy `DEFAULT` row when assembling welcomes. (`modules/recruitment/welcome.py` `_load_templates`)
- Add `_build_welcome_embed` helper to construct one embed from a single `WelcomeTemplate` row using the project’s existing placeholder, emoji, and sanitization logic. (`modules/recruitment/welcome.py`)
- Update `post_welcome` to: 1) validate that the active `C1C` row exists and is usable, 2) build a Cluster 101 embed from the `C1C` row, 3) build a clan embed from the requested clan row (including `{CLAN}`, `{CLANLEAD}`, `{DEPUTIES}` replacements and crest), and 4) send both embeds in a single message in that order while preserving `PING_USER`/`allowed_mentions`, target-channel routing, note attachment, and general-notice posting. (`modules/recruitment/welcome.py`)
- Add admin-facing error embed and logging when the `C1C` row is missing, inactive, or has no usable content to avoid posting a partial welcome. Tests updated/added to assert two-embed behavior, source isolation, placeholder replacement, ping preservation, and safe failure paths. (`tests/recruitment/test_welcome_command.py`)

### Testing
- Ran focused recruitment tests: `python -m pytest tests/recruitment/test_welcome_command.py -q` — 10 passed.  
- Ran recruitment suite: `python -m pytest tests/recruitment -q` — 157 passed.  
- Ran lint checks for changed files: `python -m ruff check modules/recruitment/welcome.py tests/recruitment/test_welcome_command.py` — passed.  
- Performed full test run: `python -m pytest -q` (1,456 passed; 25 unrelated failures observed due to the Python 3.14 structured-logging environment changing `LogRecord.message` semantics); the focused welcome and recruitment suites that exercise this change passed.  

No Google Sheets changes were included; the `C1C` row content is read from the existing `WELCOME_TEMPLATES_TAB` cache and must be present/active for the command to post the combined welcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6100626514832388853d1157eebe41)