### PR TITLE
Allow clan leads to set open spots

### DIFF
--- a/cogs/recruitment_open_spots.py
+++ b/cogs/recruitment_open_spots.py
@@ -9,9 +9,10 @@ from typing import Optional
 from discord.ext import commands
 
 from c1c_coreops.helpers import help_metadata, tier
-from c1c_coreops.rbac import is_admin_member, is_staff_member, ops_only
+from c1c_coreops.rbac import is_admin_member, is_staff_member
 from modules.common import runtime as runtime_helpers
 from modules.recruitment import availability
+from shared import config
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,45 @@ QUOTA_FAILURE_MESSAGE = "Google Sheets quota/rate limits are temporarily exhaust
 ROW_CONFIG_FAILURE_MESSAGE = "The correction could not be applied because the clan row or recruitment sheet configuration could not be resolved."
 WRITE_FAILURE_MESSAGE = "The correction could not be applied because the sheet write failed. Please try again or contact an admin."
 VERIFY_FAILURE_MESSAGE = "The correction may have written to Sheets, but post-write verification failed. Please check the clan row before retrying."
+
+
+def _can_set_open_spots(ctx: commands.Context) -> bool:
+    if getattr(ctx, "guild", None) is None:
+        return False
+    if is_staff_member(ctx) or is_admin_member(ctx):
+        return True
+    author = getattr(ctx, "author", None)
+    member_role_ids = {
+        role.id for role in getattr(author, "roles", []) if hasattr(role, "id")
+    }
+    return bool(member_role_ids & config.get_clan_lead_ids())
+
+
+def _set_open_spots_only():
+    """Allow staff/admins and configured clan lead roles for this command only."""
+
+    async def predicate(ctx: commands.Context) -> bool:
+        if getattr(ctx, "guild", None) is None:
+            if not getattr(ctx, "_coreops_suppress_denials", False):
+                try:
+                    await ctx.reply(
+                        "This command can only be used in servers.",
+                        mention_author=False,
+                    )
+                except Exception:
+                    pass
+            raise commands.CheckFailure("Guild only.")
+        if _can_set_open_spots(ctx):
+            return True
+        if getattr(ctx, "_coreops_suppress_denials", False):
+            raise commands.CheckFailure("Staff only.")
+        try:
+            await ctx.reply("Staff only.", mention_author=False)
+        except Exception:
+            pass
+        raise commands.CheckFailure("Staff only.")
+
+    return commands.check(predicate)
 
 
 def _display_name(author: object) -> str:
@@ -140,7 +180,7 @@ class RecruitmentOpenSpotsCog(commands.Cog):
         help="Emergency staff/admin correction for configured clan open spots.",
         brief="Corrects configured clan open spots.",
     )
-    @ops_only()
+    @_set_open_spots_only()
     async def setopenspots(
         self,
         ctx: commands.Context,
@@ -151,7 +191,7 @@ class RecruitmentOpenSpotsCog(commands.Cog):
     ) -> None:
         """Manually correct a clan's configured open-spots availability value."""
 
-        if not (is_staff_member(ctx) or is_admin_member(ctx)):
+        if not _can_set_open_spots(ctx):
             await ctx.reply(
                 "You do not have permission to use this command.", mention_author=False
             )

--- a/tests/recruitment/test_set_open_spots_command.py
+++ b/tests/recruitment/test_set_open_spots_command.py
@@ -7,10 +7,11 @@ from cogs.recruitment_open_spots import RecruitmentOpenSpotsCog
 
 
 class FakeAuthor:
-    def __init__(self, member_id=123, display_name="Caillean"):
+    def __init__(self, member_id=123, display_name="Caillean", role_ids=()):
         self.id = member_id
         self.display_name = display_name
         self.name = display_name
+        self.roles = [SimpleNamespace(id=role_id) for role_id in role_ids]
 
 
 class FakeContext:
@@ -64,11 +65,38 @@ def test_staff_can_set_open_spots_successfully(monkeypatch):
     assert "missed promo close correction" in logs[0]
 
 
+def test_admin_remains_authorized(monkeypatch):
+    ctx = FakeContext()
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: True)
+    monkeypatch.setattr(command_module.config, "get_clan_lead_ids", lambda: set())
+
+    assert command_module._can_set_open_spots(ctx) is True
+
+
+def test_clan_lead_role_can_set_open_spots(monkeypatch):
+    ctx = FakeContext()
+    ctx.author = FakeAuthor(role_ids=(2468,))
+    setter = AsyncMock(return_value=(3, 4, "C1CC"))
+    monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.config, "get_clan_lead_ids", lambda: {2468})
+    monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
+    monkeypatch.setattr(command_module.runtime_helpers, "send_log_message", AsyncMock())
+
+    cog = RecruitmentOpenSpotsCog(bot=None)
+    _run(cog.setopenspots.callback(cog, ctx, "C1CC", "4", reason="reason"))
+
+    setter.assert_awaited_once_with("C1CC", 4)
+    assert "Open spots corrected" in ctx.replies[0][0]
+
+
 def test_non_staff_cannot_run(monkeypatch):
     ctx = FakeContext()
     setter = AsyncMock()
     monkeypatch.setattr(command_module, "is_staff_member", lambda _ctx: False)
     monkeypatch.setattr(command_module, "is_admin_member", lambda _ctx: False)
+    monkeypatch.setattr(command_module.config, "get_clan_lead_ids", lambda: {2468})
     monkeypatch.setattr(command_module.availability, "set_manual_open_spots", setter)
 
     cog = RecruitmentOpenSpotsCog(bot=None)


### PR DESCRIPTION
### Motivation

- Allow members with roles listed in the existing `CLAN_LEAD_IDS` env config to run the emergency `!setopenspots` command without widening access to other recruiter/admin commands.

### Description

- Added a command-local RBAC predicate in `cogs/recruitment_open_spots.py` that authorizes: staff, admins, or any member whose `ctx.author.roles` intersects `config.get_clan_lead_ids()`, and preserved guild-only denial behavior.
- Replaced the shared `ops_only()` check for `!setopenspots` with the new `_set_open_spots_only()` decorator and introduced `_can_set_open_spots()` to centralize the runtime check used inside the command body so other predicates are not widened.
- Imported `shared.config` to reuse the existing `CLAN_LEAD_IDS` helper and avoided hard-coding any role IDs.
- Added focused unit tests in `tests/recruitment/test_set_open_spots_command.py` to assert staff and admin remain authorized, a clan-lead-role member is authorized, and a member without required roles is denied.

### Testing

- Ran unit tests for the modified command: `python -m pytest tests/recruitment/test_set_open_spots_command.py -q`, and all tests in that file passed.
- Ran the linter on the modified files: `python -m ruff check cogs/recruitment_open_spots.py tests/recruitment/test_set_open_spots_command.py`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a632ac32fd0832386e5639fd133b075)