### PR TITLE
Register bare !help command for all users

### DIFF
--- a/packages/c1c-coreops/src/c1c_coreops/cog.py
+++ b/packages/c1c-coreops/src/c1c_coreops/cog.py
@@ -1678,6 +1678,7 @@ class CoreOpsCog(commands.Cog):
     def _build_command_metadata_overrides(self) -> dict[str, dict[str, str]]:
         return {
             "ops": {"function_group": "operational", "access_tier": "user"},
+            "help": {"function_group": "operational", "access_tier": "user"},
             "ops help": {"function_group": "operational", "access_tier": "user"},
             "health": {"function_group": "operational"},
             "ops health": {"function_group": "operational"},
@@ -3834,6 +3835,19 @@ class CoreOpsCog(commands.Cog):
         brief="Shows the permission-aware help menu.",
     )
     async def ops_help(
+        self, ctx: commands.Context, *, query: str | None = None
+    ) -> None:
+        await self.render_help(ctx, query=query)
+
+    @tier("user")
+    @commands.command(
+        name="help",
+        usage="[command]",
+        extras={"hide_in_help": True},
+        help="Shows the permission-aware help menu with dynamic visibility.",
+        brief="Shows the permission-aware help menu.",
+    )
+    async def bare_help(
         self, ctx: commands.Context, *, query: str | None = None
     ) -> None:
         await self.render_help(ctx, query=query)

--- a/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
+++ b/packages/c1c-coreops/tests/test_alias_and_bang_behavior.py
@@ -74,6 +74,7 @@ def test_multi_bot_alias_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
         intents = discord.Intents.none()
         bot = commands.Bot(command_prefix="!", intents=intents)
+        bot.remove_command("help")
         await bot.add_cog(CoreOpsCog(bot))
 
         try:
@@ -109,6 +110,7 @@ def test_generic_alias_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def runner() -> None:
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        bot.remove_command("help")
         await bot.add_cog(CoreOpsCog(bot))
 
         try:
@@ -151,6 +153,7 @@ def test_reload_requires_admin(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def runner() -> None:
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        bot.remove_command("help")
         await bot.add_cog(CoreOpsCog(bot))
 
         try:

--- a/packages/c1c-coreops/tests/test_command_metadata_overrides.py
+++ b/packages/c1c-coreops/tests/test_command_metadata_overrides.py
@@ -41,6 +41,7 @@ def test_operational_metadata_exposed(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def runner() -> None:
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        bot.remove_command("help")
         await bot.add_cog(CoreOpsCog(bot))
         await bot.add_cog(PermissionsUICog(bot))
         await bot.add_cog(RecruiterPanelCog(bot))

--- a/packages/c1c-coreops/tests/test_help_admin_surface_complete.py
+++ b/packages/c1c-coreops/tests/test_help_admin_surface_complete.py
@@ -177,6 +177,7 @@ async def _gather_help_embeds(
         monkeypatch.setenv("COREOPS_ADMIN_BANG_ALLOWLIST", allowlist)
 
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    bot.remove_command("help")
 
     await bot.add_cog(CoreOpsCog(bot))
     await bot.add_cog(PermissionsUICog(bot))

--- a/packages/c1c-coreops/tests/test_help_diagnostics.py
+++ b/packages/c1c-coreops/tests/test_help_diagnostics.py
@@ -164,6 +164,7 @@ def patch_rbac(monkeypatch: pytest.MonkeyPatch) -> Iterable[None]:
 
 async def _setup_bot(monkeypatch: pytest.MonkeyPatch) -> tuple[commands.Bot, DummyLogChannel]:
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    bot.remove_command("help")
     channel = DummyLogChannel()
     monkeypatch.setattr(
         "c1c_coreops.cog.resolve_ops_log_channel_id", lambda *_, **__: 999,

--- a/packages/c1c-coreops/tests/test_help_renderer.py
+++ b/packages/c1c-coreops/tests/test_help_renderer.py
@@ -248,6 +248,58 @@ def test_help_access_views_are_sheet_driven(monkeypatch: pytest.MonkeyPatch) -> 
     asyncio.run(runner())
 
 
+def test_bare_help_is_registered_and_reuses_permission_aware_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def runner() -> None:
+        async def rows():
+            return _sheet_rows()
+
+        monkeypatch.setattr("c1c_coreops.cog.help_commands.get_rows", rows)
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            command = bot.get_command("help")
+            assert command is not None
+            assert command.qualified_name == "help"
+            assert command.callback is CoreOpsCog.bare_help.callback
+
+            ctx = HelpContext(bot, DummyMember())
+            for check in command.checks:
+                assert await check(ctx)
+            await command.callback(command.cog, ctx)
+
+            view = ctx._views[0]
+            assert view is not None
+            assert set(view.embeds) == {"user"}
+            assert "!clan <tag>" in _collect_text(view.embeds["user"][0])
+            assert "!ops config" not in _collect_text(view.embeds["user"][0])
+        finally:
+            await bot.close()
+
+    asyncio.run(runner())
+
+
+def test_bare_help_query_reuses_existing_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def runner() -> None:
+        bot = await _setup_test_bot(monkeypatch)
+        try:
+            cog = bot.get_cog("CoreOpsCog")
+            command = bot.get_command("help")
+            assert cog is not None
+            assert command is not None
+            render_help = AsyncMock()
+            monkeypatch.setattr(cog, "render_help", render_help)
+            ctx = HelpContext(bot, DummyMember())
+
+            await command.callback(command.cog, ctx, query="clan")
+
+            render_help.assert_awaited_once_with(ctx, query="clan")
+        finally:
+            await bot.close()
+
+    asyncio.run(runner())
+
+
 def test_help_pages_group_categories_inside_access_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     async def runner() -> None:
         async def rows():


### PR DESCRIPTION
### Motivation
- The bot removed discord.py's default `help` and relied on an admin-only bare-command shortcut, which caused `!help` to raise `CommandNotFound` for normal users.
- Provide a real, registered bare-prefix `help` command that reuses the existing CoreOps permission-aware renderer so `!help` works for everyone without changing help sheet structure or RBAC policies.

### Description
- Register a user-tier bare `help` command (`CoreOpsCog.bare_help`) that delegates to the existing `render_help` implementation so both `!help` and `!ops help` reuse the same renderer (changes in `packages/c1c-coreops/src/c1c_coreops/cog.py`).
- Add `help` metadata to the CoreOps command metadata overrides so the bare help is treated as a user-level command.
- Update test bot fixtures to mirror runtime behavior by removing discord.py's default `help` before adding the cog (several test files under `packages/c1c-coreops/tests/`).
- Add focused tests that assert `help` is registered as a bare command, that a non-admin can invoke `!help`, that admin-only commands are not exposed to normal users, and that `!help <command>` forwards to the existing renderer (new/modified assertions in `test_help_renderer.py` and small test adjustments elsewhere).

### Testing
- Ran focused unit tests: `pytest -q packages/c1c-coreops/tests/test_help_renderer.py packages/c1c-coreops/tests/test_alias_and_bang_behavior.py packages/c1c-coreops/tests/test_command_metadata_overrides.py`, and the focused changes passed locally (focused coverage exercised and assertions for registration and renderer reuse succeeded).
- Verified code compiles with `python -m compileall` for the modified package and tests without syntax errors.
- Ran the full `packages/c1c-coreops` test shard which surfaced pre-existing unrelated failures in environment-overview and diagnostics tests; those failures are not introduced by this patch and are orthogonal to the `!help` change.
- Executed the repository guardrails runner which reports unrelated, pre-existing violations across the repo and did not flag any issues created by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6364cf2d748323879301ab43b62abb)