### PR TITLE
Fix shard emoji config snapshot regression

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -588,6 +588,15 @@ def _load_config_snapshot() -> Dict[str, object]:
         "TAG_BADGE_PX": _int_env("TAG_BADGE_PX", 128, min_value=32, max_value=512),
         "TAG_BADGE_BOX": _float_env("TAG_BADGE_BOX", 0.90, min_value=0.2, max_value=0.95),
         "STRICT_EMOJI_PROXY": _env_bool("STRICT_EMOJI_PROXY", True),
+        "SHARD_PANEL_OVERVIEW_EMOJI": (
+            os.getenv("SHARD_PANEL_OVERVIEW_EMOJI") or ""
+        ).strip(),
+        "SHARD_EMOJI_MYSTERY": (os.getenv("SHARD_EMOJI_MYSTERY") or "").strip(),
+        "SHARD_EMOJI_ANCIENT": (os.getenv("SHARD_EMOJI_ANCIENT") or "").strip(),
+        "SHARD_EMOJI_VOID": (os.getenv("SHARD_EMOJI_VOID") or "").strip(),
+        "SHARD_EMOJI_PRIMAL": (os.getenv("SHARD_EMOJI_PRIMAL") or "").strip(),
+        "SHARD_EMOJI_SACRED": (os.getenv("SHARD_EMOJI_SACRED") or "").strip(),
+        "SHARD_EMOJI_REMNANT": (os.getenv("SHARD_EMOJI_REMNANT") or "").strip(),
         "SERVER_MAP_CHANNEL_ID": _first_int(os.getenv("SERVER_MAP_CHANNEL_ID")),
         "SERVER_MAP_REFRESH_DAYS": _int_env("SERVER_MAP_REFRESH_DAYS", 30, min_value=1),
     }

--- a/tests/config/test_reload_config_entrypoint.py
+++ b/tests/config/test_reload_config_entrypoint.py
@@ -23,6 +23,40 @@ def test_reload_config_happy_path(monkeypatch):
     cfg.reload_config()
 
 
+def test_reload_config_populates_shard_emoji_getters(monkeypatch):
+    _apply_required_env(monkeypatch)
+    import shared.config as cfg
+
+    configured = {
+        "SHARD_PANEL_OVERVIEW_EMOJI": "overview-configured",
+        "SHARD_EMOJI_MYSTERY": "mystery-configured",
+        "SHARD_EMOJI_ANCIENT": "ancient-configured",
+        "SHARD_EMOJI_VOID": "void-configured",
+        "SHARD_EMOJI_PRIMAL": "primal-configured",
+        "SHARD_EMOJI_SACRED": "sacred-configured",
+        "SHARD_EMOJI_REMNANT": "remnant-configured",
+    }
+    for key, value in configured.items():
+        monkeypatch.setenv(key, value)
+
+    monkeypatch.setattr(cfg, "_CONFIG", dict(cfg._CONFIG))
+    monkeypatch.setattr(cfg, "_merge_onboarding_tab", lambda _config: None)
+    monkeypatch.setattr(cfg, "_merge_milestones_tab", lambda _config: None)
+
+    cfg.reload_config()
+
+    assert (
+        cfg.get_shard_panel_overview_emoji()
+        == configured["SHARD_PANEL_OVERVIEW_EMOJI"]
+    )
+    assert cfg.get_shard_emoji_mystery() == configured["SHARD_EMOJI_MYSTERY"]
+    assert cfg.get_shard_emoji_ancient() == configured["SHARD_EMOJI_ANCIENT"]
+    assert cfg.get_shard_emoji_void() == configured["SHARD_EMOJI_VOID"]
+    assert cfg.get_shard_emoji_primal() == configured["SHARD_EMOJI_PRIMAL"]
+    assert cfg.get_shard_emoji_sacred() == configured["SHARD_EMOJI_SACRED"]
+    assert cfg.get_shard_emoji_remnant() == configured["SHARD_EMOJI_REMNANT"]
+
+
 def test_areload_config_uses_async_sheet_loaders(monkeypatch):
     _apply_required_env(monkeypatch)
     import shared.config as cfg


### PR DESCRIPTION
### Motivation
- The shard tracker consumes emoji values via the shared config getters but the environment-backed snapshot in `shared/config.py` did not include the shard emoji variables, causing every getter to return the empty/default fallback and breaking configured emojis. 

### Description
- Load all seven shard emoji environment variables into the environment-backed snapshot inside `_load_config_snapshot()`: `SHARD_PANEL_OVERVIEW_EMOJI`, `SHARD_EMOJI_MYSTERY`, `SHARD_EMOJI_ANCIENT`, `SHARD_EMOJI_VOID`, `SHARD_EMOJI_PRIMAL`, `SHARD_EMOJI_SACRED`, and `SHARD_EMOJI_REMNANT`.
- Add a focused regression test `test_reload_config_populates_shard_emoji_getters` in `tests/config/test_reload_config_entrypoint.py` that sets representative env values, calls `reload_config()`, and asserts each shard emoji getter returns the configured value.
- Preserve existing getter APIs and shard tracker rendering logic and keep the safe fallback behavior when variables are missing; no direct `os.getenv()` calls were restored in cogs and no emoji IDs or embed/button formatting were changed.

### Testing
- `python -m pytest tests/config/test_reload_config_entrypoint.py tests/community/shard_tracker --disable-warnings -ra` — 72 passed, 281 warnings.
- `ruff check shared/config.py tests/config/test_reload_config_entrypoint.py` — all checks passed.
- `black --check shared/config.py tests/config/test_reload_config_entrypoint.py` — formatting checks passed after ensuring files were formatted.
- `git diff --check` — no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a81c8f2648323a36ac6a08ee451d6)