### PR TITLE
Accept human-friendly onboarding score inputs

### DIFF
--- a/docs/modules/Onboarding.md
+++ b/docs/modules/Onboarding.md
@@ -22,6 +22,8 @@ The onboarding module is the generic questionnaire engine that powers welcome an
 - **Headers:** `flow`, `order`, `qid`, `label`, `type`, `required`, `maxlen`, `validate`, `help`, `options`, `visibility_rules`, `nav_rules`, `rules` (Config doc mirrors this schema). Rows with `flow=welcome` drive the Discord welcome dialog; other flows reuse the same engine.
 - **Options:** stored as comma-separated tokens; converted into `(label, value)` tuples so both dropdowns and multi-select prompts retain sheet ordering.
 - **Rules:** `visibility_rules` and `nav_rules` reference other `qid` values; parser rejects unknown IDs so skip logic does not drift.
+- **Score validation:** set `validate=score` for approximate scores, or use inclusive base-unit bounds such as `validate=score:min=10000,max=1000000`. Accepted answers include compact forms (`500K`, `12.6M`, `40b`), word forms (`40 billion`), qualifiers (`about`, `over`, `~`), a trailing `+`, and full numbers (`40,000,000,000` or `40000000000`). Values are stored as canonical compact strings such as `500K`, `12.6M`, and `40B`.
+- **Directive-driven behavior:** score parsing is selected only by the row's `validate` directive, never by `qid`, label, help text, order, flow, question type, or an existing regex. Exact numeric fields—including player power, account levels, ranks, counts, and IDs—continue to use their own sheet-authored validators without score-specific qualifiers, suffix words, or decimal-comma handling.
 
 ### Session Persistence (`OnboardingSessions` tab)
 - **Columns (minimum required):** `thread_name`, `user_id`, `thread_id`, `panel_message_id`, `step_index`, `completed`, `completed_at`, `answers_json`, `updated_at`, `first_reminder_at`, `warning_sent_at`, `auto_closed_at` (extra columns are tolerated so long as the required ones exist).
@@ -68,4 +70,4 @@ The onboarding module is the generic questionnaire engine that powers welcome an
 - [`docs/Runbook.md`](../Runbook.md)
 - [`docs/adr/ADR-0022-Module-Boundaries.md`](../adr/ADR-0022-Module-Boundaries.md)
 
-Doc last updated: 2025-12-06 (v0.9.8.2)
+Doc last updated: 2026-07-30 (v0.9.8.2)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -266,6 +266,8 @@ explicitly configured in the sheet.
 
 ### Onboarding
 - `ONBOARDING_TAB` (string) — Sheet tab name containing the onboarding questions with headers `flow, order, qid, label, type, required, maxlen, validate, help, options, visibility_rules, nav_rules`. Preloaded at startup and refreshed weekly; missing or invalid values surface `missing config key: ONBOARDING_TAB` during refresh.
+- The questions tab controls validation per row through `validate`. Use `score` for approximate scores, or `score:min=10000,max=1000000` for inclusive bounds measured in base units. Score rows accept compact and word suffixes (`500K`, `12.6M`, `40b`, `40 billion`), leading approximation words or `~`, a trailing `+`, and separated or unseparated full numbers. Accepted values are stored canonically with the largest appropriate unit (for example, `40B` or `40.5B`).
+- Score behavior is enabled only by the explicit sheet directive—not by `qid`, question text, help text, order, flow, `type=number`, or regex contents. Exact numeric fields such as player power, levels, ranks, counts, and IDs retain their own validators and do not receive approximate-score syntax.
 - `ONBOARDING_SESSIONS_TAB` (string) — Worksheet storing onboarding sessions keyed by `user_id` + `thread_id`. Columns (order enforced): `user_id`, `thread_id`, `panel_message_id`, `step_index`, `completed`, `completed_at`, `answers_json`, `updated_at`, `first_reminder_at`, `warning_sent_at`, `auto_closed_at`.
 - Feature toggles `PROMO_ENABLED` and `promo_dialog` gate promo onboarding dialogs (`promo.r`, `promo.m`, `promo.l`). Both must be enabled for promo dialogs to run once detected.
 
@@ -437,4 +439,4 @@ Feature enable/disable is always sourced from the FeatureToggles worksheet; ENV 
 
 > **Template note:** The `.env.example` file in this directory mirrors the tables below. Treat that file as the canonical template for new deployments and update both assets together.
 
-Doc last updated: 2026-07-19 (v0.9.8.2)
+Doc last updated: 2026-07-30 (v0.9.8.2)

--- a/modules/onboarding/controllers/welcome_controller.py
+++ b/modules/onboarding/controllers/welcome_controller.py
@@ -7,6 +7,7 @@ import logging
 import math
 import re
 import sys
+from decimal import Decimal, InvalidOperation
 from typing import (
     Any,
     Awaitable,
@@ -30,6 +31,7 @@ from modules.onboarding.schema import (
     parse_values_list,
 )
 from modules.onboarding.sessions import Session, ensure_session_for_thread, utc_now
+from modules.onboarding.score_input import ScoreInputError, parse_score
 from modules.onboarding.session_store import SessionData, store
 from modules.onboarding.summary_detection import find_recruitment_summary_message
 from modules.onboarding.ui.card import RollingCard
@@ -85,6 +87,10 @@ async def _delete_captured_answer_message(message: discord.Message | None) -> No
 
 # --- Sheet-driven validator (no fallbacks/coercion) --------------------------
 NUMERIC_HINTS = ("number",)
+SCORE_INPUT_ERROR = (
+    "Enter a score such as 500K, 12.6M, 1B, or 40 billion. "
+    "Include K, M, or B when using a shortened value."
+)
 
 
 def _sheet_regex(meta: dict[str, Any]) -> str | None:
@@ -104,6 +110,34 @@ def validate_answer(
     """
 
     raw = "" if raw is None else str(raw)
+
+    directive = (meta.get("validate") or "").strip()
+    if directive.lower() == "score" or directive.lower().startswith("score:"):
+        minimum: Decimal | None = None
+        maximum: Decimal | None = None
+        if ":" in directive:
+            try:
+                options = directive.split(":", 1)[1].split(",")
+                bounds = {
+                    key.strip().lower(): Decimal(value.strip())
+                    for option in options
+                    for key, value in [option.split("=", 1)]
+                }
+                if set(bounds) - {"min", "max"}:
+                    raise ValueError
+                minimum = bounds.get("min")
+                maximum = bounds.get("max")
+            except (InvalidOperation, ValueError):
+                log.warning(
+                    "welcome: bad score validator in sheet",
+                    extra={"validate": directive},
+                )
+                return False, None, SCORE_INPUT_ERROR
+        try:
+            parsed = parse_score(raw, minimum=minimum, maximum=maximum)
+        except ScoreInputError:
+            return False, None, SCORE_INPUT_ERROR
+        return True, parsed.compact, None
 
     pattern = _sheet_regex(meta)
     if pattern:

--- a/modules/onboarding/score_input.py
+++ b/modules/onboarding/score_input.py
@@ -1,0 +1,121 @@
+"""Parsing and canonical formatting for sheet-declared score answers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+
+class ScoreInputError(ValueError):
+    """Raised when a score answer is malformed, ambiguous, or out of bounds."""
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedScore:
+    """A score in base units and its canonical compact representation."""
+
+    value: Decimal
+    compact: str
+
+
+_QUALIFIER = re.compile(
+    r"^(?:(?:over|about|around|roughly|approximately|approx)\s+|~\s*)",
+    re.IGNORECASE,
+)
+_SCORE = re.compile(r"^(?P<number>[0-9][0-9.,]*)(?:\s*(?P<suffix>[a-z]+))?$", re.I)
+_MULTIPLIERS = {
+    "k": Decimal("1000"),
+    "thousand": Decimal("1000"),
+    "m": Decimal("1000000"),
+    "mn": Decimal("1000000"),
+    "mil": Decimal("1000000"),
+    "mill": Decimal("1000000"),
+    "million": Decimal("1000000"),
+    "b": Decimal("1000000000"),
+    "bn": Decimal("1000000000"),
+    "bil": Decimal("1000000000"),
+    "bill": Decimal("1000000000"),
+    "billion": Decimal("1000000000"),
+}
+
+
+def _decimal_text(number: str, *, has_suffix: bool) -> str:
+    if "," not in number:
+        if number.count(".") > 1:
+            raise ScoreInputError("malformed score")
+        return number
+
+    if "." in number:
+        raise ScoreInputError("malformed score")
+    if has_suffix:
+        if number.count(",") != 1:
+            raise ScoreInputError("malformed score")
+        whole, fraction = number.split(",")
+        if not whole or not fraction:
+            raise ScoreInputError("malformed score")
+        return f"{whole}.{fraction}"
+
+    groups = number.split(",")
+    if not groups[0] or not (1 <= len(groups[0]) <= 3):
+        raise ScoreInputError("malformed score")
+    if len(groups) < 2 or any(len(group) != 3 for group in groups[1:]):
+        raise ScoreInputError("malformed score")
+    return "".join(groups)
+
+
+def _format_decimal(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def _compact(value: Decimal) -> str:
+    for multiplier, suffix in (
+        (Decimal("1000000000"), "B"),
+        (Decimal("1000000"), "M"),
+        (Decimal("1000"), "K"),
+    ):
+        if value >= multiplier:
+            return f"{_format_decimal(value / multiplier)}{suffix}"
+    return _format_decimal(value)
+
+
+def parse_score(
+    raw: str,
+    *,
+    minimum: Decimal | None = None,
+    maximum: Decimal | None = None,
+) -> ParsedScore:
+    """Parse a human-friendly score and enforce inclusive base-unit bounds."""
+
+    text = "" if raw is None else str(raw).strip()
+    if not text:
+        raise ScoreInputError("empty score")
+    text = _QUALIFIER.sub("", text, count=1).strip()
+    if text.endswith("+"):
+        text = text[:-1].strip()
+
+    match = _SCORE.fullmatch(text)
+    if not match:
+        raise ScoreInputError("malformed score")
+    number = match.group("number")
+    suffix = (match.group("suffix") or "").lower()
+    if suffix and suffix not in _MULTIPLIERS:
+        raise ScoreInputError("unknown score suffix")
+
+    decimal_text = _decimal_text(number, has_suffix=bool(suffix))
+    if not suffix and (not decimal_text.isdigit() or len(decimal_text) < 4):
+        raise ScoreInputError("ambiguous shortened score")
+    try:
+        value = Decimal(decimal_text) * _MULTIPLIERS.get(suffix, Decimal(1))
+    except InvalidOperation as exc:
+        raise ScoreInputError("malformed score") from exc
+    if not value.is_finite() or value <= 0:
+        raise ScoreInputError("score must be positive")
+    if minimum is not None and value < minimum:
+        raise ScoreInputError("score is below the configured minimum")
+    if maximum is not None and value > maximum:
+        raise ScoreInputError("score is above the configured maximum")
+    return ParsedScore(value=value, compact=_compact(value))

--- a/shared/sheets/onboarding_questions.py
+++ b/shared/sheets/onboarding_questions.py
@@ -33,6 +33,7 @@ log = logging.getLogger(__name__)
 _cached_rows_snapshot: Tuple[dict[str, str], ...] | None = None
 _cached_questions_by_flow: dict[str, Tuple[Question, ...]] = {}
 
+
 def _question_tab() -> str:
     """Return the configured onboarding question tab name."""
 
@@ -67,13 +68,6 @@ class Question:
     rules: str | None = None
 
 
-_VALIDATION_OVERRIDES: dict[str, str] = {
-    "w_power": r"regex:^[0-9]+(\.[0-9]{1,2})?[Mm]?$",
-    "w_hydra_clash": r"regex:^\d+(?:\.\d+)?[MmBb]?$",
-    "w_chimera_clash": r"regex:^\d+(?:\.\d+)?[MmBb]?$",
-}
-
-
 def _sheet_id() -> str:
     sheet_id = get_onboarding_sheet_id().strip()
     if not sheet_id:
@@ -98,7 +92,9 @@ def describe_source() -> dict[str, str]:
     return {"sheet": redacted, "tab": tab}
 
 
-def _normalise_records(records: Iterable[Mapping[str, object]]) -> Tuple[dict[str, str], ...]:
+def _normalise_records(
+    records: Iterable[Mapping[str, object]],
+) -> Tuple[dict[str, str], ...]:
     parsed: list[dict[str, str]] = []
     for record in records:
         normalized: dict[str, str] = {}
@@ -241,7 +237,9 @@ def _parse_options(raw_options: str | None) -> tuple[Option, ...]:
         start = int(match.group("start"))
         end = int(match.group("end"))
         if start <= end:
-            return tuple(_canonicalise_option(str(number)) for number in range(start, end + 1))
+            return tuple(
+                _canonicalise_option(str(number)) for number in range(start, end + 1)
+            )
 
     raw_segments = re.split(r"[\n,]", text)
     segments = [segment.strip() for segment in raw_segments if segment.strip()]
@@ -325,18 +323,16 @@ def _build_questions(flow: str, rows: Sequence[Mapping[str, str]]) -> list[Quest
         try:
             qtype, multi_max = _normalise_type(qtype_raw)
         except ValueError:
-            log.warning("onboarding question missing type", extra={"qid": qid, "order": order})
+            log.warning(
+                "onboarding question missing type", extra={"qid": qid, "order": order}
+            )
             continue
-        qid_key = qid.strip()
         options = (
             _parse_options(row.get("options"))
             if qtype in {"single-select", "multi-select"}
             else ()
         )
         validate_text = _normalise_whitespace(row.get("validate"))
-        override = _VALIDATION_OVERRIDES.get(qid_key)
-        if override:
-            validate_text = override
         question = Question(
             flow=flow,
             order=order.strip(),
@@ -379,7 +375,9 @@ def _hash_payload(questions: Iterable[Question]) -> str:
                 "maxlen": question.maxlen,
                 "validate": question.validate,
                 "help": question.help,
-                "options": [(option.value, option.label) for option in question.options],
+                "options": [
+                    (option.value, option.label) for option in question.options
+                ],
                 "visibility_rules": question.visibility_rules,
                 "nav_rules": question.nav_rules,
             }

--- a/tests/onboarding/test_auto_capture.py
+++ b/tests/onboarding/test_auto_capture.py
@@ -58,6 +58,91 @@ def test_handle_thread_message_captures_answer() -> None:
     asyncio.run(runner())
 
 
+def test_handle_thread_message_normalizes_sheet_declared_score() -> None:
+    async def runner() -> None:
+        loop = asyncio.get_running_loop()
+        controller = WelcomeController(SimpleNamespace(loop=loop, logger=None))
+        thread_id = 1025
+        question = SimpleNamespace(
+            qid="sheet_score",
+            label="Score",
+            type="number",
+            required=True,
+            validate="score",
+            help="",
+            options=(),
+        )
+        controller._questions[thread_id] = [question]
+        controller._threads[thread_id] = SimpleNamespace(id=thread_id)
+        session = store.ensure(thread_id, flow=controller.flow, schema_hash="hash")
+        session.pending_step = {"kind": "inline", "index": 0}
+        session.status = "in_progress"
+        session.respondent_id = 555
+        session.thread_id = thread_id
+        session.answers = {}
+        message = SimpleNamespace(
+            channel=SimpleNamespace(id=thread_id),
+            author=SimpleNamespace(id=555, bot=False),
+            content="Over 40b",
+            id=100,
+            add_reaction=AsyncMock(),
+            delete=AsyncMock(),
+        )
+        controller._react_to_message = AsyncMock()
+        controller._refresh_inline_message = AsyncMock()
+
+        assert await controller.handle_thread_message(message) is True
+        assert controller.answers_by_thread[thread_id]["sheet_score"] == "40B"
+        controller._react_to_message.assert_called_with(message, "✅")
+        controller._refresh_inline_message.assert_awaited_with(thread_id, index=0)
+        message.delete.assert_awaited_once()
+        store.end(thread_id)
+
+    asyncio.run(runner())
+
+
+def test_handle_thread_message_rejects_ambiguous_bare_score() -> None:
+    async def runner() -> None:
+        loop = asyncio.get_running_loop()
+        controller = WelcomeController(SimpleNamespace(loop=loop, logger=None))
+        thread_id = 1026
+        question = SimpleNamespace(
+            qid="sheet_score",
+            label="Score",
+            type="number",
+            required=True,
+            validate="score",
+            help="",
+            options=(),
+        )
+        controller._questions[thread_id] = [question]
+        session = store.ensure(thread_id, flow=controller.flow, schema_hash="hash")
+        session.pending_step = {"kind": "inline", "index": 0}
+        session.status = "in_progress"
+        session.respondent_id = 555
+        session.thread_id = thread_id
+        session.answers = {}
+        message = SimpleNamespace(
+            channel=SimpleNamespace(id=thread_id),
+            author=SimpleNamespace(id=555, bot=False),
+            content="40",
+            id=101,
+            add_reaction=AsyncMock(),
+            delete=AsyncMock(),
+        )
+        controller._react_to_message = AsyncMock()
+        controller._refresh_inline_message = AsyncMock()
+
+        assert await controller.handle_thread_message(message) is True
+        assert controller.answers_by_thread.get(thread_id) in (None, {})
+        controller._react_to_message.assert_called_with(message, "❌")
+        controller._refresh_inline_message.assert_not_awaited()
+        message.delete.assert_not_awaited()
+        store.end(thread_id)
+
+    asyncio.run(runner())
+
+
 def test_handle_thread_message_ignores_other_users() -> None:
     async def runner() -> None:
         loop = asyncio.get_running_loop()
@@ -409,7 +494,9 @@ def test_refresh_inline_message_reuses_existing_message(monkeypatch) -> None:
         message = SimpleNamespace(id=999, edit=AsyncMock())
         controller._inline_messages[thread_id] = message
 
-        thread = SimpleNamespace(id=thread_id, send=AsyncMock(), fetch_message=AsyncMock())
+        thread = SimpleNamespace(
+            id=thread_id, send=AsyncMock(), fetch_message=AsyncMock()
+        )
         controller._threads[thread_id] = thread
 
         await controller._refresh_inline_message(thread_id, index=0)

--- a/tests/onboarding/test_onboarding_questions_module.py
+++ b/tests/onboarding/test_onboarding_questions_module.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from shared import config as shared_config
 from shared.sheets import onboarding_questions
 
@@ -55,7 +57,9 @@ def test_normalise_type_maps_boolean_aliases() -> None:
         assert max_count is None
 
 
-def _option_pairs(options: tuple[onboarding_questions.Option, ...]) -> list[tuple[str, str]]:
+def _option_pairs(
+    options: tuple[onboarding_questions.Option, ...],
+) -> list[tuple[str, str]]:
     return [(option.label, option.value) for option in options]
 
 
@@ -119,6 +123,34 @@ def test_build_questions_supports_promo_subflows() -> None:
     assert [question.qid for question in promo_r] == ["r1"]
     assert [question.qid for question in promo_m] == ["m1"]
     assert [question.qid for question in welcome] == ["w1"]
+
+
+def test_build_questions_preserves_sheet_validation_without_qid_overrides() -> None:
+    rows = (
+        {
+            "flow": "welcome",
+            "order": "1",
+            "qid": "w_hydra_clash",
+            "label": "Hydra",
+            "type": "number",
+            "validate": "score:min=10000,max=1000000",
+        },
+        {
+            "flow": "welcome",
+            "order": "2",
+            "qid": "w_chimera_clash",
+            "label": "Chimera",
+            "type": "number",
+            "validate": "none",
+        },
+    )
+
+    questions = onboarding_questions._build_questions("welcome", rows)
+
+    assert [question.validate for question in questions] == [
+        "score:min=10000,max=1000000",
+        "none",
+    ]
 
 
 def test_schema_hash_varies_by_flow() -> None:

--- a/tests/onboarding/test_score_input.py
+++ b/tests/onboarding/test_score_input.py
@@ -1,0 +1,95 @@
+from decimal import Decimal
+
+import pytest
+
+from modules.onboarding.controllers.welcome_controller import validate_answer
+from modules.onboarding.score_input import ScoreInputError, parse_score
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("40b", "40B"),
+        ("40 B", "40B"),
+        ("40bn", "40B"),
+        ("40 bil", "40B"),
+        ("40 bill", "40B"),
+        ("40 billion", "40B"),
+        ("40 BILLION", "40B"),
+        ("40 BiLl", "40B"),
+        ("40.5b", "40.5B"),
+        ("40,5b", "40.5B"),
+        ("500K", "500K"),
+        ("12.6M", "12.6M"),
+        ("150K+", "150K"),
+        ("40,000,000,000", "40B"),
+        ("40000000000", "40B"),
+        ("12600000", "12.6M"),
+        ("1 thousand", "1K"),
+        ("2mn", "2M"),
+        ("2 mil", "2M"),
+        ("2 mill", "2M"),
+        ("2 million", "2M"),
+        ("Over 40b", "40B"),
+        ("about 40b", "40B"),
+        ("around 40b", "40B"),
+        ("roughly 40b", "40B"),
+        ("approximately 40b", "40B"),
+        ("approx 40b", "40B"),
+        ("~40b", "40B"),
+        ("40.500b", "40.5B"),
+    ],
+)
+def test_parse_score_accepts_and_normalizes_supported_inputs(
+    raw: str, expected: str
+) -> None:
+    assert parse_score(raw).compact == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", " ", "40", "0", "0K", "-40B", "score 40B", "40B-ish", "40MM", "1,23,000"],
+)
+def test_parse_score_rejects_invalid_or_ambiguous_inputs(raw: str) -> None:
+    with pytest.raises(ScoreInputError):
+        parse_score(raw)
+
+
+def test_parse_score_enforces_inclusive_decimal_bounds() -> None:
+    assert parse_score("10K", minimum=Decimal("10000")).compact == "10K"
+    assert parse_score("1M", maximum=Decimal("1000000")).compact == "1M"
+    with pytest.raises(ScoreInputError):
+        parse_score("9999", minimum=Decimal("10000"))
+    with pytest.raises(ScoreInputError):
+        parse_score("1.1M", maximum=Decimal("1000000"))
+
+
+def test_validate_answer_dispatches_score_and_bounds() -> None:
+    assert validate_answer({"validate": "score"}, "Over 40b") == (True, "40B", None)
+    assert validate_answer({"validate": "score:min=10000,max=1000000"}, "10K") == (
+        True,
+        "10K",
+        None,
+    )
+    assert validate_answer({"validate": "score:min=10000,max=1000000"}, "1M") == (
+        True,
+        "1M",
+        None,
+    )
+    assert (
+        validate_answer({"validate": "score:min=10000,max=1000000"}, "9999")[0] is False
+    )
+    assert (
+        validate_answer({"validate": "score:min=10000,max=1000000"}, "1.1M")[0] is False
+    )
+
+
+def test_validate_answer_leaves_regex_and_unrelated_numbers_unchanged() -> None:
+    player_power = {"type": "number", "validate": r"regex:^[0-9]+(\.[0-9]{1,2})?[Mm]?$"}
+    assert validate_answer(player_power, "40M") == (True, "40M", None)
+    assert validate_answer(player_power, "Over 40M")[0] is False
+    assert validate_answer(player_power, "40,5M")[0] is False
+
+    unrelated = {"type": "number", "validate": "none"}
+    assert validate_answer(unrelated, "40") == (True, "40", None)
+    assert validate_answer(unrelated, "not a score") == (True, "not a score", None)


### PR DESCRIPTION
### Motivation
- Allow recruits to enter human-friendly approximate scores (K/M/B and word forms, qualifiers, decimal commas, trailing `+`) while keeping exact numeric fields and player-power validators strict. 
- Make the onboarding sheet the single source of truth for per-question validation by removing hidden qid-based overrides and by dispatching validation from the row `validate` directive. 

### Description
- Add a focused `Decimal`-based parser in `modules/onboarding/score_input.py` that accepts qualifiers (`over`, `about`, `~`), decimal-comma and decimal-dot forms, suffix families (`K`, `M`, `B` and word aliases), trailing `+`, and full unseparated numbers, and normalizes accepted answers to canonical compact strings such as `40B`, `40.5B`, `12.6M`, or `150K`. 
- Extend the sheet-driven dispatcher `validate_answer(meta, raw)` in `modules/onboarding/controllers/welcome_controller.py` to handle `validate=score` and `validate=score:min=...,max=...` (inclusive bounds) and return the normalized compact value as the cleaned result; regex-based validators remain unchanged. 
- Remove `_VALIDATION_OVERRIDES` and its qid-based application from `shared/sheets/onboarding_questions.py` so the row `validate` value from Sheets is preserved as the source of truth. 
- Add focused tests: `tests/onboarding/test_score_input.py` (parser unit coverage), updates to `tests/onboarding/test_auto_capture.py` (active inline capture path stores `40B` and rejects `40`), and `tests/onboarding/test_onboarding_questions_module.py` (proves sheet validator value survives `_build_questions()`). 
- Update docs `docs/modules/Onboarding.md` and `docs/ops/Config.md` to document `validate=score` and optional `min`/`max` bounds and the canonical storage rules (footer: `Doc last updated: 2026-07-30 (v0.9.8.2)`). 

### Testing
- Ran the focused pytest suite: `python -m pytest -q tests/onboarding/test_onboarding_questions_module.py tests/onboarding/test_auto_capture.py tests/onboarding/test_score_input.py tests/onboarding/test_summary_embed.py tests/recruitment/test_promo_summary_embed.py`, and the run passed (73 tests passed). 
- Ran linters/format checks: `python -m ruff format --check ...` and `python -m ruff check ...`, both passed for the touched files. 
- Verified active inline validation path is `app.py::_maybe_capture_onboarding_answer()` → `BaseWelcomeController.handle_thread_message()` → module-level `validate_answer()` in `modules/onboarding/controllers/welcome_controller.py`. 

Additional required notes and examples
- Removed hidden override: `_VALIDATION_OVERRIDES` and its qid application were deleted so sheet rows control validation directly. 
- Accepted example inputs and normalized storage: `Over 40b` → `40B`, `40 bill` → `40B`, `40,5b` → `40.5B`, `40,000,000,000` → `40B`, `12600000` → `12.6M`, `150K+` → `150K`. 
- Rejected examples: blank input, ambiguous bare `40`, zero or negative (`0`, `-40B`), malformed mixed text (`40B-ish`), invalid suffixes (`40MM`), and values outside configured inclusive `min`/`max` bounds. 
- Player-power and other exact numeric fields keep their existing `regex:` validators and are not implicitly treated as `score` (their behavior is unchanged). 
- The nine sheet rows (Hydra/Chimera and CvC mappings) will be updated separately in Sheets only after this code is deployed; no Google Sheets edits are included in this PR. 

Captured sample user-visible output
- Input: `Over 40b`  → Stored: `40B` 
- Input: `40`  → Error: `Enter a score such as 500K, 12.6M, 1B, or 40 billion. Include K, M, or B when using a shortened value.` 

[approval]
footer_date: 2026-07-30
[/approval]

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb81cc85c8323a917a0e34ffb7a5e)