### PR TITLE
Ignore known external bot commands in Woadkeeper error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
 - Added parser and command coverage for the Daily Recruiter Update utilities.
 ## Unreleased / Next
 
+- Fixed Woadkeeper command-error noise by silently ignoring unregistered commands that the cached shared help registry assigns only to other bots, while preserving reporting for unknown, ambiguous, unavailable, and Woadkeeper-owned cases.
 - Docs: Added EPIC and ADR for Phase 6 (Daily Recruiter Update v1).
 - Audit: Published docs hygiene findings at `AUDIT/20251030_DOCS_CLEANUP/report.md`.
 
@@ -386,4 +387,4 @@
 - Sheet tab names moved out of env into each Sheet's **Config** tab.
 
 ---
-Doc last updated: 2025-12-02 (v0.9.8.2)
+Doc last updated: 2026-08-04 (v0.9.8.2)

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from shared.logfmt import LogTemplates, guild_label, user_label, human_reason
 from shared.redaction import sanitize_text
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
+from shared.sheets import help_commands
 from modules.common.runtime import Runtime, StartupPhaseError, scheduler_report_lines
 from modules.common import keepalive
 from modules.coreops import ready as core_ready
@@ -172,6 +173,7 @@ INTENTS.message_content = True
 INTENTS.members = True
 
 BANG_PREFIX = "!"
+WOADKEEPER_HELP_BOT_KEY = "woadkeeper"
 COREOPS_SETTINGS = load_coreops_settings()
 COREOPS_COMMANDS = tuple(COREOPS_SETTINGS.admin_bang_base_commands)
 COREOPS_ADMIN_ALLOWLIST = {
@@ -691,8 +693,38 @@ async def on_message(message: discord.Message):
     await bot.process_commands(message)
 
 
+async def _is_known_external_command(ctx: commands.Context) -> bool:
+    invoked_with = help_commands.normalize_lookup(getattr(ctx, "invoked_with", ""))
+    root_command = invoked_with.split(" ", 1)[0]
+    if not root_command:
+        return False
+
+    try:
+        rows = await help_commands.get_rows()
+    except Exception:
+        log.warning(
+            "shared help lookup failed while classifying unknown command",
+            exc_info=True,
+        )
+        return False
+    if rows is None:
+        return False
+
+    matches = help_commands.find_rows(rows, root_command)
+    if not matches:
+        return False
+
+    owners = tuple(row.bot_key.strip().casefold() for row in matches)
+    return all(owner and owner != WOADKEEPER_HELP_BOT_KEY for owner in owners)
+
+
 @bot.event
 async def on_command_error(ctx: commands.Context, error: Exception):
+    if isinstance(error, commands.CommandNotFound) and await _is_known_external_command(
+        ctx
+    ):
+        return
+
     log.warning(
         "cmd error: cmd=%s user=%s err=%r",
         getattr(ctx.command, "name", None),

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -21,6 +21,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 - `FeatureToggles` worksheet schema: headers `feature_name`, `enabled` (case-insensitive).
 - Only `TRUE` enables a feature; missing tabs/rows fail closed. See [README](../../README.md#feature-toggles)
   and [Ops Config](../ops/Config.md#feature-toggles-worksheet) for operator workflow.
+- Cross-bot command ownership is read from enabled rows in the existing cached shared help registry selected by `HELP_COMMANDS_TAB`.
 
 ## Intents / Permissions
 - Dev Portal: enable **Server Members Intent** and **Message Content**.
@@ -46,6 +47,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 - Supported: `!ops`, `!ops␣`, `ops`, `ops␣`, `@mention`.
 - Admin bang shortcuts: `!env`, `!reload`, `!health`, `!digest`, `!checksheet`, `!config`, `!help`, `!ping`, `!refresh all` (Admin role only).
 - `!env` returns a four-page admin overview (Overview, Channels, Roles, Sheets & Config) and surfaces warnings for missing/not-found config on Page 1.
+- When a prefixed command is not registered in Woadkeeper, it is ignored only if every matching shared-help row has a nonblank owner other than `woadkeeper`. Unknown commands, ambiguous ownership, unavailable help data, and Woadkeeper-owned registry mismatches retain normal error reporting.
 - No bare-word shortcuts.
 
 ## CoreOps v1.5 contract
@@ -72,7 +74,7 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 ## Logging
 - Level via `LOG_LEVEL` (default INFO).
 - Startup confirms parsed role IDs.
-- Logs heartbeat/watchdog decisions and command errors.
+- Logs heartbeat/watchdog decisions and command errors, excluding commands that the shared help registry unambiguously assigns to other bots.
 
 ## CI/CD
 - GitHub Actions deploys queue sequentially; only one run per branch can execute at a time.
@@ -95,4 +97,4 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 - Embed footer standardized: `Bot vX.Y.Z · CoreOps vA.B.C` (Discord timestamp replaces
   inline timezone text).
 
-Doc last updated: 2025-12-03 (v0.9.8.2)
+Doc last updated: 2026-08-04 (v0.9.8.2)

--- a/shared/sheets/help_commands.py
+++ b/shared/sheets/help_commands.py
@@ -145,8 +145,13 @@ def normalize_lookup(value: object) -> str:
     return text.lstrip("!").strip()
 
 
-def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | None:
+def find_rows(
+    rows: Sequence[HelpCommandRow], query: object
+) -> tuple[HelpCommandRow, ...]:
     needle = normalize_lookup(query)
+    if not needle:
+        return ()
+    matches: list[HelpCommandRow] = []
     for row in rows:
         candidates = (
             row.command_key.replace("_", " "),
@@ -154,8 +159,13 @@ def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | 
             row.usage.split(" ", 1)[0],
         )
         if any(normalize_lookup(candidate) == needle for candidate in candidates):
-            return row
-    return None
+            matches.append(row)
+    return tuple(matches)
+
+
+def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | None:
+    matches = find_rows(rows, query)
+    return matches[0] if matches else None
 
 
 def visible_rows(

--- a/tests/shared/sheets/test_help_commands.py
+++ b/tests/shared/sheets/test_help_commands.py
@@ -70,6 +70,25 @@ def test_lookup_normalizes_leading_bang_and_access_filtering() -> None:
     assert len(help_commands.visible_rows(rows, staff=True, admin=True)) == 2
 
 
+def test_find_rows_returns_every_matching_owner() -> None:
+    rows = help_commands.parse_rows(
+        [
+            HEADERS,
+            _row(command="!responder", command_key="responder", bot_key="reminder"),
+            _row(
+                command="!responder",
+                command_key="responder",
+                bot_key="achievements",
+            ),
+            _row(command="!other", command_key="other", bot_key="woadkeeper"),
+        ]
+    )
+
+    matches = help_commands.find_rows(rows, "!responder")
+
+    assert [row.bot_key for row in matches] == ["reminder", "achievements"]
+
+
 def test_recruiter_only_visibility_uses_separate_access() -> None:
     rows = help_commands.parse_rows(
         [

--- a/tests/test_app_command_errors.py
+++ b/tests/test_app_command_errors.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from discord.ext import commands
+
+import app
+from shared.sheets import help_commands
+
+
+def _row(*, bot_key: str, command: str = "responder") -> help_commands.HelpCommandRow:
+    return help_commands.HelpCommandRow(
+        bot_key=bot_key,
+        command_key=command,
+        command=f"!{command}",
+        usage=f"!{command}",
+        category="Test",
+        access_level="user",
+        summary="Test command",
+        details="",
+        sort_order=1,
+        source_order=0,
+    )
+
+
+def _ctx(invoked_with: str = "responder") -> SimpleNamespace:
+    return SimpleNamespace(
+        command=None,
+        invoked_with=invoked_with,
+        author=SimpleNamespace(id=123),
+        guild=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "owners",
+    [
+        ("reminder",),
+        ("achievements",),
+        ("reminder", "achievements"),
+    ],
+)
+async def test_known_external_command_is_ignored(monkeypatch, owners) -> None:
+    monkeypatch.setattr(
+        app.help_commands,
+        "get_rows",
+        AsyncMock(return_value=tuple(_row(bot_key=owner) for owner in owners)),
+    )
+    send_log_message = AsyncMock()
+    monkeypatch.setattr(app.runtime, "send_log_message", send_log_message)
+
+    await app.on_command_error(_ctx(), commands.CommandNotFound("not registered"))
+
+    send_log_message.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        (_row(bot_key="woadkeeper"),),
+        (_row(bot_key="reminder"), _row(bot_key="woadkeeper")),
+        (_row(bot_key=""),),
+        (_row(bot_key="reminder", command="different"),),
+        (),
+        None,
+    ],
+)
+async def test_command_not_found_is_reported_when_ownership_is_not_external_only(
+    monkeypatch, rows
+) -> None:
+    monkeypatch.setattr(
+        app.help_commands,
+        "get_rows",
+        AsyncMock(return_value=rows),
+    )
+    send_log_message = AsyncMock()
+    monkeypatch.setattr(app.runtime, "send_log_message", send_log_message)
+
+    await app.on_command_error(_ctx(), commands.CommandNotFound("not registered"))
+
+    send_log_message.assert_awaited_once()
+
+
+async def test_command_not_found_is_reported_when_help_lookup_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        app.help_commands,
+        "get_rows",
+        AsyncMock(side_effect=RuntimeError("sheet unavailable")),
+    )
+    send_log_message = AsyncMock()
+    monkeypatch.setattr(app.runtime, "send_log_message", send_log_message)
+
+    await app.on_command_error(_ctx(), commands.CommandNotFound("not registered"))
+
+    send_log_message.assert_awaited_once()
+
+
+async def test_non_command_not_found_errors_keep_existing_reporting(monkeypatch) -> None:
+    get_rows = AsyncMock()
+    monkeypatch.setattr(app.help_commands, "get_rows", get_rows)
+    send_log_message = AsyncMock()
+    monkeypatch.setattr(app.runtime, "send_log_message", send_log_message)
+    ctx = _ctx()
+    ctx.command = SimpleNamespace(name="responder")
+
+    await app.on_command_error(ctx, RuntimeError("boom"))
+
+    get_rows.assert_not_awaited()
+    send_log_message.assert_awaited_once()


### PR DESCRIPTION
## What changed

- Intercept only `commands.CommandNotFound` before Woadkeeper's existing command-error logging.
- Resolve the attempted root command through the existing cached `HelpCommands` registry and its current normalization fields.
- Silently ignore the error only when every matching enabled registry row has a nonblank `bot_key` owned by another bot.
- Preserve existing reporting for Woadkeeper-owned commands, unknown commands, blank or mixed ownership, unavailable help data, and every non-`CommandNotFound` exception.
- Add an all-matches help lookup without changing the existing first-match helper used by `!help`.
- Add regression coverage and update the Core Infra contract and changelog.

## Why

All bots receive prefixed Discord messages. When a valid Reminder or Achievement command is used, Woadkeeper cannot resolve it locally and currently posts a command-error alert. The shared help registry already identifies command ownership, so Woadkeeper can distinguish valid external commands from genuine unknown or broken Woadkeeper commands without a hard-coded cross-bot allowlist.

## User and developer impact

- Valid commands owned only by Reminder/Achievement no longer make Woadkeeper complain.
- Genuine typos and registry/code mismatches remain observable.
- Reminder Bot and Achievement Bot are unchanged.
- No Google Sheets structure or data changes are required.

## Validation

- ✅ `python -m pytest tests/test_app_command_errors.py tests/shared/sheets/test_help_commands.py --maxfail=5 --timeout=180` — 19 passed.
- ✅ `python -m pytest tests/docs tests/guardrails tests/scripts --maxfail=10 --timeout=180` — 18 passed.
- ✅ `python -m compileall -q app.py shared/sheets/help_commands.py tests/test_app_command_errors.py tests/shared/sheets/test_help_commands.py`.
- ✅ `git diff --check`.
- ⚠️ Full suite reached 1,482 passes, then stopped at the repository's existing 25-failure cap. Failures were outside this diff (primarily existing logging-record assertions plus a date-sensitive Fusion expectation).
- ⚠️ The repository-wide docs/guardrails scanners still report pre-existing violations in untouched files; the Markdown files changed here have valid required footers.

[approval]
footer_date: 2026-08-04
[/approval]