### PR TITLE
Add sheet-driven Server Rules publisher and admin cog; expose colours and config cron

### DIFF
--- a/cogs/server_rules.py
+++ b/cogs/server_rules.py
@@ -1,0 +1,83 @@
+"""Admin commands for the sheet-driven Server Rules and FAQ publisher."""
+
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from c1c_coreops.helpers import help_metadata, tier
+from c1c_coreops.rbac import admin_only
+from modules.common import feature_flags, runtime as runtime_helpers
+from modules.common.embeds import get_embed_colour
+from modules.common.logs import channel_label
+from modules.ops import server_rules
+
+FEATURE_TOGGLE = "server_rules_faq"
+
+
+def _usage_embed() -> discord.Embed:
+    embed = discord.Embed()
+    embed.title = "Server rules"
+    embed.description = "Use `!serverrules publish` or `!serverrules refresh`."
+    embed.colour = get_embed_colour("admin")
+    return embed
+
+
+def _disabled_embed() -> discord.Embed:
+    embed = discord.Embed()
+    embed.title = "Server rules disabled"
+    embed.description = "Server rules FAQ publishing is disabled in FeatureToggles."
+    embed.colour = get_embed_colour("admin")
+    return embed
+
+
+class ServerRulesCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @tier("admin")
+    @help_metadata(
+        function_group="operational",
+        section="utilities",
+        access_tier="admin",
+    )
+    @commands.group(name="serverrules", invoke_without_command=True)
+    @admin_only()
+    async def serverrules(self, ctx: commands.Context) -> None:
+        await ctx.reply(embed=_usage_embed(), mention_author=False)
+
+    async def _run(self, ctx: commands.Context, action: str) -> None:
+        if not feature_flags.is_enabled(FEATURE_TOGGLE):
+            await ctx.reply(embed=_disabled_embed(), mention_author=False)
+            await runtime_helpers.send_log_message(
+                f"📘 **Server rules** — cmd=serverrules {action} • status=disabled"
+            )
+            return
+        if action == "publish":
+            summary, target = await server_rules.publish(self.bot)
+        else:
+            summary, target = await server_rules.refresh(self.bot)
+        await ctx.reply(
+            embed=server_rules.result_embed(action, summary), mention_author=False
+        )
+        await runtime_helpers.send_log_message(
+            "📘 **Server rules** — "
+            f"cmd=serverrules {action} • admin={getattr(getattr(ctx, 'author', None), 'id', 'unknown')} "
+            f"• destination={channel_label(getattr(target, 'guild', getattr(ctx, 'guild', None)), getattr(target, 'id', None))} "
+            f"• created={summary.created} • refreshed={summary.refreshed} • removed={summary.removed} "
+            f"• skipped={summary.skipped} • failed={summary.failed}"
+        )
+
+    @serverrules.command(name="publish")
+    @admin_only()
+    async def publish(self, ctx: commands.Context) -> None:
+        await self._run(ctx, "publish")
+
+    @serverrules.command(name="refresh")
+    @admin_only()
+    async def refresh(self, ctx: commands.Context) -> None:
+        await self._run(ctx, "refresh")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ServerRulesCog(bot))

--- a/modules/common/embeds.py
+++ b/modules/common/embeds.py
@@ -6,13 +6,24 @@ from typing import Literal
 
 import discord
 
-
 EmbedCategory = Literal["admin", "recruitment", "community"]
 
 _COLOURS: dict[EmbedCategory, discord.Colour] = {
     "admin": discord.Colour(0xF200E5),
     "recruitment": discord.Colour(0x1B8009),
     "community": discord.Colour(0x3498DB),
+}
+
+SERVER_RULES_PRIMARY_COLOUR = discord.Colour(0x4472C4)
+SERVER_RULES_SPIRIT_COLOUR = discord.Colour(0x356854)
+SERVER_RULES_QUICK_GUIDE_COLOUR = discord.Colour(0xFFD666)
+SERVER_RULES_FAQ_COLOUR = discord.Colour(0x607D8B)
+
+_SERVER_RULES_COLOURS: dict[str, discord.Colour] = {
+    "#4472c4": SERVER_RULES_PRIMARY_COLOUR,
+    "#356854": SERVER_RULES_SPIRIT_COLOUR,
+    "#ffd666": SERVER_RULES_QUICK_GUIDE_COLOUR,
+    "#607d8b": SERVER_RULES_FAQ_COLOUR,
 }
 
 
@@ -22,4 +33,16 @@ def get_embed_colour(category: EmbedCategory) -> discord.Colour:
     return _COLOURS.get(category, discord.Colour.default())
 
 
-__all__ = ["EmbedCategory", "get_embed_colour"]
+def get_server_rules_colour(value: str) -> discord.Colour | None:
+    return _SERVER_RULES_COLOURS.get(str(value).strip().lower())
+
+
+__all__ = [
+    "EmbedCategory",
+    "SERVER_RULES_FAQ_COLOUR",
+    "SERVER_RULES_PRIMARY_COLOUR",
+    "SERVER_RULES_QUICK_GUIDE_COLOUR",
+    "SERVER_RULES_SPIRIT_COLOUR",
+    "get_embed_colour",
+    "get_server_rules_colour",
+]

--- a/modules/common/runtime.py
+++ b/modules/common/runtime.py
@@ -45,7 +45,7 @@ from shared.logging import get_trace_id, set_trace_id, setup_logging
 from shared.obs.events import refresh_bucket_results
 from c1c_coreops.helpers import audit_tiers, rehydrate_tiers
 from shared.web_routes import mount_emoji_pad
-from . import keepalive
+from modules.common import keepalive
 
 import modules.onboarding as onboarding_pkg
 from modules.community import COMMUNITY_EXTENSIONS
@@ -134,7 +134,7 @@ async def create_app(*, runtime: "Runtime | None" = None) -> web.Application:
             "ok": True,
             "bot": get_bot_name(),
             "env": get_env_name(),
-            "version": os.getenv("BOT_VERSION", "dev"),
+            "version": str(shared_config.cfg.get("BOT_VERSION", "dev") or "dev"),
             "trace": get_trace_id(),
         }
         return web.json_response(payload)
@@ -150,7 +150,7 @@ async def create_app(*, runtime: "Runtime | None" = None) -> web.Application:
                 "ok": True,
                 "bot": get_bot_name(),
                 "env": get_env_name(),
-                "version": os.getenv("BOT_VERSION", "dev"),
+                "version": str(shared_config.cfg.get("BOT_VERSION", "dev") or "dev"),
             }
             return payload, True
         return await runtime._health_payload()
@@ -1231,7 +1231,7 @@ class Runtime:
             "ok": healthy,
             "bot": get_bot_name(),
             "env": get_env_name(),
-            "version": os.getenv("BOT_VERSION", "dev"),
+            "version": str(shared_config.cfg.get("BOT_VERSION", "dev") or "dev"),
             "age_seconds": round(age, 3),
             "stall_after_sec": stall,
             "keepalive_sec": keepalive,
@@ -1678,7 +1678,7 @@ class Runtime:
             self._alert_feature_toggle_failure(failure_reason, skipped_feature_modules)
 
         # === Always-on internal extensions (admin-gated debug/ops commands) ===
-        ALWAYS_EXTENSIONS = ("modules.coreops.cmd_cfg",)
+        ALWAYS_EXTENSIONS = ("modules.coreops.cmd_cfg", "cogs.server_rules")
         for ext in ALWAYS_EXTENSIONS:
             try:
                 await self.bot.load_extension(ext)
@@ -2105,7 +2105,9 @@ class Runtime:
             housekeeping_cleanup=housekeeping_cleanup,
         )
 
-        mirralith_cron = os.getenv("MIRRALITH_POST_CRON", "").strip()
+        mirralith_cron = str(
+            shared_config.cfg.get("MIRRALITH_POST_CRON", "") or ""
+        ).strip()
         if mirralith_cron and toggles.mirralith_overview_enabled:
             mirralith_job = self.scheduler.cron(
                 mirralith_cron,

--- a/modules/ops/__init__.py
+++ b/modules/ops/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "permissions_ui",
     "server_map",
     "cluster_role_map",
+    "server_rules",
 ]

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -1,0 +1,621 @@
+"""Sheet-driven Server Rules and FAQ publisher."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+from urllib.parse import urlparse
+
+import discord
+
+from modules.common.discord_utils import resolve_message_target
+from modules.common.embeds import get_embed_colour, get_server_rules_colour
+from shared.sheets import async_adapter
+from shared.sheets import core as sheets_core
+from shared.sheets import recruitment as recruitment_sheet
+from shared.config import get_recruitment_sheet_id
+from shared.theme import colors
+
+MARKER_PREFIX = "\u2063\u200bserverrules:"
+REQUIRED_HEADERS = {
+    "message_key",
+    "section",
+    "order",
+    "enabled",
+    "title",
+    "description",
+    "colour",
+    "thumbnail_url",
+    "footer",
+    "message_id",
+}
+TRUE_VALUES = {"1", "true", "yes", "y", "on", "enabled", "publish", "published"}
+FALSE_VALUES = {"", "0", "false", "no", "n", "off", "disabled"}
+MAX_TITLE = 256
+MAX_DESCRIPTION = 4096
+MAX_FOOTER = 2048
+MAX_TOTAL = 6000
+MIN_SNOWFLAKE_LEN = 17
+MAX_SNOWFLAKE_LEN = 20
+MAX_UINT64 = 2**64 - 1
+
+
+class FetchState(Enum):
+    FOUND = "found"
+    MISSING = "missing"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class Row:
+    row_number: int
+    values: list[Any]
+    data: dict[str, str]
+    enabled: bool
+    order: float | None = None
+    embed: discord.Embed | None = None
+
+    @property
+    def key(self) -> str:
+        return self.data.get("message_key", "").strip()
+
+    @property
+    def message_id(self) -> str:
+        return self.data.get("message_id", "").strip()
+
+
+@dataclass
+class Summary:
+    created: int = 0
+    refreshed: int = 0
+    removed: int = 0
+    skipped: int = 0
+    failed: int = 0
+    failures: dict[str, list[str]] = field(default_factory=dict)
+
+    def fail(self, key: str, reason: str) -> None:
+        self.failed += 1
+        self.failures.setdefault(key or "row", []).append(reason)
+
+
+def marker_for(message_key: str) -> str:
+    return f"{MARKER_PREFIX}{message_key}\u2060\u2063"
+
+
+def is_feature_message(message: Any, keys: set[str] | None = None) -> bool:
+    content = getattr(message, "content", "") or ""
+    if not content.startswith(MARKER_PREFIX):
+        return False
+    if keys is None:
+        return True
+    return any(content.startswith(marker_for(key)) for key in keys)
+
+
+def _mirralith_sheet_id() -> str:
+    sheet_id = get_recruitment_sheet_id().strip()
+    if not sheet_id:
+        raise RuntimeError("RECRUITMENT_SHEET_ID not set for Mirralith spreadsheet")
+    return sheet_id
+
+
+def _a1_col(index: int) -> str:
+    result = ""
+    while index >= 0:
+        index, rem = divmod(index, 26)
+        result = chr(65 + rem) + result
+        index -= 1
+    return result
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+PLACEHOLDER_FIELDS = {
+    "message_key",
+    "section",
+    "order",
+    "title",
+    "description",
+    "colour",
+    "thumbnail_url",
+    "footer",
+    "message_id",
+    "review_status",
+    "review_notes",
+}
+
+
+def _is_empty_placeholder(data: dict[str, str]) -> bool:
+    return parse_enabled(data.get("enabled")) is False and all(
+        not data.get(field, "").strip() for field in PLACEHOLDER_FIELDS
+    )
+
+
+def parse_enabled(value: Any) -> bool | None:
+    text = _text(value).lower()
+    if text in TRUE_VALUES:
+        return True
+    if text in FALSE_VALUES:
+        return False
+    return None
+
+
+def parse_colour(value: Any) -> discord.Colour | None:
+    text = _text(value).lower()
+    server_rules_colour = get_server_rules_colour(text)
+    if server_rules_colour is not None:
+        return server_rules_colour
+    if not text or text in {"community", "c1c_blue", "blue"}:
+        return get_embed_colour("community")
+    if text in {"recruitment", "green"}:
+        return get_embed_colour("recruitment")
+    if text == "admin":
+        return get_embed_colour("admin")
+    if text == "theme_c1c_blue":
+        return colors.c1c_blue
+    if text == "theme_admin":
+        return colors.admin
+    return None
+
+
+def valid_snowflake(value: str) -> bool:
+    if not value or not value.isdecimal():
+        return False
+    if not MIN_SNOWFLAKE_LEN <= len(value) <= MAX_SNOWFLAKE_LEN:
+        return False
+    number = int(value)
+    return 0 < number <= MAX_UINT64
+
+
+def _valid_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def build_embed(row: Row) -> tuple[discord.Embed | None, list[str]]:
+    errors: list[str] = []
+    title = row.data.get("title", "").strip()
+    description = row.data.get("description", "").strip()
+    footer = row.data.get("footer", "").strip()
+    thumbnail = row.data.get("thumbnail_url", "").strip()
+    colour = parse_colour(row.data.get("colour", ""))
+    if colour is None:
+        errors.append("colour must be an approved palette value")
+    if not title and not description:
+        errors.append("embed needs a title or description")
+    if len(title) > MAX_TITLE:
+        errors.append("title exceeds Discord limit")
+    if len(description) > MAX_DESCRIPTION:
+        errors.append("description exceeds Discord limit")
+    if len(footer) > MAX_FOOTER:
+        errors.append("footer exceeds Discord limit")
+    if thumbnail and not _valid_url(thumbnail):
+        errors.append("thumbnail_url must be http or https")
+    if len(title) + len(description) + len(footer) > MAX_TOTAL:
+        errors.append("embed total text exceeds Discord limit")
+    if errors:
+        return None, errors
+    embed = discord.Embed()
+    embed.title = title or None
+    embed.description = description or None
+    embed.colour = colour
+    if footer:
+        embed.set_footer(text=footer)
+    if thumbnail:
+        embed.set_thumbnail(url=thumbnail)
+    return embed, []
+
+
+async def load_rows() -> tuple[str, dict[str, int], list[Row], list[str]]:
+    tab = await recruitment_sheet.get_config_value_async(
+        "SERVER_RULES_FAQ_TAB", None, force=True
+    )
+    if not tab:
+        return "", {}, [], ["Config key SERVER_RULES_FAQ_TAB is missing"]
+    matrix = await sheets_core.afetch_values(_mirralith_sheet_id(), tab)
+    if not matrix:
+        return tab, {}, [], ["sheet tab has no header row"]
+    headers = [_text(value).lower() for value in matrix[0]]
+    header_map = {header: idx for idx, header in enumerate(headers) if header}
+    missing = sorted(REQUIRED_HEADERS - set(header_map))
+    if missing:
+        return tab, header_map, [], ["missing headers: " + ", ".join(missing)]
+    rows: list[Row] = []
+    for offset, values in enumerate(matrix[1:], start=2):
+        data = {
+            name: _text(values[idx]) if idx < len(values) else ""
+            for name, idx in header_map.items()
+        }
+        if _is_empty_placeholder(data):
+            continue
+        rows.append(
+            Row(offset, list(values), data, parse_enabled(data.get("enabled")) is True)
+        )
+    return tab, header_map, rows, []
+
+
+async def preflight(
+    bot: discord.Client,
+) -> tuple[Any | None, str, dict[str, int], list[Row], Summary | None]:
+    summary = Summary()
+    tab, header_map, rows, load_errors = await load_rows()
+    if load_errors:
+        for err in load_errors:
+            summary.fail("config", err)
+        return None, tab, header_map, rows, summary
+    dest_raw = await recruitment_sheet.get_config_value_async(
+        "SERVER_RULES_FAQ_CHANNEL_ID", None, force=True
+    )
+    try:
+        dest_id = int(str(dest_raw or "").strip())
+        target = await resolve_message_target(bot, dest_id)
+    except Exception:
+        summary.fail(
+            "config",
+            "SERVER_RULES_FAQ_CHANNEL_ID must resolve to a text channel or thread",
+        )
+        target = None
+    seen_keys: set[str] = set()
+    enabled_orders: dict[float, str] = {}
+    for row in rows:
+        key = row.key
+        label = key or f"row {row.row_number}"
+        if not key:
+            summary.fail(label, "message_key is required")
+        elif key in seen_keys:
+            summary.fail(key, "message_key must be unique")
+        seen_keys.add(key)
+        if parse_enabled(row.data.get("enabled")) is None:
+            summary.fail(label, "enabled value is not recognised")
+        if row.message_id and not valid_snowflake(row.message_id):
+            summary.fail(label, "message_id must be blank or a valid Discord snowflake")
+        if row.enabled:
+            order_text = row.data.get("order", "")
+            try:
+                order = float(order_text)
+            except ValueError:
+                summary.fail(label, "enabled rows require numeric order")
+            else:
+                if not math.isfinite(order):
+                    summary.fail(label, "enabled rows require finite order")
+                elif order in enabled_orders:
+                    summary.fail(
+                        label, f"enabled order duplicates {enabled_orders[order]}"
+                    )
+                else:
+                    row.order = order
+                    enabled_orders[order] = label
+            row.embed, errors = build_embed(row)
+            for err in errors:
+                summary.fail(label, err)
+    return target, tab, header_map, rows, summary if summary.failures else None
+
+
+async def _worksheet(tab: str) -> Any:
+    return await sheets_core.aget_worksheet(_mirralith_sheet_id(), tab)
+
+
+def _message_id_range(header_map: dict[str, int], row_number: int) -> str:
+    return f"{_a1_col(header_map['message_id'])}{row_number}"
+
+
+async def _write_message_id(
+    tab: str, header_map: dict[str, int], row: Row, message_id: str
+) -> None:
+    ws = await _worksheet(tab)
+    await async_adapter.aworksheet_values_update(
+        ws, _message_id_range(header_map, row.row_number), [[message_id]]
+    )
+
+
+def _batch_payload(
+    header_map: dict[str, int], updates: list[tuple[Row, str]]
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "range": _message_id_range(header_map, row.row_number),
+            "values": [[message_id]],
+        }
+        for row, message_id in updates
+    ]
+
+
+async def _write_ids_batch(
+    tab: str, header_map: dict[str, int], updates: list[tuple[Row, str]]
+) -> None:
+    if not updates:
+        return
+    ws = await _worksheet(tab)
+    await sheets_core.acall_with_backoff(
+        ws.batch_update, _batch_payload(header_map, updates)
+    )
+
+
+async def _restore_ids_batch(
+    tab: str, header_map: dict[str, int], snapshot: dict[int, str]
+) -> None:
+    rows = [Row(row_number, [], {}, False) for row_number in snapshot]
+    await _write_ids_batch(
+        tab, header_map, [(row, value) for row, value in zip(rows, snapshot.values())]
+    )
+
+
+async def _fetch(target: Any, message_id: str) -> tuple[FetchState, Any | None, str]:
+    if not message_id or not valid_snowflake(message_id):
+        return FetchState.MISSING, None, "message_id is blank or invalid"
+    try:
+        return FetchState.FOUND, await target.fetch_message(int(message_id)), ""
+    except discord.NotFound:
+        return FetchState.MISSING, None, "stored message was not found"
+    except discord.Forbidden:
+        return FetchState.UNKNOWN, None, "missing permission to fetch stored message"
+    except (TimeoutError, OSError):
+        return FetchState.UNKNOWN, None, "temporary error while fetching stored message"
+    except discord.HTTPException:
+        return FetchState.UNKNOWN, None, "Discord error while fetching stored message"
+    except Exception:
+        return (
+            FetchState.UNKNOWN,
+            None,
+            "unexpected error while fetching stored message",
+        )
+
+
+def _is_managed_message(
+    message: Any, *, bot_id: int | None, message_key: str | None = None
+) -> bool:
+    if (
+        bot_id is not None
+        and getattr(getattr(message, "author", None), "id", None) != bot_id
+    ):
+        return False
+    if message_key is not None:
+        return is_feature_message(message, {message_key})
+    return is_feature_message(message)
+
+
+async def _iter_feature_messages(
+    target: Any, bot_id: int | None, summary: Summary | None = None
+) -> list[Any]:
+    history = getattr(target, "history", None)
+    if not callable(history):
+        return []
+    found: list[Any] = []
+    try:
+        async for message in history(limit=500):
+            if _is_managed_message(message, bot_id=bot_id):
+                found.append(message)
+    except Exception:
+        if summary is not None:
+            summary.fail(
+                "cleanup", "failed to scan history for orphaned managed messages"
+            )
+    return found
+
+
+async def _delete_old_message(
+    message: Any, *, bot_id: int | None, message_key: str, summary: Summary
+) -> None:
+    message_id = str(getattr(message, "id", ""))
+    if not _is_managed_message(message, bot_id=bot_id, message_key=message_key):
+        summary.fail(
+            message_key,
+            f"stored message {message_id or 'unknown'} is not a server-rules message for this row",
+        )
+        return
+    try:
+        await message.delete()
+        summary.removed += 1
+    except discord.NotFound:
+        return
+    except discord.Forbidden:
+        summary.fail(
+            "cleanup", f"missing permission to delete old message {message_id}"
+        )
+    except (TimeoutError, OSError):
+        summary.fail("cleanup", f"temporary error deleting old message {message_id}")
+    except discord.HTTPException:
+        summary.fail("cleanup", f"Discord error deleting old message {message_id}")
+    except Exception:
+        summary.fail("cleanup", f"unexpected error deleting old message {message_id}")
+
+
+async def _cleanup_previous_messages(
+    target: Any,
+    bot_id: int | None,
+    rows: list[Row],
+    new_ids: set[str],
+    summary: Summary,
+) -> None:
+    processed_old_ids: set[str] = set()
+    for row in rows:
+        message_id = row.message_id
+        if not message_id or message_id in new_ids or message_id in processed_old_ids:
+            continue
+        processed_old_ids.add(message_id)
+        state, message, reason = await _fetch(target, message_id)
+        if state is FetchState.MISSING:
+            continue
+        if state is FetchState.UNKNOWN or message is None:
+            summary.fail(
+                row.key, f"cleanup could not verify old message {message_id}: {reason}"
+            )
+            continue
+        await _delete_old_message(
+            message, bot_id=bot_id, message_key=row.key, summary=summary
+        )
+
+    for msg in await _iter_feature_messages(target, bot_id, summary):
+        message_id = str(getattr(msg, "id", ""))
+        if message_id in new_ids or message_id in processed_old_ids:
+            continue
+        try:
+            await msg.delete()
+            summary.removed += 1
+        except discord.NotFound:
+            continue
+        except discord.Forbidden:
+            summary.fail(
+                "cleanup", f"missing permission to delete orphaned message {message_id}"
+            )
+        except (TimeoutError, OSError):
+            summary.fail(
+                "cleanup", f"temporary error deleting orphaned message {message_id}"
+            )
+        except discord.HTTPException:
+            summary.fail(
+                "cleanup", f"Discord error deleting orphaned message {message_id}"
+            )
+        except Exception:
+            summary.fail(
+                "cleanup", f"unexpected error deleting orphaned message {message_id}"
+            )
+
+
+async def _delete_new(messages: list[Any]) -> None:
+    for sent in messages:
+        try:
+            await sent.delete()
+        except Exception:
+            pass
+
+
+async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
+    target, tab, header_map, rows, errors = await preflight(bot)
+    if errors:
+        return errors, target
+    assert target is not None
+    summary = Summary()
+    snapshot = {row.row_number: row.message_id for row in rows}
+    enabled_rows = sorted(
+        [r for r in rows if r.enabled], key=lambda r: (r.order, r.key)
+    )
+    new_pairs: list[tuple[Row, Any]] = []
+    try:
+        for row in enabled_rows:
+            new_pairs.append(
+                (row, await target.send(content=marker_for(row.key), embed=row.embed))
+            )
+    except Exception:
+        summary.fail(row.key, "Discord send failed during rebuild")
+        await _delete_new([msg for _row, msg in new_pairs])
+        return summary, target
+    updates = [(row, str(msg.id)) for row, msg in new_pairs]
+    updates.extend((row, "") for row in rows if not row.enabled and row.message_id)
+    try:
+        await _write_ids_batch(tab, header_map, updates)
+        summary.created = len(new_pairs)
+    except Exception:
+        summary.fail(
+            "sheet",
+            "message_id update failed during rebuild; original IDs were restored where possible",
+        )
+        try:
+            await _restore_ids_batch(tab, header_map, snapshot)
+        except Exception:
+            summary.fail("sheet", "failed to restore original message_id values")
+        await _delete_new([msg for _row, msg in new_pairs])
+        return summary, target
+    new_ids = {str(getattr(msg, "id", "")) for _row, msg in new_pairs}
+    bot_id = getattr(getattr(bot, "user", None), "id", None)
+    await _cleanup_previous_messages(target, bot_id, rows, new_ids, summary)
+    return summary, target
+
+
+async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
+    target, tab, header_map, rows, errors = await preflight(bot)
+    if errors:
+        return errors, target
+    assert target is not None
+    summary = Summary()
+    for row in rows:
+        try:
+            state, msg, reason = await _fetch(target, row.message_id)
+            if row.enabled:
+                if state is FetchState.UNKNOWN:
+                    summary.fail(row.key, reason)
+                    continue
+                if (
+                    state is FetchState.FOUND
+                    and msg is not None
+                    and is_feature_message(msg, {row.key})
+                ):
+                    try:
+                        await msg.edit(content=marker_for(row.key), embed=row.embed)
+                    except Exception:
+                        summary.fail(row.key, "failed to edit stored message")
+                    else:
+                        summary.refreshed += 1
+                    continue
+                sent = None
+                try:
+                    sent = await target.send(
+                        content=marker_for(row.key), embed=row.embed
+                    )
+                    await _write_message_id(tab, header_map, row, str(sent.id))
+                except Exception:
+                    if sent is not None:
+                        try:
+                            await sent.delete()
+                        except Exception:
+                            pass
+                    summary.fail(
+                        row.key, "failed to create replacement or store its message_id"
+                    )
+                else:
+                    summary.created += 1
+            else:
+                if not row.message_id:
+                    summary.skipped += 1
+                elif state is FetchState.UNKNOWN:
+                    summary.fail(row.key, reason)
+                elif state is FetchState.MISSING:
+                    try:
+                        await _write_message_id(tab, header_map, row, "")
+                    except Exception:
+                        summary.fail(
+                            row.key,
+                            "stored message was missing but message_id could not be cleared",
+                        )
+                    else:
+                        summary.skipped += 1
+                elif msg is not None and is_feature_message(msg, {row.key}):
+                    try:
+                        await msg.delete()
+                        await _write_message_id(tab, header_map, row, "")
+                    except Exception:
+                        summary.fail(
+                            row.key,
+                            "failed to delete disabled message or clear message_id",
+                        )
+                    else:
+                        summary.removed += 1
+                else:
+                    summary.fail(
+                        row.key, "stored message is not managed by server rules"
+                    )
+        except Exception:
+            summary.fail(row.key, "unexpected row processing failure")
+    return summary, target
+
+
+def result_embed(action: str, summary: Summary) -> discord.Embed:
+    embed = discord.Embed(
+        title=f"Server rules {action}", colour=get_embed_colour("admin")
+    )
+    embed.add_field(name="Created", value=str(summary.created), inline=True)
+    embed.add_field(name="Refreshed", value=str(summary.refreshed), inline=True)
+    embed.add_field(name="Removed", value=str(summary.removed), inline=True)
+    embed.add_field(name="Skipped", value=str(summary.skipped), inline=True)
+    embed.add_field(name="Failed", value=str(summary.failed), inline=True)
+    if summary.failures:
+        details = [
+            f"{key}: {'; '.join(reasons)}" for key, reasons in summary.failures.items()
+        ]
+        embed.add_field(
+            name="Failure details", value="\n".join(details)[:1024], inline=False
+        )
+    return embed

--- a/shared/config.py
+++ b/shared/config.py
@@ -110,6 +110,7 @@ _REQUIRED_ENV = (
     "RECRUITMENT_SHEET_ID",
 )
 
+
 def _require_env(name: str) -> str:
     value = os.getenv(name)
     if value is None or str(value).strip() == "":
@@ -482,7 +483,9 @@ async def amerge_onboarding_config_early() -> int:
     try:
         _, milestone_values = await _aload_milestones_config_values()
     except RuntimeError:
-        log.debug("config: milestones sheet id not configured; skipping async tab merge")
+        log.debug(
+            "config: milestones sheet id not configured; skipping async tab merge"
+        )
     except Exception as exc:  # pragma: no cover - network or credential failures
         log.warning("config: failed to async-load milestones Config tab: %s", exc)
     else:
@@ -528,19 +531,29 @@ def _load_config_snapshot() -> Dict[str, object]:
         "DISCORD_TOKEN": os.getenv("DISCORD_TOKEN", ""),
         "ENV_NAME": _runtime.get_env_name(),
         "GUILD_IDS": _int_set(os.getenv("GUILD_IDS")),
-        "TIMEZONE": (os.getenv("TIMEZONE") or "Europe/Vienna").strip() or "Europe/Vienna",
+        "TIMEZONE": (os.getenv("TIMEZONE") or "Europe/Vienna").strip()
+        or "Europe/Vienna",
         "REFRESH_TIMES": _parse_schedule(os.getenv("REFRESH_TIMES"), refresh_default),
         "GSPREAD_CREDENTIALS": os.getenv("GSPREAD_CREDENTIALS", ""),
         "RECRUITMENT_SHEET_ID": (os.getenv("RECRUITMENT_SHEET_ID") or "").strip(),
         "ONBOARDING_SHEET_ID": (os.getenv("ONBOARDING_SHEET_ID") or "").strip(),
         "MILESTONES_SHEET_ID": (os.getenv("MILESTONES_SHEET_ID") or "").strip(),
         "LEAGUES_SHEET_ID": (os.getenv("LEAGUES_SHEET_ID") or "").strip(),
-        "LEAGUES_CONFIG_TAB": (os.getenv("LEAGUES_CONFIG_TAB") or "Config").strip() or "Config",
-        "LEAGUES_SUBMISSION_CHANNEL_ID": _first_int(os.getenv("LEAGUES_SUBMISSION_CHANNEL_ID")),
-        "LEAGUES_LEGENDARY_THREAD_ID": _first_int(os.getenv("LEAGUES_LEGENDARY_THREAD_ID")),
+        "LEAGUES_CONFIG_TAB": (os.getenv("LEAGUES_CONFIG_TAB") or "Config").strip()
+        or "Config",
+        "LEAGUES_SUBMISSION_CHANNEL_ID": _first_int(
+            os.getenv("LEAGUES_SUBMISSION_CHANNEL_ID")
+        ),
+        "LEAGUES_LEGENDARY_THREAD_ID": _first_int(
+            os.getenv("LEAGUES_LEGENDARY_THREAD_ID")
+        ),
         "LEAGUES_RISING_THREAD_ID": _first_int(os.getenv("LEAGUES_RISING_THREAD_ID")),
-        "LEAGUES_STORMFORGED_THREAD_ID": _first_int(os.getenv("LEAGUES_STORMFORGED_THREAD_ID")),
-        "LEAGUES_REMINDER_THREAD_ID": _first_int(os.getenv("LEAGUES_REMINDER_THREAD_ID")),
+        "LEAGUES_STORMFORGED_THREAD_ID": _first_int(
+            os.getenv("LEAGUES_STORMFORGED_THREAD_ID")
+        ),
+        "LEAGUES_REMINDER_THREAD_ID": _first_int(
+            os.getenv("LEAGUES_REMINDER_THREAD_ID")
+        ),
         "ANNOUNCEMENT_CHANNEL_ID": _first_int(os.getenv("ANNOUNCEMENT_CHANNEL_ID")),
         "C1C_LEAGUE_ROLE_ID": _first_int(os.getenv("C1C_LEAGUE_ROLE_ID")),
         "LEAGUE_ADMIN_IDS": _int_set(os.getenv("LEAGUE_ADMIN_IDS")),
@@ -552,7 +565,9 @@ def _load_config_snapshot() -> Dict[str, object]:
         "CLAN_ROLE_IDS": _int_set(os.getenv("CLAN_ROLE_IDS")),
         "RAID_ROLE_ID": _first_int(os.getenv("RAID_ROLE_ID")),
         "WANDERING_SOULS_ROLE_ID": _first_int(os.getenv("WANDERING_SOULS_ROLE_ID")),
-        "WANDERING_SOULS_EXCLUDE_ROLE_ID": _first_int(os.getenv("WANDERING_SOULS_EXCLUDE_ROLE_ID")),
+        "WANDERING_SOULS_EXCLUDE_ROLE_ID": _first_int(
+            os.getenv("WANDERING_SOULS_EXCLUDE_ROLE_ID")
+        ),
         "VISITOR_ROLE_ID": _first_int(os.getenv("VISITOR_ROLE_ID")),
         "LEAD_ROLE_IDS": _int_set(os.getenv("LEAD_ROLE_IDS")),
         "CLAN_LEAD_IDS": _int_set(os.getenv("CLAN_LEAD_IDS")),
@@ -564,7 +579,9 @@ def _load_config_snapshot() -> Dict[str, object]:
         "RECRUITMENT_INTERACT_CHANNEL": _first_int(
             os.getenv("RECRUITMENT_INTERACT_CHANNEL")
         ),
-        "WELCOME_GENERAL_CHANNEL_ID": _first_int(os.getenv("WELCOME_GENERAL_CHANNEL_ID")),
+        "WELCOME_GENERAL_CHANNEL_ID": _first_int(
+            os.getenv("WELCOME_GENERAL_CHANNEL_ID")
+        ),
         "WELCOME_CHANNEL_ID": _first_int(os.getenv("WELCOME_CHANNEL_ID")),
         "PROMO_CHANNEL_ID": _first_int(os.getenv("PROMO_CHANNEL_ID")),
         "ROLEMAP_CHANNEL_ID": _first_int(os.getenv("ROLEMAP_CHANNEL_ID")),
@@ -578,24 +595,32 @@ def _load_config_snapshot() -> Dict[str, object]:
         "WATCHDOG_CHECK_SEC": keepalive,
         "WATCHDOG_STALL_SEC": stall,
         "WATCHDOG_DISCONNECT_GRACE_SEC": grace,
-        "CLAN_TAGS_CACHE_TTL_SEC": _int_env("CLAN_TAGS_CACHE_TTL_SEC", 3600, min_value=60),
+        "CLAN_TAGS_CACHE_TTL_SEC": _int_env(
+            "CLAN_TAGS_CACHE_TTL_SEC", 3600, min_value=60
+        ),
         "PERMS_BLACKLIST_CHANNEL_IDS": _int_set(
             os.getenv("PERMS_BLACKLIST_CHANNEL_IDS")
         ),
         "PERMS_BLACKLIST_CATEGORY_IDS": _int_set(
             os.getenv("PERMS_BLACKLIST_CATEGORY_IDS")
         ),
-        "PANEL_THREAD_MODE": (os.getenv("PANEL_THREAD_MODE") or "same").strip().lower() or "same",
+        "PANEL_THREAD_MODE": (os.getenv("PANEL_THREAD_MODE") or "same").strip().lower()
+        or "same",
         "PANEL_FIXED_THREAD_ID": _first_int(os.getenv("PANEL_FIXED_THREAD_ID")),
         "BOT_VERSION": os.getenv("BOT_VERSION", "dev"),
+        "MIRRALITH_POST_CRON": (os.getenv("MIRRALITH_POST_CRON") or "").strip(),
         "LOG_LEVEL": os.getenv("LOG_LEVEL", "INFO"),
         "PUBLIC_BASE_URL": (os.getenv("PUBLIC_BASE_URL") or "").strip(),
         "RENDER_EXTERNAL_URL": (os.getenv("RENDER_EXTERNAL_URL") or "").strip(),
         "EMOJI_MAX_BYTES": _int_env("EMOJI_MAX_BYTES", 2_000_000, min_value=1),
         "EMOJI_PAD_SIZE": _int_env("EMOJI_PAD_SIZE", 256, min_value=64, max_value=512),
-        "EMOJI_PAD_BOX": _float_env("EMOJI_PAD_BOX", 0.85, min_value=0.2, max_value=0.95),
+        "EMOJI_PAD_BOX": _float_env(
+            "EMOJI_PAD_BOX", 0.85, min_value=0.2, max_value=0.95
+        ),
         "TAG_BADGE_PX": _int_env("TAG_BADGE_PX", 128, min_value=32, max_value=512),
-        "TAG_BADGE_BOX": _float_env("TAG_BADGE_BOX", 0.90, min_value=0.2, max_value=0.95),
+        "TAG_BADGE_BOX": _float_env(
+            "TAG_BADGE_BOX", 0.90, min_value=0.2, max_value=0.95
+        ),
         "STRICT_EMOJI_PROXY": _env_bool("STRICT_EMOJI_PROXY", True),
         "SHARD_PANEL_OVERVIEW_EMOJI": (
             os.getenv("SHARD_PANEL_OVERVIEW_EMOJI") or ""
@@ -790,6 +815,7 @@ def get_config_snapshot() -> Dict[str, object]:
 
     return dict(_CONFIG)
 
+
 def get_env_name(default: str = "dev") -> str:
     value = _CONFIG.get("ENV_NAME")
     return str(value) if isinstance(value, str) and value else default
@@ -939,7 +965,9 @@ def get_who_we_are_channel_id() -> Optional[int]:
     return _optional_id("WHO_WE_ARE_CHANNEL_ID")
 
 
-def get_refresh_times(default: Iterable[str] = ("02:00", "10:00", "18:00")) -> list[str]:
+def get_refresh_times(
+    default: Iterable[str] = ("02:00", "10:00", "18:00")
+) -> list[str]:
     raw = _CONFIG.get("REFRESH_TIMES")
     if isinstance(raw, (list, tuple, set)):
         values = [str(part).strip() for part in raw if str(part).strip()]
@@ -1143,7 +1171,6 @@ def get_clan_tags_cache_ttl_sec(default: int = 3600) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
-
 
 
 def get_perms_blacklist_channel_ids() -> Set[int]:

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -1,0 +1,966 @@
+import asyncio
+import discord
+from unittest.mock import AsyncMock
+
+from modules.ops import server_rules
+from cogs.server_rules import ServerRulesCog
+
+
+class Msg:
+    def __init__(self, id, content="", author_id=42):
+        self.id = id
+        self.content = content
+        self.author = type("A", (), {"id": author_id})()
+        self.deleted = False
+        self.edits = []
+
+    async def edit(self, **kw):
+        self.edits.append(kw)
+        self.content = kw.get("content", self.content)
+
+    async def delete(self):
+        self.deleted = True
+
+
+class Chan:
+    def __init__(self, id=9):
+        self.id = id
+        self.guild = type("G", (), {"id": 1, "name": "Guild"})()
+        self.sent = []
+        self.messages = {}
+
+    async def send(self, **kw):
+        msg = Msg(100 + len(self.sent), kw.get("content", ""))
+        msg.kw = kw
+        self.sent.append(msg)
+        self.messages[msg.id] = msg
+        return msg
+
+    async def fetch_message(self, mid):
+        if mid not in self.messages:
+            raise discord.NotFound(response=None, message="missing")
+        return self.messages[mid]
+
+    def history(self, limit=500):
+        async def gen():
+            for m in list(self.messages.values()):
+                yield m
+
+        return gen()
+
+
+class Bot:
+    def __init__(self, chan):
+        self.chan = chan
+        self.user = type("U", (), {"id": 42})()
+
+    def get_channel(self, id):
+        return self.chan if id == self.chan.id else None
+
+
+class Ws:
+    def __init__(self, batch_writes):
+        self.batch_writes = batch_writes
+
+    def batch_update(self, payload):
+        self.batch_writes.append(payload)
+        return {"updated": len(payload)}
+
+
+async def fake_load(monkeypatch, rows, chan):
+    async def cfg(key, default=None, force=False):
+        return {
+            "SERVER_RULES_FAQ_TAB": "Rules",
+            "SERVER_RULES_FAQ_CHANNEL_ID": str(chan.id),
+        }.get(key, default)
+
+    monkeypatch.setattr(server_rules.recruitment_sheet, "get_config_value_async", cfg)
+    monkeypatch.setattr(server_rules, "_mirralith_sheet_id", lambda: "mirralith-sheet")
+    monkeypatch.setattr(
+        server_rules.sheets_core, "afetch_values", AsyncMock(return_value=rows)
+    )
+    monkeypatch.setattr(
+        server_rules, "resolve_message_target", AsyncMock(return_value=chan)
+    )
+    writes = []
+    batch_writes = []
+    ws = Ws(batch_writes)
+    monkeypatch.setattr(
+        server_rules.sheets_core, "aget_worksheet", AsyncMock(return_value=ws)
+    )
+
+    async def write(ws, rng, vals, timeout=None):
+        writes.append((rng, vals))
+
+    async def acall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(server_rules.async_adapter, "aworksheet_values_update", write)
+    monkeypatch.setattr(server_rules.sheets_core, "acall_with_backoff", acall)
+    return {"single": writes, "batch": batch_writes}
+
+
+def sheet(*body):
+    return [
+        [
+            "review_notes",
+            "message_id",
+            "enabled",
+            "description",
+            "message_key",
+            "thumbnail_url",
+            "title",
+            "order",
+            "colour",
+            "footer",
+            "review_status",
+            "section",
+        ],
+        *body,
+    ]
+
+
+def test_publish_sorts_and_writes_message_ids_header_order_independent(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "human",
+                    "",
+                    "yes",
+                    "Second",
+                    "b",
+                    "",
+                    "Title B",
+                    "2",
+                    "community",
+                    "foot",
+                    "draft",
+                    "faq",
+                ],
+                [
+                    "human",
+                    "",
+                    "true",
+                    "First",
+                    "a",
+                    "https://e.test/t.png",
+                    "Title A",
+                    "1",
+                    "community",
+                    "",
+                    "ok",
+                    "rules",
+                ],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 2
+        assert [m.kw["embed"].title for m in chan.sent] == ["Title A", "Title B"]
+        assert chan.sent[0].kw["embed"].thumbnail.url == "https://e.test/t.png"
+        assert writes["batch"] == [
+            [{"range": "B3", "values": [["100"]]}, {"range": "B2", "values": [["101"]]}]
+        ]
+        assert writes["single"] == []
+
+    asyncio.run(run())
+
+
+def test_preflight_abort_no_mutations_on_invalid_rows(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "",
+                    "dup",
+                    "ftp://bad",
+                    "",
+                    "x",
+                    "notacolor",
+                    "",
+                    "",
+                    "",
+                ],
+                ["", "", "true", "ok", "dup", "", "T", "1", "notacolor", "", "", ""],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed >= 4
+        assert chan.sent == []
+        assert writes["single"] == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_refresh_edits_recreates_and_deletes(monkeypatch):
+    async def run():
+        chan = Chan()
+        existing = Msg(555555555555555555, server_rules.marker_for("keep"))
+        chan.messages[555555555555555555] = existing
+        disabled = Msg(777777777777777777, server_rules.marker_for("old"))
+        chan.messages[777777777777777777] = disabled
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "555555555555555555",
+                    "yes",
+                    "Updated",
+                    "keep",
+                    "",
+                    "Keep",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ],
+                [
+                    "",
+                    "666666666666666666",
+                    "on",
+                    "New",
+                    "missing",
+                    "",
+                    "Missing",
+                    "2",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ],
+                [
+                    "",
+                    "777777777777777777",
+                    "no",
+                    "Old",
+                    "old",
+                    "",
+                    "Old",
+                    "3",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ],
+            ),
+            chan,
+        )
+        original_fetch = server_rules._fetch
+
+        async def fake_fetch(target, message_id):
+            if message_id == "666666666666666666":
+                return (
+                    server_rules.FetchState.MISSING,
+                    None,
+                    "stored message was not found",
+                )
+            return await original_fetch(target, message_id)
+
+        monkeypatch.setattr(server_rules, "_fetch", fake_fetch)
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.refreshed == 1
+        assert summary.created == 1
+        assert summary.removed == 1
+        assert existing.edits
+        assert disabled.deleted
+        assert ("B3", [["100"]]) in writes["single"]
+        assert ("B4", [[""]]) in writes["single"]
+
+    asyncio.run(run())
+
+
+def test_unrelated_messages_untouched_on_rebuild(monkeypatch):
+    async def run():
+        chan = Chan()
+        unrelated = Msg(1, "hello")
+        chan.messages[1] = unrelated
+        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        chan.messages[222222222222222222] = old
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "222222222222222222",
+                    "yes",
+                    "D",
+                    "rule",
+                    "",
+                    "T",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert old.deleted
+        assert not unrelated.deleted
+
+    asyncio.run(run())
+
+
+def test_admin_usage_embed():
+    async def run():
+        cog = ServerRulesCog(Bot(Chan()))
+        ctx = type("Ctx", (), {"reply": AsyncMock()})()
+        await cog.serverrules.callback(cog, ctx)
+        kwargs = ctx.reply.call_args.kwargs
+        assert (
+            kwargs["embed"].description
+            == "Use `!serverrules publish` or `!serverrules refresh`."
+        )
+        assert "content" not in kwargs
+
+    asyncio.run(run())
+
+
+def test_no_scheduler_path_introduced():
+    from pathlib import Path
+
+    text = Path("modules/ops/server_rules.py").read_text()
+    assert "scheduler" not in text.lower()
+
+
+def test_serverrules_commands_are_admin_gated():
+    assert ServerRulesCog.serverrules.checks
+    assert ServerRulesCog.publish.checks
+    assert ServerRulesCog.refresh.checks
+
+
+def test_destination_resolution_supports_configured_target(monkeypatch):
+    async def run():
+        chan = Chan(id=123)
+        resolver = AsyncMock(return_value=chan)
+        await fake_load(
+            monkeypatch,
+            sheet(["", "", "true", "D", "k", "", "T", "1", "community", "", "", ""]),
+            chan,
+        )
+        monkeypatch.setattr(server_rules, "resolve_message_target", resolver)
+        await server_rules.preflight(Bot(chan))
+        resolver.assert_awaited_once()
+        assert resolver.await_args.args[1] == 123
+
+    asyncio.run(run())
+
+
+def test_enabled_value_parser_accepts_common_sheet_values():
+    assert server_rules.parse_enabled("yes") is True
+    assert server_rules.parse_enabled("ON") is True
+    assert server_rules.parse_enabled("0") is False
+    assert server_rules.parse_enabled("maybe") is None
+
+
+def test_rules_tab_reads_mirralith_and_not_recruitment_accessor(monkeypatch):
+    async def run():
+        chan = Chan()
+
+        async def cfg(key, default=None, force=False):
+            return {
+                "SERVER_RULES_FAQ_TAB": "Rules",
+                "SERVER_RULES_FAQ_CHANNEL_ID": str(chan.id),
+            }.get(key, default)
+
+        monkeypatch.setattr(
+            server_rules.recruitment_sheet, "get_config_value_async", cfg
+        )
+        monkeypatch.setattr(
+            server_rules.recruitment_sheet,
+            "get_recruitment_sheet_id",
+            lambda: (_ for _ in ()).throw(AssertionError("recruitment accessor used")),
+        )
+        monkeypatch.setattr(
+            server_rules, "_mirralith_sheet_id", lambda: "mirralith-sheet"
+        )
+        calls = []
+
+        async def read(sheet_id, tab):
+            calls.append((sheet_id, tab))
+            return sheet(
+                ["", "", "true", "D", "k", "", "T", "1", "community", "", "", ""]
+            )
+
+        monkeypatch.setattr(server_rules.sheets_core, "afetch_values", read)
+        monkeypatch.setattr(
+            server_rules, "resolve_message_target", AsyncMock(return_value=chan)
+        )
+        await server_rules.preflight(Bot(chan))
+        assert calls == [("mirralith-sheet", "Rules")]
+
+    asyncio.run(run())
+
+
+def test_invalid_colour_duplicate_nonfinite_order_and_snowflake_rejected(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                ["", "123", "true", "D", "badid", "", "T", "nan", "purple", "", "", ""],
+                ["", "", "true", "D", "one", "", "T", "1", "community", "", "", ""],
+                ["", "", "true", "D", "two", "", "T", "1", "community", "", "", ""],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed >= 4
+        assert chan.sent == []
+        assert writes["single"] == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_feature_disabled_stops_without_mutations(monkeypatch):
+    async def run():
+        chan = Chan()
+        cog = ServerRulesCog(Bot(chan))
+        ctx = type(
+            "Ctx",
+            (),
+            {"reply": AsyncMock(), "author": type("A", (), {"id": 5})(), "guild": None},
+        )()
+        monkeypatch.setattr(
+            "cogs.server_rules.feature_flags.is_enabled", lambda key: False
+        )
+        monkeypatch.setattr(
+            "cogs.server_rules.runtime_helpers.send_log_message", AsyncMock()
+        )
+        monkeypatch.setattr(
+            server_rules, "publish", AsyncMock(side_effect=AssertionError("mutated"))
+        )
+        await cog.publish.callback(cog, ctx)
+        assert ctx.reply.call_args.kwargs["embed"].title == "Server rules disabled"
+        assert chan.sent == []
+
+    asyncio.run(run())
+
+
+def test_publish_send_failure_deletes_new_and_keeps_sheet_ids(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "111111111111111111",
+                    "true",
+                    "D",
+                    "a",
+                    "",
+                    "A",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ],
+                [
+                    "",
+                    "222222222222222222",
+                    "true",
+                    "D",
+                    "b",
+                    "",
+                    "B",
+                    "2",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ],
+            ),
+            chan,
+        )
+        original_send = chan.send
+
+        async def send(**kw):
+            if chan.sent:
+                raise discord.HTTPException(response=None, message="boom")
+            return await original_send(**kw)
+
+        chan.send = send
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent[0].deleted
+        assert writes["single"] == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_publish_sheet_failure_restores_ids_and_deletes_new(monkeypatch):
+    async def run():
+        chan = Chan()
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "111111111111111111",
+                    "true",
+                    "D",
+                    "a",
+                    "",
+                    "A",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        batch_calls = []
+
+        async def acall(func, payload, **kwargs):
+            batch_calls.append(payload)
+            if payload != [{"range": "B2", "values": [["111111111111111111"]]}]:
+                raise RuntimeError("sheet down")
+            return {"restored": True}
+
+        monkeypatch.setattr(server_rules.sheets_core, "acall_with_backoff", acall)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent[0].deleted
+        assert [{"range": "B2", "values": [["111111111111111111"]]}] in batch_calls
+
+    asyncio.run(run())
+
+
+def test_refresh_temp_fetch_failure_does_not_duplicate(monkeypatch):
+    async def run():
+        chan = Chan()
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "111111111111111111",
+                    "true",
+                    "D",
+                    "a",
+                    "",
+                    "A",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+
+        async def fetch(mid):
+            raise discord.Forbidden(response=None, message="no")
+
+        chan.fetch_message = fetch
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+
+    asyncio.run(run())
+
+
+def test_refresh_replacement_write_failure_cleans_replacement(monkeypatch):
+    async def run():
+        chan = Chan()
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "111111111111111111",
+                    "true",
+                    "D",
+                    "a",
+                    "",
+                    "A",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+
+        async def write(ws, rng, vals, timeout=None):
+            raise RuntimeError("sheet down")
+
+        monkeypatch.setattr(
+            server_rules.async_adapter, "aworksheet_values_update", write
+        )
+
+        async def missing(target, message_id):
+            return server_rules.FetchState.MISSING, None, "stored message was not found"
+
+        monkeypatch.setattr(server_rules, "_fetch", missing)
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent[0].deleted
+
+    asyncio.run(run())
+
+
+def actual_sheet(*body):
+    return [
+        [
+            "message_key",
+            "section",
+            "order",
+            "enabled",
+            "title",
+            "description",
+            "colour",
+            "thumbnail_url",
+            "footer",
+            "review_status",
+            "review_notes",
+            "message_id",
+        ],
+        *body,
+    ]
+
+
+def test_trailing_false_placeholder_rows_are_ignored_with_actual_header_order(
+    monkeypatch,
+):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            actual_sheet(
+                [
+                    "rules",
+                    "rules",
+                    "1",
+                    "TRUE",
+                    "Rules",
+                    "Read <#123>",
+                    "blue",
+                    "",
+                    "",
+                    "approved",
+                    "",
+                    "",
+                ],
+                ["", "", "", "FALSE", "", "", "", "", "", "", "", ""],
+                ["", "", "", "FALSE", "", "", "", "", "", "", "", ""],
+                ["", "", "", "FALSE", "", "", "", "", "", "", "", ""],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert len(chan.sent) == 1
+        assert writes["batch"] == [[{"range": "L2", "values": [["100"]]}]]
+
+    asyncio.run(run())
+
+
+def test_non_empty_malformed_false_row_is_rejected(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            actual_sheet(
+                [
+                    "rules",
+                    "rules",
+                    "1",
+                    "TRUE",
+                    "Rules",
+                    "Read",
+                    "blue",
+                    "",
+                    "",
+                    "approved",
+                    "",
+                    "",
+                ],
+                [
+                    "",
+                    "faq",
+                    "",
+                    "FALSE",
+                    "",
+                    "Has data but no key",
+                    "blue",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
+                ["", "", "", "FALSE", "", "", "", "", "", "", "", ""],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed >= 1
+        assert "row 3" in summary.failures
+        assert chan.sent == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_supported_colour_names_and_hex_rejection():
+    assert server_rules.parse_colour(" #4472C4 ") is not None
+    assert server_rules.parse_colour("#356854") is not None
+    assert server_rules.parse_colour("#FFD666") is not None
+    assert server_rules.parse_colour("#607D8B") is not None
+    assert server_rules.parse_colour("community") == server_rules.get_embed_colour(
+        "community"
+    )
+    assert server_rules.parse_colour("blue") == server_rules.get_embed_colour(
+        "community"
+    )
+    assert server_rules.parse_colour("c1c_blue") == server_rules.get_embed_colour(
+        "community"
+    )
+    assert server_rules.parse_colour("recruitment") == server_rules.get_embed_colour(
+        "recruitment"
+    )
+    assert server_rules.parse_colour("green") == server_rules.get_embed_colour(
+        "recruitment"
+    )
+    assert server_rules.parse_colour("admin") == server_rules.get_embed_colour("admin")
+    assert server_rules.parse_colour("#00ff00") is None
+    assert server_rules.parse_colour("purple") is None
+
+
+def test_feature_enabled_invokes_publish(monkeypatch):
+    async def run():
+        chan = Chan()
+        cog = ServerRulesCog(Bot(chan))
+        ctx = type(
+            "Ctx",
+            (),
+            {"reply": AsyncMock(), "author": type("A", (), {"id": 5})(), "guild": None},
+        )()
+        monkeypatch.setattr(
+            "cogs.server_rules.feature_flags.is_enabled", lambda key: True
+        )
+        monkeypatch.setattr(
+            "cogs.server_rules.runtime_helpers.send_log_message", AsyncMock()
+        )
+        called = AsyncMock(return_value=(server_rules.Summary(created=1), chan))
+        monkeypatch.setattr(server_rules, "publish", called)
+        await cog.publish.callback(cog, ctx)
+        called.assert_awaited_once()
+        assert ctx.reply.call_args.kwargs["embed"].title == "Server rules publish"
+
+    asyncio.run(run())
+
+
+def test_rebuild_deletes_known_old_managed_message_by_stored_id_without_history(
+    monkeypatch,
+):
+    async def run():
+        chan = Chan()
+        old = Msg(333333333333333333, server_rules.marker_for("old"))
+        chan.messages[333333333333333333] = old
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "333333333333333333",
+                    "true",
+                    "D",
+                    "old",
+                    "",
+                    "Old",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+
+        def no_history(limit=500):
+            async def gen():
+                if False:
+                    yield None
+
+            return gen()
+
+        chan.history = no_history
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert old.deleted
+
+    asyncio.run(run())
+
+
+def test_rebuild_does_not_delete_unrelated_stored_message(monkeypatch):
+    async def run():
+        chan = Chan()
+        unrelated = Msg(444444444444444444, "not managed")
+        chan.messages[444444444444444444] = unrelated
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "444444444444444444",
+                    "true",
+                    "D",
+                    "rule",
+                    "",
+                    "Rule",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.failed == 1
+        assert not unrelated.deleted
+
+    asyncio.run(run())
+
+
+def test_rebuild_history_failure_reports_cleanup_without_rollback(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                ["", "", "true", "D", "rule", "", "Rule", "1", "community", "", "", ""]
+            ),
+            chan,
+        )
+
+        def broken_history(limit=500):
+            async def gen():
+                raise RuntimeError("history down")
+                yield None
+
+            return gen()
+
+        chan.history = broken_history
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.failed == 1
+        assert "cleanup" in summary.failures
+        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert chan.sent[0].deleted is False
+
+    asyncio.run(run())
+
+
+def test_rebuild_old_cleanup_delete_failure_keeps_new_ids(monkeypatch):
+    async def run():
+        chan = Chan()
+        old = Msg(555555555555555555, server_rules.marker_for("rule"))
+
+        async def fail_delete():
+            raise discord.Forbidden(response=None, message="no")
+
+        old.delete = fail_delete
+        chan.messages[555555555555555555] = old
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "555555555555555555",
+                    "true",
+                    "D",
+                    "rule",
+                    "",
+                    "Rule",
+                    "1",
+                    "community",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.failed == 1
+        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert chan.sent[0].deleted is False
+
+    asyncio.run(run())
+
+
+def test_orphan_cleanup_only_deletes_managed_messages(monkeypatch):
+    async def run():
+        chan = Chan()
+        orphan = Msg(666666666666666666, server_rules.marker_for("orphan"))
+        unrelated = Msg(777777777777777777, "not managed")
+        chan.messages[666666666666666666] = orphan
+        chan.messages[777777777777777777] = unrelated
+        await fake_load(
+            monkeypatch,
+            sheet(
+                ["", "", "true", "D", "rule", "", "Rule", "1", "community", "", "", ""]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert orphan.deleted
+        assert not unrelated.deleted
+
+    asyncio.run(run())
+
+
+def test_orphan_cleanup_leaves_forged_marker_from_other_author(monkeypatch):
+    async def run():
+        chan = Chan()
+        forged = Msg(
+            888888888888888888, server_rules.marker_for("forged"), author_id=999
+        )
+        ordinary = Msg(999999999999999999, "ordinary")
+        chan.messages[888888888888888888] = forged
+        chan.messages[999999999999999999] = ordinary
+        await fake_load(
+            monkeypatch,
+            sheet(
+                ["", "", "true", "D", "rule", "", "Rule", "1", "community", "", "", ""]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert not forged.deleted
+        assert not ordinary.deleted
+
+    asyncio.run(run())

--- a/tests/common/test_feature_toggle_runtime_safety.py
+++ b/tests/common/test_feature_toggle_runtime_safety.py
@@ -47,7 +47,11 @@ def test_unexpected_refresh_error_clears_previous_true_values(monkeypatch) -> No
 
 
 class _Bot:
+    def __init__(self) -> None:
+        self.loaded_extensions: list[str] = []
+
     async def load_extension(self, _extension: str) -> None:
+        self.loaded_extensions.append(_extension)
         return None
 
 
@@ -180,3 +184,25 @@ def test_runtime_does_not_alert_after_successful_refresh(monkeypatch) -> None:
     messages, _ops_calls = _run_extension_load(monkeypatch, failure_reason=None)
 
     assert messages == []
+
+
+def test_runtime_loads_server_rules_as_always_extension_once(monkeypatch) -> None:
+    bot = _Bot()
+    runtime = runtime_module.Runtime(bot)  # type: ignore[arg-type]
+    ops_calls: list[str] = []
+    _patch_always_loaded_setups(monkeypatch, ops_calls=ops_calls)
+
+    async def fake_refresh() -> str | None:
+        runtime_module.shared_config.update_feature_flags_snapshot(None)
+        return None
+
+    monkeypatch.setattr(runtime, "_refresh_feature_toggles", fake_refresh)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda _key: False)
+
+    async def run() -> None:
+        await runtime.load_extensions()
+
+    asyncio.run(run())
+    assert bot.loaded_extensions.count("cogs.server_rules") == 1
+    assert bot.loaded_extensions.count("modules.coreops.cmd_cfg") == 1
+    assert ops_calls == ["modules.ops.permissions_ui"]

--- a/tests/common/test_runtime_scheduler_quota.py
+++ b/tests/common/test_runtime_scheduler_quota.py
@@ -3,6 +3,7 @@ import logging
 from types import SimpleNamespace
 
 from modules.common import runtime as runtime_module
+from shared import config as shared_config
 
 
 class _Bot:
@@ -103,3 +104,83 @@ def test_optional_scheduler_quota_skip_returns_false_and_logs(caplog):
     )
     assert "config_source=Feature Toggle:reset_reminders" in caplog.text
     assert "exception_type=_QuotaError" in caplog.text
+
+
+def _patch_scheduler_dependencies(monkeypatch, runtime):
+    from shared.sheets import cache_scheduler
+    from shared.sheets import recruitment as recruitment_sheets
+    from modules.common import feature_flags
+    from modules.recruitment import clan_ads
+    from modules.ops import server_map
+    from modules.community.leagues import scheduler as leagues_scheduler
+    from modules.community.fusion import scheduler as fusion_scheduler
+    from modules.community.shard_tracker import scheduler as shard_scheduler
+    from modules.community.reset_reminders import scheduler as reset_scheduler
+
+    monkeypatch.setattr(cache_scheduler, "ensure_cache_registration", lambda: None)
+
+    def fake_register_refresh_job(owner, *, bucket, interval, cadence_label):
+        job = owner.scheduler.every(hours=1, tag=bucket, name=f"{bucket}_refresh")
+        return SimpleNamespace(bucket=bucket, cadence_label=cadence_label), job
+
+    monkeypatch.setattr(
+        cache_scheduler, "register_refresh_job", fake_register_refresh_job
+    )
+
+    async def fake_config_value(key, default=None):
+        return default
+
+    monkeypatch.setattr(recruitment_sheets, "get_config_value_async", fake_config_value)
+    monkeypatch.setattr(feature_flags, "is_enabled", lambda key: False)
+
+    async def no_clan_ads(*, force=False):
+        return SimpleNamespace(refresh_interval_hours=None)
+
+    monkeypatch.setattr(clan_ads, "load_config", no_clan_ads)
+    monkeypatch.setattr(server_map, "schedule_server_map_job", lambda _runtime: None)
+    monkeypatch.setattr(
+        leagues_scheduler, "schedule_leagues_jobs", lambda _runtime: None
+    )
+    monkeypatch.setattr(fusion_scheduler, "schedule_fusion_jobs", lambda _runtime: None)
+    monkeypatch.setattr(shard_scheduler, "schedule_shard_jobs", lambda _runtime: None)
+    monkeypatch.setattr(
+        reset_scheduler, "schedule_reset_reminder_jobs", lambda _runtime: None
+    )
+    monkeypatch.setattr(
+        runtime_module.shared_config,
+        "features",
+        SimpleNamespace(housekeeping_enabled=False, mirralith_overview_enabled=True),
+    )
+
+
+def test_mirralith_post_cron_env_reaches_scheduler_through_config(monkeypatch):
+    monkeypatch.setenv("MIRRALITH_POST_CRON", "17 4 * * *")
+    shared_config.reload_config()
+    runtime = runtime_module.Runtime(_Bot())
+    _patch_scheduler_dependencies(monkeypatch, runtime)
+
+    asyncio.run(runtime._register_ready_schedulers_inner())
+
+    jobs = [
+        job
+        for job in runtime.scheduler.jobs
+        if getattr(job, "name", None) == "mirralith_overview"
+    ]
+    assert len(jobs) == 1
+    assert getattr(jobs[0], "cadence_label", None) == "17 4 * * *"
+
+
+def test_empty_mirralith_post_cron_still_skips_scheduler(monkeypatch):
+    monkeypatch.setenv("MIRRALITH_POST_CRON", "")
+    shared_config.reload_config()
+    runtime = runtime_module.Runtime(_Bot())
+    _patch_scheduler_dependencies(monkeypatch, runtime)
+
+    asyncio.run(runtime._register_ready_schedulers_inner())
+
+    names = [getattr(job, "name", None) for job in runtime.scheduler.jobs]
+    assert "mirralith_overview" not in names
+    assert (
+        runtime.scheduler.registration_skips["mirralith_overview"]
+        == "MIRRALITH_POST_CRON is not set"
+    )

--- a/tests/config/test_reload_config_entrypoint.py
+++ b/tests/config/test_reload_config_entrypoint.py
@@ -3,7 +3,6 @@ import importlib
 
 import pytest
 
-
 _REQUIRED_ENV = {
     "DISCORD_TOKEN": "token",
     "GSPREAD_CREDENTIALS": "{}",
@@ -46,8 +45,7 @@ def test_reload_config_populates_shard_emoji_getters(monkeypatch):
     cfg.reload_config()
 
     assert (
-        cfg.get_shard_panel_overview_emoji()
-        == configured["SHARD_PANEL_OVERVIEW_EMOJI"]
+        cfg.get_shard_panel_overview_emoji() == configured["SHARD_PANEL_OVERVIEW_EMOJI"]
     )
     assert cfg.get_shard_emoji_mystery() == configured["SHARD_EMOJI_MYSTERY"]
     assert cfg.get_shard_emoji_ancient() == configured["SHARD_EMOJI_ANCIENT"]
@@ -88,5 +86,18 @@ def test_reload_config_fails_when_required_missing(monkeypatch, missing):
     _apply_required_env(monkeypatch)
     monkeypatch.delenv(missing, raising=False)
     import shared.config as cfg
+
     with pytest.raises(RuntimeError):
         cfg.reload_config()
+
+
+def test_reload_config_trims_mirralith_post_cron(monkeypatch):
+    _apply_required_env(monkeypatch)
+    monkeypatch.setenv("MIRRALITH_POST_CRON", " 17 4 * * * ")
+    import shared.config as cfg
+
+    monkeypatch.setattr(cfg, "_CONFIG", dict(cfg._CONFIG))
+    snapshot = cfg.reload_config()
+
+    assert snapshot["MIRRALITH_POST_CRON"] == "17 4 * * *"
+    assert cfg.cfg.get("MIRRALITH_POST_CRON") == "17 4 * * *"


### PR DESCRIPTION
### Motivation
- Provide an operational, sheet-driven publisher for server rules/FAQ so admins can publish and refresh curated embeds from a Google Sheet. 
- Surface server-rules-specific colour palette and make the server-rules feature available as an always-on admin extension. 

### Description
- Add a new ops module `modules.ops.server_rules` implementing load/validate/build/publish/refresh logic driven from a recruitment spreadsheet and producing summary embeds via `result_embed`. 
- Add an admin cog `cogs.server_rules` with `!serverrules publish` and `!serverrules refresh` commands, guarded by admin RBAC and a feature toggle. 
- Extend `modules.common.embeds` with server-rules palette constants and `get_server_rules_colour`, and update exports. 
- Wire the new cog into the runtime by loading `cogs.server_rules` as an always-on extension, and use `shared_config.cfg` snapshots for `BOT_VERSION` and `MIRRALITH_POST_CRON` lookup during runtime startup. 
- Export `server_rules` from `modules.ops.__init__` and add associated unit tests. 

### Testing
- Added comprehensive unit tests in `tests/cogs/test_server_rules.py` covering publish, refresh, validation, cleanup and guard conditions, and these tests passed. 
- Updated runtime and config tests in `tests/common/test_feature_toggle_runtime_safety.py`, `tests/common/test_runtime_scheduler_quota.py`, and `tests/config/test_reload_config_entrypoint.py` to cover loading the new cog and the trimmed `MIRRALITH_POST_CRON`, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72318eb87083239a92ea7ace11c3a7)