### PR TITLE
Make fusion progress test time-independent

### DIFF
--- a/tests/community/test_fusion_opt_in_view.py
+++ b/tests/community/test_fusion_opt_in_view.py
@@ -1115,7 +1115,10 @@ def test_traditional_overview_has_share_and_event_detail_does_not():
 
 
 def test_traditional_reopened_progress_merges_saved_rows_with_event_defaults():
-    events = [_event_row(f"e{i}", start_at_utc=dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc), end_at_utc=dt.datetime(2026, 8, 2, tzinfo=dt.timezone.utc)) for i in range(1, 17)]
+    now = dt.datetime.now(dt.timezone.utc)
+    event_start = now + dt.timedelta(days=1)
+    event_end = now + dt.timedelta(days=2)
+    events = [_event_row(f"e{i}", start_at_utc=event_start, end_at_utc=event_end) for i in range(1, 17)]
     raw_progress = {"progress": {"e1": "done", "e2": "done", "e3": "done", "e4": "in_progress", "stale": "done"}}
 
     progress_by_event = opt_in_view._normalize_saved_progress(raw_progress=raw_progress, events=events)


### PR DESCRIPTION
### Motivation
- A test used fixed event dates (August 1–2, 2026) which are now in the past and cause production logic to classify untouched events as `missed`, so the test must use relative future dates so it remains about merging saved progress rather than past-event classification.

### Description
- Update only `tests/community/test_fusion_opt_in_view.py::test_traditional_reopened_progress_merges_saved_rows_with_event_defaults` to compute `now = dt.datetime.now(dt.timezone.utc)`, set `event_start = now + dt.timedelta(days=1)` and `event_end = now + dt.timedelta(days=2)`, and use those values for the test events while preserving the existing summary assertions (`Done: 3`, `In Progress: 1`, `Not Started: 12`) and without modifying any production code.

### Testing
- Ran `python -m pytest tests/community/test_fusion_opt_in_view.py::test_traditional_reopened_progress_merges_saved_rows_with_event_defaults -q` which passed; attempted the broader test invocation with `--timeout` flags failed due to `pytest-timeout` not being installed in this environment (unrecognized `--timeout` argument); repository guardrails (`scripts.ci.guardrails_suite` and `scripts/ci/check_env_parity.py`) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72fc6e29e8832391fa9f0d92e72200)