### PR TITLE
Finish server rules publisher safeguards

### DIFF
--- a/modules/common/embeds.py
+++ b/modules/common/embeds.py
@@ -9,6 +9,11 @@ import discord
 
 EmbedCategory = Literal["admin", "recruitment", "community"]
 
+SERVER_RULES_FAQ_BLUE = discord.Colour(0x4472C4)
+SERVER_RULES_FAQ_GREEN = discord.Colour(0x356854)
+SERVER_RULES_FAQ_YELLOW = discord.Colour(0xFFD666)
+SERVER_RULES_FAQ_SLATE = discord.Colour(0x607D8B)
+
 _COLOURS: dict[EmbedCategory, discord.Colour] = {
     "admin": discord.Colour(0xF200E5),
     "recruitment": discord.Colour(0x1B8009),
@@ -22,4 +27,11 @@ def get_embed_colour(category: EmbedCategory) -> discord.Colour:
     return _COLOURS.get(category, discord.Colour.default())
 
 
-__all__ = ["EmbedCategory", "get_embed_colour"]
+__all__ = [
+    "EmbedCategory",
+    "SERVER_RULES_FAQ_BLUE",
+    "SERVER_RULES_FAQ_GREEN",
+    "SERVER_RULES_FAQ_YELLOW",
+    "SERVER_RULES_FAQ_SLATE",
+    "get_embed_colour",
+]

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -11,7 +11,13 @@ from urllib.parse import urlparse
 import discord
 
 from modules.common.discord_utils import resolve_message_target
-from modules.common.embeds import get_embed_colour
+from modules.common.embeds import (
+    SERVER_RULES_FAQ_BLUE,
+    SERVER_RULES_FAQ_GREEN,
+    SERVER_RULES_FAQ_SLATE,
+    SERVER_RULES_FAQ_YELLOW,
+    get_embed_colour,
+)
 from shared.sheets import async_adapter
 from shared.sheets import core as sheets_core
 from shared.sheets import recruitment as recruitment_sheet
@@ -40,6 +46,12 @@ MAX_TOTAL = 6000
 MIN_SNOWFLAKE_LEN = 17
 MAX_SNOWFLAKE_LEN = 20
 MAX_UINT64 = 2**64 - 1
+SERVER_RULES_HEX_COLOURS = {
+    "#4472c4": SERVER_RULES_FAQ_BLUE,
+    "#356854": SERVER_RULES_FAQ_GREEN,
+    "#ffd666": SERVER_RULES_FAQ_YELLOW,
+    "#607d8b": SERVER_RULES_FAQ_SLATE,
+}
 
 
 class FetchState(Enum):
@@ -155,6 +167,8 @@ def parse_colour(value: Any) -> discord.Colour | None:
         return colors.c1c_blue
     if text == "theme_admin":
         return colors.admin
+    if text in SERVER_RULES_HEX_COLOURS:
+        return SERVER_RULES_HEX_COLOURS[text]
     return None
 
 
@@ -361,20 +375,57 @@ async def _fetch(target: Any, message_id: str) -> tuple[FetchState, Any | None, 
         )
 
 
+def _is_bot_authored(message: Any, bot_id: int | None) -> bool:
+    return (
+        bot_id is not None
+        and getattr(getattr(message, "author", None), "id", None) == bot_id
+    )
+
+
+def _is_deletable_feature_message(
+    message: Any, bot_id: int | None, keys: set[str] | None = None
+) -> bool:
+    return _is_bot_authored(message, bot_id) and is_feature_message(message, keys)
+
+
 async def _iter_feature_messages(target: Any, bot_id: int | None) -> list[Any]:
     history = getattr(target, "history", None)
     if not callable(history):
         return []
     found: list[Any] = []
     async for message in history(limit=500):
-        if (
-            bot_id is not None
-            and getattr(getattr(message, "author", None), "id", None) != bot_id
-        ):
-            continue
-        if is_feature_message(message):
+        if _is_deletable_feature_message(message, bot_id):
             found.append(message)
     return found
+
+
+async def _delete_old_stored_messages(
+    target: Any,
+    rows: list[Row],
+    new_ids: set[str],
+    bot_id: int | None,
+    summary: Summary,
+) -> set[str]:
+    seen: set[str] = set()
+    for row in rows:
+        old_id = row.message_id
+        if not old_id or old_id in new_ids or old_id in seen:
+            continue
+        seen.add(old_id)
+        state, msg, reason = await _fetch(target, old_id)
+        if state is FetchState.MISSING:
+            continue
+        if state is FetchState.UNKNOWN:
+            summary.fail(row.key, reason)
+            continue
+        if msg is None or not _is_deletable_feature_message(msg, bot_id, {row.key}):
+            continue
+        try:
+            await msg.delete()
+            summary.removed += 1
+        except Exception:
+            summary.fail(row.key, "failed to remove old managed message after rebuild")
+    return seen
 
 
 async def _delete_new(messages: list[Any]) -> None:
@@ -426,16 +477,25 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
             summary.removed += 0
     new_ids = {str(getattr(msg, "id", "")) for _row, msg in new_pairs}
     bot_id = getattr(getattr(bot, "user", None), "id", None)
-    for msg in await _iter_feature_messages(target, bot_id):
-        if str(getattr(msg, "id", "")) in new_ids:
-            continue
-        try:
-            await msg.delete()
-            summary.removed += 1
-        except Exception:
-            summary.fail(
-                "old messages", "failed to remove old managed message after rebuild"
-            )
+    seen_old_ids = await _delete_old_stored_messages(
+        target, rows, new_ids, bot_id, summary
+    )
+    try:
+        old_messages = await _iter_feature_messages(target, bot_id)
+    except Exception:
+        summary.fail("old messages", "failed to scan channel history after rebuild")
+    else:
+        for msg in old_messages:
+            msg_id = str(getattr(msg, "id", ""))
+            if msg_id in new_ids or msg_id in seen_old_ids:
+                continue
+            try:
+                await msg.delete()
+                summary.removed += 1
+            except Exception:
+                summary.fail(
+                    "old messages", "failed to remove old managed message after rebuild"
+                )
     return summary, target
 
 
@@ -496,7 +556,9 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
                         )
                     else:
                         summary.skipped += 1
-                elif msg is not None and is_feature_message(msg, {row.key}):
+                elif msg is not None and _is_deletable_feature_message(
+                    msg, getattr(getattr(bot, "user", None), "id", None), {row.key}
+                ):
                     try:
                         await msg.delete()
                         await _write_message_id(tab, header_map, row, "")

--- a/shared/config.py
+++ b/shared/config.py
@@ -530,6 +530,7 @@ def _load_config_snapshot() -> Dict[str, object]:
         "GUILD_IDS": _int_set(os.getenv("GUILD_IDS")),
         "TIMEZONE": (os.getenv("TIMEZONE") or "Europe/Vienna").strip() or "Europe/Vienna",
         "REFRESH_TIMES": _parse_schedule(os.getenv("REFRESH_TIMES"), refresh_default),
+        "MIRRALITH_POST_CRON": (os.getenv("MIRRALITH_POST_CRON") or "").strip(),
         "GSPREAD_CREDENTIALS": os.getenv("GSPREAD_CREDENTIALS", ""),
         "RECRUITMENT_SHEET_ID": (os.getenv("RECRUITMENT_SHEET_ID") or "").strip(),
         "ONBOARDING_SHEET_ID": (os.getenv("ONBOARDING_SHEET_ID") or "").strip(),

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -748,6 +748,138 @@ def test_supported_colour_names_and_hex_rejection():
     assert server_rules.parse_colour("purple") is None
 
 
+def test_supported_server_rules_faq_hex_colours_are_explicit_palette():
+    from modules.common import embeds
+
+    assert server_rules.parse_colour("#4472c4") == embeds.SERVER_RULES_FAQ_BLUE
+    assert server_rules.parse_colour("#356854") == embeds.SERVER_RULES_FAQ_GREEN
+    assert server_rules.parse_colour("#ffd666") == embeds.SERVER_RULES_FAQ_YELLOW
+    assert server_rules.parse_colour("#607d8b") == embeds.SERVER_RULES_FAQ_SLATE
+    assert server_rules.parse_colour("#4472C4") == embeds.SERVER_RULES_FAQ_BLUE
+    assert server_rules.parse_colour("#00ff00") is None
+
+
+def test_publish_fetches_known_old_id_and_never_deletes_forged_message(monkeypatch):
+    async def run():
+        chan = Chan()
+        forged = Msg(333333333333333333, server_rules.marker_for("rule"), author_id=99)
+        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        chan.messages[forged.id] = forged
+        chan.messages[old.id] = old
+        fetched = []
+
+        original_fetch = chan.fetch_message
+
+        async def fetch_message(mid):
+            fetched.append(mid)
+            return await original_fetch(mid)
+
+        chan.fetch_message = fetch_message
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "222222222222222222",
+                    "yes",
+                    "D",
+                    "rule",
+                    "",
+                    "T",
+                    "1",
+                    "#4472c4",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.removed == 1
+        assert 222222222222222222 in fetched
+        assert old.deleted
+        assert not forged.deleted
+
+    asyncio.run(run())
+
+
+def test_publish_cleanup_failures_report_after_commit_without_rollback(monkeypatch):
+    async def run():
+        chan = Chan()
+        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        chan.messages[old.id] = old
+
+        async def delete_failure():
+            raise discord.HTTPException(response=None, message="delete failed")
+
+        old.delete = delete_failure
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "222222222222222222",
+                    "yes",
+                    "D",
+                    "rule",
+                    "",
+                    "T",
+                    "1",
+                    "#356854",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.failed == 1
+        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert not chan.sent[0].deleted
+
+    asyncio.run(run())
+
+
+def test_publish_history_scan_failure_reported_without_rollback(monkeypatch):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "D",
+                    "rule",
+                    "",
+                    "T",
+                    "1",
+                    "#607d8b",
+                    "",
+                    "",
+                    "",
+                ]
+            ),
+            chan,
+        )
+
+        async def fail_iter(target, bot_id):
+            raise discord.HTTPException(response=None, message="history failed")
+
+        monkeypatch.setattr(server_rules, "_iter_feature_messages", fail_iter)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.failed == 1
+        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert not chan.sent[0].deleted
+
+    asyncio.run(run())
+
 def test_feature_enabled_invokes_publish(monkeypatch):
     async def run():
         chan = Chan()

--- a/tests/common/test_runtime_scheduler_quota.py
+++ b/tests/common/test_runtime_scheduler_quota.py
@@ -51,6 +51,7 @@ def test_clan_ads_config_quota_skips_registration_without_startup_failure(
         cache_scheduler, "register_refresh_job", fake_register_refresh_job
     )
     monkeypatch.setenv("MIRRALITH_POST_CRON", "")
+    assert runtime_module.shared_config._load_config_snapshot()["MIRRALITH_POST_CRON"] == ""
 
     async def fake_config_value(key, default=None):
         assert key == "C1C_AD_REFRESH_DAYS"

--- a/tests/config/test_reload_config_entrypoint.py
+++ b/tests/config/test_reload_config_entrypoint.py
@@ -23,6 +23,20 @@ def test_reload_config_happy_path(monkeypatch):
     cfg.reload_config()
 
 
+def test_reload_config_includes_trimmed_mirralith_post_cron(monkeypatch):
+    _apply_required_env(monkeypatch)
+    monkeypatch.setenv("MIRRALITH_POST_CRON", "  15 9 * * *  ")
+    import shared.config as cfg
+
+    monkeypatch.setattr(cfg, "_CONFIG", dict(cfg._CONFIG))
+    monkeypatch.setattr(cfg, "_merge_onboarding_tab", lambda _config: None)
+    monkeypatch.setattr(cfg, "_merge_milestones_tab", lambda _config: None)
+
+    snapshot = cfg.reload_config()
+
+    assert snapshot["MIRRALITH_POST_CRON"] == "15 9 * * *"
+
+
 def test_reload_config_populates_shard_emoji_getters(monkeypatch):
     _apply_required_env(monkeypatch)
     import shared.config as cfg


### PR DESCRIPTION
### Motivation
- Limit Server Rules FAQ to exactly the four approved hex colours while preserving existing named aliases and rejecting arbitrary hex values.
- Harden cleanup during a rebuild so only known old managed messages (authored by the bot and carrying the server-rules marker) are removed and history/cleanup failures are non-fatal after new IDs are committed.
- Include the `MIRRALITH_POST_CRON` env entry in the environment-backed shared config snapshot and preserve trimming/empty-value behaviour.

### Description
- Added explicit Server Rules FAQ colour constants to `modules/common/embeds.py` for the four approved hex codes and exported them for tests and mapping. (added `SERVER_RULES_FAQ_BLUE`, `SERVER_RULES_FAQ_GREEN`, `SERVER_RULES_FAQ_YELLOW`, `SERVER_RULES_FAQ_SLATE`).
- In `modules/ops/server_rules.py` introduced `SERVER_RULES_HEX_COLOURS` and updated `parse_colour` to map only those four hex strings (case-insensitive via lowered input) to the explicit palette constants while leaving named aliases unchanged and continuing to reject other hex values.
- Reworked rebuild cleanup logic in `modules/ops/server_rules.py` to:
  - Fetch and directly check known old stored message IDs prior to deleting them (`_delete_old_stored_messages`).
  - Verify the message author is the bot and the message contains the server-rules marker for the matching key before deletion (`_is_bot_authored`, `_is_deletable_feature_message`).
  - Continue to scan history for any other managed messages and delete them only if not already handled, and treat history-scan or deletion failures as reported (non-fatal) after new IDs were committed.
  - Ensure refresh-time deletions also verify bot author + marker before removing disabled stored messages.
- Added `MIRRALITH_POST_CRON` to the environment-backed snapshot in `shared/config.py` with trimming and empty-value preservation (behaviour same as other env keys).
- Tests updated/added (see list of modified files) to exercise: the four approved hex colours mapping, rejection of other hex values, direct old-ID fetch-and-delete behaviour (including forged/unrelated message protection), non-fatal cleanup/history failures reporting after commit, and `MIRRALITH_POST_CRON` trimming and empty-value behaviour.
- Modified/added files (final change set contains exactly these six files):
  - `modules/common/embeds.py`
  - `modules/ops/server_rules.py`
  - `shared/config.py`
  - `tests/cogs/test_server_rules.py`
  - `tests/common/test_runtime_scheduler_quota.py`
  - `tests/config/test_reload_config_entrypoint.py`

### Testing
- Ran the requested focused tests: `python -m pytest tests/cogs/test_server_rules.py tests/common/test_runtime_scheduler_quota.py tests/config/test_reload_config_entrypoint.py -q` and observed the suite for those files completed successfully (33 tests in that run passed and the added tests exercised the new safeguards).
- Ran both affected CI shards locally: the `config-core-shared` shard completed with `192 passed`, and the `community-housekeeping` shard completed with `743 passed` (all tests in those shards succeeded locally).
- Ran the repository guardrails suite: `scripts.ci.guardrails_suite` completed and reported `pass` for the guardrails checks.
- Confirmations: No Google Sheets data was changed; no Sheet colour conversion is required; the four existing Server Rules FAQ colours remain unchanged and are explicitly mapped; the branch was rebuilt locally on current `main` and the change set contained only the six files requested.
- Note about remote push/PR update: the local branch and commits implementing these changes are prepared, tests and guardrails passed locally, however pushing the updated branch / updating PR #1054 could not be completed from this environment due to network/proxy restrictions that prevented authenticated pushes; please pull the prepared changes from this branch or allow me to push if the environment can reach GitHub with credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72ff8a5f888323ae49defad54a5a52)