### PR TITLE
Use shared config facade in app.py for env reads and move LOG_MESSAGE_CONTENT into shared config

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from typing import Optional
 import discord
 from discord.ext import commands
 
+from shared import config as shared_config
 from shared.config import (
     get_env_name,
     get_allowed_guild_ids,
@@ -44,7 +45,7 @@ from modules.recruitment.reporting.daily_recruiter_update import (
 )
 
 logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
+    level=shared_config.cfg.get("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 log = logging.getLogger("c1c.app")
@@ -202,19 +203,22 @@ _shutdown_started = False
 _startup_summary_lock: asyncio.Lock | None = None
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    value = raw.strip().lower()
-    if value in {"1", "true", "yes", "on"}:
-        return True
-    if value in {"0", "false", "no", "off"}:
-        return False
-    return default
+LOG_MESSAGE_CONTENT = bool(shared_config.cfg.get("LOG_MESSAGE_CONTENT", False))
 
 
-LOG_MESSAGE_CONTENT = _env_bool("LOG_MESSAGE_CONTENT", False)
+def _startup_channel_config_id(config_key: str) -> int | None:
+    value = shared_config.cfg.get(config_key)
+    return value if isinstance(value, int) else None
+
+
+def _startup_channel_mention_id(config_key: str) -> str:
+    channel_id = _startup_channel_config_id(config_key)
+    return str(channel_id) if channel_id is not None else ""
+
+
+def _startup_channel_raw_id(config_key: str) -> str:
+    channel_id = _startup_channel_config_id(config_key)
+    return str(channel_id) if channel_id is not None else "-"
 
 
 def _truncate_text(text: str, max_len: int = LOG_MESSAGE_CONTENT_MAX_LEN) -> str:
@@ -484,13 +488,13 @@ async def on_ready():
     watchers_lines = [
         "✅ Watchers",
         "• Promo watcher — event=enabled",
-        "  • channel=<#{}>".format(os.getenv("PROMO_CHANNEL_ID", "")),
-        f"  • channel_id={os.getenv('PROMO_CHANNEL_ID', '-')}",
+        "  • channel=<#{}>".format(_startup_channel_mention_id("PROMO_CHANNEL_ID")),
+        f"  • channel_id={_startup_channel_raw_id('PROMO_CHANNEL_ID')}",
         "  • triggers=3",
         "  • flow=promo",
         "• Welcome watcher — event=enabled",
-        "  • channel=<#{}>".format(os.getenv("WELCOME_CHANNEL_ID", "")),
-        f"  • channel_id={os.getenv('WELCOME_CHANNEL_ID', '-')}",
+        "  • channel=<#{}>".format(_startup_channel_mention_id("WELCOME_CHANNEL_ID")),
+        f"  • channel_id={_startup_channel_raw_id('WELCOME_CHANNEL_ID')}",
         "  • flow=welcome",
     ]
     if watchdog_tuple is None:
@@ -713,7 +717,7 @@ async def on_command_error(ctx: commands.Context, error: Exception):
         log.exception("failed to send command error to log channel")
 
 
-BOT_VERSION = os.getenv("BOT_VERSION", "dev")
+BOT_VERSION = str(shared_config.cfg.get("BOT_VERSION", "dev") or "dev")
 _STARTED_MONO = time.monotonic()
 
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -590,6 +590,7 @@ def _load_config_snapshot() -> Dict[str, object]:
         "PANEL_FIXED_THREAD_ID": _first_int(os.getenv("PANEL_FIXED_THREAD_ID")),
         "BOT_VERSION": os.getenv("BOT_VERSION", "dev"),
         "LOG_LEVEL": os.getenv("LOG_LEVEL", "INFO"),
+        "LOG_MESSAGE_CONTENT": _env_bool("LOG_MESSAGE_CONTENT", False),
         "PUBLIC_BASE_URL": (os.getenv("PUBLIC_BASE_URL") or "").strip(),
         "RENDER_EXTERNAL_URL": (os.getenv("RENDER_EXTERNAL_URL") or "").strip(),
         "EMOJI_MAX_BYTES": _int_env("EMOJI_MAX_BYTES", 2_000_000, min_value=1),

--- a/tests/test_app_command_errors.py
+++ b/tests/test_app_command_errors.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_REQUIRED_ENV = {
+    "DISCORD_TOKEN": "test-token",
+    "GSPREAD_CREDENTIALS": "{}",
+    "RECRUITMENT_SHEET_ID": "sheet-id",
+}
+
+
+def _import_app(monkeypatch, **env):
+    for key, value in _REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    for key in (
+        "LOG_MESSAGE_CONTENT",
+        "LOG_LEVEL",
+        "BOT_VERSION",
+        "PROMO_CHANNEL_ID",
+        "WELCOME_CHANNEL_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    for module_name in ["app", "shared.config"]:
+        sys.modules.pop(module_name, None)
+
+    import shared
+
+    if hasattr(shared, "config"):
+        delattr(shared, "config")
+    return importlib.import_module("app")
+
+
+def test_log_message_content_defaults_false(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    assert app.shared_config.cfg.get("LOG_MESSAGE_CONTENT") is False
+    assert app.LOG_MESSAGE_CONTENT is False
+
+
+def test_log_message_content_keeps_true_false_parsing(monkeypatch):
+    for raw in ["1", "true", "TRUE", "yes", "on"]:
+        app = _import_app(monkeypatch, LOG_MESSAGE_CONTENT=raw)
+        assert app.shared_config.cfg.get("LOG_MESSAGE_CONTENT") is True
+        assert app.LOG_MESSAGE_CONTENT is True
+
+    for raw in ["0", "false", "FALSE", "no", "off", "unexpected"]:
+        app = _import_app(monkeypatch, LOG_MESSAGE_CONTENT=raw)
+        assert app.shared_config.cfg.get("LOG_MESSAGE_CONTENT") is False
+        assert app.LOG_MESSAGE_CONTENT is False
+
+
+def test_log_level_and_bot_version_preserve_fallbacks(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    assert app.shared_config.cfg.get("LOG_LEVEL") == "INFO"
+    assert app.BOT_VERSION == "dev"
+
+
+def test_log_level_and_bot_version_use_shared_config_values(monkeypatch):
+    app = _import_app(monkeypatch, LOG_LEVEL="DEBUG", BOT_VERSION="v1.2.3")
+
+    assert app.shared_config.cfg.get("LOG_LEVEL") == "DEBUG"
+    assert app.BOT_VERSION == "v1.2.3"
+
+
+def test_startup_summary_channel_formatting_for_configured_ids(monkeypatch):
+    app = _import_app(
+        monkeypatch,
+        PROMO_CHANNEL_ID="12345",
+        WELCOME_CHANNEL_ID="67890",
+    )
+
+    assert app._startup_channel_mention_id("PROMO_CHANNEL_ID") == "12345"
+    assert app._startup_channel_raw_id("PROMO_CHANNEL_ID") == "12345"
+    assert app._startup_channel_mention_id("WELCOME_CHANNEL_ID") == "67890"
+    assert app._startup_channel_raw_id("WELCOME_CHANNEL_ID") == "67890"
+
+
+def test_startup_summary_channel_formatting_for_missing_ids(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    assert f"<#{app._startup_channel_mention_id('PROMO_CHANNEL_ID')}>" == "<#>"
+    assert app._startup_channel_raw_id("PROMO_CHANNEL_ID") == "-"
+    assert f"<#{app._startup_channel_mention_id('WELCOME_CHANNEL_ID')}>" == "<#>"
+    assert app._startup_channel_raw_id("WELCOME_CHANNEL_ID") == "-"


### PR DESCRIPTION
### Motivation
- Align `app.py` with repository guardrail C-10 by eliminating direct `os.getenv()` reads and using the shared config facade.
- Centralise boolean parsing for `LOG_MESSAGE_CONTENT` in the authoritative config loader so runtime code reads already-parsed values.
- Preserve existing external-command behaviour, startup-summary formatting, and fallbacks for `LOG_LEVEL` and `BOT_VERSION`.

### Description
- Import the shared config facade as `shared_config` in `app.py` and route `LOG_LEVEL` through `shared_config.cfg` while preserving the `"INFO"` fallback via `shared_config.cfg.get("LOG_LEVEL", "INFO")`.
- Move `LOG_MESSAGE_CONTENT` parsing into `_load_config_snapshot()` in `shared/config.py` using the existing `_env_bool()` helper and expose it via `cfg` as `LOG_MESSAGE_CONTENT` with default `False`.
- Remove the duplicate `_env_bool()` helper from `app.py` and read `LOG_MESSAGE_CONTENT` with `bool(shared_config.cfg.get("LOG_MESSAGE_CONTENT", False))`.
- Replace the four direct watcher-channel `os.getenv()` reads for `PROMO_CHANNEL_ID` and `WELCOME_CHANNEL_ID` with three small helpers in `app.py`: `_startup_channel_config_id()`, `_startup_channel_mention_id()`, and `_startup_channel_raw_id()` that use `shared_config.cfg` and preserve the startup-summary formatting (missing mention renders as `<#>` and missing raw id as `-`).
- Replace `BOT_VERSION` in `app.py` with `str(shared_config.cfg.get("BOT_VERSION", "dev") or "dev")` to preserve the `dev` fallback.
- Add focused tests (`tests/test_app_command_errors.py`) that validate `LOG_MESSAGE_CONTENT` parsing/default, `LOG_LEVEL`/`BOT_VERSION` fallbacks and configured values, and startup-summary promo/welcome channel formatting; keep existing external-command handling and existing tests unchanged.

### Testing
- Ran the requested focused tests with `python -m pytest tests/test_app_command_errors.py -q` and `python -m pytest tests/test_app_command_errors.py tests/shared/sheets/test_help_commands.py -q`, and all focused assertions passed (100% green).
- Ran the full relevant CI shards used by the repository: `python -m pytest tests/config tests/coreops tests/docs tests/guardrails tests/scripts tests/common tests/integration tests/shared -q` and `python -m pytest tests/community tests/housekeeping tests/modules tests/cogs tests/test_*.py -q`, and both shards completed successfully (no failures).
- Executed the repository guardrails suite (`scripts/ci/check_forbidden_imports.sh`, `python scripts/ci/check_env_parity.py --summary guardrails-summary.md`, and `python -m scripts.ci.guardrails_suite --pr 1052 --status-file guardrails_status.txt --summary guardrails-comment.md --base-ref origin/main`) and observed all guardrails passing, including C-10 (shared config accessor enforcement).
- Verified `rg -n "os\.getenv" app.py` shows no remaining direct `os.getenv()` calls in `app.py` after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7303d5f08c83238ae8c66020bac87f)