### PR TITLE
Rebase external-command handling onto current main and consult shared HelpCommands for external CommandNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### Unreleased
+**Core Infra**
+* Rebased Woadkeeper external command-error handling onto the shared-config runtime so commands owned exclusively by other bots are silently ignored via the cached HelpCommands registry while Woadkeeper, mixed-owner, blank-owner, unknown, and fail-safe cases continue normal reporting.
+
 ### v0.9.8.2 — 2025-12-02
 **Community**
 * Added a sheet-driven reaction roles module with admin `!reactrole <key>`, cached config loader, and grant/revoke handlers for emoji reacts.

--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from shared.config import (
 )
 from shared.logfmt import LogTemplates, guild_label, user_label, human_reason
 from shared.redaction import sanitize_text
+from shared.sheets import help_commands
 from shared import health as healthmod
 from shared import socket_heartbeat as hb
 from modules.common.runtime import Runtime, StartupPhaseError, scheduler_report_lines
@@ -51,6 +52,7 @@ logging.basicConfig(
 log = logging.getLogger("c1c.app")
 
 LOG_MESSAGE_CONTENT_MAX_LEN = 200
+WOADKEEPER_BOT_KEY = "woadkeeper"
 
 
 def _traceback_file_label(filename: str) -> str:
@@ -695,8 +697,48 @@ async def on_message(message: discord.Message):
     await bot.process_commands(message)
 
 
+def _attempted_command_root(ctx: commands.Context) -> str:
+    invoked_with = str(getattr(ctx, "invoked_with", None) or "").strip()
+    if invoked_with:
+        return help_commands.normalize_lookup(invoked_with.split()[0])
+    content = str(getattr(getattr(ctx, "message", None), "content", "") or "").strip()
+    if content:
+        token = content.split(maxsplit=1)[0]
+        return help_commands.normalize_lookup(token)
+    return ""
+
+
+async def _should_ignore_external_command_not_found(
+    ctx: commands.Context, error: Exception
+) -> bool:
+    if not isinstance(error, commands.CommandNotFound):
+        return False
+
+    attempted_root = _attempted_command_root(ctx)
+    if not attempted_root:
+        return False
+
+    try:
+        rows = await help_commands.get_rows()
+        if rows is None:
+            return False
+        matches = help_commands.find_rows(rows, attempted_root)
+    except Exception:
+        log.warning("failed to resolve shared help command ownership", exc_info=True)
+        return False
+
+    if not matches:
+        return False
+
+    owners = {help_commands.normalize_lookup(row.bot_key) for row in matches}
+    return bool(owners) and "" not in owners and owners.isdisjoint({WOADKEEPER_BOT_KEY})
+
+
 @bot.event
 async def on_command_error(ctx: commands.Context, error: Exception):
+    if await _should_ignore_external_command_not_found(ctx, error):
+        return
+
     log.warning(
         "cmd error: cmd=%s user=%s err=%r",
         getattr(ctx.command, "name", None),

--- a/docs/contracts/core_infra.md
+++ b/docs/contracts/core_infra.md
@@ -48,6 +48,12 @@ See [`docs/ops/Config.md`](../ops/Config.md#environment-keys) for full key defin
 - `!env` returns a four-page admin overview (Overview, Channels, Roles, Sheets & Config) and surfaces warnings for missing/not-found config on Page 1.
 - No bare-word shortcuts.
 
+## External Command Ownership
+- `CommandNotFound` handling consults the cached shared HelpCommands registry to distinguish Woadkeeper commands from commands owned exclusively by external bots.
+- Commands with only enabled, nonblank, non-Woadkeeper owners are ignored silently so another bot can handle them.
+- Unknown commands, Woadkeeper-owned commands, mixed ownership, blank ownership, unavailable help data, lookup failures, and non-`CommandNotFound` exceptions continue through normal command-error reporting.
+- Command ownership must remain sheet/cache-driven; do not add hard-coded external command lists in `app.py`.
+
 ## CoreOps v1.5 contract
 - CoreOps integrates with the cache service exclusively through the public API surface:
   `list_buckets()`, `get_snapshot(name)`, `refresh_now(name, actor=…)`, and telemetry helpers.

--- a/shared/sheets/help_commands.py
+++ b/shared/sheets/help_commands.py
@@ -145,8 +145,11 @@ def normalize_lookup(value: object) -> str:
     return text.lstrip("!").strip()
 
 
-def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | None:
+def find_rows(
+    rows: Sequence[HelpCommandRow], query: object
+) -> tuple[HelpCommandRow, ...]:
     needle = normalize_lookup(query)
+    matches: list[HelpCommandRow] = []
     for row in rows:
         candidates = (
             row.command_key.replace("_", " "),
@@ -154,8 +157,13 @@ def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | 
             row.usage.split(" ", 1)[0],
         )
         if any(normalize_lookup(candidate) == needle for candidate in candidates):
-            return row
-    return None
+            matches.append(row)
+    return tuple(matches)
+
+
+def find_row(rows: Sequence[HelpCommandRow], query: object) -> HelpCommandRow | None:
+    matches = find_rows(rows, query)
+    return matches[0] if matches else None
 
 
 def visible_rows(

--- a/tests/shared/sheets/test_help_commands.py
+++ b/tests/shared/sheets/test_help_commands.py
@@ -205,3 +205,19 @@ def test_manual_helpcommands_bucket_refresh_reloads_immediately(monkeypatch) -> 
     assert first is not None and first[0].summary == "version 1"
     assert bucket is not None and bucket.value[0].summary == "version 2"
     assert reads == 2
+
+
+def test_find_rows_returns_all_matching_owners_and_find_row_keeps_first_match() -> None:
+    rows = help_commands.parse_rows(
+        [
+            HEADERS,
+            _row(bot_key="reminder", command="!remind", command_key="remind", usage="!remind me"),
+            _row(bot_key="achievements", command="!remind", command_key="remind", usage="!remind stats"),
+            _row(bot_key="woadkeeper", command="!other", command_key="other", usage="!other"),
+        ]
+    )
+
+    matches = help_commands.find_rows(rows, "!remind")
+
+    assert [row.bot_key for row in matches] == ["reminder", "achievements"]
+    assert help_commands.find_row(rows, "remind") == matches[0]

--- a/tests/test_app_command_errors.py
+++ b/tests/test_app_command_errors.py
@@ -88,3 +88,150 @@ def test_startup_summary_channel_formatting_for_missing_ids(monkeypatch):
     assert app._startup_channel_raw_id("PROMO_CHANNEL_ID") == "-"
     assert f"<#{app._startup_channel_mention_id('WELCOME_CHANNEL_ID')}>" == "<#>"
     assert app._startup_channel_raw_id("WELCOME_CHANNEL_ID") == "-"
+
+
+class _Author:
+    id = 42
+
+
+class _Ctx:
+    command = None
+    author = _Author()
+    guild = None
+
+    def __init__(self, invoked_with="remind", content="!remind now"):
+        self.invoked_with = invoked_with
+        self.message = type("Message", (), {"content": content})()
+
+
+class _Runtime:
+    def __init__(self):
+        self.messages = []
+
+    async def send_log_message(self, message):
+        self.messages.append(message)
+
+
+def _help_row(app, bot_key, command="!remind", command_key="remind", usage="!remind me"):
+    return app.help_commands.HelpCommandRow(
+        bot_key=bot_key,
+        command_key=command_key,
+        command=command,
+        usage=usage,
+        category="Ops",
+        access_level="user",
+        summary="Summary",
+        details="Details",
+        sort_order=None,
+        source_order=0,
+    )
+
+
+def _run_command_error(app, monkeypatch, rows, *, error=None, lookup_raises=False):
+    runtime = _Runtime()
+    monkeypatch.setattr(app, "runtime", runtime, raising=False)
+
+    original_find_rows = app.help_commands.find_rows
+
+    async def get_rows():
+        return rows
+
+    def find_rows(source_rows, query):
+        if lookup_raises:
+            raise RuntimeError("lookup failed")
+        return original_find_rows(source_rows, query)
+
+    monkeypatch.setattr(app.help_commands, "get_rows", get_rows)
+    monkeypatch.setattr(app.help_commands, "find_rows", find_rows)
+    err = error if error is not None else app.commands.CommandNotFound("not found")
+    asyncio = __import__("asyncio")
+    asyncio.run(app.on_command_error(_Ctx(), err))
+    return runtime.messages
+
+
+def test_external_reminder_command_not_found_is_ignored(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, "reminder"),))
+
+    assert messages == []
+
+
+def test_external_achievement_command_not_found_is_ignored(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, "achievements"),))
+
+    assert messages == []
+
+
+def test_commands_shared_only_by_external_bots_are_ignored(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(
+        app,
+        monkeypatch,
+        (_help_row(app, "reminder"), _help_row(app, "achievements")),
+    )
+
+    assert messages == []
+
+
+def test_woadkeeper_owned_command_not_found_is_reported(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, "woadkeeper"),))
+
+    assert len(messages) == 1
+
+
+def test_mixed_ownership_command_not_found_is_reported(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(
+        app,
+        monkeypatch,
+        (_help_row(app, "reminder"), _help_row(app, "woadkeeper")),
+    )
+
+    assert len(messages) == 1
+
+
+def test_blank_ownership_command_not_found_is_reported(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, ""),))
+
+    assert len(messages) == 1
+
+
+def test_unknown_command_not_found_is_reported(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, ())
+
+    assert len(messages) == 1
+
+
+def test_unavailable_help_data_reports_normally(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, None)
+
+    assert len(messages) == 1
+
+
+def test_help_lookup_exception_reports_normally(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, "reminder"),), lookup_raises=True)
+
+    assert len(messages) == 1
+
+
+def test_non_command_not_found_exception_reports_normally(monkeypatch):
+    app = _import_app(monkeypatch)
+
+    messages = _run_command_error(app, monkeypatch, (_help_row(app, "reminder"),), error=RuntimeError("boom"))
+
+    assert len(messages) == 1


### PR DESCRIPTION
### Motivation

- Rebase and reapply PR #1052’s Woadkeeper external-command handling on top of the latest `main` so recent shared-config changes from merged PRs are preserved while bringing back only the external-command feature. 
- Ensure `CommandNotFound` errors are suppressed only when the cached shared `HelpCommands` registry proves the attempted command is exclusively owned by non-Woadkeeper external bots. 

### Description

- Rebased the feature and updated `app.py` to import the shared `help_commands` module, add `WOADKEEPER_BOT_KEY`, normalize attempted command roots, and add `_should_ignore_external_command_not_found()` which consults the cached help registry and implements the exact ignore/report rules requested. 
- Extended `shared/sheets/help_commands.py` with `find_rows()` returning all matching rows and implemented `find_row()` on top of it to preserve first-match compatibility while keeping existing normalization and candidate checks. 
- Preserved shared-config integration: `LOG_LEVEL`, `LOG_MESSAGE_CONTENT`, `BOT_VERSION`, and promo/welcome channel helpers continue to be read via `shared_config.cfg`; `shared/config.py` was not modified and `app.py` contains no direct `os.getenv()` calls. 
- Exact final changed files in this PR: `app.py`, `shared/sheets/help_commands.py`, `tests/test_app_command_errors.py`, `tests/shared/sheets/test_help_commands.py`, `docs/contracts/core_infra.md`, and `CHANGELOG.md`.

### Testing

- Focused tests: ran `python -m pytest tests/test_app_command_errors.py tests/shared/sheets/test_help_commands.py -q` and the focused suite passed (all tests in those files succeeded). 
- Full test shards: ran the repo test shards used by CI (collected and ran the configured test matrices) and the suites passed locally (shard runs completed; collective results shown as all tests passing in the local run). 
- Guardrails and static checks: `scripts/ci/check_forbidden_imports.sh`, `python scripts/ci/check_env_parity.py --summary guardrails-summary.md`, and `python -m scripts.ci.guardrails_suite --pr 1052 --status-file guardrails_status.txt --summary guardrails-comment.md --base-ref HEAD` were executed and passed; AST scan confirms `app.py` contains no `os.getenv()` calls. 
- Note on environment: an attempt to install `pytest-timeout` failed due to network restrictions in the execution environment (`CONNECT tunnel failed: 403 Forbidden`), so one timeout-instrumented run was rerun locally without the `pytest-timeout` plugin; all test shards and guardrail checks passed in that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73153c8dc48323bf746b52a64553f9)