### PR TITLE
Support grouped server rules and linkable FAQ posts

### DIFF
--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -6,7 +6,7 @@ import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, unquote, urlparse
 
 import discord
 
@@ -24,7 +24,10 @@ from shared.sheets import recruitment as recruitment_sheet
 from shared.config import get_recruitment_sheet_id
 from shared.theme import colors
 
-MARKER_PREFIX = "\u2063\u200bserverrules:"
+LEGACY_MARKER_PREFIX = "\u2063\u200bserverrules:"
+HIDDEN_MARKER_PREFIX = "https://c1c.invalid/serverrules/"
+HIDDEN_MARKER_LABEL = "\u2063"
+MAX_EMBEDS_PER_MESSAGE = 10
 REQUIRED_HEADERS = {
     "message_key",
     "section",
@@ -37,6 +40,7 @@ REQUIRED_HEADERS = {
     "footer",
     "message_id",
 }
+OPTIONAL_HEADERS = {"topic_key", "topic_title"}
 TRUE_VALUES = {"1", "true", "yes", "y", "on", "enabled", "publish", "published"}
 FALSE_VALUES = {"", "0", "false", "no", "n", "off", "disabled"}
 MAX_TITLE = 256
@@ -67,6 +71,8 @@ class Row:
     data: dict[str, str]
     enabled: bool
     order: float | None = None
+    topic_key: str = ""
+    topic_title: str = ""
     embed: discord.Embed | None = None
 
     @property
@@ -76,6 +82,18 @@ class Row:
     @property
     def message_id(self) -> str:
         return self.data.get("message_id", "").strip()
+
+
+@dataclass
+class MessageGroup:
+    key: str
+    rows: list[Row]
+    embeds: list[discord.Embed]
+    stored_message_id: str = ""
+
+    @property
+    def first_row(self) -> Row:
+        return self.rows[0]
 
 
 @dataclass
@@ -93,16 +111,90 @@ class Summary:
 
 
 def marker_for(message_key: str) -> str:
-    return f"{MARKER_PREFIX}{message_key}\u2060\u2063"
+    return f"{LEGACY_MARKER_PREFIX}{message_key}\u2060\u2063"
+
+
+def hidden_marker_for(message_key: str) -> str:
+    return (
+        f"[{HIDDEN_MARKER_LABEL}]({HIDDEN_MARKER_PREFIX}{quote(message_key, safe='')})"
+    )
+
+
+def _extract_legacy_marker(message: Any) -> str | None:
+    content = getattr(message, "content", "") or ""
+    if not content.startswith(LEGACY_MARKER_PREFIX):
+        return None
+    rest = content[len(LEGACY_MARKER_PREFIX) :]
+    for suffix in ("\u2060\u2063", "\n", " "):
+        rest = rest.split(suffix, 1)[0]
+    return rest or None
+
+
+def _extract_hidden_marker(message: Any) -> str | None:
+    embeds = getattr(message, "embeds", None) or []
+    if not embeds:
+        return None
+    description = getattr(embeds[0], "description", None) or ""
+    needle = f"[{HIDDEN_MARKER_LABEL}]({HIDDEN_MARKER_PREFIX}"
+    pos = description.rfind(needle)
+    if pos < 0:
+        return None
+    start = pos + len(needle)
+    end = description.find(")", start)
+    if end < 0:
+        return None
+    encoded = description[start:end]
+    decoded = unquote(encoded)
+    if not decoded or quote(decoded, safe="") != encoded:
+        return None
+    return decoded
+
+
+def _managed_message_key(message: Any) -> str | None:
+    return _extract_hidden_marker(message) or _extract_legacy_marker(message)
 
 
 def is_feature_message(message: Any, keys: set[str] | None = None) -> bool:
-    content = getattr(message, "content", "") or ""
-    if not content.startswith(MARKER_PREFIX):
+    key = _managed_message_key(message)
+    if key is None:
         return False
-    if keys is None:
-        return True
-    return any(content.startswith(marker_for(key)) for key in keys)
+    return keys is None or key in keys
+
+
+def _is_managed_message(
+    message: Any, bot_id: int | None = None, expected_key: str | None = None
+) -> bool:
+    if bot_id is not None and not _is_bot_authored(message, bot_id):
+        return False
+    key = _managed_message_key(message)
+    if key is None:
+        return False
+    return expected_key is None or key == expected_key
+
+
+def _embed_text_len(embed: discord.Embed) -> int:
+    total = len(getattr(embed, "title", None) or "") + len(
+        getattr(embed, "description", None) or ""
+    )
+    footer = getattr(embed, "footer", None)
+    total += len(getattr(footer, "text", None) or "")
+    for field in getattr(embed, "fields", []) or []:
+        total += len(getattr(field, "name", "") or "") + len(
+            getattr(field, "value", "") or ""
+        )
+    return total
+
+
+def _copy_embed(embed: discord.Embed) -> discord.Embed:
+    return discord.Embed.from_dict(embed.to_dict())
+
+
+def _embeds_with_marker(group: MessageGroup) -> list[discord.Embed]:
+    embeds = [_copy_embed(embed) for embed in group.embeds]
+    embeds[0].description = (
+        f"{embeds[0].description or ''}{hidden_marker_for(group.key)}"
+    )
+    return embeds
 
 
 def _mirralith_sheet_id() -> str:
@@ -135,6 +227,8 @@ PLACEHOLDER_FIELDS = {
     "thumbnail_url",
     "footer",
     "message_id",
+    "topic_key",
+    "topic_title",
     "review_status",
     "review_notes",
 }
@@ -242,9 +336,12 @@ async def load_rows() -> tuple[str, dict[str, int], list[Row], list[str]]:
         }
         if _is_empty_placeholder(data):
             continue
-        rows.append(
-            Row(offset, list(values), data, parse_enabled(data.get("enabled")) is True)
+        row = Row(
+            offset, list(values), data, parse_enabled(data.get("enabled")) is True
         )
+        row.topic_key = data.get("topic_key", "").strip()
+        row.topic_title = data.get("topic_title", "").strip()
+        rows.append(row)
     return tab, header_map, rows, []
 
 
@@ -269,16 +366,12 @@ async def preflight(
             "SERVER_RULES_FAQ_CHANNEL_ID must resolve to a text channel or thread",
         )
         target = None
-    seen_keys: set[str] = set()
     enabled_orders: dict[float, str] = {}
     for row in rows:
         key = row.key
         label = key or f"row {row.row_number}"
         if not key:
             summary.fail(label, "message_key is required")
-        elif key in seen_keys:
-            summary.fail(key, "message_key must be unique")
-        seen_keys.add(key)
         if parse_enabled(row.data.get("enabled")) is None:
             summary.fail(label, "enabled value is not recognised")
         if row.message_id and not valid_snowflake(row.message_id):
@@ -302,7 +395,46 @@ async def preflight(
             row.embed, errors = build_embed(row)
             for err in errors:
                 summary.fail(label, err)
+    if not summary.failures:
+        _groups, group_errors = build_groups(rows)
+        for key, err in group_errors:
+            summary.fail(key, err)
     return target, tab, header_map, rows, summary if summary.failures else None
+
+
+def build_groups(rows: list[Row]) -> tuple[list[MessageGroup], list[tuple[str, str]]]:
+    ordered = sorted(
+        [r for r in rows if r.enabled], key=lambda r: (r.order, r.row_number)
+    )
+    grouped: dict[str, list[Row]] = {}
+    for row in ordered:
+        grouped.setdefault(row.key, []).append(row)
+    groups = [
+        MessageGroup(
+            key, group_rows, [r.embed for r in group_rows if r.embed is not None]
+        )
+        for key, group_rows in grouped.items()
+    ]
+    groups.sort(key=lambda group: (group.rows[0].order, group.rows[0].row_number))
+    errors: list[tuple[str, str]] = []
+    for group in groups:
+        if len(group.embeds) > MAX_EMBEDS_PER_MESSAGE:
+            errors.append((group.key, "message group exceeds Discord's 10 embed limit"))
+        ids = {row.message_id for row in group.rows if row.message_id}
+        if len(ids) > 1:
+            errors.append(
+                (group.key, "message group has multiple different stored message IDs")
+            )
+        group.stored_message_id = next(iter(ids), "")
+        marked = _embeds_with_marker(group) if group.embeds else []
+        if sum(_embed_text_len(embed) for embed in marked) > MAX_TOTAL:
+            errors.append(
+                (
+                    group.key,
+                    "message group embed text exceeds Discord 6000 character limit",
+                )
+            )
+    return groups, errors
 
 
 async def _worksheet(tab: str) -> Any:
@@ -443,20 +575,21 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     assert target is not None
     summary = Summary()
     snapshot = {row.row_number: row.message_id for row in rows}
-    enabled_rows = sorted(
-        [r for r in rows if r.enabled], key=lambda r: (r.order, r.key)
-    )
-    new_pairs: list[tuple[Row, Any]] = []
+    groups, _ = build_groups(rows)
+    new_pairs: list[tuple[MessageGroup, Any]] = []
     try:
-        for row in enabled_rows:
+        for group in groups:
             new_pairs.append(
-                (row, await target.send(content=marker_for(row.key), embed=row.embed))
+                (group, await target.send(embeds=_embeds_with_marker(group)))
             )
     except Exception:
-        summary.fail(row.key, "Discord send failed during rebuild")
-        await _delete_new([msg for _row, msg in new_pairs])
+        summary.fail(group.key, "Discord send failed during rebuild")
+        await _delete_new([msg for _group, msg in new_pairs])
         return summary, target
-    updates = [(row, str(msg.id)) for row, msg in new_pairs]
+    updates: list[tuple[Row, str]] = []
+    for group, msg in new_pairs:
+        updates.append((group.first_row, str(msg.id)))
+        updates.extend((row, "") for row in group.rows[1:] if row.message_id)
     updates.extend((row, "") for row in rows if not row.enabled and row.message_id)
     try:
         await _write_ids_batch(tab, header_map, updates)
@@ -475,7 +608,7 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     for row in rows:
         if not row.enabled and row.message_id:
             summary.removed += 0
-    new_ids = {str(getattr(msg, "id", "")) for _row, msg in new_pairs}
+    new_ids = {str(getattr(msg, "id", "")) for _group, msg in new_pairs}
     bot_id = getattr(getattr(bot, "user", None), "id", None)
     seen_old_ids = await _delete_old_stored_messages(
         target, rows, new_ids, bot_id, summary
@@ -505,42 +638,31 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
         return errors, target
     assert target is not None
     summary = Summary()
-    for row in rows:
+    groups, _ = build_groups(rows)
+    grouped_rows = {id(row) for group in groups for row in group.rows}
+    for group in groups:
+        row = group.first_row
         try:
-            state, msg, reason = await _fetch(target, row.message_id)
-            if row.enabled:
+            state, msg, reason = await _fetch(target, group.stored_message_id)
+            if True:
                 if state is FetchState.UNKNOWN:
                     summary.fail(row.key, reason)
                     continue
                 if (
                     state is FetchState.FOUND
                     and msg is not None
-                    and is_feature_message(msg, {row.key})
+                    and _is_managed_message(
+                        msg, getattr(getattr(bot, "user", None), "id", None), group.key
+                    )
                 ):
                     try:
-                        await msg.edit(content=marker_for(row.key), embed=row.embed)
+                        await msg.edit(content=None, embeds=_embeds_with_marker(group))
                     except Exception:
                         summary.fail(row.key, "failed to edit stored message")
                     else:
                         summary.refreshed += 1
                     continue
-                sent = None
-                try:
-                    sent = await target.send(
-                        content=marker_for(row.key), embed=row.embed
-                    )
-                    await _write_message_id(tab, header_map, row, str(sent.id))
-                except Exception:
-                    if sent is not None:
-                        try:
-                            await sent.delete()
-                        except Exception:
-                            pass
-                    summary.fail(
-                        row.key, "failed to create replacement or store its message_id"
-                    )
-                else:
-                    summary.created += 1
+                summary.skipped += 1
             else:
                 if not row.message_id:
                     summary.skipped += 1
@@ -573,6 +695,41 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
                     summary.fail(
                         row.key, "stored message is not managed by server rules"
                     )
+        except Exception:
+            summary.fail(row.key, "unexpected row processing failure")
+    for row in rows:
+        if id(row) in grouped_rows:
+            continue
+        try:
+            state, msg, reason = await _fetch(target, row.message_id)
+            if not row.message_id:
+                summary.skipped += 1
+            elif state is FetchState.UNKNOWN:
+                summary.fail(row.key, reason)
+            elif state is FetchState.MISSING:
+                try:
+                    await _write_message_id(tab, header_map, row, "")
+                except Exception:
+                    summary.fail(
+                        row.key,
+                        "stored message was missing but message_id could not be cleared",
+                    )
+                else:
+                    summary.skipped += 1
+            elif msg is not None and _is_deletable_feature_message(
+                msg, getattr(getattr(bot, "user", None), "id", None), {row.key}
+            ):
+                try:
+                    await msg.delete()
+                    await _write_message_id(tab, header_map, row, "")
+                except Exception:
+                    summary.fail(
+                        row.key, "failed to delete disabled message or clear message_id"
+                    )
+                else:
+                    summary.removed += 1
+            else:
+                summary.fail(row.key, "stored message is not managed by server rules")
         except Exception:
             summary.fail(row.key, "unexpected row processing failure")
     return summary, target

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -90,6 +90,7 @@ class MessageGroup:
     rows: list[Row]
     embeds: list[discord.Embed]
     stored_message_id: str = ""
+    marked_embeds: list[discord.Embed] = field(default_factory=list)
 
     @property
     def first_row(self) -> Row:
@@ -195,6 +196,27 @@ def _embeds_with_marker(group: MessageGroup) -> list[discord.Embed]:
         f"{embeds[0].description or ''}{hidden_marker_for(group.key)}"
     )
     return embeds
+
+
+def _validate_embed_payload(embeds: list[discord.Embed]) -> list[str]:
+    errors: list[str] = []
+    if len(embeds) > MAX_EMBEDS_PER_MESSAGE:
+        errors.append("message group exceeds Discord's 10 embed limit")
+    total = 0
+    for embed in embeds:
+        title = getattr(embed, "title", None) or ""
+        description = getattr(embed, "description", None) or ""
+        footer = getattr(getattr(embed, "footer", None), "text", None) or ""
+        if len(title) > MAX_TITLE:
+            errors.append("title exceeds Discord limit")
+        if len(description) > MAX_DESCRIPTION:
+            errors.append("description exceeds Discord limit")
+        if len(footer) > MAX_FOOTER:
+            errors.append("footer exceeds Discord limit")
+        total += _embed_text_len(embed)
+    if total > MAX_TOTAL:
+        errors.append("message group embed text exceeds Discord 6000 character limit")
+    return errors
 
 
 def _mirralith_sheet_id() -> str:
@@ -406,6 +428,7 @@ def build_groups(rows: list[Row]) -> tuple[list[MessageGroup], list[tuple[str, s
     ordered = sorted(
         [r for r in rows if r.enabled], key=lambda r: (r.order, r.row_number)
     )
+    topic_errors = _validate_topic_runs(ordered)
     grouped: dict[str, list[Row]] = {}
     for row in ordered:
         grouped.setdefault(row.key, []).append(row)
@@ -416,25 +439,37 @@ def build_groups(rows: list[Row]) -> tuple[list[MessageGroup], list[tuple[str, s
         for key, group_rows in grouped.items()
     ]
     groups.sort(key=lambda group: (group.rows[0].order, group.rows[0].row_number))
-    errors: list[tuple[str, str]] = []
+    errors: list[tuple[str, str]] = topic_errors
     for group in groups:
-        if len(group.embeds) > MAX_EMBEDS_PER_MESSAGE:
-            errors.append((group.key, "message group exceeds Discord's 10 embed limit"))
         ids = {row.message_id for row in group.rows if row.message_id}
         if len(ids) > 1:
             errors.append(
                 (group.key, "message group has multiple different stored message IDs")
             )
         group.stored_message_id = next(iter(ids), "")
-        marked = _embeds_with_marker(group) if group.embeds else []
-        if sum(_embed_text_len(embed) for embed in marked) > MAX_TOTAL:
-            errors.append(
-                (
-                    group.key,
-                    "message group embed text exceeds Discord 6000 character limit",
-                )
-            )
+        group.marked_embeds = _embeds_with_marker(group) if group.embeds else []
+        errors.extend(
+            (group.key, err) for err in _validate_embed_payload(group.marked_embeds)
+        )
     return groups, errors
+
+
+def _validate_topic_runs(rows: list[Row]) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    seen_closed: set[str] = set()
+    active_topic = ""
+    for row in rows:
+        topic = row.topic_key
+        if not topic:
+            continue
+        if topic == active_topic:
+            continue
+        if active_topic:
+            seen_closed.add(active_topic)
+        if topic in seen_closed:
+            errors.append((topic, "topic_key rows must be consecutive by order"))
+        active_topic = topic
+    return errors
 
 
 async def _worksheet(tab: str) -> Any:
@@ -520,6 +555,13 @@ def _is_deletable_feature_message(
     return _is_bot_authored(message, bot_id) and is_feature_message(message, keys)
 
 
+def _cleanup_keys_for_row(row: Row) -> set[str]:
+    keys = {row.key}
+    if row.topic_key:
+        keys.add(row.topic_key)
+    return keys
+
+
 async def _iter_feature_messages(target: Any, bot_id: int | None) -> list[Any]:
     history = getattr(target, "history", None)
     if not callable(history):
@@ -543,15 +585,17 @@ async def _delete_old_stored_messages(
         old_id = row.message_id
         if not old_id or old_id in new_ids or old_id in seen:
             continue
-        seen.add(old_id)
         state, msg, reason = await _fetch(target, old_id)
         if state is FetchState.MISSING:
             continue
         if state is FetchState.UNKNOWN:
             summary.fail(row.key, reason)
             continue
-        if msg is None or not _is_deletable_feature_message(msg, bot_id, {row.key}):
+        if msg is None or not _is_deletable_feature_message(
+            msg, bot_id, _cleanup_keys_for_row(row)
+        ):
             continue
+        seen.add(old_id)
         try:
             await msg.delete()
             summary.removed += 1
@@ -579,9 +623,7 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     new_pairs: list[tuple[MessageGroup, Any]] = []
     try:
         for group in groups:
-            new_pairs.append(
-                (group, await target.send(embeds=_embeds_with_marker(group)))
-            )
+            new_pairs.append((group, await target.send(embeds=group.marked_embeds)))
     except Exception:
         summary.fail(group.key, "Discord send failed during rebuild")
         await _delete_new([msg for _group, msg in new_pairs])
@@ -644,57 +686,24 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
         row = group.first_row
         try:
             state, msg, reason = await _fetch(target, group.stored_message_id)
-            if True:
-                if state is FetchState.UNKNOWN:
-                    summary.fail(row.key, reason)
-                    continue
-                if (
-                    state is FetchState.FOUND
-                    and msg is not None
-                    and _is_managed_message(
-                        msg, getattr(getattr(bot, "user", None), "id", None), group.key
-                    )
-                ):
-                    try:
-                        await msg.edit(content=None, embeds=_embeds_with_marker(group))
-                    except Exception:
-                        summary.fail(row.key, "failed to edit stored message")
-                    else:
-                        summary.refreshed += 1
-                    continue
-                summary.skipped += 1
-            else:
-                if not row.message_id:
-                    summary.skipped += 1
-                elif state is FetchState.UNKNOWN:
-                    summary.fail(row.key, reason)
-                elif state is FetchState.MISSING:
-                    try:
-                        await _write_message_id(tab, header_map, row, "")
-                    except Exception:
-                        summary.fail(
-                            row.key,
-                            "stored message was missing but message_id could not be cleared",
-                        )
-                    else:
-                        summary.skipped += 1
-                elif msg is not None and _is_deletable_feature_message(
-                    msg, getattr(getattr(bot, "user", None), "id", None), {row.key}
-                ):
-                    try:
-                        await msg.delete()
-                        await _write_message_id(tab, header_map, row, "")
-                    except Exception:
-                        summary.fail(
-                            row.key,
-                            "failed to delete disabled message or clear message_id",
-                        )
-                    else:
-                        summary.removed += 1
+            if state is FetchState.UNKNOWN:
+                summary.fail(row.key, reason)
+                continue
+            if (
+                state is FetchState.FOUND
+                and msg is not None
+                and _is_managed_message(
+                    msg, getattr(getattr(bot, "user", None), "id", None), group.key
+                )
+            ):
+                try:
+                    await msg.edit(content=None, embeds=group.marked_embeds)
+                except Exception:
+                    summary.fail(row.key, "failed to edit stored message")
                 else:
-                    summary.fail(
-                        row.key, "stored message is not managed by server rules"
-                    )
+                    summary.refreshed += 1
+                continue
+            summary.skipped += 1
         except Exception:
             summary.fail(row.key, "unexpected row processing failure")
     for row in rows:

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -1235,3 +1235,366 @@ def test_refresh_group_edits_once_and_conflicting_ids_fail(monkeypatch):
         assert writes["batch"] == []
 
     asyncio.run(run())
+
+
+def test_hidden_marker_description_overflow_rejected_before_side_effects(monkeypatch):
+    async def run():
+        chan = Chan()
+        marker_len = len(server_rules.hidden_marker_for("near"))
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "x" * (server_rules.MAX_DESCRIPTION - marker_len + 1),
+                    "near",
+                    "",
+                    "",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_hidden_marker_combined_total_overflow_rejected_before_side_effects(
+    monkeypatch,
+):
+    async def run():
+        chan = Chan()
+        marker_len = len(server_rules.hidden_marker_for("combo"))
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "a" * 3000,
+                    "combo",
+                    "",
+                    "",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    "",
+                    "yes",
+                    "b" * (server_rules.MAX_TOTAL - 3000 - marker_len + 1),
+                    "combo",
+                    "",
+                    "",
+                    "2",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_valid_near_limit_marked_payload_publishes(monkeypatch):
+    async def run():
+        chan = Chan()
+        marker_len = len(server_rules.hidden_marker_for("ok"))
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "x" * (server_rules.MAX_DESCRIPTION - marker_len),
+                    "ok",
+                    "",
+                    "",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert len(chan.sent[0].embeds[0].description) == server_rules.MAX_DESCRIPTION
+        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+
+    asyncio.run(run())
+
+
+def test_interleaved_topic_keys_rejected_before_side_effects(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = actual_sheet(
+            [
+                "faq_a1",
+                "faq",
+                "1",
+                "TRUE",
+                "A1",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "topic_a",
+                "A",
+            ],
+            [
+                "faq_b",
+                "faq",
+                "2",
+                "TRUE",
+                "B",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "topic_b",
+                "B",
+            ],
+            [
+                "faq_a2",
+                "faq",
+                "3",
+                "TRUE",
+                "A2",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "topic_a",
+                "A",
+            ],
+        )
+        rows[0].extend(["topic_key", "topic_title"])
+        writes = await fake_load(monkeypatch, rows, chan)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_blank_rule_topic_metadata_remains_valid(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = actual_sheet(
+            [
+                "rule",
+                "rules",
+                "1",
+                "TRUE",
+                "Rule",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            [
+                "faq",
+                "faq",
+                "2",
+                "TRUE",
+                "FAQ",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "topic",
+                "Topic",
+            ],
+        )
+        rows[0].extend(["topic_key", "topic_title"])
+        summary_target = await fake_load(monkeypatch, rows, chan)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 2
+        assert summary_target["batch"] == [
+            [
+                {"range": "L2", "values": [["100"]]},
+                {"range": "L3", "values": [["101"]]},
+            ]
+        ]
+
+    asyncio.run(run())
+
+
+def test_cleanup_accepts_legacy_faq_topic_marker_for_stored_question_row(monkeypatch):
+    async def run():
+        chan = Chan()
+        old = Msg(222222222222222222, server_rules.marker_for("topic_legacy"))
+        chan.messages[old.id] = old
+        rows = actual_sheet(
+            [
+                "faq_question",
+                "faq",
+                "1",
+                "TRUE",
+                "Q",
+                "D",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                str(old.id),
+                "topic_legacy",
+                "Topic",
+            ],
+        )
+        rows[0].extend(["topic_key", "topic_title"])
+        await fake_load(monkeypatch, rows, chan)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.removed == 1
+        assert old.deleted
+        assert not chan.sent[0].deleted
+
+    asyncio.run(run())
+
+
+def test_failed_direct_cleanup_verification_does_not_hide_orphan(monkeypatch):
+    async def run():
+        chan = Chan()
+        orphan = Msg(222222222222222222, server_rules.marker_for("old_cluster"))
+        wrong_author = Msg(
+            333333333333333333, server_rules.marker_for("old_cluster"), author_id=99
+        )
+        malformed = Msg(444444444444444444, "")
+        malformed.embeds = [
+            discord.Embed(description="[\u2063](https://c1c.invalid/serverrules/%ZZ)")
+        ]
+        unrelated = Msg(555555555555555555, "hello")
+        chan.messages[orphan.id] = orphan
+        chan.messages[wrong_author.id] = wrong_author
+        chan.messages[malformed.id] = malformed
+        chan.messages[unrelated.id] = unrelated
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    str(orphan.id),
+                    "yes",
+                    "New",
+                    "new_question",
+                    "",
+                    "Q",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "faq",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 1
+        assert summary.removed == 1
+        assert orphan.deleted
+        assert not chan.sent[0].deleted
+        assert not wrong_author.deleted
+        assert not malformed.deleted
+        assert not unrelated.deleted
+
+    asyncio.run(run())
+
+
+def test_refresh_failed_group_does_not_stop_other_group(monkeypatch):
+    async def run():
+        chan = Chan()
+        bad = Msg(111111111111111111, server_rules.marker_for("bad"))
+        good = Msg(222222222222222222, server_rules.marker_for("good"))
+        chan.messages[bad.id] = bad
+        chan.messages[good.id] = good
+
+        async def bad_edit(**kw):
+            raise discord.HTTPException(response=None, message="boom")
+
+        bad.edit = bad_edit
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    str(bad.id),
+                    "yes",
+                    "Bad",
+                    "bad",
+                    "",
+                    "Bad",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    str(good.id),
+                    "yes",
+                    "Good",
+                    "good",
+                    "",
+                    "Good",
+                    "2",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.failed == 1
+        assert summary.refreshed == 1
+        assert good.content is None
+        assert server_rules._is_managed_message(good, 42, "good")
+
+    asyncio.run(run())

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -12,11 +12,16 @@ class Msg:
         self.content = content
         self.author = type("A", (), {"id": author_id})()
         self.deleted = False
+        self.embeds = []
         self.edits = []
 
     async def edit(self, **kw):
         self.edits.append(kw)
         self.content = kw.get("content", self.content)
+        if "embeds" in kw:
+            self.embeds = kw["embeds"]
+        if "embed" in kw:
+            self.embeds = [kw["embed"]]
 
     async def delete(self):
         self.deleted = True
@@ -32,6 +37,7 @@ class Chan:
     async def send(self, **kw):
         msg = Msg(100 + len(self.sent), kw.get("content", ""))
         msg.kw = kw
+        msg.embeds = kw.get("embeds") or ([kw["embed"]] if "embed" in kw else [])
         self.sent.append(msg)
         self.messages[msg.id] = msg
         return msg
@@ -159,8 +165,9 @@ def test_publish_sorts_and_writes_message_ids_header_order_independent(monkeypat
         )
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 2
-        assert [m.kw["embed"].title for m in chan.sent] == ["Title A", "Title B"]
-        assert chan.sent[0].kw["embed"].thumbnail.url == "https://e.test/t.png"
+        assert [m.kw["embeds"][0].title for m in chan.sent] == ["Title A", "Title B"]
+        assert chan.sent[0].kw["embeds"][0].thumbnail.url == "https://e.test/t.png"
+        assert "content" not in chan.sent[0].kw
         assert writes["batch"] == [
             [{"range": "B3", "values": [["100"]]}, {"range": "B2", "values": [["101"]]}]
         ]
@@ -271,11 +278,11 @@ def test_refresh_edits_recreates_and_deletes(monkeypatch):
         monkeypatch.setattr(server_rules, "_fetch", fake_fetch)
         summary, _ = await server_rules.refresh(Bot(chan))
         assert summary.refreshed == 1
-        assert summary.created == 1
+        assert summary.created == 0
         assert summary.removed == 1
         assert existing.edits
         assert disabled.deleted
-        assert ("B3", [["100"]]) in writes["single"]
+        assert ("B3", [["100"]]) not in writes["single"]
         assert ("B4", [[""]]) in writes["single"]
 
     asyncio.run(run())
@@ -618,8 +625,9 @@ def test_refresh_replacement_write_failure_cleans_replacement(monkeypatch):
 
         monkeypatch.setattr(server_rules, "_fetch", missing)
         summary, _ = await server_rules.refresh(Bot(chan))
-        assert summary.failed == 1
-        assert chan.sent[0].deleted
+        assert summary.failed == 0
+        assert summary.skipped == 1
+        assert chan.sent == []
 
     asyncio.run(run())
 
@@ -880,6 +888,7 @@ def test_publish_history_scan_failure_reported_without_rollback(monkeypatch):
 
     asyncio.run(run())
 
+
 def test_feature_enabled_invokes_publish(monkeypatch):
     async def run():
         chan = Chan()
@@ -900,5 +909,329 @@ def test_feature_enabled_invokes_publish(monkeypatch):
         await cog.publish.callback(cog, ctx)
         called.assert_awaited_once()
         assert ctx.reply.call_args.kwargs["embed"].title == "Server rules publish"
+
+    asyncio.run(run())
+
+
+def test_grouped_rows_publish_one_message_with_ordered_embeds_and_group_ids(
+    monkeypatch,
+):
+    async def run():
+        chan = Chan()
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "",
+                    "yes",
+                    "One",
+                    "rule",
+                    "https://e.test/icon.png",
+                    "T1",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    "999999999999999999",
+                    "yes",
+                    "Two",
+                    "rule",
+                    "",
+                    "T2",
+                    "2",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    "",
+                    "yes",
+                    "Three",
+                    "rule",
+                    "",
+                    "T3",
+                    "3",
+                    "blue",
+                    "Foot",
+                    "",
+                    "rules",
+                ],
+                ["", "", "yes", "FAQ", "faq_1", "", "Q", "4", "green", "", "", "faq"],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 2
+        assert len(chan.sent) == 2
+        assert chan.sent[0].content == ""
+        assert [e.title for e in chan.sent[0].embeds] == ["T1", "T2", "T3"]
+        assert chan.sent[0].embeds[0].thumbnail.url == "https://e.test/icon.png"
+        assert not chan.sent[0].embeds[1].thumbnail.url
+        assert not chan.sent[0].embeds[1].footer.text
+        assert chan.sent[0].embeds[2].footer.text == "Foot"
+        assert "serverrules:" not in (chan.sent[0].embeds[0].description or "")
+        assert server_rules._is_managed_message(chan.sent[0], 42, "rule")
+        assert writes["batch"] == [
+            [
+                {"range": "B2", "values": [["100"]]},
+                {"range": "B3", "values": [[""]]},
+                {"range": "B5", "values": [["101"]]},
+            ]
+        ]
+
+    asyncio.run(run())
+
+
+def test_group_limits_rejected_before_mutation(monkeypatch):
+    async def run():
+        chan = Chan()
+        body = [
+            ["", "", "yes", "D", "rule", "", f"T{i}", str(i), "blue", "", "", "rules"]
+            for i in range(1, 12)
+        ]
+        writes = await fake_load(monkeypatch, sheet(*body), chan)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+        assert writes["batch"] == []
+        body = [
+            [
+                "",
+                "",
+                "yes",
+                "x" * 1000,
+                "long",
+                "",
+                f"T{i}",
+                str(i),
+                "blue",
+                "",
+                "",
+                "rules",
+            ]
+            for i in range(1, 8)
+        ]
+        writes = await fake_load(monkeypatch, sheet(*body), chan)
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert chan.sent == []
+        assert writes["batch"] == []
+
+    asyncio.run(run())
+
+
+def test_faq_topic_metadata_does_not_combine_or_render(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = actual_sheet(
+            [
+                "faq_a",
+                "faq",
+                "1",
+                "TRUE",
+                "Q1",
+                "A1",
+                "blue",
+                "https://e.test/topic.png",
+                "",
+                "",
+                "",
+                "",
+                "topic",
+                "Topic",
+            ],
+            [
+                "faq_b",
+                "faq",
+                "2",
+                "TRUE",
+                "Q2",
+                "A2",
+                "blue",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "topic",
+                "Topic",
+            ],
+            [
+                "faq_c",
+                "faq",
+                "3",
+                "TRUE",
+                "Q3",
+                "A3",
+                "blue",
+                "",
+                "Topic foot",
+                "",
+                "",
+                "",
+                "topic",
+                "Topic",
+            ],
+        )
+        rows[0].extend(["topic_key", "topic_title"])
+        writes = await fake_load(monkeypatch, rows, chan)
+        _tab, _header, parsed, errors = await server_rules.load_rows()
+        assert not errors
+        assert [r.topic_key for r in parsed] == ["topic", "topic", "topic"]
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.created == 3
+        assert len(chan.sent) == 3
+        assert all(len(m.embeds) == 1 for m in chan.sent)
+        assert "Topic" not in "".join(
+            (m.content or "") + (m.embeds[0].description or "") for m in chan.sent
+        )
+        assert chan.sent[0].embeds[0].thumbnail.url == "https://e.test/topic.png"
+        assert not chan.sent[1].embeds[0].thumbnail.url
+        assert not chan.sent[1].embeds[0].footer.text
+        assert chan.sent[2].embeds[0].footer.text == "Topic foot"
+        assert writes["batch"] == [
+            [
+                {"range": "L2", "values": [["100"]]},
+                {"range": "L3", "values": [["101"]]},
+                {"range": "L4", "values": [["102"]]},
+            ]
+        ]
+
+    asyncio.run(run())
+
+
+def test_hidden_marker_validation_and_legacy_refresh(monkeypatch):
+    async def run():
+        chan = Chan()
+        legacy = Msg(555555555555555555, server_rules.marker_for("keep"))
+        chan.messages[legacy.id] = legacy
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    str(legacy.id),
+                    "yes",
+                    "Updated",
+                    "keep",
+                    "",
+                    "Keep",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ]
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.refreshed == 1
+        assert legacy.content is None
+        assert server_rules._is_managed_message(legacy, 42, "keep")
+        assert not server_rules._is_managed_message(legacy, 42, "wrong")
+        forged = Msg(1, author_id=99)
+        forged.embeds = legacy.embeds
+        assert not server_rules._is_managed_message(forged, 42, "keep")
+        malformed = Msg(2, author_id=42)
+        e = discord.Embed(description="[\u2063](https://c1c.invalid/serverrules/%ZZ)")
+        malformed.embeds = [e]
+        assert not server_rules._is_managed_message(malformed, 42, "keep")
+        ordinary = Msg(3, "hello", 42)
+        assert not server_rules._is_managed_message(ordinary, 42)
+        assert server_rules._is_managed_message(
+            Msg(4, server_rules.marker_for("old")), 42, "old"
+        )
+
+    asyncio.run(run())
+
+
+def test_refresh_group_edits_once_and_conflicting_ids_fail(monkeypatch):
+    async def run():
+        chan = Chan()
+        existing = Msg(555555555555555555, server_rules.marker_for("rule"))
+        chan.messages[existing.id] = existing
+        await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    str(existing.id),
+                    "yes",
+                    "One",
+                    "rule",
+                    "",
+                    "T1",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    str(existing.id),
+                    "yes",
+                    "Two",
+                    "rule",
+                    "",
+                    "T2",
+                    "2",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.refresh(Bot(chan))
+        assert summary.refreshed == 1
+        assert len(existing.edits) == 1
+        assert len(existing.edits[0]["embeds"]) == 2
+        writes = await fake_load(
+            monkeypatch,
+            sheet(
+                [
+                    "",
+                    "555555555555555555",
+                    "yes",
+                    "One",
+                    "bad",
+                    "",
+                    "T1",
+                    "1",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+                [
+                    "",
+                    "666666666666666666",
+                    "yes",
+                    "Two",
+                    "bad",
+                    "",
+                    "T2",
+                    "2",
+                    "blue",
+                    "",
+                    "",
+                    "rules",
+                ],
+            ),
+            chan,
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+        assert summary.failed == 1
+        assert writes["batch"] == []
 
     asyncio.run(run())


### PR DESCRIPTION
### Motivation
- The ServerRulesFAQ sheet was restructured so multiple sheet rows may now map to multiple embeds within a single Discord message identified by the same `message_key` and FAQ rows must remain individual messages with `topic_key`/`topic_title` preserved for future features.
- The publisher must stop embedding visible management markers into message content while keeping robust managed-message verification and cleanup compatibility with legacy visible markers.
- Publish and refresh operations must remain transactional, batched, and preserve all existing safeguards around colours, cron, batched ID writes, orphan cleanup and placeholder handling.

### Description
- Implement grouped message model and grouping pipeline so enabled rows are sorted by `order`, grouped by `message_key`, group order is by the lowest row order, row order is preserved within a group, and each row renders to one `discord.Embed` while each distinct `message_key` produces one Discord message using `embeds=[...]` (up to 10 embeds).
- Preserve all per-row decorations exactly (title, description, colour, thumbnail/icon, footer) and do not propagate icon/footer across embeds; first row keeps icon, final row keeps footer per the sheet configuration.
- Replace visible management content with an invisible hidden marker appended to the first embed using the reserved URL prefix `https://c1c.invalid/serverrules/` and an invisible link label, retain legacy visible marker extraction for cleanup, and add helpers to validate and extract hidden markers and verify bot ownership.
- Update stored-ID handling to treat a group as having zero or one stored ID (tolerate identical repeated IDs, fail on conflicting different IDs), write the new message ID only to the group's first row in a single batched Sheet update, and preserve snapshot/restore rollback behaviour on failures.
- Update `publish` to validate groups (embed count and combined embed text length <= 6000), create one Discord message per group with `embeds=[...]`, batch-write first-row IDs, and perform non-fatal post-commit cleanup; update `refresh` to fetch/edit each stored group once (editing with `content=None` and `embeds=[...]`), clear legacy visible content during refresh edits, avoid creating missing FAQ messages during refresh, and continue processing other groups on failure.
- Add parsing of `topic_key` and `topic_title` onto the row model while ensuring they do not affect grouping or add visible content, and add helpers to compute embed text lengths and copy/mark embeds immutably.
- Tests: extend and adjust `tests/cogs/test_server_rules.py` to exercise grouping, group limits, combined embed length limits, icon/footer placement, FAQ topic metadata preservation, hidden-marker validation and migration, group-level stored-ID behaviour, and all prior transactional/cleanup behaviours.

### Testing
- Ran formatter: `python -m black modules/ops/server_rules.py tests/cogs/test_server_rules.py` and updated tests accordingly.
- Focused unit suite: `python -m pytest tests/cogs/test_server_rules.py -q` — PASS (all assertions in the expanded test file succeeded).
- Affected CI shard: `python -m pytest tests/community tests/housekeeping tests/modules tests/cogs tests/test_*.py --maxfail=25 --durations=20` — PASS when executed without the optional `pytest-timeout` plugin (the environment could not install `pytest-timeout` due to outbound network restrictions, so the job was run without the timeout flag and passed).
- Broader repository shards: `python -m pytest tests/config tests/coreops tests/docs tests/guardrails tests/scripts tests/common tests/integration tests/shared` and the remaining recruitment/onboarding shards were executed and passed locally in this environment.
- Guardrails: `python -m scripts.ci.guardrails_suite --pr 0 --status-file guardrails_status.txt --summary guardrails-comment.md --base-ref HEAD` executed locally and reported pre-existing repository guardrail violations (examples: C-03 parent-relative imports, C-09 legacy paths, C-10 ad-hoc env reads, C-17 embed colours, S-02/S-03 structure items, D-02/D-05 docs rules) when run without PR context against latest origin; these appear to be repository-wide items unrelated to this change and were reported by the suite run.

Notes: the ServerRulesFAQ sheet structure was not modified by this change, and the first command after deployment should be `!serverrules publish` (not `refresh`) to create grouped messages in the target channel before relying on `refresh` for edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a738637363083239ae1e7b38359965e)