### PR TITLE
Publish server rules without management markers

### DIFF
--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -620,8 +620,9 @@ async def _delete_old_stored_messages(
     new_ids: set[str],
     bot_id: int | None,
     summary: Summary,
-) -> set[str]:
+) -> tuple[set[str], bool]:
     seen: set[str] = set()
+    complete = True
     for row in rows:
         old_id = row.message_id
         if not old_id or old_id in new_ids or old_id in seen:
@@ -631,14 +632,24 @@ async def _delete_old_stored_messages(
             continue
         if state is FetchState.UNKNOWN:
             summary.fail(row.key, reason)
+            complete = False
             continue
-        if msg is None or not _is_valid_stored_message(
+        if msg is None:
+            complete = False
+            continue
+        if not _is_valid_stored_message(
             msg,
             stored_message_id=old_id,
             target=target,
             bot_id=bot_id,
             permitted_legacy_keys=_cleanup_keys_for_row(row),
         ):
+            marker = _legacy_marker(msg)
+            if not (
+                _is_bot_authored(msg, bot_id)
+                and marker.state is LegacyMarkerState.VALID
+            ):
+                complete = False
             continue
         seen.add(old_id)
         try:
@@ -646,15 +657,18 @@ async def _delete_old_stored_messages(
             summary.removed += 1
         except Exception:
             summary.fail(row.key, "failed to remove old managed message after rebuild")
-    return seen
+            complete = False
+    return seen, complete
 
 
-async def _delete_new(messages: list[Any]) -> None:
+async def _delete_new(messages: list[Any]) -> bool:
+    complete = True
     for sent in messages:
         try:
             await sent.delete()
         except Exception:
-            pass
+            complete = False
+    return complete
 
 
 async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
@@ -699,9 +713,27 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
             summary.removed += 0
     new_ids = {str(getattr(msg, "id", "")) for _group, msg in new_pairs}
     bot_id = getattr(getattr(bot, "user", None), "id", None)
-    seen_old_ids = await _delete_old_stored_messages(
+    seen_old_ids, cleanup_complete = await _delete_old_stored_messages(
         target, rows, new_ids, bot_id, summary
     )
+    if not cleanup_complete:
+        replacements = [msg for _group, msg in new_pairs]
+        try:
+            await _restore_ids_batch(tab, header_map, snapshot)
+        except Exception:
+            summary.fail(
+                "sheet",
+                "failed to restore stored message IDs after cleanup rollback",
+            )
+        else:
+            summary.created = 0
+        replacements_removed = await _delete_new(replacements)
+        if not replacements_removed:
+            summary.fail(
+                "rollback",
+                "failed to remove replacement messages after old-message cleanup failed",
+            )
+        return summary, target
     try:
         old_messages = await _iter_feature_messages(target, bot_id)
     except Exception:

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -64,6 +64,20 @@ class FetchState(Enum):
     UNKNOWN = "unknown"
 
 
+class LegacyMarkerState(Enum):
+    """Migration-only classification for markers emitted by older releases."""
+
+    NONE = "none"
+    VALID = "valid"
+    MALFORMED = "malformed"
+
+
+@dataclass(frozen=True)
+class LegacyMarkerResult:
+    state: LegacyMarkerState
+    key: str | None = None
+
+
 @dataclass
 class Row:
     row_number: int
@@ -90,7 +104,7 @@ class MessageGroup:
     rows: list[Row]
     embeds: list[discord.Embed]
     stored_message_id: str = ""
-    marked_embeds: list[discord.Embed] = field(default_factory=list)
+    payload_embeds: list[discord.Embed] = field(default_factory=list)
 
     @property
     def first_row(self) -> Row:
@@ -111,66 +125,64 @@ class Summary:
         self.failures.setdefault(key or "row", []).append(reason)
 
 
-def marker_for(message_key: str) -> str:
-    return f"{LEGACY_MARKER_PREFIX}{message_key}\u2060\u2063"
-
-
-def hidden_marker_for(message_key: str) -> str:
-    return (
-        f"[{HIDDEN_MARKER_LABEL}]({HIDDEN_MARKER_PREFIX}{quote(message_key, safe='')})"
-    )
-
-
-def _extract_legacy_marker(message: Any) -> str | None:
+def _extract_legacy_marker(message: Any) -> tuple[bool, str | None]:
     content = getattr(message, "content", "") or ""
+    if LEGACY_MARKER_PREFIX not in content:
+        return False, None
     if not content.startswith(LEGACY_MARKER_PREFIX):
-        return None
+        return True, None
     rest = content[len(LEGACY_MARKER_PREFIX) :]
     for suffix in ("\u2060\u2063", "\n", " "):
         rest = rest.split(suffix, 1)[0]
-    return rest or None
+    return True, rest or None
 
 
-def _extract_hidden_marker(message: Any) -> str | None:
+def _extract_hidden_marker(message: Any) -> tuple[bool, str | None]:
     embeds = getattr(message, "embeds", None) or []
     if not embeds:
-        return None
+        return False, None
     description = getattr(embeds[0], "description", None) or ""
     needle = f"[{HIDDEN_MARKER_LABEL}]({HIDDEN_MARKER_PREFIX}"
     pos = description.rfind(needle)
     if pos < 0:
-        return None
+        return (HIDDEN_MARKER_PREFIX in description), None
     start = pos + len(needle)
     end = description.find(")", start)
     if end < 0:
-        return None
+        return True, None
     encoded = description[start:end]
     decoded = unquote(encoded)
     if not decoded or quote(decoded, safe="") != encoded:
-        return None
-    return decoded
+        return True, None
+    return True, decoded
 
 
-def _managed_message_key(message: Any) -> str | None:
-    return _extract_hidden_marker(message) or _extract_legacy_marker(message)
+def _legacy_marker(message: Any) -> LegacyMarkerResult:
+    """Parse old marker formats solely to migrate or clean existing posts.
+
+    Marker artifacts are deliberately distinguished from markerless messages so
+    corrupt or conflicting legacy data can never use the trusted stored-ID path.
+    """
+
+    visible_present, visible_key = _extract_legacy_marker(message)
+    hidden_present, hidden_key = _extract_hidden_marker(message)
+    if not visible_present and not hidden_present:
+        return LegacyMarkerResult(LegacyMarkerState.NONE)
+    if (visible_present and visible_key is None) or (
+        hidden_present and hidden_key is None
+    ):
+        return LegacyMarkerResult(LegacyMarkerState.MALFORMED)
+    keys = {key for key in (visible_key, hidden_key) if key is not None}
+    if len(keys) != 1:
+        return LegacyMarkerResult(LegacyMarkerState.MALFORMED)
+    return LegacyMarkerResult(LegacyMarkerState.VALID, keys.pop())
 
 
 def is_feature_message(message: Any, keys: set[str] | None = None) -> bool:
-    key = _managed_message_key(message)
-    if key is None:
+    marker = _legacy_marker(message)
+    if marker.state is not LegacyMarkerState.VALID:
         return False
-    return keys is None or key in keys
-
-
-def _is_managed_message(
-    message: Any, bot_id: int | None = None, expected_key: str | None = None
-) -> bool:
-    if bot_id is not None and not _is_bot_authored(message, bot_id):
-        return False
-    key = _managed_message_key(message)
-    if key is None:
-        return False
-    return expected_key is None or key == expected_key
+    return keys is None or marker.key in keys
 
 
 def _embed_text_len(embed: discord.Embed) -> int:
@@ -179,9 +191,9 @@ def _embed_text_len(embed: discord.Embed) -> int:
     )
     footer = getattr(embed, "footer", None)
     total += len(getattr(footer, "text", None) or "")
-    for field in getattr(embed, "fields", []) or []:
-        total += len(getattr(field, "name", "") or "") + len(
-            getattr(field, "value", "") or ""
+    for embed_field in getattr(embed, "fields", []) or []:
+        total += len(getattr(embed_field, "name", "") or "") + len(
+            getattr(embed_field, "value", "") or ""
         )
     return total
 
@@ -190,12 +202,10 @@ def _copy_embed(embed: discord.Embed) -> discord.Embed:
     return discord.Embed.from_dict(embed.to_dict())
 
 
-def _embeds_with_marker(group: MessageGroup) -> list[discord.Embed]:
-    embeds = [_copy_embed(embed) for embed in group.embeds]
-    embeds[0].description = (
-        f"{embeds[0].description or ''}{hidden_marker_for(group.key)}"
-    )
-    return embeds
+def _clean_embed_payload(group: MessageGroup) -> list[discord.Embed]:
+    """Copy rendered Sheet embeds without adding management metadata."""
+
+    return [_copy_embed(embed) for embed in group.embeds]
 
 
 def _validate_embed_payload(embeds: list[discord.Embed]) -> list[str]:
@@ -447,9 +457,9 @@ def build_groups(rows: list[Row]) -> tuple[list[MessageGroup], list[tuple[str, s
                 (group.key, "message group has multiple different stored message IDs")
             )
         group.stored_message_id = next(iter(ids), "")
-        group.marked_embeds = _embeds_with_marker(group) if group.embeds else []
+        group.payload_embeds = _clean_embed_payload(group) if group.embeds else []
         errors.extend(
-            (group.key, err) for err in _validate_embed_payload(group.marked_embeds)
+            (group.key, err) for err in _validate_embed_payload(group.payload_embeds)
         )
     return groups, errors
 
@@ -549,6 +559,37 @@ def _is_bot_authored(message: Any, bot_id: int | None) -> bool:
     )
 
 
+def _is_valid_stored_message(
+    message: Any,
+    *,
+    stored_message_id: str,
+    target: Any,
+    bot_id: int | None,
+    permitted_legacy_keys: set[str],
+) -> bool:
+    """Verify an exact stored post, accepting legacy markers only for migration."""
+
+    if str(getattr(message, "id", "")) != stored_message_id:
+        return False
+    if getattr(getattr(message, "channel", None), "id", None) != getattr(
+        target, "id", None
+    ):
+        return False
+    if not _is_bot_authored(message, bot_id):
+        return False
+    embeds = list(getattr(message, "embeds", None) or [])
+    if not 1 <= len(embeds) <= MAX_EMBEDS_PER_MESSAGE:
+        return False
+    if _validate_embed_payload(embeds):
+        return False
+    marker = _legacy_marker(message)
+    if marker.state is LegacyMarkerState.MALFORMED:
+        return False
+    if marker.state is LegacyMarkerState.VALID:
+        return marker.key in permitted_legacy_keys
+    return not (getattr(message, "content", "") or "")
+
+
 def _is_deletable_feature_message(
     message: Any, bot_id: int | None, keys: set[str] | None = None
 ) -> bool:
@@ -591,8 +632,12 @@ async def _delete_old_stored_messages(
         if state is FetchState.UNKNOWN:
             summary.fail(row.key, reason)
             continue
-        if msg is None or not _is_deletable_feature_message(
-            msg, bot_id, _cleanup_keys_for_row(row)
+        if msg is None or not _is_valid_stored_message(
+            msg,
+            stored_message_id=old_id,
+            target=target,
+            bot_id=bot_id,
+            permitted_legacy_keys=_cleanup_keys_for_row(row),
         ):
             continue
         seen.add(old_id)
@@ -623,7 +668,9 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     new_pairs: list[tuple[MessageGroup, Any]] = []
     try:
         for group in groups:
-            new_pairs.append((group, await target.send(embeds=group.marked_embeds)))
+            new_pairs.append(
+                (group, await target.send(content=None, embeds=group.payload_embeds))
+            )
     except Exception:
         summary.fail(group.key, "Discord send failed during rebuild")
         await _delete_new([msg for _group, msg in new_pairs])
@@ -692,12 +739,17 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
             if (
                 state is FetchState.FOUND
                 and msg is not None
-                and _is_managed_message(
-                    msg, getattr(getattr(bot, "user", None), "id", None), group.key
+                and _is_valid_stored_message(
+                    msg,
+                    stored_message_id=group.stored_message_id,
+                    target=target,
+                    bot_id=getattr(getattr(bot, "user", None), "id", None),
+                    permitted_legacy_keys={group.key}
+                    | {row.topic_key for row in group.rows if row.topic_key},
                 )
             ):
                 try:
-                    await msg.edit(content=None, embeds=group.marked_embeds)
+                    await msg.edit(content=None, embeds=group.payload_embeds)
                 except Exception:
                     summary.fail(row.key, "failed to edit stored message")
                 else:
@@ -725,8 +777,12 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
                     )
                 else:
                     summary.skipped += 1
-            elif msg is not None and _is_deletable_feature_message(
-                msg, getattr(getattr(bot, "user", None), "id", None), {row.key}
+            elif msg is not None and _is_valid_stored_message(
+                msg,
+                stored_message_id=row.message_id,
+                target=target,
+                bot_id=getattr(getattr(bot, "user", None), "id", None),
+                permitted_legacy_keys=_cleanup_keys_for_row(row),
             ):
                 try:
                     await msg.delete()

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass, field
 from enum import Enum
@@ -27,6 +28,9 @@ from shared.theme import colors
 LEGACY_MARKER_PREFIX = "\u2063\u200bserverrules:"
 HIDDEN_MARKER_PREFIX = "https://c1c.invalid/serverrules/"
 HIDDEN_MARKER_LABEL = "\u2063"
+RECOVERY_PREFIX = "serverrules-recovery:v1:"
+RECOVERY_EMPTY = "-"
+MUTATION_LOCK = asyncio.Lock()
 MAX_EMBEDS_PER_MESSAGE = 10
 REQUIRED_HEADERS = {
     "message_key",
@@ -76,6 +80,40 @@ class LegacyMarkerState(Enum):
 class LegacyMarkerResult:
     state: LegacyMarkerState
     key: str | None = None
+
+
+@dataclass(frozen=True)
+class RecoveryState:
+    keep_id: str
+    cleanup_ids: tuple[str, ...]
+
+
+def _recovery_value(keep_id: str, cleanup_ids: list[str] | tuple[str, ...]) -> str:
+    unique = tuple(dict.fromkeys(value for value in cleanup_ids if value != keep_id))
+    if not unique:
+        return keep_id
+    return f"{RECOVERY_PREFIX}{keep_id or RECOVERY_EMPTY}:{','.join(unique)}"
+
+
+def _parse_recovery(value: str) -> RecoveryState | None:
+    if not value.startswith(RECOVERY_PREFIX):
+        return None
+    payload = value[len(RECOVERY_PREFIX) :]
+    keep_raw, separator, cleanup_raw = payload.partition(":")
+    if not separator:
+        return None
+    keep_id = "" if keep_raw == RECOVERY_EMPTY else keep_raw
+    cleanup_ids = tuple(item for item in cleanup_raw.split(",") if item)
+    all_ids = ((keep_id,) if keep_id else ()) + cleanup_ids
+    if not cleanup_ids or any(not valid_snowflake(item) for item in all_ids):
+        return None
+    if len(set(all_ids)) != len(all_ids):
+        return None
+    return RecoveryState(keep_id, cleanup_ids)
+
+
+def _is_recovery_artifact(value: str) -> bool:
+    return value.startswith(RECOVERY_PREFIX)
 
 
 @dataclass
@@ -406,7 +444,9 @@ async def preflight(
             summary.fail(label, "message_key is required")
         if parse_enabled(row.data.get("enabled")) is None:
             summary.fail(label, "enabled value is not recognised")
-        if row.message_id and not valid_snowflake(row.message_id):
+        if row.message_id and not (
+            valid_snowflake(row.message_id) or _parse_recovery(row.message_id)
+        ):
             summary.fail(label, "message_id must be blank or a valid Discord snowflake")
         if row.enabled:
             order_text = row.data.get("order", "")
@@ -451,7 +491,11 @@ def build_groups(rows: list[Row]) -> tuple[list[MessageGroup], list[tuple[str, s
     groups.sort(key=lambda group: (group.rows[0].order, group.rows[0].row_number))
     errors: list[tuple[str, str]] = topic_errors
     for group in groups:
-        ids = {row.message_id for row in group.rows if row.message_id}
+        ids = {
+            row.message_id
+            for row in group.rows
+            if row.message_id and not _is_recovery_artifact(row.message_id)
+        }
         if len(ids) > 1:
             errors.append(
                 (group.key, "message group has multiple different stored message IDs")
@@ -519,15 +563,6 @@ async def _write_ids_batch(
     ws = await _worksheet(tab)
     await sheets_core.acall_with_backoff(
         ws.batch_update, _batch_payload(header_map, updates)
-    )
-
-
-async def _restore_ids_batch(
-    tab: str, header_map: dict[str, int], snapshot: dict[int, str]
-) -> None:
-    rows = [Row(row_number, [], {}, False) for row_number in snapshot]
-    await _write_ids_batch(
-        tab, header_map, [(row, value) for row, value in zip(rows, snapshot.values())]
     )
 
 
@@ -614,70 +649,100 @@ async def _iter_feature_messages(target: Any, bot_id: int | None) -> list[Any]:
     return found
 
 
-async def _delete_old_stored_messages(
-    target: Any,
-    rows: list[Row],
-    new_ids: set[str],
-    bot_id: int | None,
-    summary: Summary,
-) -> tuple[set[str], bool]:
-    seen: set[str] = set()
-    complete = True
-    for row in rows:
-        old_id = row.message_id
-        if not old_id or old_id in new_ids or old_id in seen:
-            continue
-        state, msg, reason = await _fetch(target, old_id)
-        if state is FetchState.MISSING:
-            continue
-        if state is FetchState.UNKNOWN:
-            summary.fail(row.key, reason)
-            complete = False
-            continue
-        if msg is None:
-            complete = False
-            continue
-        if not _is_valid_stored_message(
-            msg,
-            stored_message_id=old_id,
-            target=target,
-            bot_id=bot_id,
-            permitted_legacy_keys=_cleanup_keys_for_row(row),
-        ):
-            marker = _legacy_marker(msg)
-            if not (
-                _is_bot_authored(msg, bot_id)
-                and marker.state is LegacyMarkerState.VALID
-            ):
-                complete = False
-            continue
-        seen.add(old_id)
-        try:
-            await msg.delete()
-            summary.removed += 1
-        except Exception:
-            summary.fail(row.key, "failed to remove old managed message after rebuild")
-            complete = False
-    return seen, complete
-
-
-async def _delete_new(messages: list[Any]) -> bool:
-    complete = True
+async def _delete_new_survivors(messages: list[Any]) -> list[Any]:
+    survivors: list[Any] = []
     for sent in messages:
         try:
             await sent.delete()
         except Exception:
-            complete = False
+            survivors.append(sent)
+    return survivors
+
+
+async def _delete_new(messages: list[Any]) -> bool:
+    return not await _delete_new_survivors(messages)
+
+
+async def _recover_pending(
+    target: Any,
+    tab: str,
+    header_map: dict[str, int],
+    rows: list[Row],
+    bot_id: int | None,
+    summary: Summary,
+) -> bool:
+    """Resume exact-ID cleanup recorded in message_id cells."""
+
+    updates: list[tuple[Row, str]] = []
+    complete = True
+    for row in rows:
+        recovery = _parse_recovery(row.message_id)
+        if recovery is None:
+            continue
+        remaining: list[str] = []
+        for message_id in recovery.cleanup_ids:
+            state, message, reason = await _fetch(target, message_id)
+            if state is FetchState.MISSING:
+                continue
+            if state is FetchState.UNKNOWN:
+                summary.fail(row.key, reason)
+                remaining.append(message_id)
+                complete = False
+                continue
+            if message is None or not _is_valid_stored_message(
+                message,
+                stored_message_id=message_id,
+                target=target,
+                bot_id=bot_id,
+                permitted_legacy_keys=_cleanup_keys_for_row(row),
+            ):
+                marker = _legacy_marker(message) if message is not None else None
+                if not (
+                    message is not None
+                    and _is_bot_authored(message, bot_id)
+                    and marker is not None
+                    and marker.state is LegacyMarkerState.VALID
+                ):
+                    summary.fail(
+                        row.key, "recovery message failed stored-ID verification"
+                    )
+                    remaining.append(message_id)
+                    complete = False
+                continue
+            try:
+                await message.delete()
+            except Exception:
+                summary.fail(row.key, "failed to delete stored recovery message")
+                remaining.append(message_id)
+                complete = False
+            else:
+                summary.removed += 1
+        value = (
+            _recovery_value(recovery.keep_id, remaining)
+            if remaining
+            else recovery.keep_id
+        )
+        updates.append((row, value))
+    if updates:
+        try:
+            await _write_ids_batch(tab, header_map, updates)
+        except Exception:
+            summary.fail("sheet", "failed to persist server-rules recovery progress")
+            return False
+        for row, value in updates:
+            row.data["message_id"] = value
     return complete
 
 
-async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
+async def _publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     target, tab, header_map, rows, errors = await preflight(bot)
     if errors:
         return errors, target
     assert target is not None
     summary = Summary()
-    snapshot = {row.row_number: row.message_id for row in rows}
+    bot_id = getattr(getattr(bot, "user", None), "id", None)
+    if not await _recover_pending(target, tab, header_map, rows, bot_id, summary):
+        return summary, target
     groups, _ = build_groups(rows)
     new_pairs: list[tuple[MessageGroup, Any]] = []
     try:
@@ -687,53 +752,72 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
             )
     except Exception:
         summary.fail(group.key, "Discord send failed during rebuild")
-        await _delete_new([msg for _group, msg in new_pairs])
+        recovery_updates = [
+            (
+                sent_group.first_row,
+                _recovery_value(
+                    sent_group.stored_message_id, [str(getattr(message, "id", ""))]
+                ),
+            )
+            for sent_group, message in new_pairs
+        ]
+        if recovery_updates:
+            try:
+                await _write_ids_batch(tab, header_map, recovery_updates)
+            except Exception:
+                summary.fail("sheet", "failed to journal partial Discord sends")
+            else:
+                for row, value in recovery_updates:
+                    row.data["message_id"] = value
+                await _recover_pending(target, tab, header_map, rows, bot_id, summary)
         return summary, target
     updates: list[tuple[Row, str]] = []
     for group, msg in new_pairs:
-        updates.append((group.first_row, str(msg.id)))
+        old_ids = [row.message_id for row in group.rows if row.message_id]
+        updates.append(
+            (
+                group.first_row,
+                _recovery_value(str(msg.id), old_ids),
+            )
+        )
         updates.extend((row, "") for row in group.rows[1:] if row.message_id)
-    updates.extend((row, "") for row in rows if not row.enabled and row.message_id)
+    updates.extend(
+        (row, _recovery_value("", [row.message_id]))
+        for row in rows
+        if not row.enabled and row.message_id
+    )
     try:
         await _write_ids_batch(tab, header_map, updates)
-        summary.created = len(new_pairs)
     except Exception:
         summary.fail(
             "sheet",
-            "message_id update failed during rebuild; original IDs were restored where possible",
+            "failed to journal replacement messages during rebuild",
         )
-        try:
-            await _restore_ids_batch(tab, header_map, snapshot)
-        except Exception:
-            summary.fail("sheet", "failed to restore original message_id values")
-        await _delete_new([msg for _row, msg in new_pairs])
+        survivors = await _delete_new_survivors([msg for _row, msg in new_pairs])
+        if survivors:
+            survivor_ids = {str(getattr(message, "id", "")) for message in survivors}
+            fallback_updates = [
+                (
+                    group.first_row,
+                    _recovery_value(group.stored_message_id, [str(message.id)]),
+                )
+                for group, message in new_pairs
+                if str(message.id) in survivor_ids
+            ]
+            try:
+                await _write_ids_batch(tab, header_map, fallback_updates)
+            except Exception:
+                summary.fail(
+                    "rollback", "failed to journal surviving replacement messages"
+                )
         return summary, target
-    for row in rows:
-        if not row.enabled and row.message_id:
-            summary.removed += 0
+    for row, value in updates:
+        row.data["message_id"] = value
+    if not await _recover_pending(target, tab, header_map, rows, bot_id, summary):
+        return summary, target
+    summary.created = len(new_pairs)
     new_ids = {str(getattr(msg, "id", "")) for _group, msg in new_pairs}
-    bot_id = getattr(getattr(bot, "user", None), "id", None)
-    seen_old_ids, cleanup_complete = await _delete_old_stored_messages(
-        target, rows, new_ids, bot_id, summary
-    )
-    if not cleanup_complete:
-        replacements = [msg for _group, msg in new_pairs]
-        try:
-            await _restore_ids_batch(tab, header_map, snapshot)
-        except Exception:
-            summary.fail(
-                "sheet",
-                "failed to restore stored message IDs after cleanup rollback",
-            )
-        else:
-            summary.created = 0
-        replacements_removed = await _delete_new(replacements)
-        if not replacements_removed:
-            summary.fail(
-                "rollback",
-                "failed to remove replacement messages after old-message cleanup failed",
-            )
-        return summary, target
+    seen_old_ids: set[str] = set()
     try:
         old_messages = await _iter_feature_messages(target, bot_id)
     except Exception:
@@ -741,7 +825,11 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     else:
         for msg in old_messages:
             msg_id = str(getattr(msg, "id", ""))
-            if msg_id in new_ids or msg_id in seen_old_ids:
+            if (
+                msg_id in new_ids
+                or msg_id in seen_old_ids
+                or getattr(msg, "deleted", False)
+            ):
                 continue
             try:
                 await msg.delete()
@@ -753,12 +841,20 @@ async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     return summary, target
 
 
-async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
+async def publish(bot: discord.Client) -> tuple[Summary, Any | None]:
+    async with MUTATION_LOCK:
+        return await _publish(bot)
+
+
+async def _refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
     target, tab, header_map, rows, errors = await preflight(bot)
     if errors:
         return errors, target
     assert target is not None
     summary = Summary()
+    bot_id = getattr(getattr(bot, "user", None), "id", None)
+    if not await _recover_pending(target, tab, header_map, rows, bot_id, summary):
+        return summary, target
     groups, _ = build_groups(rows)
     grouped_rows = {id(row) for group in groups for row in group.rows}
     for group in groups:
@@ -830,6 +926,11 @@ async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
         except Exception:
             summary.fail(row.key, "unexpected row processing failure")
     return summary, target
+
+
+async def refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
+    async with MUTATION_LOCK:
+        return await _refresh(bot)
 
 
 def result_embed(action: str, summary: Summary) -> discord.Embed:

--- a/modules/ops/server_rules.py
+++ b/modules/ops/server_rules.py
@@ -137,6 +137,16 @@ class Row:
 
 
 @dataclass
+class PendingRollback:
+    row_number: int
+    keep_id: str
+    messages: list[Any]
+
+
+_FAILSAFE_PENDING: list[PendingRollback] = []
+
+
+@dataclass
 class MessageGroup:
     key: str
     rows: list[Row]
@@ -654,6 +664,8 @@ async def _delete_new_survivors(messages: list[Any]) -> list[Any]:
     for sent in messages:
         try:
             await sent.delete()
+        except discord.NotFound:
+            continue
         except Exception:
             survivors.append(sent)
     return survivors
@@ -661,6 +673,105 @@ async def _delete_new_survivors(messages: list[Any]) -> list[Any]:
 
 async def _delete_new(messages: list[Any]) -> bool:
     return not await _delete_new_survivors(messages)
+
+
+async def _persist_rollback_journal(
+    tab: str,
+    header_map: dict[str, int],
+    pairs: list[tuple[MessageGroup, Any]],
+) -> list[tuple[Row, str]]:
+    updates = [
+        (
+            group.first_row,
+            _recovery_value(group.stored_message_id, [str(message.id)]),
+        )
+        for group, message in pairs
+    ]
+    await _write_ids_batch(tab, header_map, updates)
+    for row, value in updates:
+        row.data["message_id"] = value
+    return updates
+
+
+async def _rollback_replacements(
+    target: Any,
+    tab: str,
+    header_map: dict[str, int],
+    rows: list[Row],
+    pairs: list[tuple[MessageGroup, Any]],
+    bot_id: int | None,
+    summary: Summary,
+) -> None:
+    """Delete or durably journal only replacements created by this mutation."""
+
+    if not pairs:
+        return
+    try:
+        await _persist_rollback_journal(tab, header_map, pairs)
+    except Exception:
+        summary.fail("sheet", "failed to journal replacement rollback")
+    else:
+        await _recover_pending(target, tab, header_map, rows, bot_id, summary)
+        return
+
+    survivors = await _delete_new_survivors([message for _group, message in pairs])
+    if not survivors:
+        return
+    survivor_ids = {str(message.id) for message in survivors}
+    survivor_pairs = [
+        (group, message) for group, message in pairs if str(message.id) in survivor_ids
+    ]
+    try:
+        await _persist_rollback_journal(tab, header_map, survivor_pairs)
+    except Exception:
+        summary.fail("sheet", "failed to journal replacement rollback survivors")
+        for group, message in survivor_pairs:
+            _FAILSAFE_PENDING.append(
+                PendingRollback(
+                    group.first_row.row_number,
+                    group.stored_message_id,
+                    [message],
+                )
+            )
+
+
+async def _resolve_failsafe_pending(
+    target: Any,
+    tab: str,
+    header_map: dict[str, int],
+    rows: list[Row],
+    summary: Summary,
+) -> bool:
+    """Block mutations until in-memory rollback survivors are deleted or journalled."""
+
+    if not _FAILSAFE_PENDING:
+        return True
+    by_number = {row.row_number: row for row in rows}
+    unresolved: list[PendingRollback] = []
+    for pending in list(_FAILSAFE_PENDING):
+        survivors = await _delete_new_survivors(pending.messages)
+        if not survivors:
+            continue
+        row = by_number.get(pending.row_number)
+        if row is None:
+            pending.messages = survivors
+            unresolved.append(pending)
+            continue
+        value = _recovery_value(
+            pending.keep_id, [str(message.id) for message in survivors]
+        )
+        try:
+            await _write_ids_batch(tab, header_map, [(row, value)])
+        except Exception:
+            pending.messages = survivors
+            unresolved.append(pending)
+        else:
+            row.data["message_id"] = value
+    _FAILSAFE_PENDING[:] = unresolved
+    if unresolved:
+        summary.fail("rollback", "server-rules rollback survivors remain pending")
+        return False
+    return True
 
 
 async def _recover_pending(
@@ -741,6 +852,8 @@ async def _publish(bot: discord.Client) -> tuple[Summary, Any | None]:
     assert target is not None
     summary = Summary()
     bot_id = getattr(getattr(bot, "user", None), "id", None)
+    if not await _resolve_failsafe_pending(target, tab, header_map, rows, summary):
+        return summary, target
     if not await _recover_pending(target, tab, header_map, rows, bot_id, summary):
         return summary, target
     groups, _ = build_groups(rows)
@@ -752,24 +865,9 @@ async def _publish(bot: discord.Client) -> tuple[Summary, Any | None]:
             )
     except Exception:
         summary.fail(group.key, "Discord send failed during rebuild")
-        recovery_updates = [
-            (
-                sent_group.first_row,
-                _recovery_value(
-                    sent_group.stored_message_id, [str(getattr(message, "id", ""))]
-                ),
-            )
-            for sent_group, message in new_pairs
-        ]
-        if recovery_updates:
-            try:
-                await _write_ids_batch(tab, header_map, recovery_updates)
-            except Exception:
-                summary.fail("sheet", "failed to journal partial Discord sends")
-            else:
-                for row, value in recovery_updates:
-                    row.data["message_id"] = value
-                await _recover_pending(target, tab, header_map, rows, bot_id, summary)
+        await _rollback_replacements(
+            target, tab, header_map, rows, new_pairs, bot_id, summary
+        )
         return summary, target
     updates: list[tuple[Row, str]] = []
     for group, msg in new_pairs:
@@ -793,23 +891,9 @@ async def _publish(bot: discord.Client) -> tuple[Summary, Any | None]:
             "sheet",
             "failed to journal replacement messages during rebuild",
         )
-        survivors = await _delete_new_survivors([msg for _row, msg in new_pairs])
-        if survivors:
-            survivor_ids = {str(getattr(message, "id", "")) for message in survivors}
-            fallback_updates = [
-                (
-                    group.first_row,
-                    _recovery_value(group.stored_message_id, [str(message.id)]),
-                )
-                for group, message in new_pairs
-                if str(message.id) in survivor_ids
-            ]
-            try:
-                await _write_ids_batch(tab, header_map, fallback_updates)
-            except Exception:
-                summary.fail(
-                    "rollback", "failed to journal surviving replacement messages"
-                )
+        await _rollback_replacements(
+            target, tab, header_map, rows, new_pairs, bot_id, summary
+        )
         return summary, target
     for row, value in updates:
         row.data["message_id"] = value
@@ -853,6 +937,8 @@ async def _refresh(bot: discord.Client) -> tuple[Summary, Any | None]:
     assert target is not None
     summary = Summary()
     bot_id = getattr(getattr(bot, "user", None), "id", None)
+    if not await _resolve_failsafe_pending(target, tab, header_map, rows, summary):
+        return summary, target
     if not await _recover_pending(target, tab, header_map, rows, bot_id, summary):
         return summary, target
     groups, _ = build_groups(rows)

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -1,9 +1,21 @@
 import asyncio
 import discord
 from unittest.mock import AsyncMock
+from urllib.parse import quote
 
 from modules.ops import server_rules
 from cogs.server_rules import ServerRulesCog
+
+
+def legacy_marker(key):
+    return f"{server_rules.LEGACY_MARKER_PREFIX}{key}\u2060\u2063"
+
+
+def hidden_marker(key):
+    return (
+        f"[{server_rules.HIDDEN_MARKER_LABEL}]"
+        f"({server_rules.HIDDEN_MARKER_PREFIX}{quote(key, safe='')})"
+    )
 
 
 class Msg:
@@ -12,7 +24,8 @@ class Msg:
         self.content = content
         self.author = type("A", (), {"id": author_id})()
         self.deleted = False
-        self.embeds = []
+        self.embeds = [discord.Embed(description="legacy payload")]
+        self.channel = None
         self.edits = []
 
     async def edit(self, **kw):
@@ -38,6 +51,7 @@ class Chan:
         msg = Msg(100 + len(self.sent), kw.get("content", ""))
         msg.kw = kw
         msg.embeds = kw.get("embeds") or ([kw["embed"]] if "embed" in kw else [])
+        msg.channel = self
         self.sent.append(msg)
         self.messages[msg.id] = msg
         return msg
@@ -45,6 +59,7 @@ class Chan:
     async def fetch_message(self, mid):
         if mid not in self.messages:
             raise discord.NotFound(response=None, message="missing")
+        self.messages[mid].channel = self
         return self.messages[mid]
 
     def history(self, limit=500):
@@ -167,7 +182,7 @@ def test_publish_sorts_and_writes_message_ids_header_order_independent(monkeypat
         assert summary.created == 2
         assert [m.kw["embeds"][0].title for m in chan.sent] == ["Title A", "Title B"]
         assert chan.sent[0].kw["embeds"][0].thumbnail.url == "https://e.test/t.png"
-        assert "content" not in chan.sent[0].kw
+        assert chan.sent[0].kw["content"] is None
         assert writes["batch"] == [
             [{"range": "B3", "values": [["100"]]}, {"range": "B2", "values": [["101"]]}]
         ]
@@ -212,9 +227,9 @@ def test_preflight_abort_no_mutations_on_invalid_rows(monkeypatch):
 def test_refresh_edits_recreates_and_deletes(monkeypatch):
     async def run():
         chan = Chan()
-        existing = Msg(555555555555555555, server_rules.marker_for("keep"))
+        existing = Msg(555555555555555555, legacy_marker("keep"))
         chan.messages[555555555555555555] = existing
-        disabled = Msg(777777777777777777, server_rules.marker_for("old"))
+        disabled = Msg(777777777777777777, legacy_marker("old"))
         chan.messages[777777777777777777] = disabled
         writes = await fake_load(
             monkeypatch,
@@ -293,7 +308,7 @@ def test_unrelated_messages_untouched_on_rebuild(monkeypatch):
         chan = Chan()
         unrelated = Msg(1, "hello")
         chan.messages[1] = unrelated
-        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        old = Msg(222222222222222222, legacy_marker("rule"))
         chan.messages[222222222222222222] = old
         await fake_load(
             monkeypatch,
@@ -770,8 +785,8 @@ def test_supported_server_rules_faq_hex_colours_are_explicit_palette():
 def test_publish_fetches_known_old_id_and_never_deletes_forged_message(monkeypatch):
     async def run():
         chan = Chan()
-        forged = Msg(333333333333333333, server_rules.marker_for("rule"), author_id=99)
-        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        forged = Msg(333333333333333333, legacy_marker("rule"), author_id=99)
+        old = Msg(222222222222222222, legacy_marker("rule"))
         chan.messages[forged.id] = forged
         chan.messages[old.id] = old
         fetched = []
@@ -816,7 +831,7 @@ def test_publish_fetches_known_old_id_and_never_deletes_forged_message(monkeypat
 def test_publish_cleanup_failures_report_after_commit_without_rollback(monkeypatch):
     async def run():
         chan = Chan()
-        old = Msg(222222222222222222, server_rules.marker_for("rule"))
+        old = Msg(222222222222222222, legacy_marker("rule"))
         chan.messages[old.id] = old
 
         async def delete_failure():
@@ -970,14 +985,17 @@ def test_grouped_rows_publish_one_message_with_ordered_embeds_and_group_ids(
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 2
         assert len(chan.sent) == 2
-        assert chan.sent[0].content == ""
+        assert chan.sent[0].content is None
         assert [e.title for e in chan.sent[0].embeds] == ["T1", "T2", "T3"]
         assert chan.sent[0].embeds[0].thumbnail.url == "https://e.test/icon.png"
         assert not chan.sent[0].embeds[1].thumbnail.url
         assert not chan.sent[0].embeds[1].footer.text
         assert chan.sent[0].embeds[2].footer.text == "Foot"
         assert "serverrules:" not in (chan.sent[0].embeds[0].description or "")
-        assert server_rules._is_managed_message(chan.sent[0], 42, "rule")
+        assert (
+            server_rules._legacy_marker(chan.sent[0]).state
+            is server_rules.LegacyMarkerState.NONE
+        )
         assert writes["batch"] == [
             [
                 {"range": "B2", "values": [["100"]]},
@@ -1107,10 +1125,10 @@ def test_faq_topic_metadata_does_not_combine_or_render(monkeypatch):
     asyncio.run(run())
 
 
-def test_hidden_marker_validation_and_legacy_refresh(monkeypatch):
+def test_legacy_marker_validation_and_clean_refresh(monkeypatch):
     async def run():
         chan = Chan()
-        legacy = Msg(555555555555555555, server_rules.marker_for("keep"))
+        legacy = Msg(555555555555555555, legacy_marker("keep"))
         chan.messages[legacy.id] = legacy
         await fake_load(
             monkeypatch,
@@ -1135,28 +1153,126 @@ def test_hidden_marker_validation_and_legacy_refresh(monkeypatch):
         summary, _ = await server_rules.refresh(Bot(chan))
         assert summary.refreshed == 1
         assert legacy.content is None
-        assert server_rules._is_managed_message(legacy, 42, "keep")
-        assert not server_rules._is_managed_message(legacy, 42, "wrong")
+        assert (
+            server_rules._legacy_marker(legacy).state
+            is server_rules.LegacyMarkerState.NONE
+        )
+        assert legacy.embeds[0].description == "Updated"
         forged = Msg(1, author_id=99)
         forged.embeds = legacy.embeds
-        assert not server_rules._is_managed_message(forged, 42, "keep")
+        assert (
+            server_rules._legacy_marker(forged).state
+            is server_rules.LegacyMarkerState.NONE
+        )
         malformed = Msg(2, author_id=42)
         e = discord.Embed(description="[\u2063](https://c1c.invalid/serverrules/%ZZ)")
         malformed.embeds = [e]
-        assert not server_rules._is_managed_message(malformed, 42, "keep")
-        ordinary = Msg(3, "hello", 42)
-        assert not server_rules._is_managed_message(ordinary, 42)
-        assert server_rules._is_managed_message(
-            Msg(4, server_rules.marker_for("old")), 42, "old"
+        assert (
+            server_rules._legacy_marker(malformed).state
+            is server_rules.LegacyMarkerState.MALFORMED
         )
+        ordinary = Msg(3, "hello", 42)
+        assert (
+            server_rules._legacy_marker(ordinary).state
+            is server_rules.LegacyMarkerState.NONE
+        )
+        assert server_rules.is_feature_message(Msg(4, legacy_marker("old")), {"old"})
 
     asyncio.run(run())
+
+
+def test_hidden_marker_migrates_then_markerless_stored_id_refreshes(monkeypatch):
+    async def run():
+        chan = Chan()
+        message_id = 555555555555555555
+        existing = Msg(message_id, "")
+        existing.embeds = [discord.Embed(description=f"Old{hidden_marker('keep')}")]
+        chan.messages[message_id] = existing
+        rows = sheet(
+            [
+                "",
+                str(message_id),
+                "yes",
+                "Clean Sheet description",
+                "keep",
+                "",
+                "Keep",
+                "1",
+                "blue",
+                "Sheet footer",
+                "",
+                "rules",
+            ]
+        )
+        await fake_load(monkeypatch, rows, chan)
+
+        first, _ = await server_rules.refresh(Bot(chan))
+        second, _ = await server_rules.refresh(Bot(chan))
+
+        assert first.refreshed == second.refreshed == 1
+        assert len(existing.edits) == 2
+        assert existing.content is None
+        assert existing.embeds[0].description == "Clean Sheet description"
+        assert existing.embeds[0].footer.text == "Sheet footer"
+        assert "serverrules:" not in existing.embeds[0].description
+        assert "c1c.invalid" not in existing.embeds[0].description
+
+    asyncio.run(run())
+
+
+def test_stored_message_verifier_rejects_untrusted_identity_and_payload():
+    target = Chan(9)
+    stored_id = "555555555555555555"
+
+    def valid_message():
+        message = Msg(int(stored_id), "")
+        message.channel = target
+        message.embeds = [discord.Embed(description="valid")]
+        return message
+
+    def accepted(message):
+        return server_rules._is_valid_stored_message(
+            message,
+            stored_message_id=stored_id,
+            target=target,
+            bot_id=42,
+            permitted_legacy_keys={"keep"},
+        )
+
+    assert accepted(valid_message())
+    wrong_id = valid_message()
+    wrong_id.id += 1
+    assert not accepted(wrong_id)
+    wrong_channel = valid_message()
+    wrong_channel.channel = Chan(10)
+    assert not accepted(wrong_channel)
+    wrong_author = valid_message()
+    wrong_author.author.id = 99
+    assert not accepted(wrong_author)
+    empty = valid_message()
+    empty.embeds = []
+    assert not accepted(empty)
+    invalid = valid_message()
+    invalid.embeds[0].description = "x" * (server_rules.MAX_DESCRIPTION + 1)
+    assert not accepted(invalid)
+    visible_content = valid_message()
+    visible_content.content = "not management data"
+    assert not accepted(visible_content)
+    wrong_key = valid_message()
+    wrong_key.content = legacy_marker("wrong")
+    assert not accepted(wrong_key)
+    malformed = valid_message()
+    malformed.embeds[0].description = (
+        f"[{server_rules.HIDDEN_MARKER_LABEL}]"
+        f"({server_rules.HIDDEN_MARKER_PREFIX}%ZZ)"
+    )
+    assert not accepted(malformed)
 
 
 def test_refresh_group_edits_once_and_conflicting_ids_fail(monkeypatch):
     async def run():
         chan = Chan()
-        existing = Msg(555555555555555555, server_rules.marker_for("rule"))
+        existing = Msg(555555555555555555, legacy_marker("rule"))
         chan.messages[existing.id] = existing
         await fake_load(
             monkeypatch,
@@ -1237,10 +1353,9 @@ def test_refresh_group_edits_once_and_conflicting_ids_fail(monkeypatch):
     asyncio.run(run())
 
 
-def test_hidden_marker_description_overflow_rejected_before_side_effects(monkeypatch):
+def test_clean_description_overflow_rejected_before_side_effects(monkeypatch):
     async def run():
         chan = Chan()
-        marker_len = len(server_rules.hidden_marker_for("near"))
         writes = await fake_load(
             monkeypatch,
             sheet(
@@ -1248,7 +1363,7 @@ def test_hidden_marker_description_overflow_rejected_before_side_effects(monkeyp
                     "",
                     "",
                     "yes",
-                    "x" * (server_rules.MAX_DESCRIPTION - marker_len + 1),
+                    "x" * (server_rules.MAX_DESCRIPTION + 1),
                     "near",
                     "",
                     "",
@@ -1269,12 +1384,11 @@ def test_hidden_marker_description_overflow_rejected_before_side_effects(monkeyp
     asyncio.run(run())
 
 
-def test_hidden_marker_combined_total_overflow_rejected_before_side_effects(
+def test_clean_combined_total_overflow_rejected_before_side_effects(
     monkeypatch,
 ):
     async def run():
         chan = Chan()
-        marker_len = len(server_rules.hidden_marker_for("combo"))
         writes = await fake_load(
             monkeypatch,
             sheet(
@@ -1296,7 +1410,7 @@ def test_hidden_marker_combined_total_overflow_rejected_before_side_effects(
                     "",
                     "",
                     "yes",
-                    "b" * (server_rules.MAX_TOTAL - 3000 - marker_len + 1),
+                    "b" * (server_rules.MAX_TOTAL - 3000 + 1),
                     "combo",
                     "",
                     "",
@@ -1317,10 +1431,9 @@ def test_hidden_marker_combined_total_overflow_rejected_before_side_effects(
     asyncio.run(run())
 
 
-def test_valid_near_limit_marked_payload_publishes(monkeypatch):
+def test_valid_4096_character_clean_payload_publishes(monkeypatch):
     async def run():
         chan = Chan()
-        marker_len = len(server_rules.hidden_marker_for("ok"))
         writes = await fake_load(
             monkeypatch,
             sheet(
@@ -1328,7 +1441,7 @@ def test_valid_near_limit_marked_payload_publishes(monkeypatch):
                     "",
                     "",
                     "yes",
-                    "x" * (server_rules.MAX_DESCRIPTION - marker_len),
+                    "x" * server_rules.MAX_DESCRIPTION,
                     "ok",
                     "",
                     "",
@@ -1466,7 +1579,7 @@ def test_blank_rule_topic_metadata_remains_valid(monkeypatch):
 def test_cleanup_accepts_legacy_faq_topic_marker_for_stored_question_row(monkeypatch):
     async def run():
         chan = Chan()
-        old = Msg(222222222222222222, server_rules.marker_for("topic_legacy"))
+        old = Msg(222222222222222222, legacy_marker("topic_legacy"))
         chan.messages[old.id] = old
         rows = actual_sheet(
             [
@@ -1500,9 +1613,9 @@ def test_cleanup_accepts_legacy_faq_topic_marker_for_stored_question_row(monkeyp
 def test_failed_direct_cleanup_verification_does_not_hide_orphan(monkeypatch):
     async def run():
         chan = Chan()
-        orphan = Msg(222222222222222222, server_rules.marker_for("old_cluster"))
+        orphan = Msg(222222222222222222, legacy_marker("old_cluster"))
         wrong_author = Msg(
-            333333333333333333, server_rules.marker_for("old_cluster"), author_id=99
+            333333333333333333, legacy_marker("old_cluster"), author_id=99
         )
         malformed = Msg(444444444444444444, "")
         malformed.embeds = [
@@ -1548,8 +1661,8 @@ def test_failed_direct_cleanup_verification_does_not_hide_orphan(monkeypatch):
 def test_refresh_failed_group_does_not_stop_other_group(monkeypatch):
     async def run():
         chan = Chan()
-        bad = Msg(111111111111111111, server_rules.marker_for("bad"))
-        good = Msg(222222222222222222, server_rules.marker_for("good"))
+        bad = Msg(111111111111111111, legacy_marker("bad"))
+        good = Msg(222222222222222222, legacy_marker("good"))
         chan.messages[bad.id] = bad
         chan.messages[good.id] = good
 
@@ -1595,6 +1708,9 @@ def test_refresh_failed_group_does_not_stop_other_group(monkeypatch):
         assert summary.failed == 1
         assert summary.refreshed == 1
         assert good.content is None
-        assert server_rules._is_managed_message(good, 42, "good")
+        assert (
+            server_rules._legacy_marker(good).state
+            is server_rules.LegacyMarkerState.NONE
+        )
 
     asyncio.run(run())

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -48,7 +48,7 @@ class Chan:
         self.messages = {}
 
     async def send(self, **kw):
-        msg = Msg(100 + len(self.sent), kw.get("content", ""))
+        msg = Msg(100000000000000100 + len(self.sent), kw.get("content", ""))
         msg.kw = kw
         msg.embeds = kw.get("embeds") or ([kw["embed"]] if "embed" in kw else [])
         msg.channel = self
@@ -80,11 +80,23 @@ class Bot:
 
 
 class Ws:
-    def __init__(self, batch_writes):
+    def __init__(self, batch_writes, matrix=None):
         self.batch_writes = batch_writes
+        self.matrix = matrix
 
     def batch_update(self, payload):
         self.batch_writes.append(payload)
+        if self.matrix is not None:
+            for update in payload:
+                cell = update["range"]
+                letters = "".join(char for char in cell if char.isalpha())
+                row_number = int("".join(char for char in cell if char.isdigit()))
+                column = 0
+                for char in letters:
+                    column = column * 26 + ord(char.upper()) - 64
+                while len(self.matrix[row_number - 1]) < column:
+                    self.matrix[row_number - 1].append("")
+                self.matrix[row_number - 1][column - 1] = update["values"][0][0]
         return {"updated": len(payload)}
 
 
@@ -105,7 +117,7 @@ async def fake_load(monkeypatch, rows, chan):
     )
     writes = []
     batch_writes = []
-    ws = Ws(batch_writes)
+    ws = Ws(batch_writes, rows)
     monkeypatch.setattr(
         server_rules.sheets_core, "aget_worksheet", AsyncMock(return_value=ws)
     )
@@ -184,7 +196,10 @@ def test_publish_sorts_and_writes_message_ids_header_order_independent(monkeypat
         assert chan.sent[0].kw["embeds"][0].thumbnail.url == "https://e.test/t.png"
         assert chan.sent[0].kw["content"] is None
         assert writes["batch"] == [
-            [{"range": "B3", "values": [["100"]]}, {"range": "B2", "values": [["101"]]}]
+            [
+                {"range": "B3", "values": [["100000000000000100"]]},
+                {"range": "B2", "values": [["100000000000000101"]]},
+            ]
         ]
         assert writes["single"] == []
 
@@ -297,7 +312,7 @@ def test_refresh_edits_recreates_and_deletes(monkeypatch):
         assert summary.removed == 1
         assert existing.edits
         assert disabled.deleted
-        assert ("B3", [["100"]]) not in writes["single"]
+        assert ("B3", [["100000000000000100"]]) not in writes["single"]
         assert ("B4", [[""]]) in writes["single"]
 
     asyncio.run(run())
@@ -524,7 +539,10 @@ def test_publish_send_failure_deletes_new_and_keeps_sheet_ids(monkeypatch):
         assert summary.failed == 1
         assert chan.sent[0].deleted
         assert writes["single"] == []
-        assert writes["batch"] == []
+        assert len(writes["batch"]) == 2
+        assert writes["batch"][-1] == [
+            {"range": "B2", "values": [["111111111111111111"]]}
+        ]
 
     asyncio.run(run())
 
@@ -564,7 +582,74 @@ def test_publish_sheet_failure_restores_ids_and_deletes_new(monkeypatch):
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.failed == 1
         assert chan.sent[0].deleted
-        assert [{"range": "B2", "values": [["111111111111111111"]]}] in batch_calls
+        assert batch_calls == [
+            [
+                {
+                    "range": "B2",
+                    "values": [
+                        [
+                            "serverrules-recovery:v1:100000000000000100:111111111111111111"
+                        ]
+                    ],
+                }
+            ]
+        ]
+
+    asyncio.run(run())
+
+
+def test_sheet_failure_and_failed_replacement_cleanup_are_journalled(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = sheet(
+            [
+                "",
+                "111111111111111111",
+                "true",
+                "D",
+                "a",
+                "",
+                "A",
+                "1",
+                "community",
+                "",
+                "",
+                "",
+            ]
+        )
+        await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+
+        async def send_with_failed_delete(**kwargs):
+            message = await original_send(**kwargs)
+
+            async def failed_delete():
+                raise discord.HTTPException(response=None, message="delete failed")
+
+            message.delete = failed_delete
+            return message
+
+        chan.send = send_with_failed_delete
+        calls = 0
+
+        async def fail_then_write(func, payload, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("temporary sheet failure")
+            return func(payload)
+
+        monkeypatch.setattr(
+            server_rules.sheets_core, "acall_with_backoff", fail_then_write
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+
+        assert summary.failed == 1
+        assert not chan.sent[0].deleted
+        recovery = server_rules._parse_recovery(rows[1][1])
+        assert recovery is not None
+        assert recovery.keep_id == "111111111111111111"
+        assert recovery.cleanup_ids == (str(chan.sent[0].id),)
 
     asyncio.run(run())
 
@@ -698,7 +783,9 @@ def test_trailing_false_placeholder_rows_are_ignored_with_actual_header_order(
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 1
         assert len(chan.sent) == 1
-        assert writes["batch"] == [[{"range": "L2", "values": [["100"]]}]]
+        assert writes["batch"] == [
+            [{"range": "L2", "values": [["100000000000000100"]]}]
+        ]
 
     asyncio.run(run())
 
@@ -828,7 +915,7 @@ def test_publish_fetches_known_old_id_and_never_deletes_forged_message(monkeypat
     asyncio.run(run())
 
 
-def test_publish_cleanup_failures_restore_ids_and_remove_replacement(monkeypatch):
+def test_publish_cleanup_failures_leave_durable_recovery_journal(monkeypatch):
     async def run():
         chan = Chan()
         old = Msg(222222222222222222, legacy_marker("rule"))
@@ -861,11 +948,15 @@ def test_publish_cleanup_failures_restore_ids_and_remove_replacement(monkeypatch
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 0
         assert summary.failed == 1
-        assert writes["batch"] == [
-            [{"range": "B2", "values": [["100"]]}],
-            [{"range": "B2", "values": [[str(old.id)]]}],
+        assert writes["batch"][-1] == [
+            {
+                "range": "B2",
+                "values": [
+                    ["serverrules-recovery:v1:100000000000000100:222222222222222222"]
+                ],
+            }
         ]
-        assert chan.sent[0].deleted
+        assert not chan.sent[0].deleted
 
     asyncio.run(run())
 
@@ -911,22 +1002,24 @@ def test_markerless_cleanup_failure_rolls_back_and_publish_retry_converges(
         assert first.created == 0
         assert first.failed == 1
         assert not old.deleted
-        assert chan.sent[0].deleted
-        assert first_writes["batch"] == [
-            [{"range": "B2", "values": [["100"]]}],
-            [{"range": "B2", "values": [[str(old.id)]]}],
-        ]
+        assert not chan.sent[0].deleted
+        recovery_value = first_writes["batch"][-1][0]["values"][0][0]
+        assert str(old.id) in recovery_value
+        assert str(chan.sent[0].id) in recovery_value
 
+        rows[1][1] = recovery_value
         second_writes = await fake_load(monkeypatch, rows, chan)
         second, _ = await server_rules.publish(Bot(chan))
 
         assert second.created == 1
         assert second.failed == 0
         assert old.deleted
-        assert second_writes["batch"] == [[{"range": "B2", "values": [["101"]]}]]
+        assert second_writes["batch"][-1] == [
+            {"range": "B2", "values": [["100000000000000101"]]}
+        ]
         live_publication = [message for message in chan.sent if not message.deleted]
         assert len(live_publication) == 1
-        assert live_publication[0].id == 101
+        assert live_publication[0].id == 100000000000000101
         assert live_publication[0].content is None
         assert live_publication[0].embeds[0].description == "Replacement"
 
@@ -964,7 +1057,9 @@ def test_publish_history_scan_failure_reported_without_rollback(monkeypatch):
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 1
         assert summary.failed == 1
-        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert writes["batch"] == [
+            [{"range": "B2", "values": [["100000000000000100"]]}]
+        ]
         assert not chan.sent[0].deleted
 
     asyncio.run(run())
@@ -1064,12 +1159,8 @@ def test_grouped_rows_publish_one_message_with_ordered_embeds_and_group_ids(
             server_rules._legacy_marker(chan.sent[0]).state
             is server_rules.LegacyMarkerState.NONE
         )
-        assert writes["batch"] == [
-            [
-                {"range": "B2", "values": [["100"]]},
-                {"range": "B3", "values": [[""]]},
-                {"range": "B5", "values": [["101"]]},
-            ]
+        assert writes["batch"][-1] == [
+            {"range": "B2", "values": [["100000000000000100"]]}
         ]
 
     asyncio.run(run())
@@ -1184,9 +1275,9 @@ def test_faq_topic_metadata_does_not_combine_or_render(monkeypatch):
         assert chan.sent[2].embeds[0].footer.text == "Topic foot"
         assert writes["batch"] == [
             [
-                {"range": "L2", "values": [["100"]]},
-                {"range": "L3", "values": [["101"]]},
-                {"range": "L4", "values": [["102"]]},
+                {"range": "L2", "values": [["100000000000000100"]]},
+                {"range": "L3", "values": [["100000000000000101"]]},
+                {"range": "L4", "values": [["100000000000000102"]]},
             ]
         ]
 
@@ -1525,7 +1616,9 @@ def test_valid_4096_character_clean_payload_publishes(monkeypatch):
         summary, _ = await server_rules.publish(Bot(chan))
         assert summary.created == 1
         assert len(chan.sent[0].embeds[0].description) == server_rules.MAX_DESCRIPTION
-        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
+        assert writes["batch"] == [
+            [{"range": "B2", "values": [["100000000000000100"]]}]
+        ]
 
     asyncio.run(run())
 
@@ -1636,8 +1729,8 @@ def test_blank_rule_topic_metadata_remains_valid(monkeypatch):
         assert summary.created == 2
         assert summary_target["batch"] == [
             [
-                {"range": "L2", "values": [["100"]]},
-                {"range": "L3", "values": [["101"]]},
+                {"range": "L2", "values": [["100000000000000100"]]},
+                {"range": "L3", "values": [["100000000000000101"]]},
             ]
         ]
 
@@ -1780,5 +1873,127 @@ def test_refresh_failed_group_does_not_stop_other_group(monkeypatch):
             server_rules._legacy_marker(good).state
             is server_rules.LegacyMarkerState.NONE
         )
+
+    asyncio.run(run())
+
+
+def test_concurrent_publishes_are_serialized_and_leave_one_generation(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = sheet(
+            ["", "", "yes", "Clean", "rule", "", "Rule", "1", "blue", "", "", "rules"]
+        )
+        writes = await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+        active_sends = 0
+        max_active_sends = 0
+
+        async def observed_send(**kwargs):
+            nonlocal active_sends, max_active_sends
+            active_sends += 1
+            max_active_sends = max(max_active_sends, active_sends)
+            await asyncio.sleep(0.01)
+            message = await original_send(**kwargs)
+            active_sends -= 1
+            return message
+
+        chan.send = observed_send
+        first, second = await asyncio.gather(
+            server_rules.publish(Bot(chan)), server_rules.publish(Bot(chan))
+        )
+
+        assert first[0].created == second[0].created == 1
+        assert max_active_sends == 1
+        live = [message for message in chan.sent if not message.deleted]
+        assert [message.id for message in live] == [100000000000000101]
+        assert rows[1][1] == str(live[0].id)
+        assert writes["batch"][-1] == [{"range": "B2", "values": [[str(live[0].id)]]}]
+
+    asyncio.run(run())
+
+
+def test_partial_send_failure_journals_survivor_and_restart_recovers(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = sheet(
+            ["", "", "yes", "A", "a", "", "A", "1", "blue", "", "", "rules"],
+            ["", "", "yes", "B", "b", "", "B", "2", "blue", "", "", "rules"],
+        )
+        await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+
+        async def partial_send(**kwargs):
+            if chan.sent:
+                raise discord.HTTPException(response=None, message="send failed")
+            message = await original_send(**kwargs)
+
+            async def failed_delete():
+                raise discord.HTTPException(response=None, message="delete failed")
+
+            message.delete = failed_delete
+            return message
+
+        chan.send = partial_send
+        failed, _ = await server_rules.publish(Bot(chan))
+
+        assert failed.failed == 2
+        assert not chan.sent[0].deleted
+        recovery = server_rules._parse_recovery(rows[1][1])
+        assert recovery is not None
+        assert recovery.keep_id == ""
+        assert recovery.cleanup_ids == (str(chan.sent[0].id),)
+
+        async def successful_delete():
+            chan.sent[0].deleted = True
+
+        chan.sent[0].delete = successful_delete
+        chan.send = original_send
+        recovered, _ = await server_rules.publish(Bot(chan))
+
+        assert recovered.created == 2
+        assert chan.sent[0].deleted
+        live = [message for message in chan.sent if not message.deleted]
+        assert len(live) == 2
+        assert rows[1][1] == str(live[0].id)
+        assert rows[2][1] == str(live[1].id)
+
+    asyncio.run(run())
+
+
+def test_refresh_resumes_recovery_journal_after_restart(monkeypatch):
+    async def run():
+        chan = Chan()
+        current = Msg(555555555555555555, "")
+        current.embeds = [discord.Embed(description="Current")]
+        stale = Msg(666666666666666666, "")
+        stale.embeds = [discord.Embed(description="Stale")]
+        chan.messages[current.id] = current
+        chan.messages[stale.id] = stale
+        journal = server_rules._recovery_value(str(current.id), [str(stale.id)])
+        rows = sheet(
+            [
+                "",
+                journal,
+                "yes",
+                "Updated",
+                "rule",
+                "",
+                "Rule",
+                "1",
+                "blue",
+                "",
+                "",
+                "rules",
+            ]
+        )
+        await fake_load(monkeypatch, rows, chan)
+
+        summary, _ = await server_rules.refresh(Bot(chan))
+
+        assert summary.removed == 1
+        assert summary.refreshed == 1
+        assert stale.deleted
+        assert rows[1][1] == str(current.id)
+        assert current.embeds[0].description == "Updated"
 
     asyncio.run(run())

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -828,7 +828,7 @@ def test_publish_fetches_known_old_id_and_never_deletes_forged_message(monkeypat
     asyncio.run(run())
 
 
-def test_publish_cleanup_failures_report_after_commit_without_rollback(monkeypatch):
+def test_publish_cleanup_failures_restore_ids_and_remove_replacement(monkeypatch):
     async def run():
         chan = Chan()
         old = Msg(222222222222222222, legacy_marker("rule"))
@@ -859,10 +859,76 @@ def test_publish_cleanup_failures_report_after_commit_without_rollback(monkeypat
             chan,
         )
         summary, _ = await server_rules.publish(Bot(chan))
-        assert summary.created == 1
+        assert summary.created == 0
         assert summary.failed == 1
-        assert writes["batch"] == [[{"range": "B2", "values": [["100"]]}]]
-        assert not chan.sent[0].deleted
+        assert writes["batch"] == [
+            [{"range": "B2", "values": [["100"]]}],
+            [{"range": "B2", "values": [[str(old.id)]]}],
+        ]
+        assert chan.sent[0].deleted
+
+    asyncio.run(run())
+
+
+def test_markerless_cleanup_failure_rolls_back_and_publish_retry_converges(
+    monkeypatch,
+):
+    async def run():
+        chan = Chan()
+        old = Msg(222222222222222222, "")
+        old.embeds = [discord.Embed(title="Previous", description="Clean")]
+        chan.messages[old.id] = old
+        rows = sheet(
+            [
+                "",
+                str(old.id),
+                "yes",
+                "Replacement",
+                "rule",
+                "",
+                "Current",
+                "1",
+                "blue",
+                "",
+                "",
+                "rules",
+            ]
+        )
+        first_writes = await fake_load(monkeypatch, rows, chan)
+        original_delete = old.delete
+        delete_attempts = 0
+
+        async def fail_once():
+            nonlocal delete_attempts
+            delete_attempts += 1
+            if delete_attempts == 1:
+                raise discord.HTTPException(response=None, message="temporary")
+            await original_delete()
+
+        old.delete = fail_once
+        first, _ = await server_rules.publish(Bot(chan))
+
+        assert first.created == 0
+        assert first.failed == 1
+        assert not old.deleted
+        assert chan.sent[0].deleted
+        assert first_writes["batch"] == [
+            [{"range": "B2", "values": [["100"]]}],
+            [{"range": "B2", "values": [[str(old.id)]]}],
+        ]
+
+        second_writes = await fake_load(monkeypatch, rows, chan)
+        second, _ = await server_rules.publish(Bot(chan))
+
+        assert second.created == 1
+        assert second.failed == 0
+        assert old.deleted
+        assert second_writes["batch"] == [[{"range": "B2", "values": [["101"]]}]]
+        live_publication = [message for message in chan.sent if not message.deleted]
+        assert len(live_publication) == 1
+        assert live_publication[0].id == 101
+        assert live_publication[0].content is None
+        assert live_publication[0].embeds[0].description == "Replacement"
 
     asyncio.run(run())
 
@@ -933,6 +999,8 @@ def test_grouped_rows_publish_one_message_with_ordered_embeds_and_group_ids(
 ):
     async def run():
         chan = Chan()
+        previous = Msg(999999999999999999, legacy_marker("rule"))
+        chan.messages[previous.id] = previous
         writes = await fake_load(
             monkeypatch,
             sheet(

--- a/tests/cogs/test_server_rules.py
+++ b/tests/cogs/test_server_rules.py
@@ -580,20 +580,9 @@ def test_publish_sheet_failure_restores_ids_and_deletes_new(monkeypatch):
 
         monkeypatch.setattr(server_rules.sheets_core, "acall_with_backoff", acall)
         summary, _ = await server_rules.publish(Bot(chan))
-        assert summary.failed == 1
+        assert summary.failed == 2
         assert chan.sent[0].deleted
-        assert batch_calls == [
-            [
-                {
-                    "range": "B2",
-                    "values": [
-                        [
-                            "serverrules-recovery:v1:100000000000000100:111111111111111111"
-                        ]
-                    ],
-                }
-            ]
-        ]
+        assert len(batch_calls) == 2
 
     asyncio.run(run())
 
@@ -644,7 +633,7 @@ def test_sheet_failure_and_failed_replacement_cleanup_are_journalled(monkeypatch
         )
         summary, _ = await server_rules.publish(Bot(chan))
 
-        assert summary.failed == 1
+        assert summary.failed == 2
         assert not chan.sent[0].deleted
         recovery = server_rules._parse_recovery(rows[1][1])
         assert recovery is not None
@@ -1956,6 +1945,151 @@ def test_partial_send_failure_journals_survivor_and_restart_recovers(monkeypatch
         assert len(live) == 2
         assert rows[1][1] == str(live[0].id)
         assert rows[2][1] == str(live[1].id)
+
+    asyncio.run(run())
+
+
+def test_partial_send_journal_failure_deletes_exact_replacement(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = sheet(
+            ["", "", "yes", "A", "a", "", "A", "1", "blue", "", "", "rules"],
+            ["", "", "yes", "B", "b", "", "B", "2", "blue", "", "", "rules"],
+        )
+        await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+        delete_attempts = 0
+
+        async def partial_send(**kwargs):
+            nonlocal delete_attempts
+            if chan.sent:
+                raise discord.HTTPException(response=None, message="send failed")
+            message = await original_send(**kwargs)
+            original_delete = message.delete
+
+            async def observed_delete():
+                nonlocal delete_attempts
+                delete_attempts += 1
+                await original_delete()
+
+            message.delete = observed_delete
+            return message
+
+        async def failed_write(*_args, **_kwargs):
+            raise RuntimeError("sheet unavailable")
+
+        chan.send = partial_send
+        monkeypatch.setattr(
+            server_rules.sheets_core, "acall_with_backoff", failed_write
+        )
+        summary, _ = await server_rules.publish(Bot(chan))
+
+        assert summary.failed == 2
+        assert delete_attempts == 1
+        assert chan.sent[0].deleted
+        assert server_rules._FAILSAFE_PENDING == []
+
+    asyncio.run(run())
+
+
+def test_partial_send_survivor_uses_fallback_journal_and_converges(monkeypatch):
+    async def run():
+        chan = Chan()
+        rows = sheet(
+            ["", "", "yes", "A", "a", "", "A", "1", "blue", "", "", "rules"],
+            ["", "", "yes", "B", "b", "", "B", "2", "blue", "", "", "rules"],
+        )
+        await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+
+        async def partial_send(**kwargs):
+            if chan.sent:
+                raise discord.HTTPException(response=None, message="send failed")
+            message = await original_send(**kwargs)
+
+            async def failed_delete():
+                raise discord.HTTPException(response=None, message="delete failed")
+
+            message.delete = failed_delete
+            return message
+
+        calls = 0
+
+        async def fail_then_write(func, payload, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("first journal failed")
+            return func(payload)
+
+        chan.send = partial_send
+        monkeypatch.setattr(
+            server_rules.sheets_core, "acall_with_backoff", fail_then_write
+        )
+        failed, _ = await server_rules.publish(Bot(chan))
+
+        assert failed.failed == 2
+        recovery = server_rules._parse_recovery(rows[1][1])
+        assert recovery is not None
+        assert recovery.cleanup_ids == (str(chan.sent[0].id),)
+
+        async def successful_delete():
+            chan.sent[0].deleted = True
+
+        chan.sent[0].delete = successful_delete
+        chan.send = original_send
+        recovered, _ = await server_rules.publish(Bot(chan))
+        assert recovered.created == 2
+        assert chan.sent[0].deleted
+        assert len([message for message in chan.sent if not message.deleted]) == 2
+
+    asyncio.run(run())
+
+
+def test_full_send_survivor_stays_failsafe_pending_until_next_mutation(monkeypatch):
+    async def run():
+        server_rules._FAILSAFE_PENDING.clear()
+        chan = Chan()
+        rows = sheet(["", "", "yes", "A", "a", "", "A", "1", "blue", "", "", "rules"])
+        await fake_load(monkeypatch, rows, chan)
+        original_send = chan.send
+
+        async def send_with_failed_delete(**kwargs):
+            message = await original_send(**kwargs)
+
+            async def failed_delete():
+                raise discord.HTTPException(response=None, message="delete failed")
+
+            message.delete = failed_delete
+            return message
+
+        async def failed_write(*_args, **_kwargs):
+            raise RuntimeError("sheet unavailable")
+
+        chan.send = send_with_failed_delete
+        monkeypatch.setattr(
+            server_rules.sheets_core, "acall_with_backoff", failed_write
+        )
+        failed, _ = await server_rules.publish(Bot(chan))
+
+        assert failed.failed == 3
+        assert not chan.sent[0].deleted
+        assert [
+            str(message.id) for message in server_rules._FAILSAFE_PENDING[0].messages
+        ] == [str(chan.sent[0].id)]
+
+        async def successful_delete():
+            chan.sent[0].deleted = True
+
+        chan.sent[0].delete = successful_delete
+        chan.send = original_send
+        await fake_load(monkeypatch, rows, chan)
+        recovered, _ = await server_rules.publish(Bot(chan))
+
+        assert recovered.created == 1
+        assert chan.sent[0].deleted
+        assert server_rules._FAILSAFE_PENDING == []
+        assert len([message for message in chan.sent if not message.deleted]) == 1
 
     asyncio.run(run())
 


### PR DESCRIPTION
### Motivation

- Remove visible/hidden management markers from Discord output while preserving the ability to manage posts via stored message IDs and preserving #1059 grouping/FAQ behavior.
- Ensure legacy markers are only recognised for migration/cleanup and never allowed to impersonate or be treated as markerless managed posts.

### Description

- Replace marker-injection with a clean payload builder: `_clean_embed_payload()` copies Sheet-rendered embeds unchanged and `publish` now sends `content=None` and the clean `payload_embeds` instead of adding markers. 
- Introduce an explicit migration-only parser returning `LegacyMarkerState` (`NONE`, `VALID`, `MALFORMED`) and `LegacyMarkerResult` so visible/hidden legacy markers are classified and rejected when malformed or conflicting. 
- Add `_is_valid_stored_message()` to verify stored-message identity by exact stored ID, target channel/thread, bot ownership, 1–10 valid embeds, validated payload size, and empty visible content for genuinely markerless posts, and use it consistently for refresh, deletion and rebuild cleanup. 
- Remove production helper that generated new hidden markers from the publish path, rename marker-specific state to `payload_embeds`, and keep legacy marker parsing isolated for migration-only compatibility.

### Testing

- `python -m pytest tests/cogs/test_server_rules.py -q` — all tests in `tests/cogs/test_server_rules.py` passed locally (39 passed). 
- Ran targeted repo shards and checks: `python -m ruff check modules/ops/server_rules.py tests/cogs/test_server_rules.py` passed and `git diff --check` returned clean; larger test shards executed locally produced the expected passing results for `config-core-shared` (`193` passed), `recruitment-placement` (`207` passed) and `onboarding-welcome` (`435` passed), and the community/housekeeping shard was run without the environment timeout plugin where it passed (one unrelated earlier timing-bound failure was observed when `pytest-timeout` was requested in this container). 
- Guardrails: `scripts.ci.guardrails_suite` was executed against the local `origin/main` reference and reported pre-existing repository-wide violations that do not reference the two changed files; no new guardrail violations were introduced by these edits.

Note: the changes were committed on a fresh branch `codex/publish-server-rules-without-management-markers` (local commit `85ea96f`) and the patch contains only modifications to `modules/ops/server_rules.py` and `tests/cogs/test_server_rules.py`; no Google Sheets or unrelated modules were changed. This environment could not create or close GitHub PRs (no authenticated GitHub access), so there is no PR URL to provide from this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73cda789688323b104d1c31a22549d)