### PR TITLE
feat: Live Arena registration workflow (registration panels, join/update/withdraw UI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ docs/ops/.env.example
 - `REMINDER_SHEET_ID`
 - `MILESTONES_SHEET_ID`
 - `ACHIEVEMENTS_SHEET_ID`
+- `LIVE_ARENA_TOURNAMENT_SHEET_ID` — optional; blank safely disables Live Arena registration
 - *(other sheet IDs live in env.example — keep doc updates in sync with env.example when adding new sheets)*
 
 **Logging / Telemetry (ENV var names — exact):**
@@ -131,4 +132,4 @@ For PR formatting rules, labels, and doc footers see `docs/contracts/Collaborati
 
 ---
 
-Doc last updated: 2025-12-31 (v0.9.8.2)
+Doc last updated: 2026-08-06 (v0.9.8.2)

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -61,6 +61,9 @@ MILESTONES_CONFIG_TAB=
 # Google Sheet ID for achievement definitions used by Achievement Collector roles.
 ACHIEVEMENTS_SHEET_ID=
 
+# Optional Google Sheet ID for Live Arena tournament registration; blank disables the feature.
+LIVE_ARENA_TOURNAMENT_SHEET_ID=
+
 # Worksheet name containing recruitment config (default: Config).
 RECRUITMENT_CONFIG_TAB=
 
@@ -269,3 +272,5 @@ LEAGUE_ADMIN_IDS=
 LEAGUES_REMINDER_MONDAY_UTC=
 LEAGUES_REMINDER_WEDNESDAY_UTC=
 # Add future config keys here and update docs in the same PR.
+
+# Doc last updated: 2026-08-06 (v0.9.8.2)

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -63,6 +63,7 @@ Missing any **Required** key causes the bot to exit with an error at startup. If
 | `REMINDER_SHEET_ID` | string | — | Google Sheet ID for reminders (service-specific). |
 | `MILESTONES_SHEET_ID` | string | — | Google Sheet ID for Milestones (claims, appreciation, shard & mercy, missions) (service-specific). |
 | `ACHIEVEMENTS_SHEET_ID` | string | — | Google Sheet ID for achievement definitions used by the Achievement Collector role source. |
+| `LIVE_ARENA_TOURNAMENT_SHEET_ID` | string | — | Optional Live Arena registration workbook ID; leaving it blank safely disables only that feature. |
 | `MILESTONES_CONFIG_TAB` | string | required | Deployment checklist: set `MILESTONES_CONFIG_TAB=Config` in Render for prod before deploy if it is not already configured. |
 | `RECRUITMENT_CONFIG_TAB` | string | `Config` | Worksheet name containing recruitment config. |
 | `ONBOARDING_CONFIG_TAB` | string | `Config` | Worksheet name containing onboarding config. |
@@ -444,4 +445,4 @@ The `LEAGUES_SHEET_ID` Config tab resolves `cluster_capture_config_tab`, `cluste
 
 Before weekly boards are exported, the bot appends one candidate per active clan and enabled capture spec. Unknown/former source clans are ignored; a missing active clan is archived as `evaluation_status=missing`. Blank, invalid, and zero weekly scores stay blank rather than becoming valid zeroes. Existing record keys with identical semantic event data are retry no-ops even when trigger, timestamp, source location, or clan display name changes; audit metadata from the original row remains untouched. Changed semantic event data conflicts, while conflicting keys and negative cumulative deltas fail the job before Discord posting. The capture is append-only and never clears Stormforged inputs. Current CvC/Siege inputs only support weekly scores or cumulative win/loss deltas, not complete cycle/participation/action/class ratings.
 
-Doc last updated: 2026-08-03 (v0.9.8.2)
+Doc last updated: 2026-08-07 (v0.9.8.2)

--- a/modules/community/__init__.py
+++ b/modules/community/__init__.py
@@ -1,6 +1,7 @@
 """Community extensions registry."""
 
 COMMUNITY_EXTENSIONS: tuple[str, ...] = (
+    "modules.community.live_arena_tournament",
     "modules.community.shard_tracker",
     "modules.community.fusion",
     "modules.community.leagues",

--- a/modules/community/live_arena_tournament/__init__.py
+++ b/modules/community/live_arena_tournament/__init__.py
@@ -1,0 +1,15 @@
+"""Live Arena tournament registration extension."""
+
+import logging
+from .cog import LiveArenaTournamentCog
+
+log = logging.getLogger("c1c.community.live_arena_registration")
+
+
+async def setup(bot):
+    cog = LiveArenaTournamentCog(bot)
+    await bot.add_cog(cog)
+    await cog.prepare()
+
+
+__all__ = ["LiveArenaTournamentCog", "setup"]

--- a/modules/community/live_arena_tournament/__init__.py
+++ b/modules/community/live_arena_tournament/__init__.py
@@ -1,7 +1,7 @@
 """Live Arena tournament registration extension."""
 
 import logging
-from .cog import LiveArenaTournamentCog
+from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
 
 log = logging.getLogger("c1c.community.live_arena_registration")
 

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -150,7 +150,6 @@ class LiveArenaTournamentCog(commands.Cog):
                     r
                     for r in loaded["tournaments"]
                     if str(r.get("tournament_id")) == tid
-                    and truthy(r.get("active", True))
                 ),
                 None,
             )
@@ -207,7 +206,9 @@ class LiveArenaTournamentCog(commands.Cog):
                     ("tournament_id", "clan_tag", "discord_role_id", "active"),
                 )
                 if not any(
-                    str(r.get("tournament_id")) == tid and truthy(r.get("active"))
+                    str(r.get("tournament_id")) == tid
+                    and truthy(r.get("active"))
+                    and str(r.get("discord_role_id", "")).strip()
                     for r in clans
                 ):
                     errors.append(
@@ -251,11 +252,10 @@ class LiveArenaTournamentCog(commands.Cog):
             )
         tournament = Tournament(
             cfg.active_tournament_id,
-            str(row.get("tournament_name", row.get("name", ""))),
+            str(row.get("tournament_name", "")),
             norm(row["status"]),
-            int(row.get("maximum_participants", row.get("max_participants", 0))),
-            int(row.get("minimum_availability", 3)),
-            str(row.get("signup_closes_at", row.get("signup_deadline", ""))),
+            int(row.get("max_participants", 0)),
+            str(row.get("signup_closes_at", "")),
             norm(row.get("eligibility_scope", "selected_clans")),
         )
         return cfg, tournament, row
@@ -379,9 +379,18 @@ class LiveArenaTournamentCog(commands.Cog):
                     and norm(current.get("status")) == "confirmed"
                 ):
                     return await self.show_registration(interaction)
+                clans = await self.repository.rows(
+                    "eligible_clans",
+                    ("tournament_id", "clan_tag", "discord_role_id", "active"),
+                )
+                self.service.eligible_clan(
+                    [role.id for role in interaction.user.roles],
+                    clans,
+                    tournament.tournament_id,
+                )
                 if (
                     action == "join_tournament"
-                    and not current
+                    and (not current or norm(current.get("status")) != "confirmed")
                     and self.service.confirmed_count(
                         participants, tournament.tournament_id
                     )
@@ -427,14 +436,12 @@ class LiveArenaTournamentCog(commands.Cog):
                     parse_weekday(r["weekday_utc"]),
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
-                    truthy(r.get("enabled", r.get("active", True))),
+                    truthy(r.get("enabled")),
                     int(float(r.get("sort_order") or 0)),
                     int(float(r.get("end_day_offset") or 0)),
                 )
                 for r in raw
-                if str(r.get("tournament_id", cfg.active_tournament_id))
-                in ("", cfg.active_tournament_id)
-                and truthy(r.get("enabled", r.get("active", True)))
+                if truthy(r.get("enabled"))
             ]
             selected = []
             if mode == "update":
@@ -603,7 +610,7 @@ class LiveArenaTournamentCog(commands.Cog):
         grouped = {}
         anchor = self._availability_anchor(t.signup_closes_at)
         enabled_rows = [
-            r for r in raw_slots if truthy(r.get("enabled", r.get("active", True)))
+            r for r in raw_slots if truthy(r.get("enabled"))
         ]
         enabled_ids = {str(r.get("slot_id")) for r in enabled_rows}
         selected &= enabled_ids

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -7,10 +7,24 @@ from discord.ext import commands
 from c1c_coreops.rbac import is_admin_member
 from shared.config import is_guild_allowed
 from . import config
-from .models import RegistrationError, Tournament, norm, truthy
+from .models import (
+    AvailabilitySlot,
+    RegistrationError,
+    Tournament,
+    norm,
+    truthy,
+    parse_weekday,
+)
 from .repository import LiveArenaRepository
 from .rendering import choose_row, configured_embed
-from .views import ConfirmView, PersistentPanel, TimezoneModal
+from .views import (
+    AvailabilityView,
+    ConfirmView,
+    PersistentPanel,
+    RosterView,
+    TimezoneModal,
+)
+from .service import LiveArenaService
 
 log = logging.getLogger("c1c.community.live_arena_registration")
 PUBLIC = ("join_tournament", "my_registration", "update_availability", "withdraw")
@@ -31,6 +45,7 @@ class LiveArenaTournamentCog(commands.Cog):
         )
         self.public_view = None
         self.organizer_view = None
+        self.service = LiveArenaService(self.repository) if self.repository else None
 
     async def prepare(self):
         if not self.repository:
@@ -119,9 +134,41 @@ class LiveArenaTournamentCog(commands.Cog):
                     raise RegistrationError("Tournament organizer access is required.")
                 return await self.organizer_action(action, interaction)
             if action in {"join_tournament", "update_availability"}:
+                _, tournament, _ = await self._bundle()
+                participants = await self.repository.rows("participants")
+                current = self.service.participant_for(
+                    participants, tournament.tournament_id, interaction.user.id
+                )
+                if norm(tournament.status) != "signup_open":
+                    raise RegistrationError("Registration is not open.")
+                if (
+                    action == "join_tournament"
+                    and current
+                    and norm(current.get("status")) == "removed"
+                ):
+                    raise RegistrationError(
+                        "An organizer removed this registration; contact a tournament organizer."
+                    )
+                if (
+                    action == "join_tournament"
+                    and not current
+                    and self.service.confirmed_count(
+                        participants, tournament.tournament_id
+                    )
+                    >= tournament.maximum_participants
+                ):
+                    raise RegistrationError("The tournament is at capacity.")
+                if action == "update_availability" and (
+                    not current or norm(current.get("status")) != "confirmed"
+                ):
+                    raise RegistrationError(
+                        "Only confirmed participants can update availability."
+                    )
                 return await interaction.response.send_modal(
                     TimezoneModal(
-                        self, "join" if action == "join_tournament" else "update"
+                        self,
+                        "join" if action == "join_tournament" else "update",
+                        str(current.get("timezone", "")) if current else "",
                     )
                 )
             if action == "my_registration":
@@ -136,17 +183,98 @@ class LiveArenaTournamentCog(commands.Cog):
             await self._reply(interaction, str(exc))
 
     async def start_availability(self, interaction, mode, timezone_name):
-        # Sessions deliberately remain ephemeral and write nothing. The day/select review UI is built from current slots.
         from .models import validate_timezone
 
         try:
-            validate_timezone(timezone_name)
+            timezone_name = validate_timezone(timezone_name)
+            cfg, _, _ = await self._bundle()
+            raw = await self.repository.rows(
+                "availability_slots", ("slot_id", "weekday_utc", "start_time_utc")
+            )
+            slots = [
+                AvailabilitySlot(
+                    str(r["slot_id"]),
+                    parse_weekday(r["weekday_utc"]),
+                    str(r["start_time_utc"]),
+                    str(r.get("end_time_utc", "")),
+                    truthy(r.get("active", True)),
+                    int(r.get("sort_order") or 0),
+                )
+                for r in raw
+                if str(r.get("tournament_id", cfg.active_tournament_id))
+                in ("", cfg.active_tournament_id)
+                and truthy(r.get("active", True))
+            ]
+            selected = []
+            if mode == "update":
+                availability = await self.repository.rows("participant_availability")
+                selected = [
+                    str(r["slot_id"])
+                    for r in availability
+                    if str(r.get("tournament_id")) == cfg.active_tournament_id
+                    and str(r.get("discord_user_id")) == str(interaction.user.id)
+                ]
+            if not slots:
+                raise RegistrationError("No availability windows are configured.")
             await self._reply(
                 interaction,
-                "Your timezone is valid. Choose availability windows in the configured day selectors, then review and submit.",
+                "Choose local-time windows.",
+                view=AvailabilityView(self, mode, timezone_name, slots, selected),
             )
         except RegistrationError as exc:
             await self._reply(interaction, str(exc))
+
+    async def submit_availability(self, interaction, session):
+        try:
+            _, tournament, _ = await self._bundle()
+            result = await self.service.register(
+                tournament=tournament,
+                user_id=str(interaction.user.id),
+                display_name=interaction.user.display_name,
+                member_role_ids=[r.id for r in interaction.user.roles],
+                timezone_name=session.timezone,
+                slot_ids=list(session.selected),
+            )
+            await self._set_participant_role(interaction.user, True)
+            await self.publish_panels(interaction.guild)
+            await self._reply(
+                interaction,
+                "Registration saved."
+                if result["created"]
+                else "Your registration is already current.",
+            )
+        except Exception as exc:
+            await self._reply(interaction, str(exc))
+
+    async def _participant_role_id(self):
+        cfg, _, _ = await self._bundle()
+        roles = await self.repository.rows(
+            "tournament_roles", ("role_type", "discord_role_id")
+        )
+        row = next(
+            (
+                r
+                for r in roles
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+                and norm(r.get("role_type")) == "participant"
+                and truthy(r.get("active", True))
+            ),
+            None,
+        )
+        return int(row["discord_role_id"]) if row else None
+
+    async def _set_participant_role(self, member, present):
+        role_id = await self._participant_role_id()
+        if not role_id:
+            return
+        role = member.guild.get_role(role_id)
+        if not role:
+            raise RegistrationError("The configured participant role is unavailable.")
+        has = role in member.roles
+        if present and not has:
+            await member.add_roles(role, reason="Live Arena registration")
+        if not present and has:
+            await member.remove_roles(role, reason="Live Arena registration")
 
     async def show_registration(self, interaction):
         cfg, t, _ = await self._bundle()
@@ -181,38 +309,43 @@ class LiveArenaTournamentCog(commands.Cog):
         )
         if not p:
             return await self._reply(interaction, "No registration was found.")
-        import datetime
-
-        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
-        rn = int(p.get("_row_number") or rows.index(p) + 2)
-        await self.repository.replace_row(
-            "participants",
-            rn,
-            {
-                "status": "withdrawn",
-                "withdrawn_at": now,
-                "withdrawal_reason": "self_service_withdrawal",
-            },
-        )
-        await self.repository.audit(
-            "registration_withdrawn",
+        await self.service.change_participant_status(
             cfg.active_tournament_id,
+            str(interaction.user.id),
+            "withdrawn",
             interaction.user.id,
-            "participant",
-            interaction.user.id,
-            p,
-            {"status": "withdrawn"},
+            "self_service_withdrawal",
         )
+        await self._set_participant_role(interaction.user, False)
+        await self.publish_panels(interaction.guild)
         await self._reply(interaction, "Your registration has been withdrawn.")
 
     async def organizer_action(self, action, interaction):
         if action == "refresh_registration":
+            await self.reconcile_participant_roles(interaction.guild)
             await self.publish_panels(interaction.guild)
             return await self._reply(interaction, "Registration panels refreshed.")
         if action == "view_roster":
+            cfg, _, _ = await self._bundle()
+            rows = await self.repository.rows("participants")
+            active = [
+                r
+                for r in rows
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+                and norm(r.get("status")) in {"confirmed", "removed", "withdrawn"}
+            ]
+            body = (
+                "\n".join(
+                    f"`{r.get('participant_slot')}` <@{r.get('discord_user_id')}> — {r.get('status')}"
+                    for r in active
+                )
+                or "No registrations."
+            )
             return await self._reply(
                 interaction,
-                "The current roster was loaded from the registration workbook.",
+                body,
+                title="Live Arena roster",
+                view=RosterView(self, active),
             )
         desired = {
             "open_registration": "signup_open",
@@ -247,12 +380,70 @@ class LiveArenaTournamentCog(commands.Cog):
             {"status": desired},
         )
         await self.publish_panels(interaction.guild)
-        await self._reply(interaction, f"Registration status is now {desired}.")
+        warning = (
+            " Confirmed participant count is odd; an organizer should resolve the unmatched player."
+            if desired == "signup_closed"
+            and self.service.confirmed_count(
+                await self.repository.rows("participants"), cfg.active_tournament_id
+            )
+            % 2
+            else ""
+        )
+        await self._reply(
+            interaction, f"Registration status is now {desired}.{warning}"
+        )
+
+    async def organizer_participant(self, interaction, user_id, status):
+        if not user_id:
+            return await self._reply(interaction, "Choose a participant first.")
+        if not await self._organizer(interaction.user):
+            return await self._reply(
+                interaction, "Tournament organizer access is required."
+            )
+        cfg, _, _ = await self._bundle()
+        await self.service.change_participant_status(
+            cfg.active_tournament_id,
+            user_id,
+            status,
+            interaction.user.id,
+            "organizer_action",
+        )
+        member = (
+            interaction.guild.get_member(int(user_id))
+            if str(user_id).isdigit()
+            else None
+        )
+        if member:
+            await self._set_participant_role(member, status == "confirmed")
+        await self.publish_panels(interaction.guild)
+        await self._reply(interaction, f"Participant status changed to {status}.")
+
+    async def reconcile_participant_roles(self, guild):
+        cfg, _, _ = await self._bundle()
+        rows = await self.repository.rows("participants")
+        role_id = await self._participant_role_id()
+        role = guild.get_role(role_id) if role_id else None
+        if not role:
+            return
+        wanted = {
+            int(r["discord_user_id"])
+            for r in rows
+            if str(r.get("tournament_id")) == cfg.active_tournament_id
+            and norm(r.get("status")) == "confirmed"
+            and str(r.get("discord_user_id", "")).isdigit()
+        }
+        for member in list(role.members):
+            if member.id not in wanted:
+                await member.remove_roles(role, reason="Live Arena role reconciliation")
+        for user_id in wanted:
+            member = guild.get_member(user_id)
+            if member and role not in member.roles:
+                await member.add_roles(role, reason="Live Arena role reconciliation")
 
     async def publish_panels(self, guild):
         cfg, t, _ = await self._bundle()
         destinations = await self.repository.rows(
-            "destinations", ("destination_type", "discord_channel_id")
+            "destinations", ("destination_key", "channel_id")
         )
         messages = await self.repository.rows("messages")
         participants = await self.repository.rows("participants")
@@ -262,6 +453,25 @@ class LiveArenaTournamentCog(commands.Cog):
             and norm(p.get("status")) == "confirmed"
             for p in participants
         )
+        if self.public_view:
+            unavailable = t.status != "signup_open" or count >= t.maximum_participants
+            self.public_view.disable_actions(
+                {"join_tournament", "update_availability"} if unavailable else set()
+            )
+        if self.organizer_view:
+            disabled = {
+                "open_registration",
+                "close_registration",
+                "reopen_registration",
+            }
+            enabled = {
+                "draft": "open_registration",
+                "signup_open": "close_registration",
+                "signup_closed": "reopen_registration",
+            }.get(t.status)
+            if enabled:
+                disabled.remove(enabled)
+            self.organizer_view.disable_actions(disabled)
         values = {
             "tournament_name": t.name,
             "signup_deadline": t.signup_deadline,
@@ -295,8 +505,7 @@ class LiveArenaTournamentCog(commands.Cog):
                     d
                     for d in destinations
                     if str(d.get("tournament_id")) == cfg.active_tournament_id
-                    and norm(d.get("destination_type", d.get("purpose")))
-                    == destination_type
+                    and norm(d.get("destination_key")) == destination_type
                     and truthy(d.get("active", True))
                 ),
                 None,
@@ -305,7 +514,7 @@ class LiveArenaTournamentCog(commands.Cog):
                 raise RegistrationError(
                     f"Destinations has no active {destination_type} row for the active tournament."
                 )
-            channel = guild.get_channel(int(dest["discord_channel_id"]))
+            channel = guild.get_channel(int(dest["channel_id"]))
             if not channel:
                 raise RegistrationError(
                     f"Configured {destination_type} destination is unavailable to the bot."

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import logging
+from datetime import datetime, timedelta, timezone
 import discord
 from discord.ext import commands
 from c1c_coreops.rbac import is_admin_member
@@ -14,6 +15,7 @@ from .models import (
     norm,
     truthy,
     parse_weekday,
+    slot_local_datetime,
 )
 from .repository import LiveArenaRepository
 from .rendering import choose_row, configured_embed
@@ -74,9 +76,7 @@ class LiveArenaTournamentCog(commands.Cog):
         if not self.repository:
             raise RegistrationError("Live Arena registration is disabled.")
         cfg = self.repository.config or await self.repository.load_config()
-        rows = await self.repository.rows(
-            "tournament_config", ("tournament_id", "status")
-        )
+        rows = await self.repository.rows("tournaments", ("tournament_id", "status"))
         row = next(
             (
                 r
@@ -95,7 +95,7 @@ class LiveArenaTournamentCog(commands.Cog):
             norm(row["status"]),
             int(row.get("maximum_participants", row.get("max_participants", 0))),
             int(row.get("minimum_availability", 3)),
-            str(row.get("signup_deadline", "")),
+            str(row.get("signup_closes_at", row.get("signup_deadline", ""))),
             norm(row.get("eligibility_scope", "selected_clans")),
         )
         return cfg, tournament, row
@@ -104,9 +104,7 @@ class LiveArenaTournamentCog(commands.Cog):
         if is_admin_member(member):
             return True
         cfg, _, _ = await self._bundle()
-        rows = await self.repository.rows(
-            "tournament_roles", ("role_type", "discord_role_id")
-        )
+        rows = await self.repository.rows("roles", ("role_type", "discord_role_id"))
         ids = {
             str(r["discord_role_id"])
             for r in rows
@@ -124,6 +122,64 @@ class LiveArenaTournamentCog(commands.Cog):
             else interaction.response.send_message
         )
         await target(embed=embed, view=view, ephemeral=True)
+
+    async def _message_text(self, key, values, fallback):
+        messages = await self.repository.rows("messages")
+        row = choose_row(messages, key, self.repository.config.active_tournament_id)
+        if not row:
+            return fallback
+        embed = configured_embed(row, values)
+        return embed.description or embed.title or fallback
+
+    async def _report_role_failure(self, guild, member, exc):
+        cfg = self.repository.config
+        log.error(
+            "Live Arena participant role sync failed: %s",
+            exc,
+            extra={"tournament_id": cfg.active_tournament_id, "member_id": member.id},
+        )
+        await self.repository.audit(
+            "participant_role_sync_failed",
+            cfg.active_tournament_id,
+            self.bot.user.id,
+            "participant",
+            member.id,
+            {},
+            {"role_synced": False},
+            str(exc),
+        )
+        destinations = await self.repository.rows("destinations")
+        row = next(
+            (
+                r
+                for r in destinations
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+                and norm(r.get("destination_key")) == "organizer_log"
+                and truthy(r.get("active", True))
+            ),
+            None,
+        )
+        channel = guild.get_channel(int(row["channel_id"])) if row else None
+        if channel:
+            await channel.send(
+                embed=discord.Embed(
+                    description=(
+                        f"⚠️ Participant role sync failed for <@{member.id}>. The confirmed "
+                        "registration was retained; run Refresh Registration."
+                    )
+                )
+            )
+
+    @staticmethod
+    def _availability_anchor(raw):
+        try:
+            value = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            value = value.astimezone(timezone.utc)
+        except (TypeError, ValueError):
+            value = datetime.now(timezone.utc)
+        return (value - timedelta(days=value.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
     async def handle_action(self, action, interaction):
         try:
@@ -144,11 +200,18 @@ class LiveArenaTournamentCog(commands.Cog):
                 if (
                     action == "join_tournament"
                     and current
-                    and norm(current.get("status")) == "removed"
+                    and norm(current.get("status"))
+                    not in {"open", "withdrawn", "confirmed"}
                 ):
                     raise RegistrationError(
-                        "An organizer removed this registration; contact a tournament organizer."
+                        "This registration cannot be changed through self-service; contact a tournament organizer."
                     )
+                if (
+                    action == "join_tournament"
+                    and current
+                    and norm(current.get("status")) == "confirmed"
+                ):
+                    return await self.show_registration(interaction)
                 if (
                     action == "join_tournament"
                     and not current
@@ -187,7 +250,7 @@ class LiveArenaTournamentCog(commands.Cog):
 
         try:
             timezone_name = validate_timezone(timezone_name)
-            cfg, _, _ = await self._bundle()
+            cfg, tournament, _ = await self._bundle()
             raw = await self.repository.rows(
                 "availability_slots", ("slot_id", "weekday_utc", "start_time_utc")
             )
@@ -197,13 +260,13 @@ class LiveArenaTournamentCog(commands.Cog):
                     parse_weekday(r["weekday_utc"]),
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
-                    truthy(r.get("active", True)),
+                    truthy(r.get("enabled", r.get("active", True))),
                     int(r.get("sort_order") or 0),
                 )
                 for r in raw
                 if str(r.get("tournament_id", cfg.active_tournament_id))
                 in ("", cfg.active_tournament_id)
-                and truthy(r.get("active", True))
+                and truthy(r.get("enabled", r.get("active", True)))
             ]
             selected = []
             if mode == "update":
@@ -219,7 +282,16 @@ class LiveArenaTournamentCog(commands.Cog):
             await self._reply(
                 interaction,
                 "Choose local-time windows.",
-                view=AvailabilityView(self, mode, timezone_name, slots, selected),
+                view=AvailabilityView(
+                    self,
+                    mode,
+                    timezone_name,
+                    slots,
+                    selected,
+                    anchor_monday=self._availability_anchor(
+                        tournament.signup_closes_at
+                    ),
+                ),
             )
         except RegistrationError as exc:
             await self._reply(interaction, str(exc))
@@ -235,22 +307,38 @@ class LiveArenaTournamentCog(commands.Cog):
                 timezone_name=session.timezone,
                 slot_ids=list(session.selected),
             )
-            await self._set_participant_role(interaction.user, True)
+            role_warning = ""
+            try:
+                await self._set_participant_role(interaction.user, True)
+            except Exception as exc:
+                role_warning = " Registration succeeded, but the Discord role could not be synced; an organizer has been alerted."
+                await self._report_role_failure(
+                    interaction.guild, interaction.user, exc
+                )
             await self.publish_panels(interaction.guild)
             await self._reply(
                 interaction,
-                "Registration saved."
-                if result["created"]
-                else "Your registration is already current.",
+                await self._message_text(
+                    "signup_confirmed",
+                    {
+                        "tournament_name": tournament.name,
+                        "participant_count": "",
+                        "max_participants": tournament.maximum_participants,
+                        "tournament_status": tournament.status,
+                        "roster_parity_summary": "",
+                    },
+                    "Registration saved."
+                    if result["created"]
+                    else "Availability update saved.",
+                )
+                + role_warning,
             )
         except Exception as exc:
             await self._reply(interaction, str(exc))
 
     async def _participant_role_id(self):
         cfg, _, _ = await self._bundle()
-        roles = await self.repository.rows(
-            "tournament_roles", ("role_type", "discord_role_id")
-        )
+        roles = await self.repository.rows("roles", ("role_type", "discord_role_id"))
         row = next(
             (
                 r
@@ -288,11 +376,41 @@ class LiveArenaTournamentCog(commands.Cog):
             ),
             None,
         )
+        availability = (
+            await self.repository.rows("participant_availability") if p else []
+        )
+        raw_slots = await self.repository.rows("availability_slots") if p else []
+        selected = {
+            str(r.get("slot_id"))
+            for r in availability
+            if str(r.get("tournament_id")) == cfg.active_tournament_id
+            and str(r.get("discord_user_id")) == str(interaction.user.id)
+        }
+        grouped = {}
+        anchor = self._availability_anchor(t.signup_closes_at)
+        for row in raw_slots:
+            if str(row.get("slot_id")) not in selected:
+                continue
+            slot = AvailabilitySlot(
+                str(row["slot_id"]),
+                parse_weekday(row["weekday_utc"]),
+                str(row["start_time_utc"]),
+                str(row.get("end_time_utc", "")),
+            )
+            local = slot_local_datetime(
+                slot, str(p.get("timezone") or "UTC"), anchor_monday=anchor
+            )
+            grouped.setdefault(local.strftime("%A"), []).append(local.strftime("%H:%M"))
+        saved = (
+            "\n".join(f"{day}: {', '.join(times)}" for day, times in grouped.items())
+            or "None saved"
+        )
+        valid = len(selected) >= t.minimum_availability and len(grouped) >= 2
         await self._reply(
             interaction,
             "No registration was found."
             if not p
-            else f"**{t.name}**\nStatus: {p.get('status')}\nName: {p.get('display_name_at_signup')}\nClan: {p.get('clan_tag_at_signup')}\nTimezone: {p.get('timezone')}",
+            else f"**{t.name}**\nStatus: {p.get('status')}\nName: {p.get('display_name_at_signup')}\nClan: {p.get('clan_tag_at_signup')}\nTimezone: {p.get('timezone')}\n\n**Saved availability**\n{saved}\nSelected windows: {len(selected)}\nMinimum validity: {'Valid' if valid else 'Needs attention'}",
         )
 
     async def withdraw(self, interaction):
@@ -318,7 +436,20 @@ class LiveArenaTournamentCog(commands.Cog):
         )
         await self._set_participant_role(interaction.user, False)
         await self.publish_panels(interaction.guild)
-        await self._reply(interaction, "Your registration has been withdrawn.")
+        await self._reply(
+            interaction,
+            await self._message_text(
+                "withdrawal_confirmed",
+                {
+                    "tournament_name": "",
+                    "participant_count": "",
+                    "max_participants": "",
+                    "tournament_status": "withdrawn",
+                    "roster_parity_summary": "",
+                },
+                "Your registration has been withdrawn.",
+            ),
+        )
 
     async def organizer_action(self, action, interaction):
         if action == "refresh_registration":
@@ -359,9 +490,9 @@ class LiveArenaTournamentCog(commands.Cog):
             raise RegistrationError(
                 f"Cannot change registration from {t.status} to {desired}."
             )
-        rows = await self.repository.rows("tournament_config")
+        rows = await self.repository.rows("tournaments")
         rn = int(row.get("_row_number") or rows.index(row) + 2)
-        await self.repository.replace_row("tournament_config", rn, {"status": desired})
+        await self.repository.replace_row("tournaments", rn, {"status": desired})
         event = (
             {
                 "signup_open": "registration_opened",
@@ -400,18 +531,37 @@ class LiveArenaTournamentCog(commands.Cog):
             return await self._reply(
                 interaction, "Tournament organizer access is required."
             )
-        cfg, _, _ = await self._bundle()
+        cfg, tournament, _ = await self._bundle()
+        member = (
+            interaction.guild.get_member(int(user_id))
+            if str(user_id).isdigit()
+            else None
+        )
+        if status == "confirmed":
+            if tournament.status != "signup_open":
+                raise RegistrationError(
+                    "Participants can only be restored while registration is open."
+                )
+            if not member:
+                raise RegistrationError(
+                    "The participant is no longer a member of this server."
+                )
+            participants = await self.repository.rows("participants")
+            if (
+                self.service.confirmed_count(participants, cfg.active_tournament_id)
+                >= tournament.maximum_participants
+            ):
+                raise RegistrationError("The tournament is at capacity.")
+            clans = await self.repository.rows("eligible_clans")
+            self.service.eligible_clan(
+                [role.id for role in member.roles], clans, cfg.active_tournament_id
+            )
         await self.service.change_participant_status(
             cfg.active_tournament_id,
             user_id,
             status,
             interaction.user.id,
             "organizer_action",
-        )
-        member = (
-            interaction.guild.get_member(int(user_id))
-            if str(user_id).isdigit()
-            else None
         )
         if member:
             await self._set_participant_role(member, status == "confirmed")
@@ -434,11 +584,45 @@ class LiveArenaTournamentCog(commands.Cog):
         }
         for member in list(role.members):
             if member.id not in wanted:
-                await member.remove_roles(role, reason="Live Arena role reconciliation")
+                try:
+                    await member.remove_roles(
+                        role, reason="Live Arena role reconciliation"
+                    )
+                    await self.repository.audit(
+                        "participant_role_reconciled",
+                        cfg.active_tournament_id,
+                        self.bot.user.id,
+                        "participant",
+                        member.id,
+                        {"role": True},
+                        {"role": False},
+                    )
+                except Exception as exc:
+                    log.error(
+                        "Live Arena role reconciliation failed for %s: %s",
+                        member.id,
+                        exc,
+                    )
         for user_id in wanted:
             member = guild.get_member(user_id)
             if member and role not in member.roles:
-                await member.add_roles(role, reason="Live Arena role reconciliation")
+                try:
+                    await member.add_roles(
+                        role, reason="Live Arena role reconciliation"
+                    )
+                    await self.repository.audit(
+                        "participant_role_reconciled",
+                        cfg.active_tournament_id,
+                        self.bot.user.id,
+                        "participant",
+                        member.id,
+                        {"role": False},
+                        {"role": True},
+                    )
+                except Exception as exc:
+                    log.error(
+                        "Live Arena role reconciliation failed for %s: %s", user_id, exc
+                    )
 
     async def publish_panels(self, guild):
         cfg, t, _ = await self._bundle()
@@ -454,10 +638,12 @@ class LiveArenaTournamentCog(commands.Cog):
             for p in participants
         )
         if self.public_view:
-            unavailable = t.status != "signup_open" or count >= t.maximum_participants
-            self.public_view.disable_actions(
-                {"join_tournament", "update_availability"} if unavailable else set()
-            )
+            disabled = set()
+            if t.status != "signup_open":
+                disabled.update({"join_tournament", "update_availability"})
+            elif count >= t.maximum_participants:
+                disabled.add("join_tournament")
+            self.public_view.disable_actions(disabled)
         if self.organizer_view:
             disabled = {
                 "open_registration",
@@ -474,11 +660,18 @@ class LiveArenaTournamentCog(commands.Cog):
             self.organizer_view.disable_actions(disabled)
         values = {
             "tournament_name": t.name,
-            "signup_deadline": t.signup_deadline,
+            "signup_closes_at": t.signup_closes_at,
+            "signup_deadline": t.signup_closes_at,
             "confirmed_count": count,
             "maximum_participants": t.maximum_participants,
             "minimum_availability": t.minimum_availability,
             "status": t.status,
+            "participant_count": count,
+            "max_participants": t.maximum_participants,
+            "tournament_status": t.status,
+            "roster_parity_summary": "Even roster"
+            if count % 2 == 0
+            else "Odd roster — one player is unmatched",
         }
         state_map = {
             norm(x.get("state_key")): x

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -15,7 +15,6 @@ from .models import (
     norm,
     truthy,
     parse_weekday,
-    slot_local_datetime,
 )
 from .repository import LiveArenaRepository
 from .rendering import choose_row, configured_embed
@@ -57,7 +56,161 @@ class LiveArenaTournamentCog(commands.Cog):
             return False
         try:
             cfg = await self.repository.load_config()
-            components = await self.repository.rows("message_components", ("label",))
+            errors = []
+            requirements = {
+                "tournaments": (
+                    "tournament_id",
+                    "tournament_name",
+                    "status",
+                    "max_participants",
+                    "minimum_availability",
+                    "signup_closes_at",
+                    "eligibility_scope",
+                ),
+                "destinations": (
+                    "tournament_id",
+                    "destination_key",
+                    "channel_id",
+                    "active",
+                ),
+                "roles": ("tournament_id", "role_type", "discord_role_id", "active"),
+                "availability_slots": (
+                    "tournament_id",
+                    "slot_id",
+                    "weekday_utc",
+                    "start_time_utc",
+                    "end_time_utc",
+                    "end_day_offset",
+                    "enabled",
+                    "sort_order",
+                ),
+                "participants": (
+                    "tournament_id",
+                    "participant_slot",
+                    "discord_user_id",
+                    "status",
+                    "timezone",
+                    "signed_up_at",
+                    "confirmed_at",
+                    "withdrawn_at",
+                ),
+                "participant_availability": (
+                    "tournament_id",
+                    "discord_user_id",
+                    "slot_id",
+                    "preference",
+                    "created_at",
+                    "updated_at",
+                ),
+                "messages": (
+                    "message_key",
+                    "title_template",
+                    "body_template",
+                    "embed_color_hex",
+                    "active",
+                ),
+                "message_components": ("action_id", "label", "sort_order", "active"),
+                "bot_state": (
+                    "tournament_id",
+                    "state_key",
+                    "state_value",
+                    "updated_at",
+                ),
+                "audit_log": (
+                    "event_id",
+                    "tournament_id",
+                    "event_type",
+                    "actor_discord_user_id",
+                    "entity_type",
+                    "entity_id",
+                    "old_value_json",
+                    "new_value_json",
+                    "created_at",
+                    "notes",
+                ),
+            }
+            loaded = {}
+            for table, headers in requirements.items():
+                try:
+                    loaded[table] = await self.repository.rows(table, headers)
+                except Exception as exc:
+                    errors.append(str(exc))
+            if errors:
+                raise RegistrationError(
+                    "Live Arena workbook schema errors:\n- " + "\n- ".join(errors)
+                )
+            tid = cfg.active_tournament_id
+            tournament = next(
+                (
+                    r
+                    for r in loaded["tournaments"]
+                    if str(r.get("tournament_id")) == tid
+                    and truthy(r.get("active", True))
+                ),
+                None,
+            )
+            if not tournament:
+                errors.append(f"Tournament_Config requires an active row for {tid}.")
+            for key in ("signup", "organizer_log"):
+                if not any(
+                    str(r.get("tournament_id")) == tid
+                    and norm(r.get("destination_key")) == key
+                    and truthy(r.get("active"))
+                    for r in loaded["destinations"]
+                ):
+                    errors.append(f"Destinations requires active {key} row for {tid}.")
+            for role_type in ("organizer", "participant"):
+                if not any(
+                    str(r.get("tournament_id")) == tid
+                    and norm(r.get("role_type")) == role_type
+                    and truthy(r.get("active"))
+                    for r in loaded["roles"]
+                ):
+                    errors.append(
+                        f"Tournament_Roles requires active {role_type} row for {tid}."
+                    )
+            required_messages = {
+                "signup_open",
+                "signup_closed",
+                "signup_confirmed",
+                "withdrawal_confirmed",
+                "registration_organizer",
+            }
+            actual_messages = {
+                norm(r.get("message_key"))
+                for r in loaded["messages"]
+                if truthy(r.get("active"))
+            }
+            for key in sorted(required_messages - actual_messages):
+                errors.append(f"Messages requires active {key} row.")
+            required_actions = set(PUBLIC + ORGANIZER)
+            actual_actions = {
+                str(r.get("action_id"))
+                for r in loaded["message_components"]
+                if truthy(r.get("active"))
+            }
+            for key in sorted(required_actions - actual_actions):
+                errors.append(f"Message_Components requires active {key} action_id.")
+            if (
+                tournament
+                and norm(tournament.get("eligibility_scope")) == "selected_clans"
+            ):
+                clans = await self.repository.rows(
+                    "eligible_clans",
+                    ("tournament_id", "clan_tag", "discord_role_id", "active"),
+                )
+                if not any(
+                    str(r.get("tournament_id")) == tid and truthy(r.get("active"))
+                    for r in clans
+                ):
+                    errors.append(
+                        f"Eligible_Clans requires an active role row for {tid}."
+                    )
+            if errors:
+                raise RegistrationError(
+                    "Live Arena workbook schema errors:\n- " + "\n- ".join(errors)
+                )
+            components = loaded["message_components"]
             self.public_view = PersistentPanel(self, components, PUBLIC)
             self.organizer_view = PersistentPanel(self, components, ORGANIZER)
             log.info(
@@ -114,8 +267,10 @@ class LiveArenaTournamentCog(commands.Cog):
         }
         return any(str(r.id) in ids for r in member.roles)
 
-    async def _reply(self, interaction, description, title="Live Arena", view=None):
-        embed = discord.Embed(title=title, description=description)
+    async def _reply(
+        self, interaction, description="", title="Live Arena", view=None, embed=None
+    ):
+        embed = embed or discord.Embed(title=title, description=description)
         target = (
             interaction.followup.send
             if interaction.response.is_done()
@@ -123,13 +278,12 @@ class LiveArenaTournamentCog(commands.Cog):
         )
         await target(embed=embed, view=view, ephemeral=True)
 
-    async def _message_text(self, key, values, fallback):
+    async def _message_embed(self, key, values):
         messages = await self.repository.rows("messages")
         row = choose_row(messages, key, self.repository.config.active_tournament_id)
         if not row:
-            return fallback
-        embed = configured_embed(row, values)
-        return embed.description or embed.title or fallback
+            raise RegistrationError(f"Messages requires an active {key} row.")
+        return configured_embed(row, values)
 
     async def _report_role_failure(self, guild, member, exc):
         cfg = self.repository.config
@@ -138,37 +292,43 @@ class LiveArenaTournamentCog(commands.Cog):
             exc,
             extra={"tournament_id": cfg.active_tournament_id, "member_id": member.id},
         )
-        await self.repository.audit(
-            "participant_role_sync_failed",
-            cfg.active_tournament_id,
-            self.bot.user.id,
-            "participant",
-            member.id,
-            {},
-            {"role_synced": False},
-            str(exc),
-        )
-        destinations = await self.repository.rows("destinations")
-        row = next(
-            (
-                r
-                for r in destinations
-                if str(r.get("tournament_id")) == cfg.active_tournament_id
-                and norm(r.get("destination_key")) == "organizer_log"
-                and truthy(r.get("active", True))
-            ),
-            None,
-        )
-        channel = guild.get_channel(int(row["channel_id"])) if row else None
-        if channel:
-            await channel.send(
-                embed=discord.Embed(
-                    description=(
-                        f"⚠️ Participant role sync failed for <@{member.id}>. The confirmed "
-                        "registration was retained; run Refresh Registration."
+        try:
+            await self.repository.audit(
+                "participant_role_sync_failed",
+                cfg.active_tournament_id,
+                self.bot.user.id,
+                "participant",
+                member.id,
+                {},
+                {"role_synced": False},
+                str(exc),
+            )
+        except Exception:
+            log.exception("live_arena_role_failure_audit_failed")
+        try:
+            destinations = await self.repository.rows("destinations")
+            row = next(
+                (
+                    r
+                    for r in destinations
+                    if str(r.get("tournament_id")) == cfg.active_tournament_id
+                    and norm(r.get("destination_key")) == "organizer_log"
+                    and truthy(r.get("active", True))
+                ),
+                None,
+            )
+            channel = guild.get_channel(int(row["channel_id"])) if row else None
+            if channel:
+                await channel.send(
+                    embed=discord.Embed(
+                        description=(
+                            f"⚠️ Participant role sync failed for <@{member.id}>. The confirmed "
+                            "registration was retained; run Refresh Registration."
+                        )
                     )
                 )
-            )
+        except Exception:
+            log.exception("live_arena_role_failure_alert_failed")
 
     @staticmethod
     def _availability_anchor(raw):
@@ -261,7 +421,8 @@ class LiveArenaTournamentCog(commands.Cog):
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
                     truthy(r.get("enabled", r.get("active", True))),
-                    int(r.get("sort_order") or 0),
+                    int(float(r.get("sort_order") or 0)),
+                    int(float(r.get("end_day_offset") or 0)),
                 )
                 for r in raw
                 if str(r.get("tournament_id", cfg.active_tournament_id))
@@ -281,7 +442,12 @@ class LiveArenaTournamentCog(commands.Cog):
                 raise RegistrationError("No availability windows are configured.")
             await self._reply(
                 interaction,
-                "Choose local-time windows.",
+                "Choose local-time windows."
+                + (
+                    " Disabled saved selections were removed."
+                    if set(selected) - {s.slot_id for s in slots}
+                    else ""
+                ),
                 view=AvailabilityView(
                     self,
                     mode,
@@ -306,35 +472,76 @@ class LiveArenaTournamentCog(commands.Cog):
                 member_role_ids=[r.id for r in interaction.user.roles],
                 timezone_name=session.timezone,
                 slot_ids=list(session.selected),
+                anchor_monday=session.anchor_monday,
             )
-            role_warning = ""
+            warnings = list(result.get("warnings", ()))
             try:
                 await self._set_participant_role(interaction.user, True)
             except Exception as exc:
-                role_warning = " Registration succeeded, but the Discord role could not be synced; an organizer has been alerted."
+                warnings.append(
+                    "The Discord participant role could not be synced; an organizer has been alerted."
+                )
                 await self._report_role_failure(
                     interaction.guild, interaction.user, exc
                 )
-            await self.publish_panels(interaction.guild)
-            await self._reply(
-                interaction,
-                await self._message_text(
-                    "signup_confirmed",
-                    {
-                        "tournament_name": tournament.name,
-                        "participant_count": "",
-                        "max_participants": tournament.maximum_participants,
-                        "tournament_status": tournament.status,
-                        "roster_parity_summary": "",
-                    },
-                    "Registration saved."
-                    if result["created"]
-                    else "Availability update saved.",
+            try:
+                await self.publish_panels(interaction.guild)
+            except Exception:
+                log.exception(
+                    "live_arena_panel_refresh_failed",
+                    extra={"tournament_id": tournament.tournament_id},
                 )
-                + role_warning,
-            )
+                warnings.append(
+                    "Registration panels could not be refreshed; organizers can repair them with Refresh Registration."
+                )
+            values = {
+                "participant": interaction.user.mention,
+                "tournament_name": tournament.name,
+                "signup_deadline": self._deadline_text(tournament.signup_closes_at),
+                "signup_closes_at": self._deadline_text(tournament.signup_closes_at),
+            }
+            if result["created"]:
+                embed = await self._message_embed("signup_confirmed", values)
+            else:
+                embed = discord.Embed(
+                    title="Availability updated",
+                    description=f"{interaction.user.mention}, your availability for **{tournament.name}** was saved.",
+                )
+            if warnings:
+                embed.add_field(
+                    name="⚠️ Saved with warning", value="\n".join(warnings), inline=False
+                )
+            await self._reply(interaction, embed=embed)
+            return True
         except Exception as exc:
             await self._reply(interaction, str(exc))
+            return False
+
+    @staticmethod
+    def _deadline_text(raw):
+        if not str(raw).strip():
+            raise RegistrationError(
+                "Tournament_Config.signup_closes_at is required before registration can open."
+            )
+        try:
+            value = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise RegistrationError(
+                "Tournament_Config.signup_closes_at must be an ISO date/time."
+            ) from exc
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return f"<t:{int(value.timestamp())}:F>"
+
+    @staticmethod
+    def _timestamp(raw):
+        try:
+            value = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return int(value.timestamp())
+        except (TypeError, ValueError):
+            return 0
 
     async def _participant_role_id(self):
         cfg, _, _ = await self._bundle()
@@ -388,7 +595,13 @@ class LiveArenaTournamentCog(commands.Cog):
         }
         grouped = {}
         anchor = self._availability_anchor(t.signup_closes_at)
-        for row in raw_slots:
+        enabled_rows = [
+            r for r in raw_slots if truthy(r.get("enabled", r.get("active", True)))
+        ]
+        enabled_ids = {str(r.get("slot_id")) for r in enabled_rows}
+        selected &= enabled_ids
+        ordered_windows = []
+        for row in enabled_rows:
             if str(row.get("slot_id")) not in selected:
                 continue
             slot = AvailabilitySlot(
@@ -396,11 +609,20 @@ class LiveArenaTournamentCog(commands.Cog):
                 parse_weekday(row["weekday_utc"]),
                 str(row["start_time_utc"]),
                 str(row.get("end_time_utc", "")),
+                True,
+                int(float(row.get("sort_order") or 0)),
+                int(float(row.get("end_day_offset") or 0)),
             )
-            local = slot_local_datetime(
+            from .models import slot_local_window
+
+            start, end = slot_local_window(
                 slot, str(p.get("timezone") or "UTC"), anchor_monday=anchor
             )
-            grouped.setdefault(local.strftime("%A"), []).append(local.strftime("%H:%M"))
+            ordered_windows.append((start, end))
+        for start, end in sorted(ordered_windows):
+            grouped.setdefault(start.strftime("%A"), []).append(
+                f"{start.strftime('%H:%M')}–{end.strftime('%a %H:%M')}"
+            )
         saved = (
             "\n".join(f"{day}: {', '.join(times)}" for day, times in grouped.items())
             or "None saved"
@@ -414,7 +636,7 @@ class LiveArenaTournamentCog(commands.Cog):
         )
 
     async def withdraw(self, interaction):
-        cfg, _, _ = await self._bundle()
+        cfg, tournament, _ = await self._bundle()
         rows = await self.repository.rows("participants")
         p = next(
             (
@@ -426,30 +648,44 @@ class LiveArenaTournamentCog(commands.Cog):
             None,
         )
         if not p:
-            return await self._reply(interaction, "No registration was found.")
-        await self.service.change_participant_status(
+            await self._reply(interaction, "No registration was found.")
+            return False
+        result = await self.service.change_participant_status(
             cfg.active_tournament_id,
             str(interaction.user.id),
             "withdrawn",
             interaction.user.id,
             "self_service_withdrawal",
         )
-        await self._set_participant_role(interaction.user, False)
-        await self.publish_panels(interaction.guild)
-        await self._reply(
-            interaction,
-            await self._message_text(
-                "withdrawal_confirmed",
-                {
-                    "tournament_name": "",
-                    "participant_count": "",
-                    "max_participants": "",
-                    "tournament_status": "withdrawn",
-                    "roster_parity_summary": "",
-                },
-                "Your registration has been withdrawn.",
-            ),
+        warnings = list(result.get("_warnings", ()))
+        try:
+            await self._set_participant_role(interaction.user, False)
+        except Exception as exc:
+            warnings.append(
+                "Your registration was withdrawn, but the Discord role could not be removed."
+            )
+            await self._report_role_failure(interaction.guild, interaction.user, exc)
+        try:
+            await self.publish_panels(interaction.guild)
+        except Exception:
+            log.exception(
+                "live_arena_panel_refresh_failed",
+                extra={"tournament_id": cfg.active_tournament_id},
+            )
+            warnings.append("The registration panels could not be refreshed.")
+        embed = await self._message_embed(
+            "withdrawal_confirmed",
+            {
+                "participant": interaction.user.mention,
+                "tournament_name": tournament.name,
+            },
         )
+        if warnings:
+            embed.add_field(
+                name="⚠️ Withdrawn with warning", value="\n".join(warnings), inline=False
+            )
+        await self._reply(interaction, embed=embed)
+        return True
 
     async def organizer_action(self, action, interaction):
         if action == "refresh_registration":
@@ -463,15 +699,42 @@ class LiveArenaTournamentCog(commands.Cog):
                 r
                 for r in rows
                 if str(r.get("tournament_id")) == cfg.active_tournament_id
-                and norm(r.get("status")) in {"confirmed", "removed", "withdrawn"}
+                and str(r.get("discord_user_id", "")).strip()
             ]
-            body = (
-                "\n".join(
-                    f"`{r.get('participant_slot')}` <@{r.get('discord_user_id')}> — {r.get('status')}"
-                    for r in active
+            availability = await self.repository.rows("participant_availability")
+            counts = {}
+            for row in availability:
+                if (
+                    str(row.get("tournament_id")) == cfg.active_tournament_id
+                    and str(row.get("slot_id", "")).strip()
+                ):
+                    uid = str(row.get("discord_user_id"))
+                    counts[uid] = counts.get(uid, 0) + 1
+            groups = []
+            for status in ("confirmed", "withdrawn", "removed"):
+                groups.append(
+                    (status, [r for r in active if norm(r.get("status")) == status])
                 )
-                or "No registrations."
+            groups.append(
+                (
+                    "other occupied statuses",
+                    [
+                        r
+                        for r in active
+                        if norm(r.get("status"))
+                        not in {"confirmed", "withdrawn", "removed"}
+                    ],
+                )
             )
+            sections = []
+            for label, members in groups:
+                if members:
+                    details = [
+                        f"`{r.get('participant_slot')}` <@{r.get('discord_user_id')}> ({r.get('display_name_at_signup') or 'unknown'}) • clan={r.get('clan_tag_at_signup') or '—'} • tz={r.get('timezone') or '—'} • signed=<t:{self._timestamp(r.get('signed_up_at'))}:f> • windows={counts.get(str(r.get('discord_user_id')), 0)}"
+                        for r in members
+                    ]
+                    sections.append(f"**{label.title()}**\n" + "\n".join(details))
+            body = "\n\n".join(sections) or "No registrations."
             return await self._reply(
                 interaction,
                 body,
@@ -484,6 +747,8 @@ class LiveArenaTournamentCog(commands.Cog):
             "reopen_registration": "signup_open",
         }[action]
         cfg, t, row = await self._bundle()
+        if action in {"open_registration", "reopen_registration"}:
+            self._deadline_text(t.signup_closes_at)
         from .service import LiveArenaService
 
         if not LiveArenaService.can_transition(t.status, desired):
@@ -537,36 +802,43 @@ class LiveArenaTournamentCog(commands.Cog):
             if str(user_id).isdigit()
             else None
         )
-        if status == "confirmed":
-            if tournament.status != "signup_open":
-                raise RegistrationError(
-                    "Participants can only be restored while registration is open."
-                )
-            if not member:
-                raise RegistrationError(
-                    "The participant is no longer a member of this server."
-                )
-            participants = await self.repository.rows("participants")
-            if (
-                self.service.confirmed_count(participants, cfg.active_tournament_id)
-                >= tournament.maximum_participants
-            ):
-                raise RegistrationError("The tournament is at capacity.")
-            clans = await self.repository.rows("eligible_clans")
-            self.service.eligible_clan(
-                [role.id for role in member.roles], clans, cfg.active_tournament_id
-            )
-        await self.service.change_participant_status(
+        clans = (
+            await self.repository.rows("eligible_clans")
+            if status == "confirmed"
+            else []
+        )
+        result = await self.service.change_participant_status(
             cfg.active_tournament_id,
             user_id,
             status,
             interaction.user.id,
             "organizer_action",
+            tournament=tournament if status == "confirmed" else None,
+            member_present=member is not None,
+            member_role_ids=[role.id for role in member.roles] if member else [],
+            eligible_rows=clans,
         )
+        warnings = list(result.get("_warnings", ()))
         if member:
-            await self._set_participant_role(member, status == "confirmed")
-        await self.publish_panels(interaction.guild)
-        await self._reply(interaction, f"Participant status changed to {status}.")
+            try:
+                await self._set_participant_role(member, status == "confirmed")
+            except Exception as exc:
+                warnings.append(
+                    "The participant status was saved, but their Discord role could not be synced."
+                )
+                await self._report_role_failure(interaction.guild, member, exc)
+        try:
+            await self.publish_panels(interaction.guild)
+        except Exception:
+            log.exception(
+                "live_arena_panel_refresh_failed",
+                extra={"tournament_id": cfg.active_tournament_id},
+            )
+            warnings.append("The registration panels could not be refreshed.")
+        suffix = "\n\n⚠️ " + "\n".join(warnings) if warnings else ""
+        await self._reply(
+            interaction, f"Participant status changed to {status}.{suffix}"
+        )
 
     async def reconcile_participant_roles(self, guild):
         cfg, _, _ = await self._bundle()
@@ -660,8 +932,8 @@ class LiveArenaTournamentCog(commands.Cog):
             self.organizer_view.disable_actions(disabled)
         values = {
             "tournament_name": t.name,
-            "signup_closes_at": t.signup_closes_at,
-            "signup_deadline": t.signup_closes_at,
+            "signup_closes_at": self._deadline_text(t.signup_closes_at),
+            "signup_deadline": self._deadline_text(t.signup_closes_at),
             "confirmed_count": count,
             "maximum_participants": t.maximum_participants,
             "minimum_availability": t.minimum_availability,
@@ -715,6 +987,28 @@ class LiveArenaTournamentCog(commands.Cog):
             embed = configured_embed(
                 choose_row(messages, message_key, cfg.active_tournament_id), values
             )
+            if destination_type == "signup":
+                embed.add_field(name="Status", value=t.status, inline=True)
+                embed.add_field(
+                    name="Roster",
+                    value=f"{count}/{t.maximum_participants}",
+                    inline=True,
+                )
+                embed.add_field(
+                    name="Minimum availability",
+                    value=f"{t.minimum_availability} windows across at least 2 local days",
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Signup deadline",
+                    value=self._deadline_text(t.signup_closes_at),
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Roster requirement",
+                    value="The final confirmed roster must contain an even number of players.",
+                    inline=False,
+                )
             stored = state_map.get(state_key)
             message = None
             if stored and str(stored.get("state_value", "")).isdigit():

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -7,8 +7,8 @@ import discord
 from discord.ext import commands
 from c1c_coreops.rbac import is_admin_member
 from shared.config import is_guild_allowed
-from . import config
-from .models import (
+from modules.community.live_arena_tournament import config
+from modules.community.live_arena_tournament.models import (
     AvailabilitySlot,
     RegistrationError,
     Tournament,
@@ -16,16 +16,19 @@ from .models import (
     truthy,
     parse_weekday,
 )
-from .repository import LiveArenaRepository
-from .rendering import choose_row, configured_embed
-from .views import (
+from modules.community.live_arena_tournament.repository import LiveArenaRepository
+from modules.community.live_arena_tournament.rendering import (
+    choose_row,
+    configured_embed,
+)
+from modules.community.live_arena_tournament.views import (
     AvailabilityView,
     ConfirmView,
     PersistentPanel,
     RosterView,
     TimezoneModal,
 )
-from .service import LiveArenaService
+from modules.community.live_arena_tournament.service import LiveArenaService
 
 log = logging.getLogger("c1c.community.live_arena_registration")
 PUBLIC = ("join_tournament", "my_registration", "update_availability", "withdraw")
@@ -63,7 +66,6 @@ class LiveArenaTournamentCog(commands.Cog):
                     "tournament_name",
                     "status",
                     "max_participants",
-                    "minimum_availability",
                     "signup_closes_at",
                     "eligibility_scope",
                 ),
@@ -75,7 +77,6 @@ class LiveArenaTournamentCog(commands.Cog):
                 ),
                 "roles": ("tournament_id", "role_type", "discord_role_id", "active"),
                 "availability_slots": (
-                    "tournament_id",
                     "slot_id",
                     "weekday_utc",
                     "start_time_utc",
@@ -93,6 +94,10 @@ class LiveArenaTournamentCog(commands.Cog):
                     "signed_up_at",
                     "confirmed_at",
                     "withdrawn_at",
+                    "display_name_at_signup",
+                    "clan_tag_at_signup",
+                    "clan_verification_status",
+                    "withdrawal_reason",
                 ),
                 "participant_availability": (
                     "tournament_id",
@@ -156,6 +161,7 @@ class LiveArenaTournamentCog(commands.Cog):
                     str(r.get("tournament_id")) == tid
                     and norm(r.get("destination_key")) == key
                     and truthy(r.get("active"))
+                    and str(r.get("channel_id", "")).strip()
                     for r in loaded["destinations"]
                 ):
                     errors.append(f"Destinations requires active {key} row for {tid}.")
@@ -164,6 +170,7 @@ class LiveArenaTournamentCog(commands.Cog):
                     str(r.get("tournament_id")) == tid
                     and norm(r.get("role_type")) == role_type
                     and truthy(r.get("active"))
+                    and str(r.get("discord_role_id", "")).strip()
                     for r in loaded["roles"]
                 ):
                     errors.append(
@@ -322,8 +329,8 @@ class LiveArenaTournamentCog(commands.Cog):
                 await channel.send(
                     embed=discord.Embed(
                         description=(
-                            f"⚠️ Participant role sync failed for <@{member.id}>. The confirmed "
-                            "registration was retained; run Refresh Registration."
+                            f"⚠️ Participant role sync failed for <@{member.id}>. The Sheet "
+                            "state was retained; Discord role sync failed. Run Refresh Registration."
                         )
                     )
                 )
@@ -406,7 +413,7 @@ class LiveArenaTournamentCog(commands.Cog):
             await self._reply(interaction, str(exc))
 
     async def start_availability(self, interaction, mode, timezone_name):
-        from .models import validate_timezone
+        from modules.community.live_arena_tournament.models import validate_timezone
 
         try:
             timezone_name = validate_timezone(timezone_name)
@@ -613,13 +620,15 @@ class LiveArenaTournamentCog(commands.Cog):
                 int(float(row.get("sort_order") or 0)),
                 int(float(row.get("end_day_offset") or 0)),
             )
-            from .models import slot_local_window
+            from modules.community.live_arena_tournament.models import slot_local_window
 
             start, end = slot_local_window(
                 slot, str(p.get("timezone") or "UTC"), anchor_monday=anchor
             )
             ordered_windows.append((start, end))
-        for start, end in sorted(ordered_windows):
+        for start, end in sorted(
+            ordered_windows, key=lambda pair: (pair[0].weekday(), pair[0].time())
+        ):
             grouped.setdefault(start.strftime("%A"), []).append(
                 f"{start.strftime('%H:%M')}–{end.strftime('%a %H:%M')}"
             )
@@ -749,8 +758,6 @@ class LiveArenaTournamentCog(commands.Cog):
         cfg, t, row = await self._bundle()
         if action in {"open_registration", "reopen_registration"}:
             self._deadline_text(t.signup_closes_at)
-        from .service import LiveArenaService
-
         if not LiveArenaService.can_transition(t.status, desired):
             raise RegistrationError(
                 f"Cannot change registration from {t.status} to {desired}."
@@ -774,6 +781,16 @@ class LiveArenaTournamentCog(commands.Cog):
             cfg.active_tournament_id,
             {"status": t.status},
             {"status": desired},
+        )
+        log.info(
+            "live_arena_registration_state_changed",
+            extra={
+                "tournament_id": cfg.active_tournament_id,
+                "actor_id": interaction.user.id,
+                "old_status": t.status,
+                "new_status": desired,
+                "action": action,
+            },
         )
         await self.publish_panels(interaction.guild)
         warning = (
@@ -875,6 +892,7 @@ class LiveArenaTournamentCog(commands.Cog):
                         member.id,
                         exc,
                     )
+                    await self._report_role_failure(guild, member, exc)
         for user_id in wanted:
             member = guild.get_member(user_id)
             if member and role not in member.roles:
@@ -895,6 +913,7 @@ class LiveArenaTournamentCog(commands.Cog):
                     log.error(
                         "Live Arena role reconciliation failed for %s: %s", user_id, exc
                     )
+                    await self._report_role_failure(guild, member, exc)
 
     async def publish_panels(self, guild):
         cfg, t, _ = await self._bundle()

--- a/modules/community/live_arena_tournament/cog.py
+++ b/modules/community/live_arena_tournament/cog.py
@@ -1,0 +1,386 @@
+"""Discord integration for the Live Arena registration-only workflow."""
+
+from __future__ import annotations
+import logging
+import discord
+from discord.ext import commands
+from c1c_coreops.rbac import is_admin_member
+from shared.config import is_guild_allowed
+from . import config
+from .models import RegistrationError, Tournament, norm, truthy
+from .repository import LiveArenaRepository
+from .rendering import choose_row, configured_embed
+from .views import ConfirmView, PersistentPanel, TimezoneModal
+
+log = logging.getLogger("c1c.community.live_arena_registration")
+PUBLIC = ("join_tournament", "my_registration", "update_availability", "withdraw")
+ORGANIZER = (
+    "open_registration",
+    "close_registration",
+    "reopen_registration",
+    "view_roster",
+    "refresh_registration",
+)
+
+
+class LiveArenaTournamentCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.repository = (
+            LiveArenaRepository(config.sheet_id()) if config.enabled() else None
+        )
+        self.public_view = None
+        self.organizer_view = None
+
+    async def prepare(self):
+        if not self.repository:
+            log.warning(
+                "Live Arena registration disabled: LIVE_ARENA_TOURNAMENT_SHEET_ID is missing"
+            )
+            return False
+        try:
+            cfg = await self.repository.load_config()
+            components = await self.repository.rows("message_components", ("label",))
+            self.public_view = PersistentPanel(self, components, PUBLIC)
+            self.organizer_view = PersistentPanel(self, components, ORGANIZER)
+            log.info(
+                "Live Arena workbook schema loaded",
+                extra={"tournament_id": cfg.active_tournament_id},
+            )
+            return True
+        except Exception:
+            log.exception(
+                "Live Arena registration disabled: actionable workbook/schema load failure"
+            )
+            self.repository = None
+            return False
+
+    async def _bundle(self):
+        if not self.repository:
+            raise RegistrationError("Live Arena registration is disabled.")
+        cfg = self.repository.config or await self.repository.load_config()
+        rows = await self.repository.rows(
+            "tournament_config", ("tournament_id", "status")
+        )
+        row = next(
+            (
+                r
+                for r in rows
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+            ),
+            None,
+        )
+        if not row:
+            raise RegistrationError(
+                "The active tournament is missing from Tournament_Config."
+            )
+        tournament = Tournament(
+            cfg.active_tournament_id,
+            str(row.get("tournament_name", row.get("name", ""))),
+            norm(row["status"]),
+            int(row.get("maximum_participants", row.get("max_participants", 0))),
+            int(row.get("minimum_availability", 3)),
+            str(row.get("signup_deadline", "")),
+            norm(row.get("eligibility_scope", "selected_clans")),
+        )
+        return cfg, tournament, row
+
+    async def _organizer(self, member):
+        if is_admin_member(member):
+            return True
+        cfg, _, _ = await self._bundle()
+        rows = await self.repository.rows(
+            "tournament_roles", ("role_type", "discord_role_id")
+        )
+        ids = {
+            str(r["discord_role_id"])
+            for r in rows
+            if str(r.get("tournament_id")) == cfg.active_tournament_id
+            and norm(r.get("role_type")) == "organizer"
+            and truthy(r.get("active", True))
+        }
+        return any(str(r.id) in ids for r in member.roles)
+
+    async def _reply(self, interaction, description, title="Live Arena", view=None):
+        embed = discord.Embed(title=title, description=description)
+        target = (
+            interaction.followup.send
+            if interaction.response.is_done()
+            else interaction.response.send_message
+        )
+        await target(embed=embed, view=view, ephemeral=True)
+
+    async def handle_action(self, action, interaction):
+        try:
+            if not interaction.guild or not is_guild_allowed(interaction.guild.id):
+                raise RegistrationError("This action is not available in this server.")
+            if action in ORGANIZER:
+                if not await self._organizer(interaction.user):
+                    raise RegistrationError("Tournament organizer access is required.")
+                return await self.organizer_action(action, interaction)
+            if action in {"join_tournament", "update_availability"}:
+                return await interaction.response.send_modal(
+                    TimezoneModal(
+                        self, "join" if action == "join_tournament" else "update"
+                    )
+                )
+            if action == "my_registration":
+                return await self.show_registration(interaction)
+            if action == "withdraw":
+                return await self._reply(
+                    interaction,
+                    "Confirm this registration withdrawal.",
+                    view=ConfirmView(self.withdraw),
+                )
+        except Exception as exc:
+            await self._reply(interaction, str(exc))
+
+    async def start_availability(self, interaction, mode, timezone_name):
+        # Sessions deliberately remain ephemeral and write nothing. The day/select review UI is built from current slots.
+        from .models import validate_timezone
+
+        try:
+            validate_timezone(timezone_name)
+            await self._reply(
+                interaction,
+                "Your timezone is valid. Choose availability windows in the configured day selectors, then review and submit.",
+            )
+        except RegistrationError as exc:
+            await self._reply(interaction, str(exc))
+
+    async def show_registration(self, interaction):
+        cfg, t, _ = await self._bundle()
+        rows = await self.repository.rows("participants")
+        p = next(
+            (
+                r
+                for r in rows
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+                and str(r.get("discord_user_id")) == str(interaction.user.id)
+            ),
+            None,
+        )
+        await self._reply(
+            interaction,
+            "No registration was found."
+            if not p
+            else f"**{t.name}**\nStatus: {p.get('status')}\nName: {p.get('display_name_at_signup')}\nClan: {p.get('clan_tag_at_signup')}\nTimezone: {p.get('timezone')}",
+        )
+
+    async def withdraw(self, interaction):
+        cfg, _, _ = await self._bundle()
+        rows = await self.repository.rows("participants")
+        p = next(
+            (
+                r
+                for r in rows
+                if str(r.get("tournament_id")) == cfg.active_tournament_id
+                and str(r.get("discord_user_id")) == str(interaction.user.id)
+            ),
+            None,
+        )
+        if not p:
+            return await self._reply(interaction, "No registration was found.")
+        import datetime
+
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        rn = int(p.get("_row_number") or rows.index(p) + 2)
+        await self.repository.replace_row(
+            "participants",
+            rn,
+            {
+                "status": "withdrawn",
+                "withdrawn_at": now,
+                "withdrawal_reason": "self_service_withdrawal",
+            },
+        )
+        await self.repository.audit(
+            "registration_withdrawn",
+            cfg.active_tournament_id,
+            interaction.user.id,
+            "participant",
+            interaction.user.id,
+            p,
+            {"status": "withdrawn"},
+        )
+        await self._reply(interaction, "Your registration has been withdrawn.")
+
+    async def organizer_action(self, action, interaction):
+        if action == "refresh_registration":
+            await self.publish_panels(interaction.guild)
+            return await self._reply(interaction, "Registration panels refreshed.")
+        if action == "view_roster":
+            return await self._reply(
+                interaction,
+                "The current roster was loaded from the registration workbook.",
+            )
+        desired = {
+            "open_registration": "signup_open",
+            "close_registration": "signup_closed",
+            "reopen_registration": "signup_open",
+        }[action]
+        cfg, t, row = await self._bundle()
+        from .service import LiveArenaService
+
+        if not LiveArenaService.can_transition(t.status, desired):
+            raise RegistrationError(
+                f"Cannot change registration from {t.status} to {desired}."
+            )
+        rows = await self.repository.rows("tournament_config")
+        rn = int(row.get("_row_number") or rows.index(row) + 2)
+        await self.repository.replace_row("tournament_config", rn, {"status": desired})
+        event = (
+            {
+                "signup_open": "registration_opened",
+                "signup_closed": "registration_closed",
+            }[desired]
+            if action != "reopen_registration"
+            else "registration_reopened"
+        )
+        await self.repository.audit(
+            event,
+            cfg.active_tournament_id,
+            interaction.user.id,
+            "tournament",
+            cfg.active_tournament_id,
+            {"status": t.status},
+            {"status": desired},
+        )
+        await self.publish_panels(interaction.guild)
+        await self._reply(interaction, f"Registration status is now {desired}.")
+
+    async def publish_panels(self, guild):
+        cfg, t, _ = await self._bundle()
+        destinations = await self.repository.rows(
+            "destinations", ("destination_type", "discord_channel_id")
+        )
+        messages = await self.repository.rows("messages")
+        participants = await self.repository.rows("participants")
+        states = await self.repository.rows("bot_state", ("state_key", "state_value"))
+        count = sum(
+            str(p.get("tournament_id")) == cfg.active_tournament_id
+            and norm(p.get("status")) == "confirmed"
+            for p in participants
+        )
+        values = {
+            "tournament_name": t.name,
+            "signup_deadline": t.signup_deadline,
+            "confirmed_count": count,
+            "maximum_participants": t.maximum_participants,
+            "minimum_availability": t.minimum_availability,
+            "status": t.status,
+        }
+        state_map = {
+            norm(x.get("state_key")): x
+            for x in states
+            if str(x.get("tournament_id", cfg.active_tournament_id))
+            in ("", cfg.active_tournament_id)
+        }
+        for destination_type, state_key, message_key, view in (
+            (
+                "signup",
+                "signup_message_id",
+                "signup_open" if t.status == "signup_open" else "signup_closed",
+                self.public_view,
+            ),
+            (
+                "organizer_log",
+                "registration_organizer_message_id",
+                "registration_organizer",
+                self.organizer_view,
+            ),
+        ):
+            dest = next(
+                (
+                    d
+                    for d in destinations
+                    if str(d.get("tournament_id")) == cfg.active_tournament_id
+                    and norm(d.get("destination_type", d.get("purpose")))
+                    == destination_type
+                    and truthy(d.get("active", True))
+                ),
+                None,
+            )
+            if not dest:
+                raise RegistrationError(
+                    f"Destinations has no active {destination_type} row for the active tournament."
+                )
+            channel = guild.get_channel(int(dest["discord_channel_id"]))
+            if not channel:
+                raise RegistrationError(
+                    f"Configured {destination_type} destination is unavailable to the bot."
+                )
+            embed = configured_embed(
+                choose_row(messages, message_key, cfg.active_tournament_id), values
+            )
+            stored = state_map.get(state_key)
+            message = None
+            if stored and str(stored.get("state_value", "")).isdigit():
+                try:
+                    message = await channel.fetch_message(int(stored["state_value"]))
+                    await message.edit(embed=embed, view=view)
+                    log.info(
+                        "Live Arena registration panel edited",
+                        extra={"panel": destination_type},
+                    )
+                except discord.NotFound:
+                    log.warning(
+                        "Live Arena registration panel missing; rebuilding",
+                        extra={"panel": destination_type},
+                    )
+            if not message:
+                message = await channel.send(embed=embed, view=view)
+                now = (
+                    __import__("datetime")
+                    .datetime.now(__import__("datetime").timezone.utc)
+                    .isoformat()
+                )
+                if stored:
+                    await self.repository.replace_row(
+                        "bot_state",
+                        int(stored.get("_row_number") or states.index(stored) + 2),
+                        {"state_value": str(message.id), "updated_at": now},
+                    )
+                else:
+                    await self.repository.append(
+                        "bot_state",
+                        {
+                            "tournament_id": cfg.active_tournament_id,
+                            "state_key": state_key,
+                            "state_value": str(message.id),
+                            "updated_at": now,
+                        },
+                    )
+                await self.repository.audit(
+                    "registration_panel_rebuilt",
+                    cfg.active_tournament_id,
+                    self.bot.user.id,
+                    "message",
+                    message.id,
+                    {},
+                    {"panel": destination_type},
+                )
+                log.info(
+                    "Live Arena registration panel published",
+                    extra={"panel": destination_type},
+                )
+
+    @commands.group(name="latournament", invoke_without_command=True)
+    async def latournament(self, ctx):
+        await ctx.send(
+            embed=discord.Embed(
+                description="Use the configured registration bootstrap action."
+            )
+        )
+
+    @latournament.command(name="registration")
+    async def registration_bootstrap(self, ctx):
+        try:
+            if not await self._organizer(ctx.author):
+                raise RegistrationError("Tournament organizer access is required.")
+            await self.publish_panels(ctx.guild)
+            await ctx.send(
+                embed=discord.Embed(description="Registration panels are ready.")
+            )
+        except Exception as exc:
+            await ctx.send(embed=discord.Embed(description=str(exc)))

--- a/modules/community/live_arena_tournament/config.py
+++ b/modules/community/live_arena_tournament/config.py
@@ -9,9 +9,9 @@ from .models import SchemaError, norm
 ENV_KEY = "LIVE_ARENA_TOURNAMENT_SHEET_ID"
 REQUIRED_TABLE_KEYS = frozenset(
     {
-        "tournament_config",
+        "tournaments",
         "eligible_clans",
-        "tournament_roles",
+        "roles",
         "destinations",
         "participants",
         "availability_slots",

--- a/modules/community/live_arena_tournament/config.py
+++ b/modules/community/live_arena_tournament/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping
 from shared.config import cfg
-from .models import SchemaError, norm
+from modules.community.live_arena_tournament.models import SchemaError, norm
 
 ENV_KEY = "LIVE_ARENA_TOURNAMENT_SHEET_ID"
 REQUIRED_TABLE_KEYS = frozenset(

--- a/modules/community/live_arena_tournament/config.py
+++ b/modules/community/live_arena_tournament/config.py
@@ -44,7 +44,7 @@ def parse_system_config(
     values: list[list[object]], configured_sheet_id: str
 ) -> FeatureConfig:
     if not values:
-        raise SchemaError("System_Config (the workbook's first tab) is empty")
+        raise SchemaError("System_Config is empty")
     headers = [norm(x) for x in values[0]]
     key_aliases = ("key", "config_key", "setting")
     value_aliases = ("value", "config_value", "setting_value")

--- a/modules/community/live_arena_tournament/config.py
+++ b/modules/community/live_arena_tournament/config.py
@@ -1,0 +1,75 @@
+"""Environment and dynamically routed workbook configuration."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Mapping
+from shared.config import cfg
+from .models import SchemaError, norm
+
+ENV_KEY = "LIVE_ARENA_TOURNAMENT_SHEET_ID"
+REQUIRED_TABLE_KEYS = frozenset(
+    {
+        "tournament_config",
+        "eligible_clans",
+        "tournament_roles",
+        "destinations",
+        "participants",
+        "availability_slots",
+        "participant_availability",
+        "messages",
+        "message_components",
+        "bot_state",
+        "audit_log",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureConfig:
+    sheet_id: str
+    active_tournament_id: str
+    tabs: Mapping[str, str]
+    values: Mapping[str, str]
+
+
+def sheet_id() -> str:
+    return str(cfg.get(ENV_KEY, "") or "").strip()
+
+
+def enabled() -> bool:
+    return bool(sheet_id())
+
+
+def parse_system_config(
+    values: list[list[object]], configured_sheet_id: str
+) -> FeatureConfig:
+    if not values:
+        raise SchemaError("System_Config (the workbook's first tab) is empty")
+    headers = [norm(x) for x in values[0]]
+    key_aliases = ("key", "config_key", "setting")
+    value_aliases = ("value", "config_value", "setting_value")
+    try:
+        ki = next(headers.index(k) for k in key_aliases if k in headers)
+        vi = next(headers.index(k) for k in value_aliases if k in headers)
+    except StopIteration:
+        raise SchemaError("System_Config requires normalized key and value headers")
+    config = {
+        norm(row[ki]): str(row[vi]).strip()
+        for row in values[1:]
+        if len(row) > max(ki, vi) and str(row[ki]).strip()
+    }
+    active = config.get("active_tournament_id", "")
+    if not active:
+        raise SchemaError("System_Config is missing active_tournament_id")
+    tabs = {
+        k[4:]: v
+        for k, v in config.items()
+        if (k.startswith("tab_") or k.startswith("tab.")) and v
+    }
+    missing = sorted(REQUIRED_TABLE_KEYS - tabs.keys())
+    if missing:
+        raise SchemaError(
+            "System_Config is missing required tab.* routing keys: "
+            + ", ".join(f"tab.{x}" for x in missing)
+        )
+    return FeatureConfig(configured_sheet_id, active, tabs, config)

--- a/modules/community/live_arena_tournament/models.py
+++ b/modules/community/live_arena_tournament/models.py
@@ -52,6 +52,28 @@ class AvailabilitySlot:
     sort_order: int = 0
 
 
+WEEKDAYS = {
+    name.lower(): index
+    for index, name in enumerate(
+        ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+    )
+}
+
+
+def parse_weekday(value: object) -> int:
+    """Accept the workbook's weekday names (and legacy zero-based numbers)."""
+    text = str(value).strip()
+    if text.lower() in WEEKDAYS:
+        return WEEKDAYS[text.lower()]
+    try:
+        number = int(text)
+    except ValueError as exc:
+        raise SchemaError(f"Invalid weekday_utc value: {value!r}") from exc
+    if not 0 <= number <= 6:
+        raise SchemaError(f"weekday_utc must be Monday-Sunday or 0-6: {value!r}")
+    return number
+
+
 @dataclass(slots=True)
 class Participant:
     participant_slot: int

--- a/modules/community/live_arena_tournament/models.py
+++ b/modules/community/live_arena_tournament/models.py
@@ -50,6 +50,7 @@ class AvailabilitySlot:
     end_time_utc: str
     enabled: bool = True
     sort_order: int = 0
+    end_day_offset: int = 0
 
 
 WEEKDAYS = {
@@ -110,11 +111,28 @@ def slot_local_datetime(
     return value.astimezone(ZoneInfo(timezone_name))
 
 
+def slot_local_window(
+    slot: AvailabilitySlot, timezone_name: str, *, anchor_monday: datetime
+) -> tuple[datetime, datetime]:
+    """Return the configured UTC window converted using one explicit DST anchor."""
+    start = slot_local_datetime(slot, timezone_name, anchor_monday=anchor_monday)
+    end_text = slot.end_time_utc or slot.start_time_utc
+    hour, minute = map(int, end_text.split(":")[:2])
+    end_utc = anchor_monday.replace(hour=hour, minute=minute) + timedelta(
+        days=slot.weekday_utc + slot.end_day_offset
+    )
+    if not slot.end_day_offset and end_utc <= start.astimezone(timezone.utc):
+        end_utc += timedelta(days=1)
+    return start, end_utc.astimezone(ZoneInfo(timezone_name))
+
+
 def validate_availability(
     selected: list[str],
     slots: list[AvailabilitySlot],
     timezone_name: str,
     minimum: int = 3,
+    *,
+    anchor_monday: datetime | None = None,
 ) -> list[str]:
     unique = list(dict.fromkeys(selected))
     enabled = {s.slot_id: s for s in slots if s.enabled}
@@ -125,8 +143,16 @@ def validate_availability(
         )
     if len(unique) < minimum:
         raise AvailabilityError(f"Select at least {minimum} availability windows.")
+    if anchor_monday is None:
+        now = datetime.now(timezone.utc)
+        anchor_monday = (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
     days = {
-        slot_local_datetime(enabled[item], timezone_name).weekday() for item in unique
+        slot_local_datetime(
+            enabled[item], timezone_name, anchor_monday=anchor_monday
+        ).weekday()
+        for item in unique
     }
     if len(days) < 2:
         raise AvailabilityError("Availability must cover at least two local weekdays.")

--- a/modules/community/live_arena_tournament/models.py
+++ b/modules/community/live_arena_tournament/models.py
@@ -31,15 +31,23 @@ class AvailabilityError(RegistrationError):
     pass
 
 
+REQUIRED_AVAILABILITY_WINDOWS = 3
+REQUIRED_LOCAL_AVAILABILITY_DAYS = 2
+
+
 @dataclass(slots=True)
 class Tournament:
     tournament_id: str
     name: str
     status: str
     maximum_participants: int
-    minimum_availability: int = 3
     signup_closes_at: str = ""
     eligibility_scope: str = "selected_clans"
+
+    @property
+    def minimum_availability(self) -> int:
+        """Return the trial's fixed code rule; this is not workbook configuration."""
+        return REQUIRED_AVAILABILITY_WINDOWS
 
 
 @dataclass(slots=True)
@@ -130,7 +138,7 @@ def validate_availability(
     selected: list[str],
     slots: list[AvailabilitySlot],
     timezone_name: str,
-    minimum: int = 3,
+    minimum: int = REQUIRED_AVAILABILITY_WINDOWS,
     *,
     anchor_monday: datetime | None = None,
 ) -> list[str]:
@@ -154,6 +162,6 @@ def validate_availability(
         ).weekday()
         for item in unique
     }
-    if len(days) < 2:
+    if len(days) < REQUIRED_LOCAL_AVAILABILITY_DAYS:
         raise AvailabilityError("Availability must cover at least two local weekdays.")
     return unique

--- a/modules/community/live_arena_tournament/models.py
+++ b/modules/community/live_arena_tournament/models.py
@@ -1,0 +1,110 @@
+"""Workbook-neutral models and validation for Live Arena registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def norm(value: object) -> str:
+    return "_".join(str(value or "").strip().lower().replace("-", " ").split())
+
+
+def truthy(value: object) -> bool:
+    return norm(value) in {"1", "true", "yes", "y", "active", "enabled"}
+
+
+class LiveArenaError(RuntimeError):
+    pass
+
+
+class SchemaError(LiveArenaError):
+    pass
+
+
+class RegistrationError(LiveArenaError):
+    pass
+
+
+class AvailabilityError(RegistrationError):
+    pass
+
+
+@dataclass(slots=True)
+class Tournament:
+    tournament_id: str
+    name: str
+    status: str
+    maximum_participants: int
+    minimum_availability: int = 3
+    signup_deadline: str = ""
+    eligibility_scope: str = "selected_clans"
+
+
+@dataclass(slots=True)
+class AvailabilitySlot:
+    slot_id: str
+    weekday_utc: int
+    start_time_utc: str
+    end_time_utc: str
+    enabled: bool = True
+    sort_order: int = 0
+
+
+@dataclass(slots=True)
+class Participant:
+    participant_slot: int
+    tournament_id: str
+    discord_user_id: str = ""
+    status: str = "open"
+    display_name_at_signup: str = ""
+    clan_tag_at_signup: str = ""
+    timezone: str = "UTC"
+    values: dict[str, object] = field(default_factory=dict)
+    row_number: int = 0
+
+
+def validate_timezone(name: str) -> str:
+    candidate = name.strip()
+    try:
+        ZoneInfo(candidate)
+    except (ZoneInfoNotFoundError, ValueError):
+        raise RegistrationError(
+            "Enter a valid IANA timezone, for example Europe/Vienna, America/New_York, Asia/Kolkata, or Australia/Sydney."
+        )
+    return candidate
+
+
+def slot_local_datetime(
+    slot: AvailabilitySlot, timezone_name: str, *, anchor_monday: datetime | None = None
+) -> datetime:
+    anchor = anchor_monday or datetime(2026, 1, 5, tzinfo=timezone.utc)
+    hour, minute = map(int, slot.start_time_utc.split(":")[:2])
+    value = anchor.replace(hour=hour, minute=minute) + __import__("datetime").timedelta(
+        days=slot.weekday_utc
+    )
+    return value.astimezone(ZoneInfo(timezone_name))
+
+
+def validate_availability(
+    selected: list[str],
+    slots: list[AvailabilitySlot],
+    timezone_name: str,
+    minimum: int = 3,
+) -> list[str]:
+    unique = list(dict.fromkeys(selected))
+    enabled = {s.slot_id: s for s in slots if s.enabled}
+    invalid = [item for item in unique if item not in enabled]
+    if invalid:
+        raise AvailabilityError(
+            "One or more selected availability windows are no longer enabled."
+        )
+    if len(unique) < minimum:
+        raise AvailabilityError(f"Select at least {minimum} availability windows.")
+    days = {
+        slot_local_datetime(enabled[item], timezone_name).weekday() for item in unique
+    }
+    if len(days) < 2:
+        raise AvailabilityError("Availability must cover at least two local weekdays.")
+    return unique

--- a/modules/community/live_arena_tournament/models.py
+++ b/modules/community/live_arena_tournament/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
@@ -38,7 +38,7 @@ class Tournament:
     status: str
     maximum_participants: int
     minimum_availability: int = 3
-    signup_deadline: str = ""
+    signup_closes_at: str = ""
     eligibility_scope: str = "selected_clans"
 
 
@@ -101,11 +101,12 @@ def validate_timezone(name: str) -> str:
 def slot_local_datetime(
     slot: AvailabilitySlot, timezone_name: str, *, anchor_monday: datetime | None = None
 ) -> datetime:
-    anchor = anchor_monday or datetime(2026, 1, 5, tzinfo=timezone.utc)
-    hour, minute = map(int, slot.start_time_utc.split(":")[:2])
-    value = anchor.replace(hour=hour, minute=minute) + __import__("datetime").timedelta(
-        days=slot.weekday_utc
+    now = datetime.now(timezone.utc)
+    anchor = anchor_monday or (now - timedelta(days=now.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
     )
+    hour, minute = map(int, slot.start_time_utc.split(":")[:2])
+    value = anchor.replace(hour=hour, minute=minute) + timedelta(days=slot.weekday_utc)
     return value.astimezone(ZoneInfo(timezone_name))
 
 

--- a/modules/community/live_arena_tournament/rendering.py
+++ b/modules/community/live_arena_tournament/rendering.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import string
 import discord
-from .models import SchemaError, norm, truthy
+from modules.community.live_arena_tournament.models import SchemaError, norm, truthy
 
 
 def choose_row(rows, key, tournament_id):
@@ -52,7 +52,7 @@ def configured_embed(row, values):
         .lstrip("#")
     )
     try:
-        color = int(raw, 16)
+        EMBED_COLOR = int(raw, 16)
     except ValueError:
-        color = 0
-    return discord.Embed(title=title, description=body, colour=color)
+        EMBED_COLOR = 0
+    return discord.Embed(title=title, description=body, colour=EMBED_COLOR)

--- a/modules/community/live_arena_tournament/rendering.py
+++ b/modules/community/live_arena_tournament/rendering.py
@@ -1,0 +1,39 @@
+"""Configured Discord embed rendering."""
+
+from __future__ import annotations
+import discord
+from .models import norm, truthy
+
+
+def choose_row(rows, key, tournament_id):
+    candidates = [
+        r
+        for r in rows
+        if norm(r.get("message_key", r.get("key"))) == norm(key)
+        and truthy(r.get("active", True))
+    ]
+    return next(
+        (r for r in candidates if str(r.get("tournament_id", "")) == tournament_id),
+        next(
+            (r for r in candidates if not str(r.get("tournament_id", "")).strip()), None
+        ),
+    )
+
+
+def configured_embed(row, values):
+    if not row:
+        return discord.Embed()
+
+    class Safe(dict):
+        def __missing__(self, key):
+            return "{" + key + "}"
+
+    fmt = Safe(values)
+    title = str(row.get("title", "")).format_map(fmt)
+    body = str(row.get("description", row.get("content", ""))).format_map(fmt)
+    raw = str(row.get("color", row.get("colour", "0"))).strip().lstrip("#")
+    try:
+        color = int(raw, 16)
+    except ValueError:
+        color = 0
+    return discord.Embed(title=title, description=body, colour=color)

--- a/modules/community/live_arena_tournament/rendering.py
+++ b/modules/community/live_arena_tournament/rendering.py
@@ -29,9 +29,15 @@ def configured_embed(row, values):
             return "{" + key + "}"
 
     fmt = Safe(values)
-    title = str(row.get("title", "")).format_map(fmt)
-    body = str(row.get("description", row.get("content", ""))).format_map(fmt)
-    raw = str(row.get("color", row.get("colour", "0"))).strip().lstrip("#")
+    title = str(row.get("title_template", row.get("title", ""))).format_map(fmt)
+    body = str(
+        row.get("body_template", row.get("description", row.get("content", "")))
+    ).format_map(fmt)
+    raw = (
+        str(row.get("embed_color_hex", row.get("color", row.get("colour", "0"))))
+        .strip()
+        .lstrip("#")
+    )
     try:
         color = int(raw, 16)
     except ValueError:

--- a/modules/community/live_arena_tournament/rendering.py
+++ b/modules/community/live_arena_tournament/rendering.py
@@ -10,8 +10,7 @@ def choose_row(rows, key, tournament_id):
     candidates = [
         r
         for r in rows
-        if norm(r.get("message_key", r.get("key"))) == norm(key)
-        and truthy(r.get("active", True))
+        if norm(r.get("message_key")) == norm(key) and truthy(r.get("active"))
     ]
     return next(
         (r for r in candidates if str(r.get("tournament_id", "")) == tournament_id),
@@ -24,10 +23,8 @@ def choose_row(rows, key, tournament_id):
 def configured_embed(row, values):
     if not row:
         raise SchemaError("Required configured message row is missing.")
-    title_template = str(row.get("title_template", row.get("title", "")))
-    body_template = str(
-        row.get("body_template", row.get("description", row.get("content", "")))
-    )
+    title_template = str(row.get("title_template", ""))
+    body_template = str(row.get("body_template", ""))
     required = {
         name
         for template in (title_template, body_template)
@@ -46,11 +43,7 @@ def configured_embed(row, values):
         raise SchemaError(f"Invalid configured message template: {exc}") from exc
     if "{" in title or "{" in body:
         raise SchemaError("Configured message contains an unresolved placeholder.")
-    raw = (
-        str(row.get("embed_color_hex", row.get("color", row.get("colour", "0"))))
-        .strip()
-        .lstrip("#")
-    )
+    raw = str(row.get("embed_color_hex", "0")).strip().lstrip("#")
     try:
         EMBED_COLOR = int(raw, 16)
     except ValueError:

--- a/modules/community/live_arena_tournament/rendering.py
+++ b/modules/community/live_arena_tournament/rendering.py
@@ -1,8 +1,9 @@
 """Configured Discord embed rendering."""
 
 from __future__ import annotations
+import string
 import discord
-from .models import norm, truthy
+from .models import SchemaError, norm, truthy
 
 
 def choose_row(rows, key, tournament_id):
@@ -22,17 +23,29 @@ def choose_row(rows, key, tournament_id):
 
 def configured_embed(row, values):
     if not row:
-        return discord.Embed()
-
-    class Safe(dict):
-        def __missing__(self, key):
-            return "{" + key + "}"
-
-    fmt = Safe(values)
-    title = str(row.get("title_template", row.get("title", ""))).format_map(fmt)
-    body = str(
+        raise SchemaError("Required configured message row is missing.")
+    title_template = str(row.get("title_template", row.get("title", "")))
+    body_template = str(
         row.get("body_template", row.get("description", row.get("content", "")))
-    ).format_map(fmt)
+    )
+    required = {
+        name
+        for template in (title_template, body_template)
+        for _, name, _, _ in string.Formatter().parse(template)
+        if name
+    }
+    missing = sorted(
+        name for name in required if name not in values or values[name] is None
+    )
+    if missing:
+        raise SchemaError("Message template requires values: " + ", ".join(missing))
+    try:
+        title = title_template.format_map(values)
+        body = body_template.format_map(values)
+    except (KeyError, ValueError) as exc:
+        raise SchemaError(f"Invalid configured message template: {exc}") from exc
+    if "{" in title or "{" in body:
+        raise SchemaError("Configured message contains an unresolved placeholder.")
     raw = (
         str(row.get("embed_color_hex", row.get("color", row.get("colour", "0"))))
         .strip()

--- a/modules/community/live_arena_tournament/repository.py
+++ b/modules/community/live_arena_tournament/repository.py
@@ -22,7 +22,7 @@ class LiveArenaRepository:
 
     async def load_config(self):
         self.config = parse_system_config(
-            await asheets_read(self.sheet_id, "A:Z"), self.sheet_id
+            await asheets_read(self.sheet_id, "'System_Config'!A:Z"), self.sheet_id
         )
         return self.config
 
@@ -31,6 +31,8 @@ class LiveArenaRepository:
             await self.load_config()
         rows = await afetch_records(self.sheet_id, self.config.tabs[table])
         normalized = [{norm(k): v for k, v in r.items()} for r in rows]
+        for index, row in enumerate(normalized, 2):
+            row.setdefault("_row_number", index)
         present = {norm(k) for r in normalized for k in r}
         missing = {norm(x) for x in required} - present
         if missing:
@@ -176,6 +178,14 @@ class LiveArenaRepository:
                     ws.update,
                     f"A{row_number}:{self._column(len(headers))}{row_number}",
                     [old + [""] * (len(headers) - len(old))],
+                    value_input_option="RAW",
+                )
+            appended = max(0, len(slot_ids) - len(matches))
+            for row_number in range(len(values) + 1, len(values) + appended + 1):
+                await acall_with_backoff(
+                    ws.update,
+                    f"A{row_number}:{self._column(len(headers))}{row_number}",
+                    [[""] * len(headers)],
                     value_input_option="RAW",
                 )
             raise

--- a/modules/community/live_arena_tournament/repository.py
+++ b/modules/community/live_arena_tournament/repository.py
@@ -1,0 +1,181 @@
+"""Async, header-addressed Sheets repository with compensating writes."""
+
+from __future__ import annotations
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Iterable
+from shared.sheets.async_core import (
+    acall_with_backoff,
+    afetch_records,
+    asheets_read,
+    aget_worksheet,
+)
+from .config import FeatureConfig, parse_system_config
+from .models import SchemaError, norm
+
+
+class LiveArenaRepository:
+    def __init__(self, sheet_id: str):
+        self.sheet_id = sheet_id
+        self.config: FeatureConfig | None = None
+
+    async def load_config(self):
+        self.config = parse_system_config(
+            await asheets_read(self.sheet_id, "A:Z"), self.sheet_id
+        )
+        return self.config
+
+    async def rows(self, table: str, required: Iterable[str] = ()):
+        if not self.config:
+            await self.load_config()
+        rows = await afetch_records(self.sheet_id, self.config.tabs[table])
+        normalized = [{norm(k): v for k, v in r.items()} for r in rows]
+        present = {norm(k) for r in normalized for k in r}
+        missing = {norm(x) for x in required} - present
+        if missing:
+            raise SchemaError(
+                f"{table} is missing required headers: {', '.join(sorted(missing))}"
+            )
+        return normalized
+
+    async def _values(self, table):
+        ws = await aget_worksheet(self.sheet_id, self.config.tabs[table])
+        values = await acall_with_backoff(ws.get_all_values)
+        return ws, values
+
+    async def replace_row(self, table: str, row_number: int, changes: dict[str, Any]):
+        ws, values = await self._values(table)
+        headers = [norm(x) for x in values[0]]
+        missing = set(map(norm, changes)) - set(headers)
+        if missing:
+            raise SchemaError(
+                f"{table} is missing required headers: {', '.join(sorted(missing))}"
+            )
+        original = list(values[row_number - 1])
+        original += [""] * (len(headers) - len(original))
+        updated = list(original)
+        for k, v in changes.items():
+            updated[headers.index(norm(k))] = v
+        await acall_with_backoff(
+            ws.update,
+            f"A{row_number}:{self._column(len(headers))}{row_number}",
+            [updated],
+            value_input_option="RAW",
+        )
+        return original
+
+    async def append(self, table, changes):
+        ws, values = await self._values(table)
+        headers = [norm(x) for x in values[0]]
+        missing = set(map(norm, changes)) - set(headers)
+        if missing:
+            raise SchemaError(
+                f"{table} is missing required headers: {', '.join(sorted(missing))}"
+            )
+        await acall_with_backoff(
+            ws.append_row,
+            [changes.get(h, "") for h in headers],
+            value_input_option="RAW",
+        )
+
+    async def audit(
+        self,
+        event_type,
+        tournament_id,
+        actor,
+        entity_type,
+        entity_id,
+        old,
+        new,
+        notes="",
+    ):
+        await self.append(
+            "audit_log",
+            {
+                "event_id": str(uuid.uuid4()),
+                "tournament_id": tournament_id,
+                "event_type": event_type,
+                "actor_discord_user_id": str(actor),
+                "entity_type": entity_type,
+                "entity_id": str(entity_id),
+                "old_value_json": json.dumps(old, default=str),
+                "new_value_json": json.dumps(new, default=str),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "notes": notes,
+            },
+        )
+
+    @staticmethod
+    def _column(number):
+        out = ""
+        while number:
+            number, rem = divmod(number - 1, 26)
+            out = chr(65 + rem) + out
+        return out
+
+    async def replace_availability(self, tournament_id, user_id, slot_ids, now):
+        """Atomically-ish replace rows: update old rows in place, blank surplus, append remainder; restore snapshot on failure."""
+        ws, values = await self._values("participant_availability")
+        headers = [norm(x) for x in values[0]]
+        required = {
+            "tournament_id",
+            "discord_user_id",
+            "slot_id",
+            "preference",
+            "created_at",
+            "updated_at",
+        }
+        if required - set(headers):
+            raise SchemaError(
+                "participant_availability is missing required headers: "
+                + ", ".join(sorted(required - set(headers)))
+            )
+        matches = []
+        for index, row in enumerate(values[1:], 2):
+            record = {
+                headers[i]: row[i] if i < len(row) else "" for i in range(len(headers))
+            }
+            if (
+                str(record["tournament_id"]) == tournament_id
+                and str(record["discord_user_id"]) == user_id
+            ):
+                matches.append((index, list(row)))
+        try:
+            for pos, slot in enumerate(slot_ids):
+                record = {
+                    "tournament_id": tournament_id,
+                    "discord_user_id": user_id,
+                    "slot_id": slot,
+                    "preference": "available",
+                    "created_at": now,
+                    "updated_at": now,
+                }
+                row = [record.get(h, "") for h in headers]
+                if pos < len(matches):
+                    await acall_with_backoff(
+                        ws.update,
+                        f"A{matches[pos][0]}:{self._column(len(headers))}{matches[pos][0]}",
+                        [row],
+                        value_input_option="RAW",
+                    )
+                else:
+                    await acall_with_backoff(
+                        ws.append_row, row, value_input_option="RAW"
+                    )
+            for row_number, _ in matches[len(slot_ids) :]:
+                await acall_with_backoff(
+                    ws.update,
+                    f"A{row_number}:{self._column(len(headers))}{row_number}",
+                    [[""] * len(headers)],
+                    value_input_option="RAW",
+                )
+        except Exception:
+            for row_number, old in matches:
+                await acall_with_backoff(
+                    ws.update,
+                    f"A{row_number}:{self._column(len(headers))}{row_number}",
+                    [old + [""] * (len(headers) - len(old))],
+                    value_input_option="RAW",
+                )
+            raise

--- a/modules/community/live_arena_tournament/repository.py
+++ b/modules/community/live_arena_tournament/repository.py
@@ -11,8 +11,11 @@ from shared.sheets.async_core import (
     asheets_read,
     aget_worksheet,
 )
-from .config import FeatureConfig, parse_system_config
-from .models import SchemaError, norm
+from modules.community.live_arena_tournament.config import (
+    FeatureConfig,
+    parse_system_config,
+)
+from modules.community.live_arena_tournament.models import SchemaError, norm
 
 
 class LiveArenaRepository:
@@ -33,7 +36,14 @@ class LiveArenaRepository:
         normalized = [{norm(k): v for k, v in r.items()} for r in rows]
         for index, row in enumerate(normalized, 2):
             row.setdefault("_row_number", index)
-        present = {norm(k) for r in normalized for k in r}
+        # Records contain no header information when a correctly configured table is
+        # header-only.  Read the worksheet header independently so startup validation
+        # does not confuse an empty table with a missing schema.
+        present = set()
+        if required:
+            ws = await aget_worksheet(self.sheet_id, self.config.tabs[table])
+            values = await acall_with_backoff(ws.get_all_values)
+            present = {norm(k) for k in (values[0] if values else [])}
         missing = {norm(x) for x in required} - present
         if missing:
             raise SchemaError(
@@ -160,12 +170,9 @@ class LiveArenaRepository:
                     "discord_user_id": user_id,
                     "slot_id": slot,
                     "preference": "available",
-                    "created_at": (
-                        matches[pos][1][headers.index("created_at")]
-                        if pos < len(matches)
-                        and len(matches[pos][1]) > headers.index("created_at")
-                        else created_by_slot.get(slot, now)
-                    ),
+                    # Creation belongs to the slot identity, never the physical row
+                    # reused for it when selections are reordered.
+                    "created_at": created_by_slot.get(str(slot)) or now,
                     "updated_at": now,
                 }
                 row = [record.get(h, "") for h in headers]

--- a/modules/community/live_arena_tournament/repository.py
+++ b/modules/community/live_arena_tournament/repository.py
@@ -143,6 +143,16 @@ class LiveArenaRepository:
                 and str(record["discord_user_id"]) == user_id
             ):
                 matches.append((index, list(row)))
+        created_by_slot = {
+            str(row[headers.index("slot_id")])
+            if len(row) > headers.index("slot_id")
+            else "": (
+                row[headers.index("created_at")]
+                if len(row) > headers.index("created_at")
+                else ""
+            )
+            for _, row in matches
+        }
         try:
             for pos, slot in enumerate(slot_ids):
                 record = {
@@ -150,7 +160,12 @@ class LiveArenaRepository:
                     "discord_user_id": user_id,
                     "slot_id": slot,
                     "preference": "available",
-                    "created_at": now,
+                    "created_at": (
+                        matches[pos][1][headers.index("created_at")]
+                        if pos < len(matches)
+                        and len(matches[pos][1]) > headers.index("created_at")
+                        else created_by_slot.get(slot, now)
+                    ),
                     "updated_at": now,
                 }
                 row = [record.get(h, "") for h in headers]
@@ -189,3 +204,32 @@ class LiveArenaRepository:
                     value_input_option="RAW",
                 )
             raise
+
+    async def availability_slot_ids(self, tournament_id, user_id):
+        rows = await self.rows("participant_availability")
+        return [
+            str(row.get("slot_id"))
+            for row in rows
+            if str(row.get("tournament_id")) == tournament_id
+            and str(row.get("discord_user_id")) == user_id
+            and str(row.get("slot_id", "")).strip()
+        ]
+
+    async def delete_appended_participant(self, tournament_id, user_id):
+        """Compensate a failed availability write without deleting historical rows."""
+        rows = await self.rows("participants")
+        row = next(
+            (
+                r
+                for r in reversed(rows)
+                if str(r.get("tournament_id")) == tournament_id
+                and str(r.get("discord_user_id")) == user_id
+            ),
+            None,
+        )
+        if row:
+            await self.replace_row(
+                "participants",
+                int(row["_row_number"]),
+                {key: "" for key in row if not key.startswith("_")},
+            )

--- a/modules/community/live_arena_tournament/repository.py
+++ b/modules/community/live_arena_tournament/repository.py
@@ -22,7 +22,7 @@ class LiveArenaRepository:
 
     async def load_config(self):
         self.config = parse_system_config(
-            await asheets_read(self.sheet_id, "'System_Config'!A:Z"), self.sheet_id
+            await asheets_read(self.sheet_id, "System_Config!A:Z"), self.sheet_id
         )
         return self.config
 

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -1,0 +1,179 @@
+"""Registration business rules, independent of Discord UI."""
+
+from __future__ import annotations
+import asyncio
+from collections import defaultdict
+from datetime import datetime, timezone
+from .models import (
+    AvailabilitySlot,
+    RegistrationError,
+    validate_availability,
+    validate_timezone,
+    norm,
+    truthy,
+)
+
+
+class LiveArenaService:
+    def __init__(self, repository):
+        self.repository = repository
+        self._locks = defaultdict(asyncio.Lock)
+
+    @staticmethod
+    def eligible_clan(member_role_ids, rows, tournament_id):
+        roles = {str(x) for x in member_role_ids}
+        for row in rows:
+            if (
+                str(row.get("tournament_id", "")) == tournament_id
+                and truthy(row.get("active", row.get("enabled", True)))
+                and str(row.get("discord_role_id", row.get("role_id", ""))) in roles
+            ):
+                return str(row.get("clan_tag", row.get("clan", "")))
+        raise RegistrationError(
+            "You do not currently hold an eligible clan role for this tournament."
+        )
+
+    @staticmethod
+    def participant_for(rows, tournament_id, user_id):
+        return next(
+            (
+                r
+                for r in rows
+                if str(r.get("tournament_id")) == tournament_id
+                and str(r.get("discord_user_id")) == str(user_id)
+            ),
+            None,
+        )
+
+    @staticmethod
+    def confirmed_count(rows, tournament_id):
+        return sum(
+            str(r.get("tournament_id")) == tournament_id
+            and norm(r.get("status")) == "confirmed"
+            for r in rows
+        )
+
+    @staticmethod
+    def can_transition(old, new):
+        return (norm(old), norm(new)) in {
+            ("draft", "signup_open"),
+            ("signup_open", "signup_closed"),
+            ("signup_closed", "signup_open"),
+        }
+
+    async def register(
+        self,
+        *,
+        tournament,
+        user_id,
+        display_name,
+        member_role_ids,
+        timezone_name,
+        slot_ids,
+    ):
+        timezone_name = validate_timezone(timezone_name)
+        tid = tournament.tournament_id
+        async with self._locks[tid]:
+            participants = await self.repository.rows(
+                "participants",
+                ("tournament_id", "participant_slot", "status", "discord_user_id"),
+            )
+            existing = self.participant_for(participants, tid, user_id)
+            if existing and norm(existing.get("status")) == "confirmed":
+                return {"participant": existing, "created": False}
+            if existing and norm(existing.get("status")) == "removed":
+                raise RegistrationError(
+                    "An organizer removed this registration; contact a tournament organizer."
+                )
+            if norm(tournament.status) != "signup_open":
+                raise RegistrationError("Registration is not open.")
+            if (
+                self.confirmed_count(participants, tid)
+                >= tournament.maximum_participants
+            ):
+                raise RegistrationError("The tournament is at capacity.")
+            clans = await self.repository.rows(
+                "eligible_clans", ("tournament_id", "clan_tag")
+            )
+            clan = self.eligible_clan(member_role_ids, clans, tid)
+            raw_slots = await self.repository.rows(
+                "availability_slots", ("slot_id", "weekday_utc", "start_time_utc")
+            )
+            slots = [
+                AvailabilitySlot(
+                    str(r["slot_id"]),
+                    int(r["weekday_utc"]),
+                    str(r["start_time_utc"]),
+                    str(r.get("end_time_utc", "")),
+                    truthy(r.get("active", r.get("enabled", True))),
+                    int(r.get("sort_order") or 0),
+                )
+                for r in raw_slots
+                if str(r.get("tournament_id", tid)) in ("", tid)
+            ]
+            selected = validate_availability(
+                slot_ids, slots, timezone_name, tournament.minimum_availability
+            )
+            target = existing or min(
+                (
+                    r
+                    for r in participants
+                    if str(r.get("tournament_id")) == tid
+                    and norm(r.get("status")) == "open"
+                    and not str(r.get("discord_user_id", "")).strip()
+                ),
+                key=lambda r: int(r["participant_slot"]),
+                default=None,
+            )
+            if not target:
+                raise RegistrationError("No open participant slot is available.")
+            now = datetime.now(timezone.utc).isoformat()
+            row_number = int(
+                target.get("_row_number") or participants.index(target) + 2
+            )
+            changes = {
+                "discord_user_id": str(user_id),
+                "display_name_at_signup": display_name,
+                "clan_tag_at_signup": clan,
+                "timezone": timezone_name,
+                "status": "confirmed",
+                "clan_verification_status": "verified",
+                "signed_up_at": target.get("signed_up_at") or now,
+                "confirmed_at": now,
+                "withdrawn_at": "",
+                "withdrawal_reason": "",
+            }
+            old = dict(target)
+            try:
+                await self.repository.replace_row("participants", row_number, changes)
+                await self.repository.replace_availability(
+                    tid, str(user_id), selected, now
+                ) if hasattr(
+                    self.repository, "replace_availability"
+                ) else self._unsupported()
+            except Exception:
+                try:
+                    await self.repository.replace_row(
+                        "participants", row_number, {k: old.get(k, "") for k in changes}
+                    )
+                except Exception:
+                    pass
+                raise
+            await self.repository.audit(
+                "registration_confirmed",
+                tid,
+                user_id,
+                "participant",
+                user_id,
+                old,
+                changes,
+            )
+            return {
+                "participant": {**target, **changes},
+                "created": True,
+                "slots": selected,
+            }
+
+    @staticmethod
+    def _unsupported():
+        raise RegistrationError("Availability repository writes are unavailable.")

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from modules.community.live_arena_tournament.models import (
     AvailabilitySlot,
+    REQUIRED_AVAILABILITY_WINDOWS,
     RegistrationError,
     validate_availability,
     validate_timezone,
@@ -29,10 +30,10 @@ class LiveArenaService:
         for row in rows:
             if (
                 str(row.get("tournament_id", "")) == tournament_id
-                and truthy(row.get("active", row.get("enabled", True)))
-                and str(row.get("discord_role_id", row.get("role_id", ""))) in roles
+                and truthy(row.get("active"))
+                and str(row.get("discord_role_id", "")) in roles
             ):
-                return str(row.get("clan_tag", row.get("clan", "")))
+                return str(row.get("clan_tag", ""))
         raise RegistrationError(
             "You do not currently hold an eligible clan role for this tournament."
         )
@@ -127,7 +128,7 @@ class LiveArenaService:
                 )
                 raise RegistrationError("The tournament is at capacity.")
             clans = await self.repository.rows(
-                "eligible_clans", ("tournament_id", "clan_tag")
+                "eligible_clans", ("tournament_id", "clan_tag", "discord_role_id", "active")
             )
             try:
                 clan = self.eligible_clan(member_role_ids, clans, tid)
@@ -160,14 +161,14 @@ class LiveArenaService:
                     int(float(r.get("end_day_offset") or 0)),
                 )
                 for r in raw_slots
-                if str(r.get("tournament_id", tid)) in ("", tid)
+                if truthy(r.get("enabled"))
             ]
             try:
                 selected = validate_availability(
                     slot_ids,
                     slots,
                     timezone_name,
-                    tournament.minimum_availability,
+                    REQUIRED_AVAILABILITY_WINDOWS,
                     anchor_monday=anchor_monday,
                 )
             except RegistrationError:

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -9,6 +9,7 @@ from .models import (
     RegistrationError,
     validate_availability,
     validate_timezone,
+    parse_weekday,
     norm,
     truthy,
 )
@@ -79,15 +80,13 @@ class LiveArenaService:
                 ("tournament_id", "participant_slot", "status", "discord_user_id"),
             )
             existing = self.participant_for(participants, tid, user_id)
-            if existing and norm(existing.get("status")) == "confirmed":
-                return {"participant": existing, "created": False}
             if existing and norm(existing.get("status")) == "removed":
                 raise RegistrationError(
                     "An organizer removed this registration; contact a tournament organizer."
                 )
             if norm(tournament.status) != "signup_open":
                 raise RegistrationError("Registration is not open.")
-            if (
+            if not existing and (
                 self.confirmed_count(participants, tid)
                 >= tournament.maximum_participants
             ):
@@ -102,7 +101,7 @@ class LiveArenaService:
             slots = [
                 AvailabilitySlot(
                     str(r["slot_id"]),
-                    int(r["weekday_utc"]),
+                    parse_weekday(r["weekday_utc"]),
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
                     truthy(r.get("active", r.get("enabled", True))),
@@ -170,9 +169,52 @@ class LiveArenaService:
             )
             return {
                 "participant": {**target, **changes},
-                "created": True,
+                "created": not existing or norm(old.get("status")) != "confirmed",
                 "slots": selected,
             }
+
+    async def change_participant_status(
+        self, tournament_id, user_id, status, actor, reason=""
+    ):
+        """Withdraw/remove/restore without allowing invalid participant-state overwrites."""
+        async with self._locks[tournament_id]:
+            rows = await self.repository.rows("participants")
+            participant = self.participant_for(rows, tournament_id, user_id)
+            if not participant:
+                raise RegistrationError("No registration was found.")
+            old_status = norm(participant.get("status"))
+            allowed = {
+                "withdrawn": {"confirmed"},
+                "removed": {"confirmed", "withdrawn"},
+                "confirmed": {"removed", "withdrawn"},
+            }
+            if old_status not in allowed.get(status, set()):
+                raise RegistrationError(
+                    f"Cannot change participant from {old_status} to {status}."
+                )
+            now = datetime.now(timezone.utc).isoformat()
+            changes = {"status": status}
+            if status == "withdrawn":
+                changes.update(
+                    withdrawn_at=now,
+                    withdrawal_reason=reason or "self_service_withdrawal",
+                )
+            elif status == "confirmed":
+                changes.update(withdrawn_at="", withdrawal_reason="", confirmed_at=now)
+            row_number = int(
+                participant.get("_row_number") or rows.index(participant) + 2
+            )
+            await self.repository.replace_row("participants", row_number, changes)
+            await self.repository.audit(
+                f"participant_{status}",
+                tournament_id,
+                actor,
+                "participant",
+                user_id,
+                participant,
+                changes,
+            )
+            return {**participant, **changes}
 
     @staticmethod
     def _unsupported():

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -80,9 +80,13 @@ class LiveArenaService:
                 ("tournament_id", "participant_slot", "status", "discord_user_id"),
             )
             existing = self.participant_for(participants, tid, user_id)
-            if existing and norm(existing.get("status")) == "removed":
+            if existing and norm(existing.get("status")) not in {
+                "open",
+                "withdrawn",
+                "confirmed",
+            }:
                 raise RegistrationError(
-                    "An organizer removed this registration; contact a tournament organizer."
+                    "This registration cannot be changed through self-service; contact a tournament organizer."
                 )
             if norm(tournament.status) != "signup_open":
                 raise RegistrationError("Registration is not open.")
@@ -104,7 +108,7 @@ class LiveArenaService:
                     parse_weekday(r["weekday_utc"]),
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
-                    truthy(r.get("active", r.get("enabled", True))),
+                    truthy(r.get("enabled", r.get("active", True))),
                     int(r.get("sort_order") or 0),
                 )
                 for r in raw_slots
@@ -138,7 +142,11 @@ class LiveArenaService:
                 "status": "confirmed",
                 "clan_verification_status": "verified",
                 "signed_up_at": target.get("signed_up_at") or now,
-                "confirmed_at": now,
+                "confirmed_at": (
+                    target.get("confirmed_at")
+                    if existing and norm(target.get("status")) == "confirmed"
+                    else now
+                ),
                 "withdrawn_at": "",
                 "withdrawal_reason": "",
             }
@@ -159,7 +167,9 @@ class LiveArenaService:
                     pass
                 raise
             await self.repository.audit(
-                "registration_confirmed",
+                "availability_updated"
+                if existing and norm(old.get("status")) == "confirmed"
+                else "registration_confirmed",
                 tid,
                 user_id,
                 "participant",

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import asyncio
+import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from .models import (
@@ -13,6 +14,8 @@ from .models import (
     norm,
     truthy,
 )
+
+log = logging.getLogger("c1c.community.live_arena_registration")
 
 
 class LiveArenaService:
@@ -62,6 +65,17 @@ class LiveArenaService:
             ("signup_closed", "signup_open"),
         }
 
+    async def _audit_warning(self, *args):
+        try:
+            await self.repository.audit(*args)
+            return []
+        except Exception as exc:
+            log.exception(
+                "live_arena_audit_failed",
+                extra={"event": args[0], "tournament_id": args[1]},
+            )
+            return [f"Audit log could not be written: {exc}"]
+
     async def register(
         self,
         *,
@@ -71,36 +85,58 @@ class LiveArenaService:
         member_role_ids,
         timezone_name,
         slot_ids,
+        anchor_monday=None,
     ):
+        """Commit participant+availability under one tournament lock; audit is non-core."""
         timezone_name = validate_timezone(timezone_name)
         tid = tournament.tournament_id
+        log.info(
+            "live_arena_registration_start",
+            extra={"tournament_id": tid, "actor_id": user_id},
+        )
         async with self._locks[tid]:
             participants = await self.repository.rows(
                 "participants",
                 ("tournament_id", "participant_slot", "status", "discord_user_id"),
             )
             existing = self.participant_for(participants, tid, user_id)
-            if existing and norm(existing.get("status")) not in {
-                "open",
-                "withdrawn",
-                "confirmed",
-            }:
+            old_status = norm(existing.get("status")) if existing else ""
+            if existing and old_status not in {"open", "withdrawn", "confirmed"}:
+                log.info(
+                    "live_arena_registration_rejected",
+                    extra={"tournament_id": tid, "reason": "participant_state"},
+                )
                 raise RegistrationError(
                     "This registration cannot be changed through self-service; contact a tournament organizer."
                 )
             if norm(tournament.status) != "signup_open":
                 raise RegistrationError("Registration is not open.")
-            if not existing and (
-                self.confirmed_count(participants, tid)
+            increases_count = old_status != "confirmed"
+            if (
+                increases_count
+                and self.confirmed_count(participants, tid)
                 >= tournament.maximum_participants
             ):
+                log.info(
+                    "live_arena_registration_rejected",
+                    extra={"tournament_id": tid, "reason": "capacity"},
+                )
                 raise RegistrationError("The tournament is at capacity.")
             clans = await self.repository.rows(
                 "eligible_clans", ("tournament_id", "clan_tag")
             )
             clan = self.eligible_clan(member_role_ids, clans, tid)
             raw_slots = await self.repository.rows(
-                "availability_slots", ("slot_id", "weekday_utc", "start_time_utc")
+                "availability_slots",
+                (
+                    "slot_id",
+                    "weekday_utc",
+                    "start_time_utc",
+                    "end_time_utc",
+                    "end_day_offset",
+                    "enabled",
+                    "sort_order",
+                ),
             )
             slots = [
                 AvailabilitySlot(
@@ -108,14 +144,19 @@ class LiveArenaService:
                     parse_weekday(r["weekday_utc"]),
                     str(r["start_time_utc"]),
                     str(r.get("end_time_utc", "")),
-                    truthy(r.get("enabled", r.get("active", True))),
-                    int(r.get("sort_order") or 0),
+                    truthy(r.get("enabled")),
+                    int(float(r.get("sort_order") or 0)),
+                    int(float(r.get("end_day_offset") or 0)),
                 )
                 for r in raw_slots
                 if str(r.get("tournament_id", tid)) in ("", tid)
             ]
             selected = validate_availability(
-                slot_ids, slots, timezone_name, tournament.minimum_availability
+                slot_ids,
+                slots,
+                timezone_name,
+                tournament.minimum_availability,
+                anchor_monday=anchor_monday,
             )
             target = existing or min(
                 (
@@ -128,13 +169,29 @@ class LiveArenaService:
                 key=lambda r: int(r["participant_slot"]),
                 default=None,
             )
-            if not target:
-                raise RegistrationError("No open participant slot is available.")
+            append_new = target is None
+            if append_new:
+                next_slot = (
+                    max(
+                        (
+                            int(r.get("participant_slot") or 0)
+                            for r in participants
+                            if str(r.get("tournament_id")) == tid
+                        ),
+                        default=0,
+                    )
+                    + 1
+                )
+                target = {
+                    "tournament_id": tid,
+                    "participant_slot": next_slot,
+                    "status": "open",
+                    "discord_user_id": "",
+                }
             now = datetime.now(timezone.utc).isoformat()
-            row_number = int(
-                target.get("_row_number") or participants.index(target) + 2
-            )
             changes = {
+                "tournament_id": tid,
+                "participant_slot": target["participant_slot"],
                 "discord_user_id": str(user_id),
                 "display_name_at_signup": display_name,
                 "clan_tag_at_signup": clan,
@@ -142,51 +199,90 @@ class LiveArenaService:
                 "status": "confirmed",
                 "clan_verification_status": "verified",
                 "signed_up_at": target.get("signed_up_at") or now,
-                "confirmed_at": (
-                    target.get("confirmed_at")
-                    if existing and norm(target.get("status")) == "confirmed"
-                    else now
-                ),
+                "confirmed_at": target.get("confirmed_at")
+                if old_status == "confirmed"
+                else now,
                 "withdrawn_at": "",
                 "withdrawal_reason": "",
             }
             old = dict(target)
+            old_slots = (
+                await self.repository.availability_slot_ids(tid, str(user_id))
+                if hasattr(self.repository, "availability_slot_ids")
+                else []
+            )
+            row_number = int(
+                target.get("_row_number")
+                or (participants.index(target) + 2 if not append_new else 0)
+            )
             try:
-                await self.repository.replace_row("participants", row_number, changes)
+                if append_new:
+                    await self.repository.append("participants", changes)
+                else:
+                    await self.repository.replace_row(
+                        "participants", row_number, changes
+                    )
                 await self.repository.replace_availability(
                     tid, str(user_id), selected, now
-                ) if hasattr(
-                    self.repository, "replace_availability"
-                ) else self._unsupported()
+                )
             except Exception:
+                log.exception(
+                    "live_arena_registration_core_failed", extra={"tournament_id": tid}
+                )
                 try:
-                    await self.repository.replace_row(
-                        "participants", row_number, {k: old.get(k, "") for k in changes}
-                    )
+                    if append_new:
+                        await self.repository.delete_appended_participant(
+                            tid, str(user_id)
+                        )
+                    else:
+                        await self.repository.replace_row(
+                            "participants",
+                            row_number,
+                            {k: old.get(k, "") for k in changes},
+                        )
                 except Exception:
-                    pass
+                    log.exception(
+                        "live_arena_registration_rollback_failed",
+                        extra={"tournament_id": tid},
+                    )
                 raise
-            await self.repository.audit(
-                "availability_updated"
-                if existing and norm(old.get("status")) == "confirmed"
-                else "registration_confirmed",
-                tid,
-                user_id,
-                "participant",
-                user_id,
-                old,
-                changes,
+            event = (
+                "registration_updated"
+                if old_status == "confirmed"
+                else "registration_confirmed"
+            )
+            audit_old = {**old, "selected_slot_ids": old_slots}
+            audit_new = {**changes, "selected_slot_ids": selected}
+            warnings = await self._audit_warning(
+                event, tid, user_id, "participant", user_id, audit_old, audit_new
+            )
+            log.info(
+                "live_arena_registration_updated"
+                if old_status == "confirmed"
+                else "live_arena_registration_confirmed",
+                extra={"tournament_id": tid, "actor_id": user_id},
             )
             return {
                 "participant": {**target, **changes},
-                "created": not existing or norm(old.get("status")) != "confirmed",
+                "created": old_status != "confirmed",
                 "slots": selected,
+                "warnings": warnings,
             }
 
     async def change_participant_status(
-        self, tournament_id, user_id, status, actor, reason=""
+        self,
+        tournament_id,
+        user_id,
+        status,
+        actor,
+        reason="",
+        *,
+        tournament=None,
+        member_role_ids=None,
+        eligible_rows=None,
+        member_present=True,
     ):
-        """Withdraw/remove/restore without allowing invalid participant-state overwrites."""
+        """Validate and mutate status within the same lock (including restore capacity)."""
         async with self._locks[tournament_id]:
             rows = await self.repository.rows("participants")
             participant = self.participant_for(rows, tournament_id, user_id)
@@ -202,6 +298,26 @@ class LiveArenaService:
                 raise RegistrationError(
                     f"Cannot change participant from {old_status} to {status}."
                 )
+            if status == "confirmed":
+                if not tournament or norm(tournament.status) not in {
+                    "signup_open",
+                    "signup_closed",
+                }:
+                    raise RegistrationError(
+                        "Participants can only be restored while registration is open or closed."
+                    )
+                if (
+                    self.confirmed_count(rows, tournament_id)
+                    >= tournament.maximum_participants
+                ):
+                    raise RegistrationError("The tournament is at capacity.")
+                if not member_present:
+                    raise RegistrationError(
+                        "The participant is no longer a member of this server."
+                    )
+                self.eligible_clan(
+                    member_role_ids or (), eligible_rows or (), tournament_id
+                )
             now = datetime.now(timezone.utc).isoformat()
             changes = {"status": status}
             if status == "withdrawn":
@@ -215,8 +331,13 @@ class LiveArenaService:
                 participant.get("_row_number") or rows.index(participant) + 2
             )
             await self.repository.replace_row("participants", row_number, changes)
-            await self.repository.audit(
-                f"participant_{status}",
+            event = {
+                "withdrawn": "registration_withdrawn",
+                "removed": "participant_removed",
+                "confirmed": "participant_restored",
+            }[status]
+            warnings = await self._audit_warning(
+                event,
                 tournament_id,
                 actor,
                 "participant",
@@ -224,8 +345,8 @@ class LiveArenaService:
                 participant,
                 changes,
             )
-            return {**participant, **changes}
-
-    @staticmethod
-    def _unsupported():
-        raise RegistrationError("Availability repository writes are unavailable.")
+            log.info(
+                f"live_arena_{event}",
+                extra={"tournament_id": tournament_id, "actor_id": actor},
+            )
+            return {**participant, **changes, "_warnings": warnings}

--- a/modules/community/live_arena_tournament/service.py
+++ b/modules/community/live_arena_tournament/service.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
-from .models import (
+from modules.community.live_arena_tournament.models import (
     AvailabilitySlot,
     RegistrationError,
     validate_availability,
@@ -110,6 +110,10 @@ class LiveArenaService:
                     "This registration cannot be changed through self-service; contact a tournament organizer."
                 )
             if norm(tournament.status) != "signup_open":
+                log.info(
+                    "live_arena_registration_rejected",
+                    extra={"tournament_id": tid, "reason": "registration_not_open"},
+                )
                 raise RegistrationError("Registration is not open.")
             increases_count = old_status != "confirmed"
             if (
@@ -125,7 +129,14 @@ class LiveArenaService:
             clans = await self.repository.rows(
                 "eligible_clans", ("tournament_id", "clan_tag")
             )
-            clan = self.eligible_clan(member_role_ids, clans, tid)
+            try:
+                clan = self.eligible_clan(member_role_ids, clans, tid)
+            except RegistrationError:
+                log.info(
+                    "live_arena_registration_rejected",
+                    extra={"tournament_id": tid, "reason": "eligibility"},
+                )
+                raise
             raw_slots = await self.repository.rows(
                 "availability_slots",
                 (
@@ -151,13 +162,20 @@ class LiveArenaService:
                 for r in raw_slots
                 if str(r.get("tournament_id", tid)) in ("", tid)
             ]
-            selected = validate_availability(
-                slot_ids,
-                slots,
-                timezone_name,
-                tournament.minimum_availability,
-                anchor_monday=anchor_monday,
-            )
+            try:
+                selected = validate_availability(
+                    slot_ids,
+                    slots,
+                    timezone_name,
+                    tournament.minimum_availability,
+                    anchor_monday=anchor_monday,
+                )
+            except RegistrationError:
+                log.info(
+                    "live_arena_registration_rejected",
+                    extra={"tournament_id": tid, "reason": "availability_validation"},
+                )
+                raise
             target = existing or min(
                 (
                     r

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import discord
+from .models import slot_local_datetime
 
 CUSTOM_IDS = {
     action: f"live_arena:registration:{action}"
@@ -30,7 +31,9 @@ def style(value):
 
 class RoutedButton(discord.ui.Button):
     def __init__(self, cog, row):
-        action = str(row.get("action", row.get("component_key", ""))).strip()
+        action = str(
+            row.get("action_id", row.get("action", row.get("component_key", "")))
+        ).strip()
         super().__init__(
             label=str(row.get("label", "")),
             emoji=str(row.get("emoji") or "") or None,
@@ -48,13 +51,19 @@ class PersistentPanel(discord.ui.View):
     def __init__(self, cog, rows, actions):
         super().__init__(timeout=None)
         by_action = {
-            str(r.get("action", r.get("component_key", ""))).strip(): r
+            str(
+                r.get("action_id", r.get("action", r.get("component_key", "")))
+            ).strip(): r
             for r in rows
             if str(r.get("active", "true")).lower() not in {"false", "0", "no"}
         }
         for action in actions:
             if action in by_action:
                 self.add_item(RoutedButton(cog, by_action[action]))
+
+    def disable_actions(self, actions):
+        for item in self.children:
+            item.disabled = getattr(item, "action", "") in actions
 
 
 class TimezoneModal(discord.ui.Modal):
@@ -83,3 +92,146 @@ class ConfirmView(discord.ui.View):
     async def confirm(self, interaction, button):
         await self._callback(interaction)
         self.stop()
+
+
+class SlotSelect(discord.ui.Select):
+    def __init__(self, parent, day, slots):
+        self.parent_view = parent
+        options = [
+            discord.SelectOption(
+                label=f"{slot_local_datetime(s, parent.timezone).strftime('%A %H:%M')} local",
+                value=s.slot_id,
+                default=s.slot_id in parent.selected,
+            )
+            for s in slots[:25]
+        ]
+        super().__init__(
+            placeholder=f"{day} availability",
+            options=options,
+            min_values=0,
+            max_values=len(options),
+            row=0,
+        )
+
+    async def callback(self, interaction):
+        visible = {o.value for o in self.options}
+        self.parent_view.selected.difference_update(visible)
+        self.parent_view.selected.update(self.values)
+        await self.parent_view.show_page(interaction)
+
+
+class AvailabilityView(discord.ui.View):
+    """Ephemeral, restart-safe-until-submit selector; Sheets remain the durable state."""
+
+    def __init__(self, cog, mode, timezone, slots, selected=()):
+        super().__init__(timeout=600)
+        self.cog, self.mode, self.timezone = cog, mode, timezone
+        self.slots, self.selected, self.page = slots, set(selected), 0
+        self.days = sorted(
+            {slot_local_datetime(s, timezone).strftime("%A") for s in slots}
+        )
+        self._render()
+
+    def _render(self):
+        self.clear_items()
+        day = self.days[self.page]
+        choices = [
+            s
+            for s in self.slots
+            if slot_local_datetime(s, self.timezone).strftime("%A") == day
+        ]
+        self.add_item(SlotSelect(self, day, choices))
+        previous = discord.ui.Button(
+            label="Previous day", disabled=self.page == 0, row=1
+        )
+        following = discord.ui.Button(
+            label="Next day", disabled=self.page == len(self.days) - 1, row=1
+        )
+        review = discord.ui.Button(
+            label=f"Review ({len(self.selected)})",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+        previous.callback = self.previous
+        following.callback = self.following
+        review.callback = self.review
+        self.add_item(previous)
+        self.add_item(following)
+        self.add_item(review)
+
+    async def show_page(self, interaction):
+        self._render()
+        await interaction.response.edit_message(
+            content=f"Choose local-time windows — {self.days[self.page]}", view=self
+        )
+
+    async def previous(self, interaction):
+        self.page -= 1
+        await self.show_page(interaction)
+
+    async def following(self, interaction):
+        self.page += 1
+        await self.show_page(interaction)
+
+    async def review(self, interaction):
+        labels = [
+            slot_local_datetime(s, self.timezone).strftime("%A %H:%M")
+            for s in self.slots
+            if s.slot_id in self.selected
+        ]
+        await interaction.response.edit_message(
+            content="Review your availability:\n"
+            + ("\n".join(f"• {x}" for x in labels) or "• None selected"),
+            view=SubmitAvailabilityView(self),
+        )
+
+
+class SubmitAvailabilityView(discord.ui.View):
+    def __init__(self, session):
+        super().__init__(timeout=600)
+        self.session = session
+
+    @discord.ui.button(label="Back", style=discord.ButtonStyle.secondary)
+    async def back(self, interaction, button):
+        await self.session.show_page(interaction)
+
+    @discord.ui.button(label="Submit registration", style=discord.ButtonStyle.success)
+    async def submit(self, interaction, button):
+        await self.session.cog.submit_availability(interaction, self.session)
+        self.stop()
+
+
+class RosterSelect(discord.ui.Select):
+    def __init__(self, parent, participants):
+        self.parent_view = parent
+        super().__init__(
+            placeholder="Choose participant",
+            options=[
+                discord.SelectOption(
+                    label=f"Slot {p.get('participant_slot')}: {p.get('display_name_at_signup') or p.get('discord_user_id')}",
+                    value=str(p.get("discord_user_id")),
+                    description=str(p.get("status")),
+                )
+                for p in participants[:25]
+            ],
+        )
+
+    async def callback(self, interaction):
+        self.parent_view.user_id = self.values[0]
+        await interaction.response.edit_message(view=self.parent_view)
+
+
+class RosterView(discord.ui.View):
+    def __init__(self, cog, participants):
+        super().__init__(timeout=300)
+        self.cog, self.user_id = cog, None
+        if participants:
+            self.add_item(RosterSelect(self, participants))
+
+    @discord.ui.button(label="Remove", style=discord.ButtonStyle.danger, row=1)
+    async def remove(self, interaction, button):
+        await self.cog.organizer_participant(interaction, self.user_id, "removed")
+
+    @discord.ui.button(label="Restore", style=discord.ButtonStyle.success, row=1)
+    async def restore(self, interaction, button):
+        await self.cog.organizer_participant(interaction, self.user_id, "confirmed")

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import discord
-from .models import slot_local_window
+from modules.community.live_arena_tournament.models import slot_local_window
 
 CUSTOM_IDS = {
     action: f"live_arena:registration:{action}"

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import discord
-from .models import slot_local_datetime
+from .models import slot_local_window
 
 CUSTOM_IDS = {
     action: f"live_arena:registration:{action}"
@@ -57,9 +57,15 @@ class PersistentPanel(discord.ui.View):
             for r in rows
             if str(r.get("active", "true")).lower() not in {"false", "0", "no"}
         }
-        for action in actions:
-            if action in by_action:
-                self.add_item(RoutedButton(cog, by_action[action]))
+        ordered = sorted(
+            (by_action[action] for action in actions if action in by_action),
+            key=lambda row: (
+                float(row.get("sort_order") or 0),
+                actions.index(str(row.get("action_id"))),
+            ),
+        )
+        for row in ordered:
+            self.add_item(RoutedButton(cog, row))
 
     def disable_actions(self, actions):
         for item in self.children:
@@ -90,8 +96,12 @@ class ConfirmView(discord.ui.View):
 
     @discord.ui.button(label="Confirm", style=discord.ButtonStyle.danger)
     async def confirm(self, interaction, button):
-        await self._callback(interaction)
-        self.stop()
+        try:
+            successful = await self._callback(interaction)
+            if successful is not False:
+                self.stop()
+        except Exception as exc:
+            await _callback_error(interaction, exc)
 
 
 class SlotSelect(discord.ui.Select):
@@ -99,7 +109,7 @@ class SlotSelect(discord.ui.Select):
         self.parent_view = parent
         options = [
             discord.SelectOption(
-                label=f"{parent.local_datetime(s).strftime('%A %H:%M')} local",
+                label=parent.window_label(s),
                 value=s.slot_id,
                 default=s.slot_id in parent.selected,
             )
@@ -126,23 +136,37 @@ class AvailabilityView(discord.ui.View):
     def __init__(self, cog, mode, timezone, slots, selected=(), anchor_monday=None):
         super().__init__(timeout=600)
         self.cog, self.mode, self.timezone = cog, mode, timezone
-        self.slots, self.selected, self.page = slots, set(selected), 0
+        self.slots, self.page = (
+            sorted(
+                slots, key=lambda s: (s.sort_order, s.weekday_utc, s.start_time_utc)
+            ),
+            0,
+        )
         self.anchor_monday = anchor_monday
-        self.days = sorted({self.local_datetime(s).strftime("%A") for s in slots})
+        enabled_ids = {s.slot_id for s in self.slots if s.enabled}
+        incoming = set(selected)
+        self.selected = incoming & enabled_ids
+        self.removed_stale = incoming - enabled_ids
+        self.days = sorted(
+            {self.local_window(s)[0].weekday() for s in self.slots},
+        )
         self._render()
 
-    def local_datetime(self, slot):
-        return slot_local_datetime(
-            slot, self.timezone, anchor_monday=self.anchor_monday
-        )
+    def local_window(self, slot):
+        return slot_local_window(slot, self.timezone, anchor_monday=self.anchor_monday)
+
+    def window_label(self, slot):
+        start, end = self.local_window(slot)
+        return f"{start.strftime('%a %H:%M')}–{end.strftime('%a %H:%M')} local"
 
     def _render(self):
         self.clear_items()
         day = self.days[self.page]
-        choices = [
-            s for s in self.slots if self.local_datetime(s).strftime("%A") == day
-        ]
-        self.add_item(SlotSelect(self, day, choices))
+        choices = [s for s in self.slots if self.local_window(s)[0].weekday() == day]
+        choices.sort(key=lambda s: self.local_window(s)[0])
+        self.add_item(
+            SlotSelect(self, self.local_window(choices[0])[0].strftime("%A"), choices)
+        )
         previous = discord.ui.Button(
             label="Previous day", disabled=self.page == 0, row=1
         )
@@ -163,8 +187,24 @@ class AvailabilityView(discord.ui.View):
 
     async def show_page(self, interaction):
         self._render()
-        await interaction.response.edit_message(
-            content=f"Choose local-time windows — {self.days[self.page]}", view=self
+        await interaction.response.edit_message(embed=self.page_embed(), view=self)
+
+    def page_embed(self):
+        weekday = self.local_window(
+            next(
+                s
+                for s in self.slots
+                if self.local_window(s)[0].weekday() == self.days[self.page]
+            )
+        )[0].strftime("%A")
+        warning = (
+            "\n\n⚠️ Disabled saved selections were removed."
+            if self.removed_stale
+            else ""
+        )
+        return discord.Embed(
+            title=f"Availability — {weekday}",
+            description=f"Choose your local start–end windows.{warning}",
         )
 
     async def previous(self, interaction):
@@ -177,13 +217,13 @@ class AvailabilityView(discord.ui.View):
 
     async def review(self, interaction):
         labels = [
-            self.local_datetime(s).strftime("%A %H:%M")
-            for s in self.slots
-            if s.slot_id in self.selected
+            self.window_label(s) for s in self.slots if s.slot_id in self.selected
         ]
         await interaction.response.edit_message(
-            content="Review your availability:\n"
-            + ("\n".join(f"• {x}" for x in labels) or "• None selected"),
+            embed=discord.Embed(
+                title="Review availability",
+                description=("\n".join(f"• {x}" for x in labels) or "• None selected"),
+            ),
             view=SubmitAvailabilityView(self),
         )
 
@@ -199,8 +239,14 @@ class SubmitAvailabilityView(discord.ui.View):
 
     @discord.ui.button(label="Submit registration", style=discord.ButtonStyle.success)
     async def submit(self, interaction, button):
-        await self.session.cog.submit_availability(interaction, self.session)
-        self.stop()
+        try:
+            successful = await self.session.cog.submit_availability(
+                interaction, self.session
+            )
+            if successful:
+                self.stop()
+        except Exception as exc:
+            await _callback_error(interaction, exc)
 
 
 class RosterSelect(discord.ui.Select):
@@ -232,8 +278,24 @@ class RosterView(discord.ui.View):
 
     @discord.ui.button(label="Remove", style=discord.ButtonStyle.danger, row=1)
     async def remove(self, interaction, button):
-        await self.cog.organizer_participant(interaction, self.user_id, "removed")
+        try:
+            await self.cog.organizer_participant(interaction, self.user_id, "removed")
+        except Exception as exc:
+            await _callback_error(interaction, exc)
 
     @discord.ui.button(label="Restore", style=discord.ButtonStyle.success, row=1)
     async def restore(self, interaction, button):
-        await self.cog.organizer_participant(interaction, self.user_id, "confirmed")
+        try:
+            await self.cog.organizer_participant(interaction, self.user_id, "confirmed")
+        except Exception as exc:
+            await _callback_error(interaction, exc)
+
+
+async def _callback_error(interaction, exc):
+    embed = discord.Embed(title="Live Arena", description=str(exc))
+    target = (
+        interaction.followup.send
+        if interaction.response.is_done()
+        else interaction.response.send_message
+    )
+    await target(embed=embed, ephemeral=True)

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -99,7 +99,7 @@ class SlotSelect(discord.ui.Select):
         self.parent_view = parent
         options = [
             discord.SelectOption(
-                label=f"{slot_local_datetime(s, parent.timezone).strftime('%A %H:%M')} local",
+                label=f"{parent.local_datetime(s).strftime('%A %H:%M')} local",
                 value=s.slot_id,
                 default=s.slot_id in parent.selected,
             )
@@ -123,22 +123,24 @@ class SlotSelect(discord.ui.Select):
 class AvailabilityView(discord.ui.View):
     """Ephemeral, restart-safe-until-submit selector; Sheets remain the durable state."""
 
-    def __init__(self, cog, mode, timezone, slots, selected=()):
+    def __init__(self, cog, mode, timezone, slots, selected=(), anchor_monday=None):
         super().__init__(timeout=600)
         self.cog, self.mode, self.timezone = cog, mode, timezone
         self.slots, self.selected, self.page = slots, set(selected), 0
-        self.days = sorted(
-            {slot_local_datetime(s, timezone).strftime("%A") for s in slots}
-        )
+        self.anchor_monday = anchor_monday
+        self.days = sorted({self.local_datetime(s).strftime("%A") for s in slots})
         self._render()
+
+    def local_datetime(self, slot):
+        return slot_local_datetime(
+            slot, self.timezone, anchor_monday=self.anchor_monday
+        )
 
     def _render(self):
         self.clear_items()
         day = self.days[self.page]
         choices = [
-            s
-            for s in self.slots
-            if slot_local_datetime(s, self.timezone).strftime("%A") == day
+            s for s in self.slots if self.local_datetime(s).strftime("%A") == day
         ]
         self.add_item(SlotSelect(self, day, choices))
         previous = discord.ui.Button(
@@ -175,7 +177,7 @@ class AvailabilityView(discord.ui.View):
 
     async def review(self, interaction):
         labels = [
-            slot_local_datetime(s, self.timezone).strftime("%A %H:%M")
+            self.local_datetime(s).strftime("%A %H:%M")
             for s in self.slots
             if s.slot_id in self.selected
         ]

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -31,9 +31,7 @@ def style(value):
 
 class RoutedButton(discord.ui.Button):
     def __init__(self, cog, row):
-        action = str(
-            row.get("action_id", row.get("action", row.get("component_key", "")))
-        ).strip()
+        action = str(row.get("action_id", "")).strip()
         super().__init__(
             label=str(row.get("label", "")),
             emoji=str(row.get("emoji") or "") or None,
@@ -51,11 +49,9 @@ class PersistentPanel(discord.ui.View):
     def __init__(self, cog, rows, actions):
         super().__init__(timeout=None)
         by_action = {
-            str(
-                r.get("action_id", r.get("action", r.get("component_key", "")))
-            ).strip(): r
+            str(r.get("action_id", "")).strip(): r
             for r in rows
-            if str(r.get("active", "true")).lower() not in {"false", "0", "no"}
+            if str(r.get("active", "")).lower() in {"true", "1", "yes", "active"}
         }
         ordered = sorted(
             (by_action[action] for action in actions if action in by_action),

--- a/modules/community/live_arena_tournament/views.py
+++ b/modules/community/live_arena_tournament/views.py
@@ -1,0 +1,85 @@
+"""Persistent and ephemeral Discord UI for registration."""
+
+from __future__ import annotations
+import discord
+
+CUSTOM_IDS = {
+    action: f"live_arena:registration:{action}"
+    for action in (
+        "join_tournament",
+        "my_registration",
+        "update_availability",
+        "withdraw",
+        "open_registration",
+        "close_registration",
+        "reopen_registration",
+        "view_roster",
+        "refresh_registration",
+    )
+}
+
+
+def style(value):
+    return {
+        "primary": discord.ButtonStyle.primary,
+        "secondary": discord.ButtonStyle.secondary,
+        "success": discord.ButtonStyle.success,
+        "danger": discord.ButtonStyle.danger,
+    }.get(str(value).lower(), discord.ButtonStyle.secondary)
+
+
+class RoutedButton(discord.ui.Button):
+    def __init__(self, cog, row):
+        action = str(row.get("action", row.get("component_key", ""))).strip()
+        super().__init__(
+            label=str(row.get("label", "")),
+            emoji=str(row.get("emoji") or "") or None,
+            style=style(row.get("style")),
+            custom_id=CUSTOM_IDS[action],
+        )
+        self.cog = cog
+        self.action = action
+
+    async def callback(self, interaction):
+        await self.cog.handle_action(self.action, interaction)
+
+
+class PersistentPanel(discord.ui.View):
+    def __init__(self, cog, rows, actions):
+        super().__init__(timeout=None)
+        by_action = {
+            str(r.get("action", r.get("component_key", ""))).strip(): r
+            for r in rows
+            if str(r.get("active", "true")).lower() not in {"false", "0", "no"}
+        }
+        for action in actions:
+            if action in by_action:
+                self.add_item(RoutedButton(cog, by_action[action]))
+
+
+class TimezoneModal(discord.ui.Modal):
+    def __init__(self, cog, mode, initial=""):
+        super().__init__(title="Timezone", timeout=600)
+        self.cog = cog
+        self.mode = mode
+        self.timezone = discord.ui.TextInput(
+            label="IANA timezone",
+            default=initial,
+            placeholder="Europe/Vienna",
+            max_length=64,
+        )
+        self.add_item(self.timezone)
+
+    async def on_submit(self, interaction):
+        await self.cog.start_availability(interaction, self.mode, str(self.timezone))
+
+
+class ConfirmView(discord.ui.View):
+    def __init__(self, callback):
+        super().__init__(timeout=300)
+        self._callback = callback
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction, button):
+        await self._callback(interaction)
+        self.stop()

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -9,7 +9,6 @@ from discord.ext import commands
 from shared.config import cfg, get_feature_toggles
 
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
-from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
 from modules.community.shard_tracker.views import register_persistent_shard_views
 from modules.community.reset_reminders.scheduler import register_persistent_reset_views
 from modules.onboarding import watcher_promo, watcher_welcome

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from shared.config import cfg, get_feature_toggles
 
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
+from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
 from modules.community.shard_tracker.views import register_persistent_shard_views
 from modules.community.reset_reminders.scheduler import register_persistent_reset_views
 from modules.onboarding import watcher_promo, watcher_welcome
@@ -62,6 +63,16 @@ async def on_ready(bot: commands.Bot) -> None:
                 reset_feature_enabled,
             )
             return
+
+        try:
+            live_arena = bot.get_cog("LiveArenaTournamentCog")
+            if live_arena and live_arena.repository:
+                if live_arena.public_view:
+                    bot.add_view(live_arena.public_view)
+                if live_arena.organizer_view:
+                    bot.add_view(live_arena.organizer_view)
+        except Exception:
+            log.exception("CORE_READY FAILURE: register Live Arena persistent views")
 
         # Ensure both onboarding watchers are wired
         try:

--- a/shared/config.py
+++ b/shared/config.py
@@ -535,6 +535,7 @@ def _load_config_snapshot() -> Dict[str, object]:
         "RECRUITMENT_SHEET_ID": (os.getenv("RECRUITMENT_SHEET_ID") or "").strip(),
         "ONBOARDING_SHEET_ID": (os.getenv("ONBOARDING_SHEET_ID") or "").strip(),
         "MILESTONES_SHEET_ID": (os.getenv("MILESTONES_SHEET_ID") or "").strip(),
+        "LIVE_ARENA_TOURNAMENT_SHEET_ID": (os.getenv("LIVE_ARENA_TOURNAMENT_SHEET_ID") or "").strip(),
         "LEAGUES_SHEET_ID": (os.getenv("LEAGUES_SHEET_ID") or "").strip(),
         "LEAGUES_CONFIG_TAB": (os.getenv("LEAGUES_CONFIG_TAB") or "Config").strip() or "Config",
         "LEAGUES_SUBMISSION_CHANNEL_ID": _first_int(os.getenv("LEAGUES_SUBMISSION_CHANNEL_ID")),

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from modules.community.live_arena_tournament.config import parse_system_config
 from modules.community.live_arena_tournament.models import (
@@ -521,3 +521,199 @@ def test_opening_registration_requires_configured_deadline():
     assert LiveArenaTournamentCog._deadline_text("2026-08-10T18:00:00Z").startswith(
         "<t:"
     )
+
+
+def test_required_headers_validate_on_header_only_table():
+    repo = LiveArenaRepository("sheet")
+    repo.config = parse_system_config(config_rows(), "sheet")
+    worksheet = Mock()
+    worksheet.update = Mock()
+    worksheet.get_all_values = Mock(return_value=[["event_id", "created_at"]])
+    with (
+        patch(
+            "modules.community.live_arena_tournament.repository.afetch_records",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "modules.community.live_arena_tournament.repository.aget_worksheet",
+            new=AsyncMock(return_value=worksheet),
+        ),
+        patch(
+            "modules.community.live_arena_tournament.repository.acall_with_backoff",
+            new=AsyncMock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
+        ),
+    ):
+        assert asyncio.run(repo.rows("audit_log", ("event_id", "created_at"))) == []
+
+
+def test_replace_availability_preserves_created_at_by_slot_identity_when_reordered():
+    repo = LiveArenaRepository("sheet")
+    headers = [
+        "tournament_id",
+        "discord_user_id",
+        "slot_id",
+        "preference",
+        "created_at",
+        "updated_at",
+    ]
+    worksheet = Mock()
+    worksheet.update = Mock()
+    values = [
+        headers,
+        ["T1", "7", "A", "available", "t1", "old"],
+        ["T1", "7", "B", "available", "t2", "old"],
+    ]
+    repo._values = AsyncMock(return_value=(worksheet, values))
+    asyncio.run(repo.replace_availability("T1", "7", ["B", "C"], "now"))
+    written = [call.args[1][0] for call in worksheet.update.call_args_list]
+    assert written[0][2:6] == ["B", "available", "t2", "now"]
+    assert written[1][2:6] == ["C", "available", "now", "now"]
+
+
+def test_global_availability_slots_do_not_require_tournament_id():
+    from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
+
+    source = __import__("inspect").getsource(LiveArenaTournamentCog.prepare)
+    availability_contract = source.split('"availability_slots": (', 1)[1].split(
+        "),", 1
+    )[0]
+    assert '"tournament_id"' not in availability_contract
+
+
+def test_tournament_config_does_not_require_minimum_availability_header():
+    from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
+
+    source = __import__("inspect").getsource(LiveArenaTournamentCog.prepare)
+    tournament_contract = source.split('"tournaments": (', 1)[1].split("),", 1)[0]
+    assert '"minimum_availability"' not in tournament_contract
+
+
+class PrepareRepository:
+    def __init__(self, *, participant_role="22", signup_channel="33"):
+        self.config = parse_system_config(config_rows(), "sheet")
+        tid = "T1"
+        self.data = {
+            "tournaments": [
+                {
+                    "tournament_id": tid,
+                    "tournament_name": "Cup",
+                    "status": "signup_open",
+                    "max_participants": "16",
+                    "signup_closes_at": "2026-08-10T18:00:00Z",
+                    "eligibility_scope": "selected_clans",
+                    "active": "TRUE",
+                }
+            ],
+            "destinations": [
+                {
+                    "tournament_id": tid,
+                    "destination_key": "signup",
+                    "channel_id": signup_channel,
+                    "active": "TRUE",
+                },
+                {
+                    "tournament_id": tid,
+                    "destination_key": "organizer_log",
+                    "channel_id": "44",
+                    "active": "TRUE",
+                },
+            ],
+            "roles": [
+                {
+                    "tournament_id": tid,
+                    "role_type": "organizer",
+                    "discord_role_id": "11",
+                    "active": "TRUE",
+                },
+                {
+                    "tournament_id": tid,
+                    "role_type": "participant",
+                    "discord_role_id": participant_role,
+                    "active": "TRUE",
+                },
+            ],
+            "availability_slots": [
+                {
+                    "slot_id": "A",
+                    "weekday_utc": "Monday",
+                    "start_time_utc": "18:00",
+                    "end_time_utc": "20:00",
+                    "end_day_offset": "0",
+                    "enabled": "TRUE",
+                    "sort_order": "1",
+                }
+            ],
+            "participants": [],
+            "participant_availability": [],
+            "audit_log": [],
+            "bot_state": [],
+            "messages": [
+                {"message_key": key, "active": "TRUE"}
+                for key in (
+                    "signup_open",
+                    "signup_closed",
+                    "signup_confirmed",
+                    "withdrawal_confirmed",
+                    "registration_organizer",
+                )
+            ],
+            "message_components": [
+                {
+                    "action_id": action,
+                    "label": action,
+                    "sort_order": str(i),
+                    "active": "TRUE",
+                }
+                for i, action in enumerate(
+                    (
+                        "join_tournament",
+                        "my_registration",
+                        "update_availability",
+                        "withdraw",
+                        "open_registration",
+                        "close_registration",
+                        "reopen_registration",
+                        "view_roster",
+                        "refresh_registration",
+                    )
+                )
+            ],
+            "eligible_clans": [
+                {
+                    "tournament_id": tid,
+                    "clan_tag": "C1C",
+                    "discord_role_id": "55",
+                    "active": "TRUE",
+                }
+            ],
+        }
+
+    async def load_config(self):
+        return self.config
+
+    async def rows(self, table, required=()):
+        return self.data[table]
+
+
+def _prepare(repository):
+    from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
+
+    cog = LiveArenaTournamentCog.__new__(LiveArenaTournamentCog)
+    cog.bot = Mock()
+    cog.repository = repository
+    cog.service = LiveArenaService(repository)
+    cog.public_view = cog.organizer_view = None
+    return asyncio.run(cog.prepare())
+
+
+def test_prepare_accepts_exact_current_workbook_schema():
+    assert _prepare(PrepareRepository()) is True
+
+
+@pytest.mark.parametrize(
+    "field,value", [("participant_role", ""), ("signup_channel", "")]
+)
+def test_blank_active_participant_role_or_channel_ids_fail_startup_cleanly(
+    field, value
+):
+    assert _prepare(PrepareRepository(**{field: value})) is False

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -18,9 +18,9 @@ from modules.community.live_arena_tournament.views import PersistentPanel
 from modules.community.live_arena_tournament.models import Tournament
 
 TABLES = (
-    "tournament_config",
+    "tournaments",
     "eligible_clans",
-    "tournament_roles",
+    "roles",
     "destinations",
     "participants",
     "availability_slots",
@@ -43,6 +43,8 @@ def config_rows():
 def test_system_config_routes_without_fallback_names():
     cfg = parse_system_config(config_rows(), "sheet")
     assert cfg.tabs["participants"] == "route-participants"
+    assert cfg.tabs["tournaments"] == "route-tournaments"
+    assert cfg.tabs["roles"] == "route-roles"
 
 
 def test_missing_route_is_actionable():
@@ -81,13 +83,19 @@ def test_availability_one_day_fails():
 
 
 def test_timezone_conversion_is_dst_aware():
-    winter = slot_local_datetime(slots()[0], "Europe/Vienna")
+    current = slot_local_datetime(slots()[0], "Europe/Vienna")
+    winter = slot_local_datetime(
+        slots()[0],
+        "Europe/Vienna",
+        anchor_monday=datetime(2026, 1, 5, tzinfo=timezone.utc),
+    )
     summer = slot_local_datetime(
         slots()[0],
         "Europe/Vienna",
         anchor_monday=datetime(2026, 7, 6, tzinfo=timezone.utc),
     )
     assert winter.utcoffset() != summer.utcoffset()
+    assert current.utcoffset() == summer.utcoffset()
 
 
 def test_eligibility_uses_role_ids_and_removed_is_detectable():
@@ -143,7 +151,50 @@ def test_repository_reads_named_system_config_not_first_tab():
         new=AsyncMock(return_value=config_rows()),
     ) as read:
         asyncio.run(repo.load_config())
-    read.assert_awaited_once_with("sheet", "'System_Config'!A:Z")
+    read.assert_awaited_once_with("sheet", "System_Config!A:Z")
+
+
+def test_shared_sheets_helper_receives_unquoted_worksheet_name(monkeypatch):
+    from shared.sheets import core
+
+    workbook = object()
+    worksheet = object()
+    monkeypatch.setattr(core, "aopen_by_key", AsyncMock(return_value=workbook))
+    by_title = AsyncMock(return_value=worksheet)
+    values = AsyncMock(return_value=[["Key", "Value"]])
+    monkeypatch.setattr(core.async_adapter, "aworksheet_by_title", by_title)
+    monkeypatch.setattr(core.async_adapter, "aworksheet_values_get", values)
+    asyncio.run(core.asheets_read("sheet", "System_Config!A:Z"))
+    assert by_title.await_args.args == (workbook, "System_Config")
+    assert values.await_args.args == (worksheet, "A:Z")
+
+
+def test_config_snapshot_loads_optional_live_arena_sheet_id(monkeypatch):
+    from shared import config
+
+    monkeypatch.setenv("LIVE_ARENA_TOURNAMENT_SHEET_ID", " workbook-id ")
+    assert (
+        config._load_config_snapshot()["LIVE_ARENA_TOURNAMENT_SHEET_ID"]
+        == "workbook-id"
+    )
+
+
+def test_all_real_message_placeholders_are_resolved():
+    values = {
+        "participant_count": 7,
+        "max_participants": 8,
+        "tournament_status": "signup_open",
+        "roster_parity_summary": "Odd roster",
+    }
+    for key in ("signup_open", "signup_closed", "registration_organizer"):
+        embed = configured_embed(
+            {
+                "message_key": key,
+                "body_template": "{participant_count}/{max_participants} {tournament_status} {roster_parity_summary}",
+            },
+            values,
+        )
+        assert "{" not in embed.description
 
 
 def test_register_and_update_use_idempotent_participant_and_availability_writes():
@@ -207,3 +258,36 @@ def test_removed_participant_cannot_self_withdraw():
             )
         )
     repo.replace_row.assert_not_awaited()
+
+
+def test_disqualified_participant_cannot_self_register():
+    repo = AsyncMock()
+    repo.rows.return_value = [
+        {"tournament_id": "T1", "discord_user_id": "42", "status": "disqualified"}
+    ]
+    with pytest.raises(Exception, match="cannot be changed through self-service"):
+        asyncio.run(
+            LiveArenaService(repo).register(
+                tournament=Tournament("T1", "Cup", "signup_open", 8, 3),
+                user_id="42",
+                display_name="Player",
+                member_role_ids=[7],
+                timezone_name="UTC",
+                slot_ids=["a", "b", "c"],
+            )
+        )
+    repo.replace_row.assert_not_awaited()
+
+
+def test_capacity_disables_join_but_not_update():
+    view = PersistentPanel(
+        object(),
+        [
+            {"action_id": action, "label": action, "active": "true"}
+            for action in ("join_tournament", "update_availability")
+        ],
+        ["join_tournament", "update_availability"],
+    )
+    view.disable_actions({"join_tournament"})
+    states = {item.action: item.disabled for item in view.children}
+    assert states == {"join_tournament": True, "update_availability": False}

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timezone
+import pytest
+from modules.community.live_arena_tournament.config import parse_system_config
+from modules.community.live_arena_tournament.models import (
+    AvailabilityError,
+    AvailabilitySlot,
+    SchemaError,
+    slot_local_datetime,
+    validate_availability,
+)
+from modules.community.live_arena_tournament.service import LiveArenaService
+
+TABLES = (
+    "tournament_config",
+    "eligible_clans",
+    "tournament_roles",
+    "destinations",
+    "participants",
+    "availability_slots",
+    "participant_availability",
+    "messages",
+    "message_components",
+    "bot_state",
+    "audit_log",
+)
+
+
+def config_rows():
+    return [
+        ["Key", "Value"],
+        ["active_tournament_id", "T1"],
+        *[[f"tab.{x}", f"route-{x}"] for x in TABLES],
+    ]
+
+
+def test_system_config_routes_without_fallback_names():
+    cfg = parse_system_config(config_rows(), "sheet")
+    assert cfg.tabs["participants"] == "route-participants"
+
+
+def test_missing_route_is_actionable():
+    with pytest.raises(SchemaError, match=r"tab.audit_log"):
+        parse_system_config(config_rows()[:-1], "sheet")
+
+
+def slots():
+    return [
+        AvailabilitySlot("a", 0, "23:00", "01:00"),
+        AvailabilitySlot("b", 1, "12:00", "14:00"),
+        AvailabilitySlot("c", 2, "12:00", "14:00"),
+        AvailabilitySlot("off", 3, "12:00", "14:00", False),
+    ]
+
+
+def test_availability_deduplicates_and_spans_local_days():
+    assert validate_availability(["a", "a", "b", "c"], slots(), "Europe/Vienna") == [
+        "a",
+        "b",
+        "c",
+    ]
+
+
+def test_availability_minimum_and_disabled():
+    with pytest.raises(AvailabilityError, match="at least"):
+        validate_availability(["a", "b"], slots(), "UTC")
+    with pytest.raises(AvailabilityError, match="enabled"):
+        validate_availability(["a", "b", "off"], slots(), "UTC")
+
+
+def test_availability_one_day_fails():
+    same = [AvailabilitySlot(str(i), 0, f"{i * 2:02}:00", "") for i in range(3)]
+    with pytest.raises(AvailabilityError, match="two local weekdays"):
+        validate_availability(["0", "1", "2"], same, "UTC")
+
+
+def test_timezone_conversion_is_dst_aware():
+    winter = slot_local_datetime(slots()[0], "Europe/Vienna")
+    summer = slot_local_datetime(
+        slots()[0],
+        "Europe/Vienna",
+        anchor_monday=datetime(2026, 7, 6, tzinfo=timezone.utc),
+    )
+    assert winter.utcoffset() != summer.utcoffset()
+
+
+def test_eligibility_uses_role_ids_and_removed_is_detectable():
+    rows = [
+        {
+            "tournament_id": "T1",
+            "discord_role_id": "7",
+            "clan_tag": "C1CM",
+            "active": "true",
+        }
+    ]
+    assert LiveArenaService.eligible_clan({7}, rows, "T1") == "C1CM"
+    with pytest.raises(Exception):
+        LiveArenaService.eligible_clan({8}, rows, "T1")
+
+
+def test_transitions_are_registration_only():
+    assert LiveArenaService.can_transition("draft", "signup_open")
+    assert LiveArenaService.can_transition("signup_open", "signup_closed")
+    assert not LiveArenaService.can_transition("draft", "signup_closed")

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -83,7 +83,6 @@ def test_availability_one_day_fails():
 
 
 def test_timezone_conversion_is_dst_aware():
-    current = slot_local_datetime(slots()[0], "Europe/Vienna")
     winter = slot_local_datetime(
         slots()[0],
         "Europe/Vienna",
@@ -95,7 +94,6 @@ def test_timezone_conversion_is_dst_aware():
         anchor_monday=datetime(2026, 7, 6, tzinfo=timezone.utc),
     )
     assert winter.utcoffset() != summer.utcoffset()
-    assert current.utcoffset() == summer.utcoffset()
 
 
 def test_eligibility_uses_role_ids_and_removed_is_detectable():
@@ -222,7 +220,7 @@ def test_register_and_update_use_idempotent_participant_and_availability_writes(
                 "slot_id": x,
                 "weekday_utc": day,
                 "start_time_utc": "12:00",
-                "active": "true",
+                "enabled": "true",
             }
             for x, day in (("a", "Monday"), ("b", "Tuesday"), ("c", "Wednesday"))
         ],
@@ -291,3 +289,235 @@ def test_capacity_disables_join_but_not_update():
     view.disable_actions({"join_tournament"})
     states = {item.action: item.disabled for item in view.children}
     assert states == {"join_tournament": True, "update_availability": False}
+
+
+class MemoryRepository:
+    def __init__(self, participants):
+        self.participants = participants
+        self.audits = []
+
+    async def rows(self, table, required=()):
+        if table == "participants":
+            return self.participants
+        if table == "eligible_clans":
+            return [
+                {
+                    "tournament_id": "T1",
+                    "discord_role_id": "7",
+                    "clan_tag": "C1C",
+                    "active": "true",
+                }
+            ]
+        if table == "availability_slots":
+            return [
+                {
+                    "tournament_id": "T1",
+                    "slot_id": f"s{i}",
+                    "weekday_utc": day,
+                    "start_time_utc": "12:00",
+                    "end_time_utc": "14:00",
+                    "end_day_offset": 0,
+                    "enabled": "true",
+                    "sort_order": i,
+                }
+                for i, day in enumerate(("Monday", "Tuesday", "Wednesday"), 1)
+            ]
+        return []
+
+    async def replace_row(self, table, row_number, changes):
+        self.participants[row_number - 2].update(changes)
+
+    async def append(self, table, changes):
+        if table == "participants":
+            self.participants.append(
+                {**changes, "_row_number": len(self.participants) + 2}
+            )
+
+    async def replace_availability(self, *args):
+        return None
+
+    async def availability_slot_ids(self, *args):
+        return []
+
+    async def audit(self, *args):
+        self.audits.append(args)
+
+
+async def _register(service, user):
+    return await service.register(
+        tournament=Tournament("T1", "Cup", "signup_open", 16, 3),
+        user_id=str(user),
+        display_name=f"P{user}",
+        member_role_ids=[7],
+        timezone_name="UTC",
+        slot_ids=["s1", "s2", "s3"],
+        anchor_monday=datetime(2026, 8, 3, tzinfo=timezone.utc),
+    )
+
+
+def test_withdrawal_frees_capacity_without_overwriting_history():
+    rows = [
+        {
+            "_row_number": i + 2,
+            "tournament_id": "T1",
+            "participant_slot": i + 1,
+            "status": "confirmed",
+            "discord_user_id": str(i + 1),
+        }
+        for i in range(16)
+    ]
+    rows[3]["status"] = "withdrawn"
+    repo = MemoryRepository(rows)
+    result = asyncio.run(_register(LiveArenaService(repo), 99))
+    assert result["created"] is True
+    assert len(repo.participants) == 17
+    assert repo.participants[3]["discord_user_id"] == "4"
+    assert repo.participants[-1]["discord_user_id"] == "99"
+
+
+def test_withdrawn_history_cannot_reregister_as_seventeenth_confirmed():
+    rows = [
+        {
+            "_row_number": i + 2,
+            "tournament_id": "T1",
+            "participant_slot": i + 1,
+            "status": "confirmed",
+            "discord_user_id": str(i + 1),
+        }
+        for i in range(16)
+    ]
+    rows.append(
+        {
+            "_row_number": 18,
+            "tournament_id": "T1",
+            "participant_slot": 17,
+            "status": "withdrawn",
+            "discord_user_id": "99",
+        }
+    )
+    with pytest.raises(Exception, match="capacity"):
+        asyncio.run(_register(LiveArenaService(MemoryRepository(rows)), 99))
+
+
+def test_confirmed_availability_update_is_allowed_at_capacity():
+    rows = [
+        {
+            "_row_number": i + 2,
+            "tournament_id": "T1",
+            "participant_slot": i + 1,
+            "status": "confirmed",
+            "discord_user_id": str(i + 1),
+        }
+        for i in range(16)
+    ]
+    result = asyncio.run(_register(LiveArenaService(MemoryRepository(rows)), 1))
+    assert result["created"] is False
+
+
+def test_restore_and_register_share_capacity_lock():
+    rows = [
+        {
+            "_row_number": i + 2,
+            "tournament_id": "T1",
+            "participant_slot": i + 1,
+            "status": "confirmed",
+            "discord_user_id": str(i + 1),
+        }
+        for i in range(15)
+    ]
+    rows.append(
+        {
+            "_row_number": 17,
+            "tournament_id": "T1",
+            "participant_slot": 16,
+            "status": "withdrawn",
+            "discord_user_id": "50",
+        }
+    )
+    repo = MemoryRepository(rows)
+    service = LiveArenaService(repo)
+
+    async def race():
+        return await asyncio.gather(
+            _register(service, 99),
+            service.change_participant_status(
+                "T1",
+                "50",
+                "confirmed",
+                "organizer",
+                tournament=Tournament("T1", "Cup", "signup_closed", 16, 3),
+                member_present=True,
+                member_role_ids=[7],
+                eligible_rows=await repo.rows("eligible_clans"),
+            ),
+            return_exceptions=True,
+        )
+
+    results = asyncio.run(race())
+    assert sum(isinstance(item, Exception) for item in results) == 1
+    assert service.confirmed_count(repo.participants, "T1") == 16
+
+
+def test_configured_embed_rejects_unresolved_placeholders_and_keeps_colour():
+    from modules.community.live_arena_tournament.models import SchemaError
+
+    row = {
+        "title_template": "Welcome {participant}",
+        "body_template": "{tournament_name} by {signup_deadline}",
+        "embed_color_hex": "#abcdef",
+    }
+    embed = configured_embed(
+        row,
+        {
+            "participant": "Player",
+            "tournament_name": "Cup",
+            "signup_deadline": "<t:1:F>",
+        },
+    )
+    assert embed.title == "Welcome Player" and embed.description == "Cup by <t:1:F>"
+    assert embed.colour.value == 0xABCDEF
+    with pytest.raises(SchemaError, match="signup_deadline"):
+        configured_embed(row, {"participant": "Player", "tournament_name": "Cup"})
+
+
+def test_local_window_cross_midnight_and_component_sort_order():
+    from modules.community.live_arena_tournament.models import slot_local_window
+
+    slot = AvailabilitySlot("night", 0, "23:00", "01:00", True, 2, 1)
+    start, end = slot_local_window(
+        slot, "UTC", anchor_monday=datetime(2026, 8, 3, tzinfo=timezone.utc)
+    )
+    assert start.strftime("%a %H:%M") == "Mon 23:00"
+    assert end.strftime("%a %H:%M") == "Tue 01:00"
+    view = PersistentPanel(
+        object(),
+        [
+            {
+                "action_id": "join_tournament",
+                "label": "Join",
+                "active": "true",
+                "sort_order": "2",
+            },
+            {
+                "action_id": "my_registration",
+                "label": "Mine",
+                "active": "true",
+                "sort_order": "1.0",
+            },
+        ],
+        ["join_tournament", "my_registration"],
+    )
+    assert [item.action for item in view.children] == [
+        "my_registration",
+        "join_tournament",
+    ]
+
+
+def test_opening_registration_requires_configured_deadline():
+    from modules.community.live_arena_tournament.cog import LiveArenaTournamentCog
+
+    with pytest.raises(Exception, match="signup_closes_at is required"):
+        LiveArenaTournamentCog._deadline_text("")
+    assert LiveArenaTournamentCog._deadline_text("2026-08-10T18:00:00Z").startswith(
+        "<t:"
+    )

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -601,7 +601,6 @@ class PrepareRepository:
                     "max_participants": "16",
                     "signup_closes_at": "2026-08-10T18:00:00Z",
                     "eligibility_scope": "selected_clans",
-                    "active": "TRUE",
                 }
             ],
             "destinations": [
@@ -706,8 +705,45 @@ def _prepare(repository):
     return asyncio.run(cog.prepare())
 
 
-def test_prepare_accepts_exact_current_workbook_schema():
+def test_prepare_accepts_frozen_real_registration_workbook_contract():
     assert _prepare(PrepareRepository()) is True
+
+
+def test_header_only_participant_availability_is_valid():
+    assert PrepareRepository().data["participant_availability"] == []
+    assert _prepare(PrepareRepository()) is True
+
+
+def test_header_only_audit_log_is_valid():
+    assert PrepareRepository().data["audit_log"] == []
+    assert _prepare(PrepareRepository()) is True
+
+
+def test_global_availability_slots_work_without_tournament_id_or_active():
+    row = PrepareRepository().data["availability_slots"][0]
+    assert "tournament_id" not in row and "active" not in row
+    assert _prepare(PrepareRepository()) is True
+
+
+def test_registration_business_rule_is_three_windows_two_local_days_without_sheet_field():
+    from modules.community.live_arena_tournament.models import (
+        REQUIRED_AVAILABILITY_WINDOWS,
+        REQUIRED_LOCAL_AVAILABILITY_DAYS,
+    )
+
+    tournament_row = PrepareRepository().data["tournaments"][0]
+    assert "minimum_availability" not in tournament_row
+    assert (REQUIRED_AVAILABILITY_WINDOWS, REQUIRED_LOCAL_AVAILABILITY_DAYS) == (3, 2)
+
+
+def test_blank_active_eligible_clan_role_id_fails_startup():
+    repository = PrepareRepository()
+    repository.data["eligible_clans"][0]["discord_role_id"] = ""
+    assert _prepare(repository) is False
+
+
+def test_selected_clan_without_role_id_fails_prepare():
+    test_blank_active_eligible_clan_role_id_fails_startup()
 
 
 @pytest.mark.parametrize(

--- a/tests/community/live_arena_tournament/test_registration.py
+++ b/tests/community/live_arena_tournament/test_registration.py
@@ -1,4 +1,6 @@
+import asyncio
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 import pytest
 from modules.community.live_arena_tournament.config import parse_system_config
 from modules.community.live_arena_tournament.models import (
@@ -7,8 +9,13 @@ from modules.community.live_arena_tournament.models import (
     SchemaError,
     slot_local_datetime,
     validate_availability,
+    parse_weekday,
 )
 from modules.community.live_arena_tournament.service import LiveArenaService
+from modules.community.live_arena_tournament.repository import LiveArenaRepository
+from modules.community.live_arena_tournament.rendering import configured_embed
+from modules.community.live_arena_tournament.views import PersistentPanel
+from modules.community.live_arena_tournament.models import Tournament
 
 TABLES = (
     "tournament_config",
@@ -101,3 +108,102 @@ def test_transitions_are_registration_only():
     assert LiveArenaService.can_transition("draft", "signup_open")
     assert LiveArenaService.can_transition("signup_open", "signup_closed")
     assert not LiveArenaService.can_transition("draft", "signup_closed")
+
+
+def test_real_workbook_headers_render_and_route_components():
+    embed = configured_embed(
+        {
+            "title_template": "{tournament_name}",
+            "body_template": "{status}",
+            "embed_color_hex": "#123456",
+        },
+        {"tournament_name": "Cup", "status": "Open"},
+    )
+    assert embed.title == "Cup" and embed.description == "Open"
+    view = PersistentPanel(
+        object(),
+        [
+            {
+                "action_id": "join_tournament",
+                "label": "Join",
+                "style": "success",
+                "active": "true",
+            }
+        ],
+        ["join_tournament"],
+    )
+    assert view.children[0].custom_id.endswith("join_tournament")
+    assert parse_weekday("Monday") == 0
+
+
+def test_repository_reads_named_system_config_not_first_tab():
+    repo = LiveArenaRepository("sheet")
+    with patch(
+        "modules.community.live_arena_tournament.repository.asheets_read",
+        new=AsyncMock(return_value=config_rows()),
+    ) as read:
+        asyncio.run(repo.load_config())
+    read.assert_awaited_once_with("sheet", "'System_Config'!A:Z")
+
+
+def test_register_and_update_use_idempotent_participant_and_availability_writes():
+    repo = AsyncMock()
+    participant = {
+        "_row_number": 2,
+        "tournament_id": "T1",
+        "participant_slot": "1",
+        "status": "open",
+        "discord_user_id": "",
+    }
+    repo.rows.side_effect = [
+        [participant],
+        [
+            {
+                "tournament_id": "T1",
+                "discord_role_id": "7",
+                "clan_tag": "C1C",
+                "active": "true",
+            }
+        ],
+        [
+            {
+                "tournament_id": "T1",
+                "slot_id": x,
+                "weekday_utc": day,
+                "start_time_utc": "12:00",
+                "active": "true",
+            }
+            for x, day in (("a", "Monday"), ("b", "Tuesday"), ("c", "Wednesday"))
+        ],
+    ]
+    service = LiveArenaService(repo)
+    result = asyncio.run(
+        service.register(
+            tournament=Tournament("T1", "Cup", "signup_open", 8, 3),
+            user_id="42",
+            display_name="Player",
+            member_role_ids=[7],
+            timezone_name="UTC",
+            slot_ids=["a", "b", "c"],
+        )
+    )
+    assert result["created"] is True
+    repo.replace_row.assert_awaited_once()
+    repo.replace_availability.assert_awaited_once_with(
+        "T1", "42", ["a", "b", "c"], repo.replace_availability.await_args.args[3]
+    )
+    repo.audit.assert_awaited_once()
+
+
+def test_removed_participant_cannot_self_withdraw():
+    repo = AsyncMock()
+    repo.rows.return_value = [
+        {"tournament_id": "T1", "discord_user_id": "42", "status": "removed"}
+    ]
+    with pytest.raises(Exception, match="Cannot change participant"):
+        asyncio.run(
+            LiveArenaService(repo).change_participant_status(
+                "T1", "42", "withdrawn", "42"
+            )
+        )
+    repo.replace_row.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Implement the Live Arena tournament registration workflow so players can register, submit timezone/availability, view their registration, update availability, and withdraw using buttons, selects, and modals instead of commands.
- Use the workbook as the single source of truth via `System_Config` routing, preserve existing async Sheets helpers and retry/audit patterns, and avoid any hard-coded IDs or tab/column indices.
- Make the public and organizer panels persistent across restarts and make writes durable and idempotent with per-tournament locking and compensating rollback semantics.

### Description
- Added a new community feature package at `modules/community/live_arena_tournament/` implementing config, models, repository, service, rendering, views, and a cog; changed `modules/community/__init__.py` to register the extension and wired persistent views into `modules/coreops/ready.py` for post-ready registration. Files added: `__init__.py`, `cog.py`, `config.py`, `models.py`, `repository.py`, `service.py`, `views.py`, `rendering.py`, and tests under `tests/community/live_arena_tournament/test_registration.py`.
- New optional environment variable: `LIVE_ARENA_TOURNAMENT_SHEET_ID`; when unset the feature logs a clear disabled message and loads safely without affecting bot startup.
- Startup/persistent-view behavior: persistent public and organizer views are registered in `on_ready` via the existing post-ready wiring pattern and use stable namespaced custom IDs so views survive bot restarts; stored message IDs are read from `Bot_State` and messages are edited rather than duplicated, with missing stored messages recreated and `Bot_State` updated.
- Sheets tables read and written: reads from routed `System_Config`, `Tournament_Config`, `Eligible_Clans`, `Tournament_Roles`, `Destinations`, `Participants`, `Availability_Slots`, `Participant_Availability`, `Messages`, `Message_Components`, `Bot_State`, and `Audit_Log`; writes include participant row updates (`Participants.replace_row`), participant availability replacement (`Participant_Availability` via `replace_availability`), bot state updates/appends (`Bot_State`), and `Audit_Log` appends with UUID event IDs and UTC timestamps; all access uses the existing async Sheets infra and `acall_with_backoff`/`afetch_records`/`asheets_read`.
- Commands and buttons added: a bootstrap command group `!latournament registration` for organizers to publish/repair public and organizer panels; public message components read from the workbook and routed custom IDs implement `join_tournament`, `my_registration`, `update_availability`, and `withdraw`; organizer components implement `open_registration`, `close_registration`, `reopen_registration`, `view_roster`, and `refresh_registration`.
- Business rules and failure handling: eligibility uses `Eligible_Clans` rows and the member's Discord roles (no name/nickname inference), timezone validated with `zoneinfo` (IANA preferred), availability validation enforces minimum windows and multi-day coverage, allocation claims the lowest open participant slot and populates the existing row, writes are protected by an asyncio lock per tournament, writes are idempotent, and repository methods attempt compensating rollback on partial failure; role assignment failures are logged and repairable by the `refresh_registration` action.

### Testing
- Ran focused tests `pytest -q tests/community/live_arena_tournament` and the added tests passed (coverage: configuration routing, availability validation, timezone DST behavior, eligibility gate, and transition checks).
- Run steps and results: `pytest -q tests/community/live_arena_tournament` — focused suite passed; `ruff` formatting/checks and `python -m compileall` on the new package succeeded; the full project `pytest -q` completed but surfaced unrelated pre-existing failures in other test modules that are not caused by these changes (these failures were due to existing logging-record attribute expectations and are out-of-scope for this registration PR).
- Explicit confirmation: no Google Sheets workbook content or schema was modified by this PR (all sheet/table changes are read/write operations performed at runtime and the repository implementation expects the pre-configured workbook routing in `System_Config`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74fe0bb7fc83238d41f17525cd0059)