### PR TITLE
Live Arena PR1: workbook foundation and organizer diagnostic command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ docs/ops/.env.example
 - `REMINDER_SHEET_ID`
 - `MILESTONES_SHEET_ID`
 - `ACHIEVEMENTS_SHEET_ID`
+- `LIVE_ARENA_TOURNAMENT_SHEET_ID`
 - *(other sheet IDs live in env.example — keep doc updates in sync with env.example when adding new sheets)*
 
 **Logging / Telemetry (ENV var names — exact):**
@@ -131,4 +132,4 @@ For PR formatting rules, labels, and doc footers see `docs/contracts/Collaborati
 
 ---
 
-Doc last updated: 2025-12-31 (v0.9.8.2)
+Doc last updated: 2026-08-07 (v0.9.8.2)

--- a/cogs/live_arena.py
+++ b/cogs/live_arena.py
@@ -1,0 +1,78 @@
+"""Organizer-only Live Arena workbook diagnostic command."""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from shared.config import cfg
+
+from modules.community.live_arena.service import LiveArenaConfigError, TournamentSnapshot, load_tournament_snapshot
+
+log = logging.getLogger("c1c.community.live_arena")
+
+
+def build_check_embed(snapshot: TournamentSnapshot) -> discord.Embed:
+    embed = discord.Embed(title="Live Arena tournament check", colour=discord.Colour.green())
+    values = (
+        ("Tournament", snapshot.tournament_name),
+        ("Tournament ID", snapshot.tournament_id),
+        ("Status", snapshot.status),
+        ("Eligibility scope", snapshot.eligibility_scope),
+        ("Active eligible clans", str(snapshot.active_eligible_clans)),
+        ("Enabled availability windows", str(snapshot.enabled_availability_windows)),
+        ("Participants", f"{snapshot.min_participants}–{snapshot.max_participants}"),
+        ("Signup opens", snapshot.signup_opens_at_utc or "Not configured"),
+        ("Signup closes", snapshot.signup_closes_at_utc or "Not configured"),
+        ("Configuration", "OK"),
+    )
+    for name, value in values:
+        embed.add_field(name=name, value=value, inline=False)
+    return embed
+
+
+def build_error_embed(message: str) -> discord.Embed:
+    embed = discord.Embed(title="Live Arena tournament check", colour=discord.Colour.red())
+    embed.add_field(name="Configuration", value="Invalid", inline=False)
+    embed.add_field(name="Error", value=message, inline=False)
+    return embed
+
+
+class LiveArenaCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        if not self._sheet_id():
+            log.info("📋 Live Arena — disabled • reason=LIVE_ARENA_TOURNAMENT_SHEET_ID not configured")
+
+    @staticmethod
+    def _sheet_id() -> str:
+        return str(cfg.get("LIVE_ARENA_TOURNAMENT_SHEET_ID", "") or "").strip()
+
+    @commands.group(name="latournament", invoke_without_command=True)
+    async def latournament(self, ctx: commands.Context) -> None:
+        await ctx.send("Usage: `!latournament check`")
+
+    @latournament.command(name="check")
+    async def check(self, ctx: commands.Context) -> None:
+        sheet_id = self._sheet_id()
+        if not sheet_id:
+            await ctx.send(embed=build_error_embed("LIVE_ARENA_TOURNAMENT_SHEET_ID is not configured"))
+            return
+        try:
+            snapshot = await load_tournament_snapshot(sheet_id)
+        except LiveArenaConfigError as exc:
+            log.error("❌ Live Arena check — invalid configuration • reason=%s", exc)
+            await ctx.send(embed=build_error_embed(str(exc)))
+            return
+
+        role_ids = {getattr(role, "id", None) for role in getattr(ctx.author, "roles", ())}
+        if snapshot.organizer_role_id not in role_ids:
+            await ctx.send("You need the configured Live Arena organizer role to run this command.")
+            return
+        await ctx.send(embed=build_check_embed(snapshot))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(LiveArenaCog(bot))

--- a/docs/ops/.env.example
+++ b/docs/ops/.env.example
@@ -61,6 +61,9 @@ MILESTONES_CONFIG_TAB=
 # Google Sheet ID for achievement definitions used by Achievement Collector roles.
 ACHIEVEMENTS_SHEET_ID=
 
+# Optional Google Sheet ID for Live Arena tournaments; blank disables the feature.
+LIVE_ARENA_TOURNAMENT_SHEET_ID=
+
 # Worksheet name containing recruitment config (default: Config).
 RECRUITMENT_CONFIG_TAB=
 

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -120,6 +120,7 @@ sync modules remain available for non-async scripts and cache warmers.
 | `C1C_LEAGUE_ROLE_ID` | snowflake | — | Discord role ID for **@C1CLeague**; granted automatically on first image submission and mentioned in announcements. |
 | `ANNOUNCEMENT_CHANNEL_ID` | snowflake | — | Channel receiving the weekly cross-league announcement (jump links + @C1CLeague). |
 | `LEAGUES_SHEET_ID` | string | — | Google Sheet ID for the `C1C_Leagues` workbook; Config tab declares ranges for each league. |
+| `LIVE_ARENA_TOURNAMENT_SHEET_ID` | string | — | Optional Google Sheet ID for Live Arena tournaments; blank disables the feature. |
 | `LEAGUES_CONFIG_TAB` | string | `Config` | Optional override for the Leagues Config tab name. |
 | `LEAGUES_SUBMISSION_CHANNEL_ID` | snowflake | — | Channel watched for image uploads; grants the C1CLeague role on first qualifying attachment. |
 | `LEAGUES_LEGENDARY_THREAD_ID` | snowflake | — | Thread receiving the Legendary League header + 9 board PNGs. |
@@ -444,4 +445,4 @@ The `LEAGUES_SHEET_ID` Config tab resolves `cluster_capture_config_tab`, `cluste
 
 Before weekly boards are exported, the bot appends one candidate per active clan and enabled capture spec. Unknown/former source clans are ignored; a missing active clan is archived as `evaluation_status=missing`. Blank, invalid, and zero weekly scores stay blank rather than becoming valid zeroes. Existing record keys with identical semantic event data are retry no-ops even when trigger, timestamp, source location, or clan display name changes; audit metadata from the original row remains untouched. Changed semantic event data conflicts, while conflicting keys and negative cumulative deltas fail the job before Discord posting. The capture is append-only and never clears Stormforged inputs. Current CvC/Siege inputs only support weekly scores or cumulative win/loss deltas, not complete cycle/participation/action/class ratings.
 
-Doc last updated: 2026-08-03 (v0.9.8.2)
+Doc last updated: 2026-08-07 (v0.9.8.2)

--- a/modules/community/__init__.py
+++ b/modules/community/__init__.py
@@ -6,6 +6,7 @@ COMMUNITY_EXTENSIONS: tuple[str, ...] = (
     "modules.community.leagues",
     "modules.community.reaction_roles",
     "modules.community.progress_guides",
+    "cogs.live_arena",
 )
 
 __all__ = ["COMMUNITY_EXTENSIONS"]

--- a/modules/community/live_arena/__init__.py
+++ b/modules/community/live_arena/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only Live Arena tournament workbook support."""

--- a/modules/community/live_arena/service.py
+++ b/modules/community/live_arena/service.py
@@ -1,0 +1,153 @@
+"""Load and validate the read-only Live Arena workbook contract."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Sequence
+
+from shared.sheets.async_core import afetch_values
+
+CONFIG_TAB = "CONFIG"
+CONFIG_HEADERS = ("Key", "Value", "Notes / clear name")
+CONFIG_KEYS = (
+    "ACTIVE_TOURNAMENT_ID",
+    "TOURNAMENTS_TAB",
+    "ELIGIBLE_CLANS_TAB",
+    "AVAILABILITY_SLOTS_TAB",
+    "ORGANIZER_ROLE_ID",
+)
+TOURNAMENT_HEADERS = (
+    "tournament_id",
+    "tournament_name",
+    "status",
+    "eligibility_scope",
+    "min_participants",
+    "max_participants",
+    "signup_opens_at_utc",
+    "signup_closes_at_utc",
+    "notes",
+)
+ELIGIBLE_CLAN_HEADERS = (
+    "tournament_id",
+    "clan_tag",
+    "clan_name",
+    "discord_role_id",
+    "active",
+    "notes",
+)
+AVAILABILITY_SLOT_HEADERS = (
+    "slot_id",
+    "weekday_utc",
+    "start_time_utc",
+    "end_time_utc",
+    "enabled",
+    "sort_order",
+    "display_label",
+)
+WEEKDAYS = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+
+
+class LiveArenaConfigError(RuntimeError):
+    """The configured Live Arena workbook does not match the PR1 contract."""
+
+
+@dataclass(frozen=True)
+class TournamentSnapshot:
+    tournament_id: str
+    tournament_name: str
+    status: str
+    eligibility_scope: str
+    min_participants: int
+    max_participants: int
+    signup_opens_at_utc: str
+    signup_closes_at_utc: str
+    active_eligible_clans: int
+    enabled_availability_windows: int
+    organizer_role_id: int
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _rows(matrix: Sequence[Sequence[object]], expected: tuple[str, ...], tab: str) -> list[dict[str, object]]:
+    if not matrix:
+        raise LiveArenaConfigError(f"{tab}: required header row missing")
+    headers = tuple(_text(value) for value in matrix[0])
+    missing = [header for header in expected if header not in headers]
+    if missing:
+        raise LiveArenaConfigError(f"{tab}: required header missing: {', '.join(missing)}")
+    unexpected = [header for header in headers if header not in expected]
+    if unexpected:
+        raise LiveArenaConfigError(f"{tab}: unexpected header: {', '.join(unexpected)}")
+    return [dict(zip(headers, row)) for row in matrix[1:] if any(_text(value) for value in row)]
+
+
+def _enabled(value: object) -> bool:
+    return _text(value).lower() in {"1", "true", "yes", "on"}
+
+
+def _required_int(value: object, label: str) -> int:
+    try:
+        parsed = int(_text(value))
+    except (TypeError, ValueError) as exc:
+        raise LiveArenaConfigError(f"{label}: expected an integer") from exc
+    if parsed <= 0:
+        raise LiveArenaConfigError(f"{label}: expected a positive integer")
+    return parsed
+
+
+async def load_config(sheet_id: str) -> dict[str, str]:
+    """Read the literal CONFIG tab and return the five PR1 keys."""
+
+    matrix = await afetch_values(sheet_id, CONFIG_TAB)
+    rows = _rows(matrix or [], CONFIG_HEADERS, CONFIG_TAB)
+    values = {_text(row["Key"]): _text(row["Value"]) for row in rows}
+    for key in CONFIG_KEYS:
+        if not values.get(key):
+            raise LiveArenaConfigError(f"CONFIG: missing required key {key}")
+    return {key: values[key] for key in CONFIG_KEYS}
+
+
+async def load_tournament_snapshot(sheet_id: str) -> TournamentSnapshot:
+    """Load the active tournament and read-only supporting row counts."""
+
+    config = await load_config(sheet_id)
+    tournament_tab = config["TOURNAMENTS_TAB"]
+    clans_tab = config["ELIGIBLE_CLANS_TAB"]
+    slots_tab = config["AVAILABILITY_SLOTS_TAB"]
+    tournaments_matrix, clans_matrix, slots_matrix = await asyncio.gather(
+        afetch_values(sheet_id, tournament_tab),
+        afetch_values(sheet_id, clans_tab),
+        afetch_values(sheet_id, slots_tab),
+    )
+    tournaments = _rows(tournaments_matrix or [], TOURNAMENT_HEADERS, tournament_tab)
+    clans = _rows(clans_matrix or [], ELIGIBLE_CLAN_HEADERS, clans_tab)
+    slots = _rows(slots_matrix or [], AVAILABILITY_SLOT_HEADERS, slots_tab)
+
+    active_id = config["ACTIVE_TOURNAMENT_ID"]
+    tournament = next((row for row in tournaments if _text(row["tournament_id"]) == active_id), None)
+    if tournament is None:
+        raise LiveArenaConfigError(f"{tournament_tab}: active tournament not found: {active_id}")
+
+    for row in slots:
+        weekday = _text(row["weekday_utc"])
+        if weekday not in WEEKDAYS:
+            raise LiveArenaConfigError(f"{slots_tab}: invalid weekday_utc: {weekday or '(blank)'}")
+
+    return TournamentSnapshot(
+        tournament_id=active_id,
+        tournament_name=_text(tournament["tournament_name"]),
+        status=_text(tournament["status"]),
+        eligibility_scope=_text(tournament["eligibility_scope"]),
+        min_participants=_required_int(tournament["min_participants"], f"{tournament_tab}.min_participants"),
+        max_participants=_required_int(tournament["max_participants"], f"{tournament_tab}.max_participants"),
+        signup_opens_at_utc=_text(tournament["signup_opens_at_utc"]),
+        signup_closes_at_utc=_text(tournament["signup_closes_at_utc"]),
+        active_eligible_clans=sum(
+            1 for row in clans if _text(row["tournament_id"]) == active_id and _enabled(row["active"])
+        ),
+        enabled_availability_windows=sum(1 for row in slots if _enabled(row["enabled"])),
+        organizer_role_id=_required_int(config["ORGANIZER_ROLE_ID"], "CONFIG.ORGANIZER_ROLE_ID"),
+    )

--- a/shared/config.py
+++ b/shared/config.py
@@ -536,6 +536,9 @@ def _load_config_snapshot() -> Dict[str, object]:
         "ONBOARDING_SHEET_ID": (os.getenv("ONBOARDING_SHEET_ID") or "").strip(),
         "MILESTONES_SHEET_ID": (os.getenv("MILESTONES_SHEET_ID") or "").strip(),
         "LEAGUES_SHEET_ID": (os.getenv("LEAGUES_SHEET_ID") or "").strip(),
+        "LIVE_ARENA_TOURNAMENT_SHEET_ID": (
+            os.getenv("LIVE_ARENA_TOURNAMENT_SHEET_ID") or ""
+        ).strip(),
         "LEAGUES_CONFIG_TAB": (os.getenv("LEAGUES_CONFIG_TAB") or "Config").strip() or "Config",
         "LEAGUES_SUBMISSION_CHANNEL_ID": _first_int(os.getenv("LEAGUES_SUBMISSION_CHANNEL_ID")),
         "LEAGUES_LEGENDARY_THREAD_ID": _first_int(os.getenv("LEAGUES_LEGENDARY_THREAD_ID")),

--- a/tests/community/test_live_arena.py
+++ b/tests/community/test_live_arena.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+
+from types import SimpleNamespace
+
+import pytest
+
+from cogs import live_arena as cog
+from modules.community.live_arena import service
+from shared import config as shared_config
+
+
+def _config_rows(**overrides: str) -> list[list[object]]:
+    values = {
+        "ACTIVE_TOURNAMENT_ID": "LA-2026-TRIAL-01",
+        "TOURNAMENTS_TAB": "TOURNAMENTS",
+        "ELIGIBLE_CLANS_TAB": "ELIGIBLE_CLANS",
+        "AVAILABILITY_SLOTS_TAB": "AVAILABILITY_SLOTS",
+        "ORGANIZER_ROLE_ID": "1535031755734777967",
+        **overrides,
+    }
+    return [list(service.CONFIG_HEADERS), *[[key, value, ""] for key, value in values.items()]]
+
+
+def _tournament_rows(headers: tuple[str, ...] = service.TOURNAMENT_HEADERS) -> list[list[object]]:
+    row = {
+        "tournament_id": "LA-2026-TRIAL-01",
+        "tournament_name": "C1C Live Arena Trial Cup",
+        "status": "draft",
+        "eligibility_scope": "selected_clans",
+        "min_participants": "8",
+        "max_participants": "16",
+        "signup_opens_at_utc": "",
+        "signup_closes_at_utc": "",
+        "notes": "",
+    }
+    return [list(headers), *[[row[header] for header in headers]]]
+
+
+def _clan_rows() -> list[list[object]]:
+    return [
+        list(service.ELIGIBLE_CLAN_HEADERS),
+        ["LA-2026-TRIAL-01", "C1CM", "Martyrs", "706438713332465694", "TRUE", ""],
+        ["OTHER", "C1CX", "Other", "1", "TRUE", ""],
+        ["LA-2026-TRIAL-01", "C1CY", "Inactive", "2", "FALSE", ""],
+    ]
+
+
+def _slot_rows(count: int = 84) -> list[list[object]]:
+    weekdays = tuple(service.WEEKDAYS)
+    return [
+        list(service.AVAILABILITY_SLOT_HEADERS),
+        *[
+            [f"slot-{index}", weekdays[index % 7], "00:00", "02:00", "TRUE", index, f"Slot {index}"]
+            for index in range(count)
+        ],
+    ]
+
+
+def _matrices(config: list[list[object]] | None = None) -> dict[str, list[list[object]]]:
+    return {
+        "CONFIG": config or _config_rows(),
+        "TOURNAMENTS": _tournament_rows(),
+        "ELIGIBLE_CLANS": _clan_rows(),
+        "AVAILABILITY_SLOTS": _slot_rows(),
+    }
+
+
+def _install_fetch(monkeypatch, matrices, seen=None):
+    async def fetch(sheet_id, tab):
+        assert sheet_id == "sheet-id"
+        if seen is not None:
+            seen.append(tab)
+        return matrices[tab]
+
+    monkeypatch.setattr(service, "afetch_values", fetch)
+
+
+def test_missing_sheet_id_disables_live_arena_safely(monkeypatch, caplog):
+    monkeypatch.setitem(shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "")
+    caplog.set_level("INFO", logger="c1c.community.live_arena")
+    cog.LiveArenaCog(SimpleNamespace())
+    assert "Live Arena — disabled" in caplog.text
+
+
+def test_env_key_reaches_shared_config_snapshot(monkeypatch):
+    monkeypatch.setenv("LIVE_ARENA_TOURNAMENT_SHEET_ID", "workbook-from-env")
+    assert shared_config._load_config_snapshot()["LIVE_ARENA_TOURNAMENT_SHEET_ID"] == "workbook-from-env"
+
+
+def test_config_is_read_by_actual_name(monkeypatch):
+    seen = []
+    _install_fetch(monkeypatch, _matrices(), seen)
+    asyncio.run(service.load_config("sheet-id"))
+    assert seen == ["CONFIG"]
+
+
+def test_table_names_are_routed_from_config(monkeypatch):
+    matrices = _matrices(_config_rows(TOURNAMENTS_TAB="EVENTS", ELIGIBLE_CLANS_TAB="CLANS", AVAILABILITY_SLOTS_TAB="SLOTS"))
+    matrices.update(EVENTS=matrices.pop("TOURNAMENTS"), CLANS=matrices.pop("ELIGIBLE_CLANS"), SLOTS=matrices.pop("AVAILABILITY_SLOTS"))
+    seen = []
+    _install_fetch(monkeypatch, matrices, seen)
+    asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    assert seen == ["CONFIG", "EVENTS", "CLANS", "SLOTS"]
+
+
+def test_active_tournament_comes_from_config(monkeypatch):
+    matrices = _matrices(_config_rows(ACTIVE_TOURNAMENT_ID="missing-id"))
+    _install_fetch(monkeypatch, matrices)
+    with pytest.raises(service.LiveArenaConfigError, match="active tournament not found: missing-id"):
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+
+
+def test_exact_tournament_headers_pass(monkeypatch):
+    _install_fetch(monkeypatch, _matrices())
+    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).tournament_id == "LA-2026-TRIAL-01"
+
+
+def test_missing_tournament_header_has_useful_error(monkeypatch):
+    matrices = _matrices()
+    matrices["TOURNAMENTS"] = _tournament_rows(tuple(h for h in service.TOURNAMENT_HEADERS if h != "status"))
+    _install_fetch(monkeypatch, matrices)
+    with pytest.raises(service.LiveArenaConfigError, match="TOURNAMENTS: required header missing: status"):
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+
+
+def test_exact_eligible_clan_headers_pass(monkeypatch):
+    _install_fetch(monkeypatch, _matrices())
+    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).active_eligible_clans == 1
+
+
+def test_exact_availability_headers_pass_without_tournament_id(monkeypatch):
+    assert "tournament_id" not in service.AVAILABILITY_SLOT_HEADERS
+    _install_fetch(monkeypatch, _matrices())
+    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+
+
+def test_availability_uses_enabled_never_active():
+    assert "enabled" in service.AVAILABILITY_SLOT_HEADERS
+    assert "active" not in service.AVAILABILITY_SLOT_HEADERS
+
+
+def test_weekday_names_are_accepted(monkeypatch):
+    matrices = _matrices()
+    matrices["AVAILABILITY_SLOTS"][1][1] = "Monday"
+    _install_fetch(monkeypatch, matrices)
+    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+
+
+def test_current_fixture_has_84_enabled_windows(monkeypatch):
+    _install_fetch(monkeypatch, _matrices())
+    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+
+
+def test_blank_signup_timestamps_are_valid_for_draft(monkeypatch):
+    _install_fetch(monkeypatch, _matrices())
+    snapshot = asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    assert (snapshot.status, snapshot.signup_opens_at_utc, snapshot.signup_closes_at_utc) == ("draft", "", "")
+
+
+class _Context:
+    def __init__(self, role_ids):
+        self.author = SimpleNamespace(roles=[SimpleNamespace(id=value) for value in role_ids])
+        self.messages = []
+
+    async def send(self, content=None, *, embed=None):
+        self.messages.append((content, embed))
+
+
+def test_check_rejects_user_without_configured_organizer_role(monkeypatch):
+    monkeypatch.setitem(shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id")
+    _install_fetch(monkeypatch, _matrices())
+    ctx = _Context([])
+    instance = cog.LiveArenaCog(SimpleNamespace())
+    asyncio.run(cog.LiveArenaCog.check.callback(instance, ctx))
+    assert "organizer role" in ctx.messages[0][0]
+
+
+def test_healthy_check_embed_has_expected_values(monkeypatch):
+    monkeypatch.setitem(shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id")
+    _install_fetch(monkeypatch, _matrices())
+    ctx = _Context([1535031755734777967])
+    instance = cog.LiveArenaCog(SimpleNamespace())
+    asyncio.run(cog.LiveArenaCog.check.callback(instance, ctx))
+    fields = {field.name: field.value for field in ctx.messages[0][1].fields}
+    assert fields == {
+        "Tournament": "C1C Live Arena Trial Cup",
+        "Tournament ID": "LA-2026-TRIAL-01",
+        "Status": "draft",
+        "Eligibility scope": "selected_clans",
+        "Active eligible clans": "1",
+        "Enabled availability windows": "84",
+        "Participants": "8–16",
+        "Signup opens": "Not configured",
+        "Signup closes": "Not configured",
+        "Configuration": "OK",
+    }


### PR DESCRIPTION
### Motivation

- Provide a small, fresh PR1 slice that proves the Woadkeeper can load and validate the Live Arena tournament workbook contract and expose an organizer-only diagnostic command.
- Keep scope strictly limited to read-only workbook loading, header/schema validation, routing table names via CONFIG, and a diagnostics command; do not implement registration or participant writes.
- Make the feature opt-in via an optional env key so startup remains normal when Live Arena is not configured.

### Description

- Add a read-only Live Arena workbook loader that uses the literal `CONFIG`, `TOURNAMENTS`, `ELIGIBLE_CLANS`, and `AVAILABILITY_SLOTS` contracts, validates required headers exactly, selects the configured `ACTIVE_TOURNAMENT_ID`, and counts active clans and enabled availability windows using async Sheets helpers (`afetch_values`). (`modules/community/live_arena/service.py`).
- Add an organizer-gated diagnostic command group `!latournament check` that returns a healthy or configuration-error embed and enforces the organizer role from `CONFIG.ORGANIZER_ROLE_ID`; the command is gated by the optional env key and reports a clear error when the workbook ID is not configured. (`cogs/live_arena.py`).
- Wire `LIVE_ARENA_TOURNAMENT_SHEET_ID` into the shared config snapshot accessor and document the key in `docs/ops/.env.example`, `docs/ops/Config.md`, and `AGENTS.md` without changing any Google Sheets. (`shared/config.py`, docs). 
- Register the Live Arena extension in the existing community extensions registry and add focused unit tests that implement the PR1 acceptance checklist items (fixtures matching the exact headers and the 84 enabled-window fixture). (`modules/community/__init__.py`, `tests/community/test_live_arena.py`).

### Testing

- Ran `pytest -q tests/community/test_live_arena.py` and all tests in that file passed (covering missing env, shared-config propagation, CONFIG routing, exact headers, missing-header errors, active-tournament selection, enabled-window counts, weekday acceptance, blank signup timestamps for `draft`, organizer authorization, and healthy embed values).
- Ran style/linters: `ruff check` on the new files and touched modules (passed for the changes made). 
- Ran environment/guardrail helpers: `PYTHONPATH=. python scripts/ci/check_env_parity.py` completed; `PYTHONPATH=. python scripts/ci/guardrails_suite.py --base-ref HEAD` was executed and returned a failing status due to existing, repository-wide guardrail issues (legacy imports, missing/incorrect docs footers, ADR filename patterns, embed colour findings) that are unrelated to the Live Arena PR1 changes.
- Ran the full test suite (`pytest -q`) which completed but showed multiple pre-existing unrelated failures in other modules; the new Live Arena unit tests passed within that run.

Notes: No Google Sheets were modified as part of this change; the PR implements only the PR1 workbook foundation and the `!latournament check` diagnostic as specified in issue #1063.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75daa7fc30832392c29f5146ba0407)