### PR TITLE
Live Arena PR2: add registration data service

### DIFF
--- a/cogs/live_arena.py
+++ b/cogs/live_arena.py
@@ -8,14 +8,21 @@ import discord
 from discord.ext import commands
 
 from shared.config import cfg
+from shared.theme import colors
 
-from modules.community.live_arena.service import LiveArenaConfigError, TournamentSnapshot, load_tournament_snapshot
+from modules.community.live_arena.service import (
+    LiveArenaConfigError,
+    TournamentSnapshot,
+    load_tournament_snapshot,
+)
 
 log = logging.getLogger("c1c.community.live_arena")
 
 
 def build_check_embed(snapshot: TournamentSnapshot) -> discord.Embed:
-    embed = discord.Embed(title="Live Arena tournament check", colour=discord.Colour.green())
+    embed = discord.Embed(
+        title="Live Arena tournament check", colour=discord.Colour.green()
+    )
     values = (
         ("Tournament", snapshot.tournament_name),
         ("Tournament ID", snapshot.tournament_id),
@@ -34,17 +41,29 @@ def build_check_embed(snapshot: TournamentSnapshot) -> discord.Embed:
 
 
 def build_error_embed(message: str) -> discord.Embed:
-    embed = discord.Embed(title="Live Arena tournament check", colour=discord.Colour.red())
+    embed = discord.Embed(
+        title="Live Arena tournament check", colour=discord.Colour.red()
+    )
     embed.add_field(name="Configuration", value="Invalid", inline=False)
     embed.add_field(name="Error", value=message, inline=False)
     return embed
+
+
+def build_message_embed(message: str) -> discord.Embed:
+    return discord.Embed(
+        title="Live Arena tournament",
+        description=message,
+        colour=colors.c1c_blue,
+    )
 
 
 class LiveArenaCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         if not self._sheet_id():
-            log.info("📋 Live Arena — disabled • reason=LIVE_ARENA_TOURNAMENT_SHEET_ID not configured")
+            log.info(
+                "📋 Live Arena — disabled • reason=LIVE_ARENA_TOURNAMENT_SHEET_ID not configured"
+            )
 
     @staticmethod
     def _sheet_id() -> str:
@@ -52,13 +71,17 @@ class LiveArenaCog(commands.Cog):
 
     @commands.group(name="latournament", invoke_without_command=True)
     async def latournament(self, ctx: commands.Context) -> None:
-        await ctx.send("Usage: `!latournament check`")
+        await ctx.send(embed=build_message_embed("Usage: `!latournament check`"))
 
     @latournament.command(name="check")
     async def check(self, ctx: commands.Context) -> None:
         sheet_id = self._sheet_id()
         if not sheet_id:
-            await ctx.send(embed=build_error_embed("LIVE_ARENA_TOURNAMENT_SHEET_ID is not configured"))
+            await ctx.send(
+                embed=build_error_embed(
+                    "LIVE_ARENA_TOURNAMENT_SHEET_ID is not configured"
+                )
+            )
             return
         try:
             snapshot = await load_tournament_snapshot(sheet_id)
@@ -67,9 +90,15 @@ class LiveArenaCog(commands.Cog):
             await ctx.send(embed=build_error_embed(str(exc)))
             return
 
-        role_ids = {getattr(role, "id", None) for role in getattr(ctx.author, "roles", ())}
+        role_ids = {
+            getattr(role, "id", None) for role in getattr(ctx.author, "roles", ())
+        }
         if snapshot.organizer_role_id not in role_ids:
-            await ctx.send("You need the configured Live Arena organizer role to run this command.")
+            await ctx.send(
+                embed=build_message_embed(
+                    "You need the configured Live Arena organizer role to run this command."
+                )
+            )
             return
         await ctx.send(embed=build_check_embed(snapshot))
 

--- a/modules/community/live_arena/registration.py
+++ b/modules/community/live_arena/registration.py
@@ -225,10 +225,8 @@ class RegistrationService:
             timezone, slot_ids, slots, tournament["signup_closes_at_utc"]
         )
         now = utc_iso(self.clock())
-        previous_p, previous_a = (
-            [dict(r) for r in participants],
-            [dict(r) for r in availability],
-        )
+        previous_p = [dict(r) for r in participants]
+        previous_a = [dict(r) for r in availability]
         if existing:
             existing.update(
                 display_name_at_signup=display_name,
@@ -262,7 +260,12 @@ class RegistrationService:
         updated_a = self._replacement(
             availability, tournament_id, str(user_id), selected, now
         )
-        await self._core_write(participants, updated_a, previous_p, previous_a)
+        await self.repository.persist_core_state(
+            participants,
+            updated_a,
+            previous_participants=previous_p,
+            previous_availability=previous_a,
+        )
         await self._audit(
             tournament_id,
             str(user_id),
@@ -296,13 +299,13 @@ class RegistrationService:
                 [dict(r) for r in availability],
             )
             row.update(timezone=timezone, updated_at_utc=now)
-            await self._core_write(
+            await self.repository.persist_core_state(
                 participants,
                 self._replacement(
                     availability, tournament_id, str(user_id), selected, now
                 ),
-                old_p,
-                old_a,
+                previous_participants=old_p,
+                previous_availability=old_a,
             )
             await self._audit(
                 tournament_id,
@@ -327,11 +330,9 @@ class RegistrationService:
                 withdrawal_reason=reason,
                 updated_at_utc=now,
             )
-            try:
-                await self.repository.replace_participants(participants)
-            except Exception:
-                await self.repository.replace_participants(old)
-                raise
+            await self.repository.persist_participants(
+                participants, previous_participants=old
+            )
             await self._audit(
                 tournament_id,
                 str(user_id),
@@ -408,15 +409,6 @@ class RegistrationService:
                 )
             )
         return other
-
-    async def _core_write(self, participants, availability, old_p, old_a):
-        try:
-            await self.repository.replace_participants(participants)
-            await self.repository.replace_availability(availability)
-        except Exception:
-            await self.repository.replace_participants(old_p)
-            await self.repository.replace_availability(old_a)
-            raise
 
     async def _audit(self, tournament_id, user_id, event, details, now):
         try:

--- a/modules/community/live_arena/registration.py
+++ b/modules/community/live_arena/registration.py
@@ -1,0 +1,440 @@
+"""Discord-independent Live Arena registration domain service."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime, time, timedelta
+from typing import Callable
+from uuid import uuid4
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from shared.sheets.async_core import afetch_values
+
+from modules.community.live_arena.repository import LiveArenaRepository
+from modules.community.live_arena.service import (
+    AVAILABILITY_SLOT_HEADERS,
+    ELIGIBLE_CLAN_HEADERS,
+    TOURNAMENT_HEADERS,
+    LiveArenaConfigError,
+    _enabled,
+    _required_int,
+    _rows,
+    _text,
+    load_config,
+)
+
+log = logging.getLogger("c1c.community.live_arena")
+_locks: defaultdict[tuple[str, str], asyncio.Lock] = defaultdict(asyncio.Lock)
+
+
+class RegistrationError(ValueError):
+    """A clear, user-presentable registration rejection."""
+
+
+def utc_iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_close(value: object) -> datetime:
+    text = _text(value)
+    if not text:
+        raise RegistrationError("signup_closes_at_utc is required while signup is open")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RegistrationError("signup_closes_at_utc is invalid") from exc
+    if parsed.tzinfo is None:
+        raise RegistrationError("signup_closes_at_utc must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def validate_availability(
+    timezone: str, slot_ids: list[str], slots: list[dict[str, object]], close: object
+) -> list[str]:
+    try:
+        zone = ZoneInfo(timezone)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise RegistrationError("timezone must be a valid IANA timezone") from exc
+    selected = list(dict.fromkeys(str(value) for value in slot_ids))
+    by_id = {_text(row["slot_id"]): row for row in slots}
+    if any(slot_id not in by_id for slot_id in selected):
+        raise RegistrationError("unknown availability slot ID")
+    if any(not _enabled(by_id[slot_id]["enabled"]) for slot_id in selected):
+        raise RegistrationError("disabled availability slot selected")
+    if len(selected) < 3:
+        raise RegistrationError("select at least 3 distinct availability slots")
+    anchor = _parse_close(close)
+    monday = anchor.date() - timedelta(days=anchor.weekday())
+    weekdays = {
+        name: index
+        for index, name in enumerate(
+            (
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
+            )
+        )
+    }
+    local_days = set()
+    for slot_id in selected:
+        row = by_id[slot_id]
+        try:
+            day = monday + timedelta(days=weekdays[_text(row["weekday_utc"])])
+            start = time.fromisoformat(_text(row["start_time_utc"]))
+            end = time.fromisoformat(_text(row["end_time_utc"]))
+        except (KeyError, ValueError) as exc:
+            raise LiveArenaConfigError(f"invalid availability slot: {slot_id}") from exc
+        start_at = datetime.combine(day, start, UTC)
+        end_at = datetime.combine(day, end, UTC)
+        if end_at <= start_at:
+            end_at += timedelta(days=1)
+        if end_at - start_at != timedelta(hours=2):
+            raise RegistrationError(
+                "selected availability slots must be two-hour windows"
+            )
+        local_days.add(start_at.astimezone(zone).date())
+    if len(local_days) < 2:
+        raise RegistrationError("availability must span at least 2 local start-days")
+    return selected
+
+
+class RegistrationService:
+    def __init__(
+        self,
+        sheet_id: str,
+        repository: LiveArenaRepository | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.sheet_id = sheet_id
+        self.repository = repository or LiveArenaRepository(sheet_id)
+        self.clock = clock or (lambda: datetime.now(UTC))
+
+    async def initialize(self) -> None:
+        await self.repository.initialize()
+
+    async def _context(self):
+        config = await load_config(self.sheet_id)
+        matrices = await asyncio.gather(
+            afetch_values(self.sheet_id, config["TOURNAMENTS_TAB"]),
+            afetch_values(self.sheet_id, config["ELIGIBLE_CLANS_TAB"]),
+            afetch_values(self.sheet_id, config["AVAILABILITY_SLOTS_TAB"]),
+        )
+        tournaments = _rows(
+            matrices[0] or [], TOURNAMENT_HEADERS, config["TOURNAMENTS_TAB"]
+        )
+        tournament = next(
+            (
+                r
+                for r in tournaments
+                if _text(r["tournament_id"]) == config["ACTIVE_TOURNAMENT_ID"]
+            ),
+            None,
+        )
+        if tournament is None:
+            raise LiveArenaConfigError("active tournament not found")
+        return (
+            config,
+            tournament,
+            _rows(
+                matrices[1] or [], ELIGIBLE_CLAN_HEADERS, config["ELIGIBLE_CLANS_TAB"]
+            ),
+            _rows(
+                matrices[2] or [],
+                AVAILABILITY_SLOT_HEADERS,
+                config["AVAILABILITY_SLOTS_TAB"],
+            ),
+        )
+
+    async def register(
+        self,
+        user_id: str,
+        display_name: str,
+        role_ids: list[str],
+        timezone: str,
+        slot_ids: list[str],
+    ) -> None:
+        config, tournament, clans, slots = await self._context()
+        tournament_id = config["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tournament_id)]:
+            await self._register_locked(
+                tournament,
+                clans,
+                slots,
+                user_id,
+                display_name,
+                role_ids,
+                timezone,
+                slot_ids,
+            )
+
+    async def _register_locked(
+        self,
+        tournament,
+        clans,
+        slots,
+        user_id,
+        display_name,
+        role_ids,
+        timezone,
+        slot_ids,
+    ):
+        self._require_status(tournament, {"signup_open"})
+        tournament_id = _text(tournament["tournament_id"])
+        participants = await self.repository.participants()
+        availability = await self.repository.availability()
+        existing = next(
+            (
+                r
+                for r in participants
+                if _text(r["tournament_id"]) == tournament_id
+                and _text(r["discord_user_id"]) == str(user_id)
+            ),
+            None,
+        )
+        if existing and _text(existing["status"]) == "confirmed":
+            raise RegistrationError("already registered")
+        if existing and _text(existing["status"]) in {"removed", "disqualified"}:
+            raise RegistrationError(
+                f"{_text(existing['status'])} participant cannot self-register"
+            )
+        if existing and _text(existing["status"]) != "withdrawn":
+            raise RegistrationError(
+                f"unsupported participant status: {_text(existing['status'])}"
+            )
+        maximum = _required_int(
+            tournament["max_participants"], "TOURNAMENTS.max_participants"
+        )
+        if (
+            sum(
+                _text(r["tournament_id"]) == tournament_id
+                and _text(r["status"]) == "confirmed"
+                for r in participants
+            )
+            >= maximum
+        ):
+            raise RegistrationError("tournament capacity is full")
+        clan = self._eligible(tournament, clans, role_ids)
+        selected = validate_availability(
+            timezone, slot_ids, slots, tournament["signup_closes_at_utc"]
+        )
+        now = utc_iso(self.clock())
+        previous_p, previous_a = (
+            [dict(r) for r in participants],
+            [dict(r) for r in availability],
+        )
+        if existing:
+            existing.update(
+                display_name_at_signup=display_name,
+                clan_tag_at_signup=_text(clan["clan_tag"]),
+                timezone=timezone,
+                status="confirmed",
+                confirmed_at_utc=now,
+                withdrawn_at_utc="",
+                withdrawal_reason="",
+                updated_at_utc=now,
+            )
+            event = "registration_reconfirmed"
+        else:
+            participants.append(
+                dict(
+                    tournament_id=tournament_id,
+                    discord_user_id=str(user_id),
+                    display_name_at_signup=display_name,
+                    clan_tag_at_signup=_text(clan["clan_tag"]),
+                    timezone=timezone,
+                    status="confirmed",
+                    signed_up_at_utc=now,
+                    confirmed_at_utc=now,
+                    withdrawn_at_utc="",
+                    withdrawal_reason="",
+                    updated_at_utc=now,
+                    notes="",
+                )
+            )
+            event = "registration_confirmed"
+        updated_a = self._replacement(
+            availability, tournament_id, str(user_id), selected, now
+        )
+        await self._core_write(participants, updated_a, previous_p, previous_a)
+        await self._audit(
+            tournament_id,
+            str(user_id),
+            event,
+            {
+                "clan_tag": _text(clan["clan_tag"]),
+                "timezone": timezone,
+                "availability_count": len(selected),
+            },
+            now,
+        )
+
+    async def update_availability(
+        self, user_id: str, timezone: str, slot_ids: list[str]
+    ) -> None:
+        config, tournament, _, slots = await self._context()
+        tournament_id = config["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tournament_id)]:
+            self._require_status(tournament, {"signup_open"})
+            participants, availability = (
+                await self.repository.participants(),
+                await self.repository.availability(),
+            )
+            row = self._confirmed(participants, tournament_id, str(user_id))
+            selected = validate_availability(
+                timezone, slot_ids, slots, tournament["signup_closes_at_utc"]
+            )
+            now = utc_iso(self.clock())
+            old_p, old_a = (
+                [dict(r) for r in participants],
+                [dict(r) for r in availability],
+            )
+            row.update(timezone=timezone, updated_at_utc=now)
+            await self._core_write(
+                participants,
+                self._replacement(
+                    availability, tournament_id, str(user_id), selected, now
+                ),
+                old_p,
+                old_a,
+            )
+            await self._audit(
+                tournament_id,
+                str(user_id),
+                "availability_updated",
+                {"timezone": timezone, "availability_count": len(selected)},
+                now,
+            )
+
+    async def withdraw(self, user_id: str, reason: str = "") -> None:
+        config, tournament, _, _ = await self._context()
+        tournament_id = config["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tournament_id)]:
+            self._require_status(tournament, {"signup_open", "signup_closed"})
+            participants = await self.repository.participants()
+            row = self._confirmed(participants, tournament_id, str(user_id))
+            old = [dict(r) for r in participants]
+            now = utc_iso(self.clock())
+            row.update(
+                status="withdrawn",
+                withdrawn_at_utc=now,
+                withdrawal_reason=reason,
+                updated_at_utc=now,
+            )
+            try:
+                await self.repository.replace_participants(participants)
+            except Exception:
+                await self.repository.replace_participants(old)
+                raise
+            await self._audit(
+                tournament_id,
+                str(user_id),
+                "registration_withdrawn",
+                {"withdrawal_reason": reason},
+                now,
+            )
+
+    @staticmethod
+    def _require_status(tournament, allowed):
+        if _text(tournament["status"]) not in allowed:
+            raise RegistrationError("tournament status does not allow this mutation")
+
+    @staticmethod
+    def _confirmed(rows, tournament_id, user_id):
+        row = next(
+            (
+                r
+                for r in rows
+                if _text(r["tournament_id"]) == tournament_id
+                and _text(r["discord_user_id"]) == user_id
+            ),
+            None,
+        )
+        if row is None or _text(row["status"]) != "confirmed":
+            raise RegistrationError("participant is not confirmed")
+        return row
+
+    @staticmethod
+    def _eligible(tournament, clans, role_ids):
+        if _text(tournament["eligibility_scope"]) != "selected_clans":
+            raise RegistrationError("unsupported eligibility scope")
+        roles = {str(value) for value in role_ids}
+        match = next(
+            (
+                r
+                for r in clans
+                if _text(r["tournament_id"]) == _text(tournament["tournament_id"])
+                and _enabled(r["active"])
+                and _text(r["discord_role_id"]) in roles
+            ),
+            None,
+        )
+        if match is None:
+            raise RegistrationError("no matching active eligible clan role")
+        return match
+
+    @staticmethod
+    def _replacement(rows, tournament_id, user_id, selected, now):
+        retained = {
+            _text(r["slot_id"]): r
+            for r in rows
+            if _text(r["tournament_id"]) == tournament_id
+            and _text(r["discord_user_id"]) == user_id
+        }
+        other = [
+            r
+            for r in rows
+            if not (
+                _text(r["tournament_id"]) == tournament_id
+                and _text(r["discord_user_id"]) == user_id
+            )
+        ]
+        for slot_id in selected:
+            created = _text(retained.get(slot_id, {}).get("created_at_utc")) or now
+            other.append(
+                dict(
+                    tournament_id=tournament_id,
+                    discord_user_id=user_id,
+                    slot_id=slot_id,
+                    created_at_utc=created,
+                    updated_at_utc=now,
+                    notes="",
+                )
+            )
+        return other
+
+    async def _core_write(self, participants, availability, old_p, old_a):
+        try:
+            await self.repository.replace_participants(participants)
+            await self.repository.replace_availability(availability)
+        except Exception:
+            await self.repository.replace_participants(old_p)
+            await self.repository.replace_availability(old_a)
+            raise
+
+    async def _audit(self, tournament_id, user_id, event, details, now):
+        try:
+            await self.repository.append_audit(
+                dict(
+                    event_id=str(uuid4()),
+                    tournament_id=tournament_id,
+                    event_type=event,
+                    actor_discord_user_id=user_id,
+                    target_discord_user_id=user_id,
+                    details=json.dumps(details, sort_keys=True, separators=(",", ":")),
+                    created_at_utc=now,
+                )
+            )
+        except Exception:
+            log.exception(
+                "❌ Live Arena audit — append failed • tournament=%s • user=%s • event=%s",
+                tournament_id,
+                user_id,
+                event,
+            )

--- a/modules/community/live_arena/repository.py
+++ b/modules/community/live_arena/repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
 
@@ -74,29 +75,83 @@ class LiveArenaRepository:
             "PARTICIPANT_AVAILABILITY_TAB", PARTICIPANT_AVAILABILITY_HEADERS
         )
 
-    async def replace_participants(self, rows: Sequence[dict[str, object]]) -> None:
-        await self._replace("PARTICIPANTS_TAB", PARTICIPANT_HEADERS, rows)
-
-    async def replace_availability(self, rows: Sequence[dict[str, object]]) -> None:
-        await self._replace(
-            "PARTICIPANT_AVAILABILITY_TAB", PARTICIPANT_AVAILABILITY_HEADERS, rows
+    async def persist_core_state(
+        self,
+        participants: Sequence[dict[str, object]],
+        availability: Sequence[dict[str, object]],
+        *,
+        previous_participants: Sequence[dict[str, object]],
+        previous_availability: Sequence[dict[str, object]],
+    ) -> None:
+        """Persist both core tables in one values batch, compensating ambiguity locally."""
+        await self._persist_tables(
+            (
+                (
+                    "PARTICIPANTS_TAB",
+                    PARTICIPANT_HEADERS,
+                    participants,
+                    previous_participants,
+                ),
+                (
+                    "PARTICIPANT_AVAILABILITY_TAB",
+                    PARTICIPANT_AVAILABILITY_HEADERS,
+                    availability,
+                    previous_availability,
+                ),
+            )
         )
 
-    async def _replace(
-        self, key: str, headers: tuple[str, ...], rows: Sequence[dict[str, object]]
+    async def persist_participants(
+        self,
+        participants: Sequence[dict[str, object]],
+        *,
+        previous_participants: Sequence[dict[str, object]],
     ) -> None:
-        worksheet = await aget_worksheet(self.sheet_id, self.config[key])
-        await acall_with_backoff(worksheet.batch_clear, [f"A2:{_column(len(headers))}"])
-        if rows:
+        """Persist a participant-only mutation, including withdrawal."""
+        await self._persist_tables(
+            (
+                (
+                    "PARTICIPANTS_TAB",
+                    PARTICIPANT_HEADERS,
+                    participants,
+                    previous_participants,
+                ),
+            )
+        )
+
+    async def _persist_tables(self, tables) -> None:
+        worksheet = await aget_worksheet(self.sheet_id, self.config["PARTICIPANTS_TAB"])
+        spreadsheet = worksheet.spreadsheet
+        update = self._batch_body(tables, use_previous=False)
+        rollback = self._batch_body(tables, use_previous=True)
+        try:
+            await acall_with_backoff(spreadsheet.values_batch_update, body=update)
+        except Exception as write_error:
+            try:
+                await acall_with_backoff(spreadsheet.values_batch_update, body=rollback)
+            except Exception as rollback_error:
+                raise CoreStatePersistenceError(
+                    write_error=write_error, rollback_error=rollback_error
+                ) from rollback_error
+            raise
+
+    def _batch_body(self, tables, *, use_previous: bool) -> dict[str, object]:
+        data = []
+        for key, headers, current, previous in tables:
+            rows = previous if use_previous else current
+            row_count = max(len(current), len(previous), 1)
             values = [
                 [str(row.get(header, "") or "") for header in headers] for row in rows
             ]
-            await acall_with_backoff(
-                worksheet.update,
-                f"A2:{_column(len(headers))}{len(values) + 1}",
-                values,
-                value_input_option="RAW",
+            values.extend([[""] * len(headers) for _ in range(row_count - len(values))])
+            tab = self.config[key].replace("'", "''")
+            data.append(
+                {
+                    "range": f"'{tab}'!A2:{_column(len(headers))}{row_count + 1}",
+                    "values": values,
+                }
             )
+        return {"valueInputOption": "RAW", "data": data}
 
     async def append_audit(self, row: dict[str, object]) -> None:
         worksheet = await aget_worksheet(self.sheet_id, self.config["AUDIT_LOG_TAB"])
@@ -111,3 +166,17 @@ def _column(number: int) -> str:
     if not 1 <= number <= 26:
         raise LiveArenaConfigError("Live Arena table has unsupported width")
     return chr(64 + number)
+
+
+@dataclass
+class CoreStatePersistenceError(RuntimeError):
+    """A core write failed and its repository-local compensation also failed."""
+
+    write_error: Exception
+    rollback_error: Exception
+
+    def __str__(self) -> str:
+        return (
+            "Live Arena core persistence and compensation both failed: "
+            f"write={self.write_error!r}; rollback={self.rollback_error!r}"
+        )

--- a/modules/community/live_arena/repository.py
+++ b/modules/community/live_arena/repository.py
@@ -1,0 +1,113 @@
+"""Async Google Sheets persistence for Live Arena registration state."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
+
+from modules.community.live_arena.service import (
+    LiveArenaConfigError,
+    _rows,
+    load_config,
+)
+
+PARTICIPANT_HEADERS = (
+    "tournament_id",
+    "discord_user_id",
+    "display_name_at_signup",
+    "clan_tag_at_signup",
+    "timezone",
+    "status",
+    "signed_up_at_utc",
+    "confirmed_at_utc",
+    "withdrawn_at_utc",
+    "withdrawal_reason",
+    "updated_at_utc",
+    "notes",
+)
+PARTICIPANT_AVAILABILITY_HEADERS = (
+    "tournament_id",
+    "discord_user_id",
+    "slot_id",
+    "created_at_utc",
+    "updated_at_utc",
+    "notes",
+)
+AUDIT_LOG_HEADERS = (
+    "event_id",
+    "tournament_id",
+    "event_type",
+    "actor_discord_user_id",
+    "target_discord_user_id",
+    "details",
+    "created_at_utc",
+)
+
+
+class LiveArenaRepository:
+    """Workbook adapter whose table names always come from CONFIG."""
+
+    def __init__(self, sheet_id: str) -> None:
+        self.sheet_id = sheet_id
+        self.config: dict[str, str] = {}
+
+    async def initialize(self) -> None:
+        self.config = await load_config(self.sheet_id)
+        await self._read("PARTICIPANTS_TAB", PARTICIPANT_HEADERS)
+        await self._read(
+            "PARTICIPANT_AVAILABILITY_TAB", PARTICIPANT_AVAILABILITY_HEADERS
+        )
+        await self._read("AUDIT_LOG_TAB", AUDIT_LOG_HEADERS)
+
+    async def _read(
+        self, key: str, headers: tuple[str, ...]
+    ) -> list[dict[str, object]]:
+        tab = self.config[key]
+        return _rows(await afetch_values(self.sheet_id, tab) or [], headers, tab)
+
+    async def participants(self) -> list[dict[str, object]]:
+        return await self._read("PARTICIPANTS_TAB", PARTICIPANT_HEADERS)
+
+    async def availability(self) -> list[dict[str, object]]:
+        return await self._read(
+            "PARTICIPANT_AVAILABILITY_TAB", PARTICIPANT_AVAILABILITY_HEADERS
+        )
+
+    async def replace_participants(self, rows: Sequence[dict[str, object]]) -> None:
+        await self._replace("PARTICIPANTS_TAB", PARTICIPANT_HEADERS, rows)
+
+    async def replace_availability(self, rows: Sequence[dict[str, object]]) -> None:
+        await self._replace(
+            "PARTICIPANT_AVAILABILITY_TAB", PARTICIPANT_AVAILABILITY_HEADERS, rows
+        )
+
+    async def _replace(
+        self, key: str, headers: tuple[str, ...], rows: Sequence[dict[str, object]]
+    ) -> None:
+        worksheet = await aget_worksheet(self.sheet_id, self.config[key])
+        await acall_with_backoff(worksheet.batch_clear, [f"A2:{_column(len(headers))}"])
+        if rows:
+            values = [
+                [str(row.get(header, "") or "") for header in headers] for row in rows
+            ]
+            await acall_with_backoff(
+                worksheet.update,
+                f"A2:{_column(len(headers))}{len(values) + 1}",
+                values,
+                value_input_option="RAW",
+            )
+
+    async def append_audit(self, row: dict[str, object]) -> None:
+        worksheet = await aget_worksheet(self.sheet_id, self.config["AUDIT_LOG_TAB"])
+        await acall_with_backoff(
+            worksheet.append_row,
+            [str(row.get(header, "") or "") for header in AUDIT_LOG_HEADERS],
+            value_input_option="RAW",
+        )
+
+
+def _column(number: int) -> str:
+    if not 1 <= number <= 26:
+        raise LiveArenaConfigError("Live Arena table has unsupported width")
+    return chr(64 + number)

--- a/modules/community/live_arena/service.py
+++ b/modules/community/live_arena/service.py
@@ -16,6 +16,9 @@ CONFIG_KEYS = (
     "ELIGIBLE_CLANS_TAB",
     "AVAILABILITY_SLOTS_TAB",
     "ORGANIZER_ROLE_ID",
+    "PARTICIPANTS_TAB",
+    "PARTICIPANT_AVAILABILITY_TAB",
+    "AUDIT_LOG_TAB",
 )
 TOURNAMENT_HEADERS = (
     "tournament_id",
@@ -45,7 +48,15 @@ AVAILABILITY_SLOT_HEADERS = (
     "sort_order",
     "display_label",
 )
-WEEKDAYS = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+WEEKDAYS = {
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+}
 
 
 class LiveArenaConfigError(RuntimeError):
@@ -71,17 +82,25 @@ def _text(value: object) -> str:
     return str(value or "").strip()
 
 
-def _rows(matrix: Sequence[Sequence[object]], expected: tuple[str, ...], tab: str) -> list[dict[str, object]]:
+def _rows(
+    matrix: Sequence[Sequence[object]], expected: tuple[str, ...], tab: str
+) -> list[dict[str, object]]:
     if not matrix:
         raise LiveArenaConfigError(f"{tab}: required header row missing")
     headers = tuple(_text(value) for value in matrix[0])
     missing = [header for header in expected if header not in headers]
     if missing:
-        raise LiveArenaConfigError(f"{tab}: required header missing: {', '.join(missing)}")
+        raise LiveArenaConfigError(
+            f"{tab}: required header missing: {', '.join(missing)}"
+        )
     unexpected = [header for header in headers if header not in expected]
     if unexpected:
         raise LiveArenaConfigError(f"{tab}: unexpected header: {', '.join(unexpected)}")
-    return [dict(zip(headers, row)) for row in matrix[1:] if any(_text(value) for value in row)]
+    return [
+        dict(zip(headers, row))
+        for row in matrix[1:]
+        if any(_text(value) for value in row)
+    ]
 
 
 def _enabled(value: object) -> bool:
@@ -99,7 +118,7 @@ def _required_int(value: object, label: str) -> int:
 
 
 async def load_config(sheet_id: str) -> dict[str, str]:
-    """Read the literal CONFIG tab and return the five PR1 keys."""
+    """Read the literal CONFIG tab and return the Live Arena routing keys."""
 
     matrix = await afetch_values(sheet_id, CONFIG_TAB)
     rows = _rows(matrix or [], CONFIG_HEADERS, CONFIG_TAB)
@@ -127,27 +146,43 @@ async def load_tournament_snapshot(sheet_id: str) -> TournamentSnapshot:
     slots = _rows(slots_matrix or [], AVAILABILITY_SLOT_HEADERS, slots_tab)
 
     active_id = config["ACTIVE_TOURNAMENT_ID"]
-    tournament = next((row for row in tournaments if _text(row["tournament_id"]) == active_id), None)
+    tournament = next(
+        (row for row in tournaments if _text(row["tournament_id"]) == active_id), None
+    )
     if tournament is None:
-        raise LiveArenaConfigError(f"{tournament_tab}: active tournament not found: {active_id}")
+        raise LiveArenaConfigError(
+            f"{tournament_tab}: active tournament not found: {active_id}"
+        )
 
     for row in slots:
         weekday = _text(row["weekday_utc"])
         if weekday not in WEEKDAYS:
-            raise LiveArenaConfigError(f"{slots_tab}: invalid weekday_utc: {weekday or '(blank)'}")
+            raise LiveArenaConfigError(
+                f"{slots_tab}: invalid weekday_utc: {weekday or '(blank)'}"
+            )
 
     return TournamentSnapshot(
         tournament_id=active_id,
         tournament_name=_text(tournament["tournament_name"]),
         status=_text(tournament["status"]),
         eligibility_scope=_text(tournament["eligibility_scope"]),
-        min_participants=_required_int(tournament["min_participants"], f"{tournament_tab}.min_participants"),
-        max_participants=_required_int(tournament["max_participants"], f"{tournament_tab}.max_participants"),
+        min_participants=_required_int(
+            tournament["min_participants"], f"{tournament_tab}.min_participants"
+        ),
+        max_participants=_required_int(
+            tournament["max_participants"], f"{tournament_tab}.max_participants"
+        ),
         signup_opens_at_utc=_text(tournament["signup_opens_at_utc"]),
         signup_closes_at_utc=_text(tournament["signup_closes_at_utc"]),
         active_eligible_clans=sum(
-            1 for row in clans if _text(row["tournament_id"]) == active_id and _enabled(row["active"])
+            1
+            for row in clans
+            if _text(row["tournament_id"]) == active_id and _enabled(row["active"])
         ),
-        enabled_availability_windows=sum(1 for row in slots if _enabled(row["enabled"])),
-        organizer_role_id=_required_int(config["ORGANIZER_ROLE_ID"], "CONFIG.ORGANIZER_ROLE_ID"),
+        enabled_availability_windows=sum(
+            1 for row in slots if _enabled(row["enabled"])
+        ),
+        organizer_role_id=_required_int(
+            config["ORGANIZER_ROLE_ID"], "CONFIG.ORGANIZER_ROLE_ID"
+        ),
     )

--- a/tests/community/test_live_arena.py
+++ b/tests/community/test_live_arena.py
@@ -18,12 +18,20 @@ def _config_rows(**overrides: str) -> list[list[object]]:
         "ELIGIBLE_CLANS_TAB": "ELIGIBLE_CLANS",
         "AVAILABILITY_SLOTS_TAB": "AVAILABILITY_SLOTS",
         "ORGANIZER_ROLE_ID": "1535031755734777967",
+        "PARTICIPANTS_TAB": "PARTICIPANTS",
+        "PARTICIPANT_AVAILABILITY_TAB": "PARTICIPANT_AVAILABILITY",
+        "AUDIT_LOG_TAB": "AUDIT_LOG",
         **overrides,
     }
-    return [list(service.CONFIG_HEADERS), *[[key, value, ""] for key, value in values.items()]]
+    return [
+        list(service.CONFIG_HEADERS),
+        *[[key, value, ""] for key, value in values.items()],
+    ]
 
 
-def _tournament_rows(headers: tuple[str, ...] = service.TOURNAMENT_HEADERS) -> list[list[object]]:
+def _tournament_rows(
+    headers: tuple[str, ...] = service.TOURNAMENT_HEADERS,
+) -> list[list[object]]:
     row = {
         "tournament_id": "LA-2026-TRIAL-01",
         "tournament_name": "C1C Live Arena Trial Cup",
@@ -52,13 +60,23 @@ def _slot_rows(count: int = 84) -> list[list[object]]:
     return [
         list(service.AVAILABILITY_SLOT_HEADERS),
         *[
-            [f"slot-{index}", weekdays[index % 7], "00:00", "02:00", "TRUE", index, f"Slot {index}"]
+            [
+                f"slot-{index}",
+                weekdays[index % 7],
+                "00:00",
+                "02:00",
+                "TRUE",
+                index,
+                f"Slot {index}",
+            ]
             for index in range(count)
         ],
     ]
 
 
-def _matrices(config: list[list[object]] | None = None) -> dict[str, list[list[object]]]:
+def _matrices(
+    config: list[list[object]] | None = None,
+) -> dict[str, list[list[object]]]:
     return {
         "CONFIG": config or _config_rows(),
         "TOURNAMENTS": _tournament_rows(),
@@ -86,7 +104,10 @@ def test_missing_sheet_id_disables_live_arena_safely(monkeypatch, caplog):
 
 def test_env_key_reaches_shared_config_snapshot(monkeypatch):
     monkeypatch.setenv("LIVE_ARENA_TOURNAMENT_SHEET_ID", "workbook-from-env")
-    assert shared_config._load_config_snapshot()["LIVE_ARENA_TOURNAMENT_SHEET_ID"] == "workbook-from-env"
+    assert (
+        shared_config._load_config_snapshot()["LIVE_ARENA_TOURNAMENT_SHEET_ID"]
+        == "workbook-from-env"
+    )
 
 
 def test_config_is_read_by_actual_name(monkeypatch):
@@ -97,8 +118,18 @@ def test_config_is_read_by_actual_name(monkeypatch):
 
 
 def test_table_names_are_routed_from_config(monkeypatch):
-    matrices = _matrices(_config_rows(TOURNAMENTS_TAB="EVENTS", ELIGIBLE_CLANS_TAB="CLANS", AVAILABILITY_SLOTS_TAB="SLOTS"))
-    matrices.update(EVENTS=matrices.pop("TOURNAMENTS"), CLANS=matrices.pop("ELIGIBLE_CLANS"), SLOTS=matrices.pop("AVAILABILITY_SLOTS"))
+    matrices = _matrices(
+        _config_rows(
+            TOURNAMENTS_TAB="EVENTS",
+            ELIGIBLE_CLANS_TAB="CLANS",
+            AVAILABILITY_SLOTS_TAB="SLOTS",
+        )
+    )
+    matrices.update(
+        EVENTS=matrices.pop("TOURNAMENTS"),
+        CLANS=matrices.pop("ELIGIBLE_CLANS"),
+        SLOTS=matrices.pop("AVAILABILITY_SLOTS"),
+    )
     seen = []
     _install_fetch(monkeypatch, matrices, seen)
     asyncio.run(service.load_tournament_snapshot("sheet-id"))
@@ -108,32 +139,45 @@ def test_table_names_are_routed_from_config(monkeypatch):
 def test_active_tournament_comes_from_config(monkeypatch):
     matrices = _matrices(_config_rows(ACTIVE_TOURNAMENT_ID="missing-id"))
     _install_fetch(monkeypatch, matrices)
-    with pytest.raises(service.LiveArenaConfigError, match="active tournament not found: missing-id"):
+    with pytest.raises(
+        service.LiveArenaConfigError, match="active tournament not found: missing-id"
+    ):
         asyncio.run(service.load_tournament_snapshot("sheet-id"))
 
 
 def test_exact_tournament_headers_pass(monkeypatch):
     _install_fetch(monkeypatch, _matrices())
-    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).tournament_id == "LA-2026-TRIAL-01"
+    assert (
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    ).tournament_id == "LA-2026-TRIAL-01"
 
 
 def test_missing_tournament_header_has_useful_error(monkeypatch):
     matrices = _matrices()
-    matrices["TOURNAMENTS"] = _tournament_rows(tuple(h for h in service.TOURNAMENT_HEADERS if h != "status"))
+    matrices["TOURNAMENTS"] = _tournament_rows(
+        tuple(h for h in service.TOURNAMENT_HEADERS if h != "status")
+    )
     _install_fetch(monkeypatch, matrices)
-    with pytest.raises(service.LiveArenaConfigError, match="TOURNAMENTS: required header missing: status"):
+    with pytest.raises(
+        service.LiveArenaConfigError,
+        match="TOURNAMENTS: required header missing: status",
+    ):
         asyncio.run(service.load_tournament_snapshot("sheet-id"))
 
 
 def test_exact_eligible_clan_headers_pass(monkeypatch):
     _install_fetch(monkeypatch, _matrices())
-    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).active_eligible_clans == 1
+    assert (
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    ).active_eligible_clans == 1
 
 
 def test_exact_availability_headers_pass_without_tournament_id(monkeypatch):
     assert "tournament_id" not in service.AVAILABILITY_SLOT_HEADERS
     _install_fetch(monkeypatch, _matrices())
-    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+    assert (
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    ).enabled_availability_windows == 84
 
 
 def test_availability_uses_enabled_never_active():
@@ -145,23 +189,33 @@ def test_weekday_names_are_accepted(monkeypatch):
     matrices = _matrices()
     matrices["AVAILABILITY_SLOTS"][1][1] = "Monday"
     _install_fetch(monkeypatch, matrices)
-    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+    assert (
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    ).enabled_availability_windows == 84
 
 
 def test_current_fixture_has_84_enabled_windows(monkeypatch):
     _install_fetch(monkeypatch, _matrices())
-    assert (asyncio.run(service.load_tournament_snapshot("sheet-id"))).enabled_availability_windows == 84
+    assert (
+        asyncio.run(service.load_tournament_snapshot("sheet-id"))
+    ).enabled_availability_windows == 84
 
 
 def test_blank_signup_timestamps_are_valid_for_draft(monkeypatch):
     _install_fetch(monkeypatch, _matrices())
     snapshot = asyncio.run(service.load_tournament_snapshot("sheet-id"))
-    assert (snapshot.status, snapshot.signup_opens_at_utc, snapshot.signup_closes_at_utc) == ("draft", "", "")
+    assert (
+        snapshot.status,
+        snapshot.signup_opens_at_utc,
+        snapshot.signup_closes_at_utc,
+    ) == ("draft", "", "")
 
 
 class _Context:
     def __init__(self, role_ids):
-        self.author = SimpleNamespace(roles=[SimpleNamespace(id=value) for value in role_ids])
+        self.author = SimpleNamespace(
+            roles=[SimpleNamespace(id=value) for value in role_ids]
+        )
         self.messages = []
 
     async def send(self, content=None, *, embed=None):
@@ -169,16 +223,32 @@ class _Context:
 
 
 def test_check_rejects_user_without_configured_organizer_role(monkeypatch):
-    monkeypatch.setitem(shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id")
+    monkeypatch.setitem(
+        shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id"
+    )
     _install_fetch(monkeypatch, _matrices())
     ctx = _Context([])
     instance = cog.LiveArenaCog(SimpleNamespace())
     asyncio.run(cog.LiveArenaCog.check.callback(instance, ctx))
-    assert "organizer role" in ctx.messages[0][0]
+    assert ctx.messages[0][0] is None
+    assert "organizer role" in ctx.messages[0][1].description
+
+
+def test_bare_command_uses_embed(monkeypatch):
+    monkeypatch.setitem(
+        shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id"
+    )
+    ctx = _Context([])
+    instance = cog.LiveArenaCog(SimpleNamespace())
+    asyncio.run(cog.LiveArenaCog.latournament.callback(instance, ctx))
+    assert ctx.messages[0][0] is None
+    assert "latournament check" in ctx.messages[0][1].description
 
 
 def test_healthy_check_embed_has_expected_values(monkeypatch):
-    monkeypatch.setitem(shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id")
+    monkeypatch.setitem(
+        shared_config._CONFIG, "LIVE_ARENA_TOURNAMENT_SHEET_ID", "sheet-id"
+    )
     _install_fetch(monkeypatch, _matrices())
     ctx = _Context([1535031755734777967])
     instance = cog.LiveArenaCog(SimpleNamespace())

--- a/tests/community/test_live_arena_registration.py
+++ b/tests/community/test_live_arena_registration.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import pytest
+
+from modules.community.live_arena import registration, repository, service
+
+TID = "LA-1"
+NOW = datetime(2026, 3, 1, 12, tzinfo=UTC)
+
+
+def tournament(**changes):
+    row = dict(
+        tournament_id=TID,
+        tournament_name="Trial",
+        status="signup_open",
+        eligibility_scope="selected_clans",
+        min_participants="1",
+        max_participants="3",
+        signup_opens_at_utc="2026-02-01T00:00:00Z",
+        signup_closes_at_utc="2026-03-08T12:00:00Z",
+        notes="",
+    )
+    row.update(changes)
+    return row
+
+
+def slots():
+    return [
+        dict(
+            slot_id="mon-a",
+            weekday_utc="Monday",
+            start_time_utc="23:00",
+            end_time_utc="01:00",
+            enabled="TRUE",
+            sort_order="1",
+            display_label="A",
+        ),
+        dict(
+            slot_id="tue-a",
+            weekday_utc="Tuesday",
+            start_time_utc="01:00",
+            end_time_utc="03:00",
+            enabled="TRUE",
+            sort_order="2",
+            display_label="B",
+        ),
+        dict(
+            slot_id="wed-a",
+            weekday_utc="Wednesday",
+            start_time_utc="02:00",
+            end_time_utc="04:00",
+            enabled="TRUE",
+            sort_order="3",
+            display_label="C",
+        ),
+        dict(
+            slot_id="off",
+            weekday_utc="Thursday",
+            start_time_utc="00:00",
+            end_time_utc="02:00",
+            enabled="FALSE",
+            sort_order="4",
+            display_label="D",
+        ),
+    ]
+
+
+CLANS = [
+    dict(
+        tournament_id=TID,
+        clan_tag="C1CM",
+        clan_name="Martyrs",
+        discord_role_id="10",
+        active="TRUE",
+        notes="",
+    )
+]
+
+
+class MemoryRepository:
+    def __init__(self, participants=None, availability=None):
+        self.p = deepcopy(participants or [])
+        self.a = deepcopy(availability or [])
+        self.audit = []
+        self.fail_availability = False
+        self.fail_audit = False
+
+    async def initialize(self):
+        pass
+
+    async def participants(self):
+        return deepcopy(self.p)
+
+    async def availability(self):
+        return deepcopy(self.a)
+
+    async def replace_participants(self, rows):
+        self.p = deepcopy(rows)
+
+    async def replace_availability(self, rows):
+        if self.fail_availability:
+            self.fail_availability = False
+            raise RuntimeError("write failed")
+        self.a = deepcopy(rows)
+
+    async def append_audit(self, row):
+        if self.fail_audit:
+            raise RuntimeError("audit failed")
+        self.audit.append(deepcopy(row))
+
+
+def make_service(repo, tour=None, slot_rows=None, clan_rows=None):
+    instance = registration.RegistrationService("sheet", repo, lambda: NOW)
+
+    async def context():
+        return (
+            {"ACTIVE_TOURNAMENT_ID": TID},
+            tour or tournament(),
+            CLANS if clan_rows is None else clan_rows,
+            slots() if slot_rows is None else slot_rows,
+        )
+
+    instance._context = context
+    return instance
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+@pytest.mark.parametrize(
+    "headers,key",
+    [
+        (repository.PARTICIPANT_HEADERS, "PARTICIPANTS_TAB"),
+        (repository.PARTICIPANT_AVAILABILITY_HEADERS, "PARTICIPANT_AVAILABILITY_TAB"),
+        (repository.AUDIT_LOG_HEADERS, "AUDIT_LOG_TAB"),
+    ],
+)
+def test_exact_header_only_write_schemas_and_missing_header(headers, key):
+    assert service._rows([list(headers)], headers, key) == []
+    with pytest.raises(service.LiveArenaConfigError, match="required header missing"):
+        service._rows([list(headers[:-1])], headers, key)
+
+
+def test_repository_routes_all_write_tabs_from_config(monkeypatch):
+    seen = []
+
+    async def config(_):
+        return {
+            "PARTICIPANTS_TAB": "PEOPLE",
+            "PARTICIPANT_AVAILABILITY_TAB": "TIMES",
+            "AUDIT_LOG_TAB": "EVENTS",
+        }
+
+    async def fetch(_, tab):
+        seen.append(tab)
+        return {
+            "PEOPLE": [list(repository.PARTICIPANT_HEADERS)],
+            "TIMES": [list(repository.PARTICIPANT_AVAILABILITY_HEADERS)],
+            "EVENTS": [list(repository.AUDIT_LOG_HEADERS)],
+        }[tab]
+
+    monkeypatch.setattr(repository, "load_config", config)
+    monkeypatch.setattr(repository, "afetch_values", fetch)
+    run(repository.LiveArenaRepository("sheet").initialize())
+    assert seen == ["PEOPLE", "TIMES", "EVENTS"]
+
+
+def test_timezone_slot_count_local_days_cross_midnight_and_dst_anchor():
+    assert registration.validate_availability(
+        "America/New_York",
+        ["mon-a", "tue-a", "wed-a", "mon-a"],
+        slots(),
+        "2026-03-08T12:00:00Z",
+    ) == ["mon-a", "tue-a", "wed-a"]
+    with pytest.raises(registration.RegistrationError, match="IANA"):
+        registration.validate_availability(
+            "Mars/Olympus", ["mon-a", "tue-a", "wed-a"], slots(), "2026-03-08T12:00:00Z"
+        )
+    with pytest.raises(registration.RegistrationError, match="at least 3"):
+        registration.validate_availability(
+            "UTC", ["mon-a", "tue-a"], slots(), "2026-03-08T12:00:00Z"
+        )
+    same_day = [
+        dict(
+            row,
+            weekday_utc="Monday",
+            start_time_utc=f"{hour:02}:00",
+            end_time_utc=f"{hour + 2:02}:00",
+        )
+        for row, hour in zip(slots()[:3], (0, 2, 4))
+    ]
+    with pytest.raises(registration.RegistrationError, match="2 local"):
+        registration.validate_availability(
+            "UTC", ["mon-a", "tue-a", "wed-a"], same_day, "2026-07-01T00:00:00Z"
+        )
+    with pytest.raises(registration.RegistrationError, match="disabled"):
+        registration.validate_availability(
+            "UTC", ["mon-a", "tue-a", "off"], slots(), "2026-03-08T12:00:00Z"
+        )
+    with pytest.raises(registration.RegistrationError, match="unknown"):
+        registration.validate_availability(
+            "UTC", ["mon-a", "tue-a", "missing"], slots(), "2026-03-08T12:00:00Z"
+        )
+
+
+def test_new_registration_deduplicates_slots_and_writes_exact_audit():
+    repo = MemoryRepository()
+    svc = make_service(repo)
+    run(
+        svc.register("1", "Player", ["10"], "UTC", ["mon-a", "tue-a", "wed-a", "mon-a"])
+    )
+    assert len(repo.p) == 1 and repo.p[0]["status"] == "confirmed" and len(repo.a) == 3
+    assert repo.audit[0]["event_type"] == "registration_confirmed"
+    assert (
+        repo.audit[0]["actor_discord_user_id"]
+        == repo.audit[0]["target_discord_user_id"]
+        == "1"
+    )
+    assert all(
+        value.endswith("Z")
+        for value in (
+            repo.p[0]["signed_up_at_utc"],
+            repo.p[0]["confirmed_at_utc"],
+            repo.p[0]["updated_at_utc"],
+            repo.audit[0]["created_at_utc"],
+        )
+    )
+    with pytest.raises(registration.RegistrationError, match="already"):
+        run(svc.register("1", "Player", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]))
+    assert len(repo.p) == 1
+
+
+@pytest.mark.parametrize("status", ["removed", "disqualified", "mystery"])
+def test_non_restorable_and_unknown_statuses_reject(status):
+    repo = MemoryRepository(
+        [dict(tournament_id=TID, discord_user_id="1", status=status)]
+    )
+    with pytest.raises(
+        registration.RegistrationError,
+        match=status if status != "mystery" else "unsupported",
+    ):
+        run(
+            make_service(repo).register(
+                "1", "P", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]
+            )
+        )
+
+
+def test_eligibility_and_scope_rules():
+    with pytest.raises(registration.RegistrationError, match="eligible clan"):
+        run(
+            make_service(MemoryRepository()).register(
+                "1", "P", ["99"], "UTC", ["mon-a", "tue-a", "wed-a"]
+            )
+        )
+    with pytest.raises(registration.RegistrationError, match="unsupported eligibility"):
+        run(
+            make_service(
+                MemoryRepository(), tournament(eligibility_scope="everyone")
+            ).register("1", "P", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"])
+        )
+
+
+def test_reregister_updates_same_row_preserves_signup_and_replaces_availability():
+    old = dict(
+        tournament_id=TID,
+        discord_user_id="1",
+        display_name_at_signup="Old",
+        clan_tag_at_signup="OLD",
+        timezone="UTC",
+        status="withdrawn",
+        signed_up_at_utc="2025-01-01T00:00:00Z",
+        confirmed_at_utc="2025-01-01T00:00:00Z",
+        withdrawn_at_utc="x",
+        withdrawal_reason="x",
+        updated_at_utc="x",
+        notes="",
+    )
+    repo = MemoryRepository(
+        [old],
+        [
+            dict(
+                tournament_id=TID,
+                discord_user_id="1",
+                slot_id="mon-a",
+                created_at_utc="old",
+                updated_at_utc="old",
+                notes="",
+            )
+        ],
+    )
+    run(
+        make_service(repo).register(
+            "1", "New", ["10"], "Europe/London", ["mon-a", "tue-a", "wed-a"]
+        )
+    )
+    assert len(repo.p) == 1 and repo.p[0]["signed_up_at_utc"] == "2025-01-01T00:00:00Z"
+    assert (
+        repo.p[0]["withdrawn_at_utc"],
+        repo.p[0]["withdrawal_reason"],
+        repo.p[0]["clan_tag_at_signup"],
+    ) == ("", "", "C1CM")
+    assert next(r for r in repo.a if r["slot_id"] == "mon-a")["created_at_utc"] == "old"
+    assert next(r for r in repo.a if r["slot_id"] == "tue-a")[
+        "created_at_utc"
+    ].endswith("Z")
+    assert repo.audit[0]["event_type"] == "registration_reconfirmed"
+
+
+def test_capacity_and_concurrent_last_place_race():
+    existing = [dict(tournament_id=TID, discord_user_id="0", status="confirmed")]
+    repo = MemoryRepository(existing)
+    svc = make_service(repo, tournament(max_participants="2"))
+
+    async def race():
+        return await asyncio.gather(
+            svc.register("1", "A", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]),
+            svc.register("2", "B", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]),
+            return_exceptions=True,
+        )
+
+    results = run(race())
+    assert (
+        sum(isinstance(item, registration.RegistrationError) for item in results) == 1
+    )
+    assert sum(r.get("status") == "confirmed" for r in repo.p) == 2
+
+
+def test_withdraw_preserves_availability_and_frees_capacity():
+    participant = dict(
+        tournament_id=TID,
+        discord_user_id="1",
+        status="confirmed",
+        signed_up_at_utc="old",
+    )
+    saved = [dict(tournament_id=TID, discord_user_id="1", slot_id="mon-a")]
+    repo = MemoryRepository([participant], saved)
+    svc = make_service(repo, tournament(max_participants="1"))
+    run(svc.withdraw("1", "busy"))
+    assert repo.p[0]["status"] == "withdrawn" and repo.a == saved
+    run(svc.register("2", "B", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]))
+    assert repo.audit[0]["event_type"] == "registration_withdrawn"
+
+
+def test_update_preserves_identity_fields_and_rolls_back_core_failure():
+    participant = dict(
+        tournament_id=TID,
+        discord_user_id="1",
+        status="confirmed",
+        signed_up_at_utc="signed",
+        confirmed_at_utc="confirmed",
+        clan_tag_at_signup="C1CM",
+        timezone="UTC",
+        updated_at_utc="old",
+    )
+    saved = [
+        dict(
+            tournament_id=TID,
+            discord_user_id="1",
+            slot_id="mon-a",
+            created_at_utc="created",
+            updated_at_utc="old",
+            notes="",
+        )
+    ]
+    repo = MemoryRepository([participant], saved)
+    svc = make_service(repo)
+    repo.fail_availability = True
+    with pytest.raises(RuntimeError):
+        run(svc.update_availability("1", "Europe/London", ["mon-a", "tue-a", "wed-a"]))
+    assert repo.p == [participant] and repo.a == saved
+    run(svc.update_availability("1", "Europe/London", ["mon-a", "tue-a", "wed-a"]))
+    assert {
+        key: repo.p[0][key]
+        for key in (
+            "signed_up_at_utc",
+            "confirmed_at_utc",
+            "clan_tag_at_signup",
+            "status",
+        )
+    } == {
+        key: participant[key]
+        for key in (
+            "signed_up_at_utc",
+            "confirmed_at_utc",
+            "clan_tag_at_signup",
+            "status",
+        )
+    }
+
+
+def test_failed_new_core_write_has_no_partial_state():
+    repo = MemoryRepository()
+    repo.fail_availability = True
+    with pytest.raises(RuntimeError):
+        run(
+            make_service(repo).register(
+                "1", "P", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]
+            )
+        )
+    assert repo.p == [] and repo.a == []
+
+
+def test_audit_failure_keeps_core_and_logs(caplog):
+    repo = MemoryRepository()
+    repo.fail_audit = True
+    run(
+        make_service(repo).register(
+            "1", "P", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]
+        )
+    )
+    assert repo.p[0]["status"] == "confirmed"
+    assert (
+        "tournament=LA-1" in caplog.text
+        and "event=registration_confirmed" in caplog.text
+    )

--- a/tests/community/test_live_arena_registration.py
+++ b/tests/community/test_live_arena_registration.py
@@ -86,7 +86,8 @@ class MemoryRepository:
         self.p = deepcopy(participants or [])
         self.a = deepcopy(availability or [])
         self.audit = []
-        self.fail_availability = False
+        self.fail_core = False
+        self.fail_participants = False
         self.fail_audit = False
 
     async def initialize(self):
@@ -98,14 +99,25 @@ class MemoryRepository:
     async def availability(self):
         return deepcopy(self.a)
 
-    async def replace_participants(self, rows):
-        self.p = deepcopy(rows)
-
-    async def replace_availability(self, rows):
-        if self.fail_availability:
-            self.fail_availability = False
+    async def persist_core_state(
+        self,
+        participants,
+        availability,
+        *,
+        previous_participants,
+        previous_availability,
+    ):
+        if self.fail_core:
+            self.fail_core = False
             raise RuntimeError("write failed")
-        self.a = deepcopy(rows)
+        self.p = deepcopy(participants)
+        self.a = deepcopy(availability)
+
+    async def persist_participants(self, participants, *, previous_participants):
+        if self.fail_participants:
+            self.fail_participants = False
+            raise RuntimeError("write failed")
+        self.p = deepcopy(participants)
 
     async def append_audit(self, row):
         if self.fail_audit:
@@ -207,6 +219,30 @@ def test_timezone_slot_count_local_days_cross_midnight_and_dst_anchor():
             "UTC", ["mon-a", "tue-a", "missing"], slots(), "2026-03-08T12:00:00Z"
         )
 
+    dst_boundary_slots = [
+        dict(
+            slot_id=f"dst-{hour}",
+            weekday_utc="Monday",
+            start_time_utc=f"{hour:02}:00",
+            end_time_utc=f"{hour + 2:02}:00",
+            enabled="TRUE",
+        )
+        for hour in (0, 1, 4)
+    ]
+    selected = ["dst-0", "dst-1", "dst-4"]
+    # The same UTC slots cross two New York start-dates only in the week after
+    # DST begins, proving that signup_closes_at_utc selects the anchor week.
+    assert (
+        registration.validate_availability(
+            "America/New_York", selected, dst_boundary_slots, "2026-03-15T12:00:00Z"
+        )
+        == selected
+    )
+    with pytest.raises(registration.RegistrationError, match="2 local"):
+        registration.validate_availability(
+            "America/New_York", selected, dst_boundary_slots, "2026-03-08T12:00:00Z"
+        )
+
 
 def test_new_registration_deduplicates_slots_and_writes_exact_audit():
     repo = MemoryRepository()
@@ -216,6 +252,7 @@ def test_new_registration_deduplicates_slots_and_writes_exact_audit():
     )
     assert len(repo.p) == 1 and repo.p[0]["status"] == "confirmed" and len(repo.a) == 3
     assert repo.audit[0]["event_type"] == "registration_confirmed"
+    assert repo.audit[0]["created_at_utc"] == "2026-03-01T12:00:00Z"
     assert (
         repo.audit[0]["actor_discord_user_id"]
         == repo.audit[0]["target_discord_user_id"]
@@ -310,6 +347,7 @@ def test_reregister_updates_same_row_preserves_signup_and_replaces_availability(
         "created_at_utc"
     ].endswith("Z")
     assert repo.audit[0]["event_type"] == "registration_reconfirmed"
+    assert repo.audit[0]["created_at_utc"] == "2026-03-01T12:00:00Z"
 
 
 def test_capacity_and_concurrent_last_place_race():
@@ -345,6 +383,7 @@ def test_withdraw_preserves_availability_and_frees_capacity():
     assert repo.p[0]["status"] == "withdrawn" and repo.a == saved
     run(svc.register("2", "B", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]))
     assert repo.audit[0]["event_type"] == "registration_withdrawn"
+    assert repo.audit[0]["created_at_utc"] == "2026-03-01T12:00:00Z"
 
 
 def test_update_preserves_identity_fields_and_rolls_back_core_failure():
@@ -370,7 +409,7 @@ def test_update_preserves_identity_fields_and_rolls_back_core_failure():
     ]
     repo = MemoryRepository([participant], saved)
     svc = make_service(repo)
-    repo.fail_availability = True
+    repo.fail_core = True
     with pytest.raises(RuntimeError):
         run(svc.update_availability("1", "Europe/London", ["mon-a", "tue-a", "wed-a"]))
     assert repo.p == [participant] and repo.a == saved
@@ -392,11 +431,13 @@ def test_update_preserves_identity_fields_and_rolls_back_core_failure():
             "status",
         )
     }
+    assert repo.audit[0]["event_type"] == "availability_updated"
+    assert repo.audit[0]["created_at_utc"] == "2026-03-01T12:00:00Z"
 
 
 def test_failed_new_core_write_has_no_partial_state():
     repo = MemoryRepository()
-    repo.fail_availability = True
+    repo.fail_core = True
     with pytest.raises(RuntimeError):
         run(
             make_service(repo).register(
@@ -404,6 +445,20 @@ def test_failed_new_core_write_has_no_partial_state():
             )
         )
     assert repo.p == [] and repo.a == []
+
+
+def test_failed_reregistration_restores_exact_withdrawn_state():
+    old_p, old_a = core_rows(status="withdrawn", slots=("old-a", "old-b"))
+    repo = MemoryRepository(old_p, old_a)
+    repo.fail_core = True
+    with pytest.raises(RuntimeError, match="write failed"):
+        run(
+            make_service(repo).register(
+                "1", "New", ["10"], "UTC", ["mon-a", "tue-a", "wed-a"]
+            )
+        )
+    assert repo.p == old_p
+    assert repo.a == old_a
 
 
 def test_audit_failure_keeps_core_and_logs(caplog):
@@ -419,3 +474,142 @@ def test_audit_failure_keeps_core_and_logs(caplog):
         "tournament=LA-1" in caplog.text
         and "event=registration_confirmed" in caplog.text
     )
+
+
+class FakeSpreadsheet:
+    def __init__(self, state, failure="before"):
+        self.state = deepcopy(state)
+        self.failure = failure
+        self.calls = 0
+
+    def values_batch_update(self, body):
+        self.calls += 1
+        if self.calls == 1 and self.failure == "before":
+            raise RuntimeError("participant write failed")
+        for index, item in enumerate(body["data"]):
+            self.state[item["range"].split("!", 1)[0].strip("'")] = deepcopy(
+                item["values"]
+            )
+            if (
+                self.calls == 1
+                and self.failure in {"availability", "rollback"}
+                and index == 0
+            ):
+                raise RuntimeError("availability write failed")
+        if self.calls == 2 and self.failure == "rollback":
+            raise RuntimeError("rollback failed")
+
+
+def repository_with_spreadsheet(monkeypatch, state, failure):
+    spreadsheet = FakeSpreadsheet(state, failure)
+    worksheet = type("Worksheet", (), {"spreadsheet": spreadsheet})()
+
+    async def get_worksheet(*_):
+        return worksheet
+
+    async def call(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(repository, "aget_worksheet", get_worksheet)
+    monkeypatch.setattr(repository, "acall_with_backoff", call)
+    repo = repository.LiveArenaRepository("sheet")
+    repo.config = {
+        "PARTICIPANTS_TAB": "PEOPLE",
+        "PARTICIPANT_AVAILABILITY_TAB": "TIMES",
+    }
+    return repo, spreadsheet
+
+
+def core_rows(status="confirmed", slots=("old",)):
+    participant = [dict(tournament_id=TID, discord_user_id="1", status=status)]
+    availability = [
+        dict(tournament_id=TID, discord_user_id="1", slot_id=slot) for slot in slots
+    ]
+    return participant, availability
+
+
+@pytest.mark.parametrize("failure", ["before", "availability"])
+def test_repository_core_failure_restores_exact_prior_tables(monkeypatch, failure):
+    old_p, old_a = core_rows(status="withdrawn", slots=("old-a", "old-b"))
+    new_p, new_a = core_rows(status="confirmed", slots=("new-a", "new-b", "new-c"))
+    state = {"PEOPLE": [["prior participant"]], "TIMES": [["prior availability"]]}
+    repo, spreadsheet = repository_with_spreadsheet(monkeypatch, state, failure)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        run(
+            repo.persist_core_state(
+                new_p,
+                new_a,
+                previous_participants=old_p,
+                previous_availability=old_a,
+            )
+        )
+
+    rollback = repo._batch_body(
+        (
+            ("PARTICIPANTS_TAB", repository.PARTICIPANT_HEADERS, new_p, old_p),
+            (
+                "PARTICIPANT_AVAILABILITY_TAB",
+                repository.PARTICIPANT_AVAILABILITY_HEADERS,
+                new_a,
+                old_a,
+            ),
+        ),
+        use_previous=True,
+    )
+    assert spreadsheet.state == {
+        item["range"].split("!", 1)[0].strip("'"): item["values"]
+        for item in rollback["data"]
+    }
+
+
+def test_repository_new_registration_failure_leaves_no_partial_core(monkeypatch):
+    new_p, new_a = core_rows(slots=("one", "two", "three"))
+    repo, spreadsheet = repository_with_spreadsheet(
+        monkeypatch, {"PEOPLE": [], "TIMES": []}, "availability"
+    )
+    with pytest.raises(RuntimeError, match="availability write failed"):
+        run(
+            repo.persist_core_state(
+                new_p,
+                new_a,
+                previous_participants=[],
+                previous_availability=[],
+            )
+        )
+    assert spreadsheet.state["PEOPLE"] == [[""] * len(repository.PARTICIPANT_HEADERS)]
+    assert spreadsheet.state["TIMES"] == [
+        [""] * len(repository.PARTICIPANT_AVAILABILITY_HEADERS)
+        for _ in range(len(new_a))
+    ]
+
+
+def test_repository_failed_withdrawal_preserves_confirmed_participant(monkeypatch):
+    old_p, _ = core_rows()
+    new_p, _ = core_rows(status="withdrawn")
+    repo, spreadsheet = repository_with_spreadsheet(
+        monkeypatch, {"PEOPLE": [["prior"]]}, "before"
+    )
+    with pytest.raises(RuntimeError, match="participant write failed"):
+        run(repo.persist_participants(new_p, previous_participants=old_p))
+    assert spreadsheet.state["PEOPLE"][0][5] == "confirmed"
+
+
+def test_repository_compensation_failure_is_surfaced(monkeypatch):
+    old_p, old_a = core_rows()
+    new_p, new_a = core_rows(status="withdrawn", slots=("new",))
+    repo, _ = repository_with_spreadsheet(
+        monkeypatch, {"PEOPLE": [], "TIMES": []}, "rollback"
+    )
+    with pytest.raises(repository.CoreStatePersistenceError) as caught:
+        run(
+            repo.persist_core_state(
+                new_p,
+                new_a,
+                previous_participants=old_p,
+                previous_availability=old_a,
+            )
+        )
+    assert "compensation both failed" in str(caught.value)
+    assert isinstance(caught.value.write_error, RuntimeError)
+    assert isinstance(caught.value.rollback_error, RuntimeError)


### PR DESCRIPTION
### Motivation

- Implement the Live Arena registration data/domain service and Google Sheets persistence as the PR2 scope requires, building on the PR1 workbook foundation and honoring the exact Sheet and CONFIG contracts. 
- Provide a Discord-independent domain layer to validate IANA timezones, anchored DST/local-day availability, selected-clan eligibility, status lifecycle (confirmed/withdrawn/removed/disqualified), capacity locking, and audit semantics. 
- Ensure no Google Sheets schema changes and keep UI/Discord command surface unchanged except for the two cosmetic embed fixes required from PR1. 
- Include safety for core-write integrity with compensating rollback inside the Live Arena module and keep audit writes secondary with retry/backoff semantics.

### Description

- Added a registration domain service at `modules/community/live_arena/registration.py` implementing validation for IANA timezones, signup-close-week anchoring, two-hour slot windows, local-day counting, register/re-register/update-withdraw behaviors, per-tournament asyncio locks, capacity checks, and rollback semantics. 
- Added a Sheets-backed repository at `modules/community/live_arena/repository.py` that reads tab names from `CONFIG` and provides header-exact read/replace/append operations using the existing `shared.sheets.async_core` helpers and backoff. 
- Extended `modules/community/live_arena/service.py` to include the three routing CONFIG keys `PARTICIPANTS_TAB`, `PARTICIPANT_AVAILABILITY_TAB`, and `AUDIT_LOG_TAB` and reused the PR1 header-validation helpers. 
- Made the two PR1 cosmetic changes in `cogs/live_arena.py` to render the bare `!latournament` usage and unauthorized `!latournament check` responses as embeds, and added focused tests in `tests/community/test_live_arena_registration.py` plus small adjustments to the existing diagnostic tests.

### Testing

- Ran focused tests: `python -m pytest tests/community/test_live_arena.py tests/community/test_live_arena_registration.py -q` which passed (32 passed). 
- Ran broader community tests: `python -m pytest tests/community -q` which passed for the community shard (459 passed). 
- Ran static/format checks: `ruff check` and `ruff format --check` for the changed files, both passed after formatting. 
- Ran repository guardrails: `python -m scripts.ci.guardrails_suite --base-ref HEAD` which reported pre-existing baseline violations in unrelated areas; the Live Arena changes use absolute imports and the approved theme palette so no new Live Arena guardrail violations were introduced. 
- Ran near-full test sweep (`python -m pytest --maxfail=25 --durations=20`) which stopped after 25 unrelated failures under the local Python 3.14 environment (1,570 passed, 25 failed) caused by differences in the JSON logging/LogRecord.message behavior; CI uses Python 3.11 and the focused community tests and all changed-file checks are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e53296948323b29aacf2f860fe8a)