### PR TITLE
Live Arena PR3: add first usable player signup flow

### DIFF
--- a/modules/community/live_arena/messages.py
+++ b/modules/community/live_arena/messages.py
@@ -1,0 +1,129 @@
+"""Literal PR3 message and CONFIG contracts for Live Arena Discord UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from string import Formatter
+
+import discord
+
+from shared.sheets.async_core import afetch_values
+
+from .service import (
+    CONFIG_HEADERS,
+    CONFIG_TAB,
+    LiveArenaConfigError,
+    _enabled,
+    _rows,
+    _text,
+)
+
+PR3_CONFIG_KEYS = (
+    "MESSAGES_TAB",
+    "SIGNUP_CHANNEL_ID",
+    "PARTICIPANT_ROLE_ID",
+    "PUBLIC_PANEL_MESSAGE_ID",
+)
+MESSAGE_HEADERS = (
+    "message_key",
+    "title",
+    "description",
+    "color_hex",
+    "active",
+    "notes",
+)
+REQUIRED_MESSAGES = {
+    "signup_open": {
+        "tournament_name",
+        "signup_deadline",
+        "confirmed_count",
+        "max_participants",
+    },
+    "signup_confirmed": {"participant", "tournament_name", "signup_deadline"},
+}
+
+
+@dataclass(frozen=True)
+class MessageTemplate:
+    key: str
+    title: str
+    description: str
+    color: int
+
+    def embed(self, **values: object) -> discord.Embed:
+        expected = REQUIRED_MESSAGES[self.key]
+        fields = {
+            name
+            for _, name, _, _ in Formatter().parse(self.title + self.description)
+            if name
+        }
+        if fields != expected:
+            raise LiveArenaConfigError(
+                f"MESSAGES.{self.key}: placeholders must be exactly {', '.join(sorted(expected))}"
+            )
+        missing = expected - values.keys()
+        if missing:
+            raise LiveArenaConfigError(
+                f"MESSAGES.{self.key}: missing render value {', '.join(sorted(missing))}"
+            )
+        return discord.Embed(
+            title=self.title.format(**values),
+            description=self.description.format(**values),
+            color=self.color,
+        )
+
+
+async def load_pr3_config(sheet_id: str) -> tuple[dict[str, str], list[list[object]]]:
+    matrix = await afetch_values(sheet_id, CONFIG_TAB) or []
+    rows = _rows(matrix, CONFIG_HEADERS, CONFIG_TAB)
+    result: dict[str, str] = {}
+    for key in PR3_CONFIG_KEYS:
+        matches = [row for row in rows if _text(row["Key"]) == key]
+        if len(matches) != 1:
+            raise LiveArenaConfigError(f"CONFIG: key {key} must occur exactly once")
+        result[key] = _text(matches[0]["Value"])
+    for key in ("MESSAGES_TAB", "SIGNUP_CHANNEL_ID", "PARTICIPANT_ROLE_ID"):
+        if not result[key]:
+            raise LiveArenaConfigError(f"CONFIG: missing required key {key}")
+    try:
+        int(result["SIGNUP_CHANNEL_ID"])
+        int(result["PARTICIPANT_ROLE_ID"])
+        if result["PUBLIC_PANEL_MESSAGE_ID"]:
+            int(result["PUBLIC_PANEL_MESSAGE_ID"])
+    except ValueError as exc:
+        raise LiveArenaConfigError("CONFIG: PR3 Discord IDs must be numeric") from exc
+    return result, matrix
+
+
+async def load_messages(sheet_id: str, tab: str) -> dict[str, MessageTemplate]:
+    rows = _rows(await afetch_values(sheet_id, tab) or [], MESSAGE_HEADERS, tab)
+    templates = {}
+    for key in REQUIRED_MESSAGES:
+        matches = [row for row in rows if _text(row["message_key"]) == key]
+        if len(matches) != 1 or not _enabled(matches[0]["active"]):
+            raise LiveArenaConfigError(
+                f"MESSAGES: required active row missing or duplicated: {key}"
+            )
+        row = matches[0]
+        color = _text(row["color_hex"])
+        if len(color) != 7 or not color.startswith("#"):
+            raise LiveArenaConfigError(f"MESSAGES.{key}: color_hex must be #RRGGBB")
+        try:
+            parsed = int(color[1:], 16)
+        except ValueError as exc:
+            raise LiveArenaConfigError(
+                f"MESSAGES.{key}: color_hex must be #RRGGBB"
+            ) from exc
+        template = MessageTemplate(
+            key, _text(row["title"]), _text(row["description"]), parsed
+        )
+        # Validate placeholders at load time, before any mutation.
+        template.embed(**{name: "x" for name in REQUIRED_MESSAGES[key]})
+        templates[key] = template
+    return templates
+
+
+def discord_timestamp(value) -> str:
+    from .registration import _parse_close
+
+    return f"<t:{int(_parse_close(value).timestamp())}:F>"

--- a/modules/community/live_arena/messages.py
+++ b/modules/community/live_arena/messages.py
@@ -9,7 +9,7 @@ import discord
 
 from shared.sheets.async_core import afetch_values
 
-from .service import (
+from modules.community.live_arena.service import (
     CONFIG_HEADERS,
     CONFIG_TAB,
     LiveArenaConfigError,
@@ -124,6 +124,6 @@ async def load_messages(sheet_id: str, tab: str) -> dict[str, MessageTemplate]:
 
 
 def discord_timestamp(value) -> str:
-    from .registration import _parse_close
+    from modules.community.live_arena.registration import _parse_close
 
     return f"<t:{int(_parse_close(value).timestamp())}:F>"

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -1,0 +1,114 @@
+"""Persistent public panel lifecycle for Live Arena PR3."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import discord
+
+from shared.sheets.async_core import acall_with_backoff, aget_worksheet
+
+from .messages import discord_timestamp, load_messages, load_pr3_config
+from .repository import LiveArenaRepository
+from .service import load_tournament_snapshot
+
+log = logging.getLogger("c1c.community.live_arena.panel")
+
+
+class LiveArenaPanelManager:
+    def __init__(self, bot, sheet_id: str, service_factory=None):
+        self.bot = bot
+        self.sheet_id = sheet_id
+        self.service_factory = service_factory
+        self._lock = asyncio.Lock()
+
+    async def sync(self) -> None:
+        async with self._lock:
+            config, matrix = await load_pr3_config(self.sheet_id)
+            messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"])
+            tournament = await load_tournament_snapshot(self.sheet_id)
+            if tournament.status == "draft":
+                return
+            if tournament.status != "signup_open":
+                return
+            repository = LiveArenaRepository(self.sheet_id)
+            await repository.initialize()
+            participants = await repository.participants()
+            count = sum(
+                str(row["tournament_id"]).strip() == tournament.tournament_id
+                and str(row["status"]).strip() == "confirmed"
+                for row in participants
+            )
+            embed = messages["signup_open"].embed(
+                tournament_name=tournament.tournament_name,
+                signup_deadline=discord_timestamp(tournament.signup_closes_at_utc),
+                confirmed_count=count,
+                max_participants=tournament.max_participants,
+            )
+            channel = self.bot.get_channel(int(config["SIGNUP_CHANNEL_ID"]))
+            if channel is None:
+                channel = await self.bot.fetch_channel(int(config["SIGNUP_CHANNEL_ID"]))
+            message = None
+            if config["PUBLIC_PANEL_MESSAGE_ID"]:
+                try:
+                    message = await channel.fetch_message(
+                        int(config["PUBLIC_PANEL_MESSAGE_ID"])
+                    )
+                except discord.NotFound:
+                    message = None
+                except Exception:
+                    log.exception("❌ Live Arena panel — fetch failed")
+                    return
+            from .views import JoinTournamentView
+
+            view = JoinTournamentView(self)
+            if message is not None:
+                try:
+                    await message.edit(embed=embed, view=view)
+                except Exception:
+                    log.exception("❌ Live Arena panel — edit failed")
+                return
+            created = await channel.send(embed=embed, view=view)
+            try:
+                await self._persist_message_id(matrix, str(created.id))
+            except Exception:
+                log.exception("❌ Live Arena panel — message ID persistence failed")
+                try:
+                    await created.delete()
+                except Exception:
+                    log.exception(
+                        "⚠️ Live Arena panel — untracked message cleanup failed"
+                    )
+                raise
+
+    async def _persist_message_id(self, matrix, message_id: str) -> None:
+        headers = [str(value).strip() for value in matrix[0]]
+        key_col, value_col = headers.index("Key"), headers.index("Value")
+        rows = [
+            index
+            for index, row in enumerate(matrix[1:], 2)
+            if key_col < len(row)
+            and str(row[key_col]).strip() == "PUBLIC_PANEL_MESSAGE_ID"
+        ]
+        if len(rows) != 1:
+            raise RuntimeError(
+                "CONFIG: key PUBLIC_PANEL_MESSAGE_ID must occur exactly once"
+            )
+        worksheet = await aget_worksheet(self.sheet_id, "CONFIG")
+        await acall_with_backoff(
+            worksheet.update_cell, rows[0], value_col + 1, message_id
+        )
+
+
+async def register_live_arena(bot):
+    sheet_id = os.getenv("LIVE_ARENA_TOURNAMENT_SHEET_ID", "").strip()
+    if not sheet_id:
+        return None
+    manager = LiveArenaPanelManager(bot, sheet_id)
+    from .views import JoinTournamentView
+
+    bot.add_view(JoinTournamentView(manager))
+    await manager.sync()
+    return manager

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 
 import discord
 
+from shared.config import cfg
 from shared.sheets.async_core import acall_with_backoff, aget_worksheet
 
-from .messages import discord_timestamp, load_messages, load_pr3_config
-from .repository import LiveArenaRepository
-from .service import load_tournament_snapshot
+from modules.community.live_arena.messages import (
+    discord_timestamp,
+    load_messages,
+    load_pr3_config,
+)
+from modules.community.live_arena.repository import LiveArenaRepository
+from modules.community.live_arena.service import load_tournament_snapshot
 
 log = logging.getLogger("c1c.community.live_arena.panel")
+_sync_locks: dict[str, asyncio.Lock] = {}
+_managers: dict[tuple[int, str], "LiveArenaPanelManager"] = {}
 
 
 class LiveArenaPanelManager:
@@ -22,7 +28,9 @@ class LiveArenaPanelManager:
         self.bot = bot
         self.sheet_id = sheet_id
         self.service_factory = service_factory
-        self._lock = asyncio.Lock()
+        # Registration hooks can be invoked more than once (including overlapping
+        # on_ready dispatches).  The workbook, not a transient manager, owns sync.
+        self._lock = _sync_locks.setdefault(sheet_id, asyncio.Lock())
 
     async def sync(self) -> None:
         async with self._lock:
@@ -61,7 +69,7 @@ class LiveArenaPanelManager:
                 except Exception:
                     log.exception("❌ Live Arena panel — fetch failed")
                     return
-            from .views import JoinTournamentView
+            from modules.community.live_arena.views import JoinTournamentView
 
             view = JoinTournamentView(self)
             if message is not None:
@@ -103,11 +111,13 @@ class LiveArenaPanelManager:
 
 
 async def register_live_arena(bot):
-    sheet_id = os.getenv("LIVE_ARENA_TOURNAMENT_SHEET_ID", "").strip()
+    sheet_id = str(cfg.get("LIVE_ARENA_TOURNAMENT_SHEET_ID", "") or "").strip()
     if not sheet_id:
         return None
-    manager = LiveArenaPanelManager(bot, sheet_id)
-    from .views import JoinTournamentView
+    manager = _managers.setdefault(
+        (id(bot), sheet_id), LiveArenaPanelManager(bot, sheet_id)
+    )
+    from modules.community.live_arena.views import JoinTournamentView
 
     bot.add_view(JoinTournamentView(manager))
     await manager.sync()

--- a/modules/community/live_arena/registration.py
+++ b/modules/community/live_arena/registration.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 from typing import Callable
 from uuid import uuid4
@@ -51,21 +52,29 @@ def _parse_close(value: object) -> datetime:
     return parsed.astimezone(UTC)
 
 
-def validate_availability(
-    timezone: str, slot_ids: list[str], slots: list[dict[str, object]], close: object
-) -> list[str]:
+@dataclass(frozen=True)
+class LocalizedSlot:
+    slot_id: str
+    local_start: datetime
+    local_end: datetime
+
+
+@dataclass(frozen=True)
+class SignupPreparation:
+    config: dict[str, str]
+    tournament: dict[str, object]
+    slots: tuple[dict[str, object], ...]
+    localized_slots: tuple[LocalizedSlot, ...]
+
+
+def localize_availability(
+    timezone: str, slots: list[dict[str, object]], close: object
+) -> list[LocalizedSlot]:
+    """Project enabled slots using PR2's signup-close-week anchor."""
     try:
         zone = ZoneInfo(timezone)
     except (ZoneInfoNotFoundError, ValueError) as exc:
         raise RegistrationError("timezone must be a valid IANA timezone") from exc
-    selected = list(dict.fromkeys(str(value) for value in slot_ids))
-    by_id = {_text(row["slot_id"]): row for row in slots}
-    if any(slot_id not in by_id for slot_id in selected):
-        raise RegistrationError("unknown availability slot ID")
-    if any(not _enabled(by_id[slot_id]["enabled"]) for slot_id in selected):
-        raise RegistrationError("disabled availability slot selected")
-    if len(selected) < 3:
-        raise RegistrationError("select at least 3 distinct availability slots")
     anchor = _parse_close(close)
     monday = anchor.date() - timedelta(days=anchor.weekday())
     weekdays = {
@@ -82,9 +91,11 @@ def validate_availability(
             )
         )
     }
-    local_days = set()
-    for slot_id in selected:
-        row = by_id[slot_id]
+    result = []
+    for row in slots:
+        if not _enabled(row["enabled"]):
+            continue
+        slot_id = _text(row["slot_id"])
         try:
             day = monday + timedelta(days=weekdays[_text(row["weekday_utc"])])
             start = time.fromisoformat(_text(row["start_time_utc"]))
@@ -99,7 +110,27 @@ def validate_availability(
             raise RegistrationError(
                 "selected availability slots must be two-hour windows"
             )
-        local_days.add(start_at.astimezone(zone).date())
+        result.append(
+            LocalizedSlot(slot_id, start_at.astimezone(zone), end_at.astimezone(zone))
+        )
+    return sorted(result, key=lambda slot: slot.local_start)
+
+
+def validate_availability(
+    timezone: str, slot_ids: list[str], slots: list[dict[str, object]], close: object
+) -> list[str]:
+    selected = list(dict.fromkeys(str(value) for value in slot_ids))
+    by_id = {_text(row["slot_id"]): row for row in slots}
+    if any(slot_id not in by_id for slot_id in selected):
+        raise RegistrationError("unknown availability slot ID")
+    if any(not _enabled(by_id[slot_id]["enabled"]) for slot_id in selected):
+        raise RegistrationError("disabled availability slot selected")
+    if len(selected) < 3:
+        raise RegistrationError("select at least 3 distinct availability slots")
+    localized = {
+        slot.slot_id: slot for slot in localize_availability(timezone, slots, close)
+    }
+    local_days = {localized[slot_id].local_start.date() for slot_id in selected}
     if len(local_days) < 2:
         raise RegistrationError("availability must span at least 2 local start-days")
     return selected
@@ -118,6 +149,45 @@ class RegistrationService:
 
     async def initialize(self) -> None:
         await self.repository.initialize()
+
+    async def prepare_signup(
+        self, user_id: str, role_ids: list[str], timezone: str
+    ) -> SignupPreparation:
+        """Perform a write-free preflight using the registration domain rules."""
+        config, tournament, clans, slots = await self._context()
+        self._require_status(tournament, {"signup_open"})
+        localized = localize_availability(
+            timezone, slots, tournament["signup_closes_at_utc"]
+        )
+        self._eligible(tournament, clans, role_ids)
+        participants = await self.repository.participants()
+        existing = next(
+            (
+                row
+                for row in participants
+                if _text(row["tournament_id"]) == config["ACTIVE_TOURNAMENT_ID"]
+                and _text(row["discord_user_id"]) == str(user_id)
+            ),
+            None,
+        )
+        status = _text(existing["status"]) if existing else ""
+        if status == "confirmed":
+            raise RegistrationError("already registered")
+        if status in {"removed", "disqualified"}:
+            raise RegistrationError(f"{status} participant cannot self-register")
+        if status and status != "withdrawn":
+            raise RegistrationError(f"unsupported participant status: {status}")
+        maximum = _required_int(
+            tournament["max_participants"], "TOURNAMENTS.max_participants"
+        )
+        confirmed = sum(
+            _text(row["tournament_id"]) == config["ACTIVE_TOURNAMENT_ID"]
+            and _text(row["status"]) == "confirmed"
+            for row in participants
+        )
+        if confirmed >= maximum:
+            raise RegistrationError("tournament capacity is full")
+        return SignupPreparation(config, tournament, tuple(slots), tuple(localized))
 
     async def _context(self):
         config = await load_config(self.sheet_id)

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -7,15 +7,25 @@ from collections import defaultdict
 
 import discord
 
-from .messages import discord_timestamp, load_messages, load_pr3_config
-from .registration import RegistrationError, RegistrationService, validate_availability
+from shared.theme import colors
+
+from modules.community.live_arena.messages import (
+    discord_timestamp,
+    load_messages,
+    load_pr3_config,
+)
+from modules.community.live_arena.registration import (
+    RegistrationError,
+    RegistrationService,
+    validate_availability,
+)
 
 log = logging.getLogger("c1c.community.live_arena.views")
 
 
 def error_embed(message: object) -> discord.Embed:
     return discord.Embed(
-        title="Live Arena signup", description=str(message), color=0xD93025
+        title="Live Arena signup", description=str(message), color=colors.c1c_blue
     )
 
 
@@ -53,6 +63,7 @@ class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
             self.manager.sheet_id
         )
         try:
+            await service.initialize()
             preparation = await service.prepare_signup(
                 str(member.id), roles, str(self.timezone_input)
             )
@@ -155,7 +166,7 @@ class AvailabilityView(discord.ui.View):
         return discord.Embed(
             title=f"Availability — {current:%A, %d %B}",
             description=f"Times shown in **{self.timezone}**. Selected: **{count}** windows across **{days}** local days.",
-            color=0x1A73E8,
+            color=colors.c1c_blue,
         )
 
     async def previous(self, interaction):
@@ -209,7 +220,7 @@ class AvailabilityView(discord.ui.View):
             detail = detail[:3497] + "…"
         return discord.Embed(
             title="Review Live Arena registration",
-            color=0x1A73E8,
+            color=colors.c1c_blue,
             description=(
                 f"**Tournament:** {self.preparation.tournament['tournament_name']}\n"
                 f"**Timezone:** {self.timezone}\n**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -1,0 +1,300 @@
+"""Discord views for the first player-facing Live Arena signup slice."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+import discord
+
+from .messages import discord_timestamp, load_messages, load_pr3_config
+from .registration import RegistrationError, RegistrationService, validate_availability
+
+log = logging.getLogger("c1c.community.live_arena.views")
+
+
+def error_embed(message: object) -> discord.Embed:
+    return discord.Embed(
+        title="Live Arena signup", description=str(message), color=0xD93025
+    )
+
+
+class JoinTournamentView(discord.ui.View):
+    def __init__(self, manager):
+        super().__init__(timeout=None)
+        self.manager = manager
+
+    @discord.ui.button(
+        label="Join Tournament",
+        custom_id="live_arena:join",
+        style=discord.ButtonStyle.primary,
+    )
+    async def join(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        # Opening the modal is deliberately the first and only operation here.
+        await interaction.response.send_modal(TimezoneModal(self.manager))
+
+
+class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
+    timezone_input = discord.ui.TextInput(
+        label="Timezone",
+        required=True,
+        placeholder="Europe/Vienna, America/New_York, Asia/Kolkata",
+    )
+
+    def __init__(self, manager):
+        super().__init__()
+        self.manager = manager
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        member = interaction.user
+        roles = [str(role.id) for role in getattr(member, "roles", [])]
+        service = (self.manager.service_factory or RegistrationService)(
+            self.manager.sheet_id
+        )
+        try:
+            preparation = await service.prepare_signup(
+                str(member.id), roles, str(self.timezone_input)
+            )
+            config, _ = await load_pr3_config(self.manager.sheet_id)
+            await load_messages(self.manager.sheet_id, config["MESSAGES_TAB"])
+            view = AvailabilityView(
+                self.manager, service, preparation, str(self.timezone_input), member
+            )
+            await interaction.followup.send(
+                embed=view.embed(), view=view, ephemeral=True
+            )
+        except Exception as exc:
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+
+
+class AvailabilityView(discord.ui.View):
+    def __init__(self, manager, service, preparation, timezone: str, member):
+        super().__init__(timeout=900)
+        self.manager, self.service, self.preparation = manager, service, preparation
+        self.timezone, self.member = timezone, member
+        grouped = defaultdict(list)
+        for slot in preparation.localized_slots:
+            grouped[slot.local_start.date()].append(slot)
+        self.days = sorted(grouped)
+        self.grouped = dict(grouped)
+        if any(len(values) > 25 for values in grouped.values()):
+            raise RegistrationError(
+                "a local day exceeds Discord's 25-option component limit"
+            )
+        self.index = 0
+        self.selected: set[str] = set()
+        self._build()
+
+    def _build(self):
+        self.clear_items()
+        day = self.days[self.index]
+        options = [
+            discord.SelectOption(
+                label=f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}",
+                value=slot.slot_id,
+                default=slot.slot_id in self.selected,
+            )
+            for slot in self.grouped[day]
+        ]
+        select = discord.ui.Select(
+            placeholder="Select available windows",
+            options=options,
+            min_values=0,
+            max_values=len(options),
+            row=0,
+        )
+
+        async def selected(interaction):
+            day_ids = {slot.slot_id for slot in self.grouped[day]}
+            self.selected.difference_update(day_ids)
+            self.selected.update(select.values)
+            self._build()
+            await interaction.response.edit_message(embed=self.embed(), view=self)
+
+        select.callback = selected
+        self.add_item(select)
+        self.add_item(
+            ActionButton(
+                "Previous Day",
+                discord.ButtonStyle.secondary,
+                1,
+                self.previous,
+                disabled=self.index == 0,
+            )
+        )
+        self.add_item(
+            ActionButton(
+                "Next Day",
+                discord.ButtonStyle.secondary,
+                1,
+                self.next,
+                disabled=self.index == len(self.days) - 1,
+            )
+        )
+        self.add_item(
+            ActionButton("Clear Day", discord.ButtonStyle.secondary, 2, self.clear_day)
+        )
+        self.add_item(
+            ActionButton(
+                "Review Registration", discord.ButtonStyle.primary, 2, self.review
+            )
+        )
+
+    def counts(self):
+        lookup = {
+            slot.slot_id: slot for values in self.grouped.values() for slot in values
+        }
+        return len(self.selected), len(
+            {lookup[value].local_start.date() for value in self.selected}
+        )
+
+    def embed(self):
+        count, days = self.counts()
+        current = self.days[self.index]
+        return discord.Embed(
+            title=f"Availability — {current:%A, %d %B}",
+            description=f"Times shown in **{self.timezone}**. Selected: **{count}** windows across **{days}** local days.",
+            color=0x1A73E8,
+        )
+
+    async def previous(self, interaction):
+        self.index -= 1
+        self._build()
+        await interaction.response.edit_message(embed=self.embed(), view=self)
+
+    async def next(self, interaction):
+        self.index += 1
+        self._build()
+        await interaction.response.edit_message(embed=self.embed(), view=self)
+
+    async def clear_day(self, interaction):
+        self.selected.difference_update(
+            slot.slot_id for slot in self.grouped[self.days[self.index]]
+        )
+        self._build()
+        await interaction.response.edit_message(embed=self.embed(), view=self)
+
+    async def review(self, interaction):
+        try:
+            validate_availability(
+                self.timezone,
+                list(self.selected),
+                list(self.preparation.slots),
+                self.preparation.tournament["signup_closes_at_utc"],
+            )
+        except Exception as exc:
+            await interaction.response.send_message(
+                embed=error_embed(exc), ephemeral=True
+            )
+            return
+        await interaction.response.edit_message(
+            embed=self.review_embed(), view=ReviewView(self)
+        )
+
+    def review_embed(self):
+        count, day_count = self.counts()
+        lines = []
+        for day in self.days:
+            chosen = [s for s in self.grouped[day] if s.slot_id in self.selected]
+            if chosen:
+                lines.append(
+                    f"**{day:%A, %d %B}**\n"
+                    + ", ".join(
+                        f"{s.local_start:%H:%M}–{s.local_end:%H:%M}" for s in chosen
+                    )
+                )
+        detail = "\n".join(lines)
+        if len(detail) > 3500:
+            detail = detail[:3497] + "…"
+        return discord.Embed(
+            title="Review Live Arena registration",
+            color=0x1A73E8,
+            description=(
+                f"**Tournament:** {self.preparation.tournament['tournament_name']}\n"
+                f"**Timezone:** {self.timezone}\n**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"
+            ),
+        )
+
+
+class ReviewView(discord.ui.View):
+    def __init__(self, availability):
+        super().__init__(timeout=900)
+        self.availability = availability
+
+    @discord.ui.button(label="Back", style=discord.ButtonStyle.secondary)
+    async def back(self, interaction, _button):
+        self.availability._build()
+        await interaction.response.edit_message(
+            embed=self.availability.embed(), view=self.availability
+        )
+
+    @discord.ui.button(label="Submit Registration", style=discord.ButtonStyle.primary)
+    async def submit(self, interaction, _button):
+        await interaction.response.defer(ephemeral=True)
+        flow, member = self.availability, interaction.user
+        try:
+            config, _ = await load_pr3_config(flow.manager.sheet_id)
+            messages = await load_messages(
+                flow.manager.sheet_id, config["MESSAGES_TAB"]
+            )
+            await flow.service.register(
+                str(member.id),
+                member.display_name,
+                [str(role.id) for role in getattr(member, "roles", [])],
+                flow.timezone,
+                list(flow.selected),
+            )
+        except Exception as exc:
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+            return
+        embed = messages["signup_confirmed"].embed(
+            participant=member.mention,
+            tournament_name=flow.preparation.tournament["tournament_name"],
+            signup_deadline=discord_timestamp(
+                flow.preparation.tournament["signup_closes_at_utc"]
+            ),
+        )
+        role_id = int(config["PARTICIPANT_ROLE_ID"])
+        role = interaction.guild.get_role(role_id) if interaction.guild else None
+        if role is None:
+            embed.add_field(
+                name="Role sync warning",
+                value="Your tournament role could not be synced automatically.",
+                inline=False,
+            )
+            log.error(
+                "❌ Live Arena role — missing • tournament=%s • user=%s • role=%s",
+                flow.preparation.config["ACTIVE_TOURNAMENT_ID"],
+                member.id,
+                role_id,
+            )
+        elif role not in getattr(member, "roles", []):
+            try:
+                await member.add_roles(role, reason="Live Arena registration confirmed")
+            except Exception:
+                embed.add_field(
+                    name="Role sync warning",
+                    value="Your tournament role could not be synced automatically.",
+                    inline=False,
+                )
+                log.exception(
+                    "❌ Live Arena role — assignment failed • tournament=%s • user=%s • role=%s",
+                    flow.preparation.config["ACTIVE_TOURNAMENT_ID"],
+                    member.id,
+                    role_id,
+                )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        try:
+            await flow.manager.sync()
+        except Exception:
+            log.exception("⚠️ Live Arena panel — post-registration refresh failed")
+
+
+class ActionButton(discord.ui.Button):
+    def __init__(self, label, style, row, handler, disabled=False):
+        super().__init__(label=label, style=style, row=row, disabled=disabled)
+        self.handler = handler
+
+    async def callback(self, interaction):
+        await self.handler(interaction)

--- a/modules/coreops/ready.py
+++ b/modules/coreops/ready.py
@@ -11,6 +11,7 @@ from shared.config import cfg, get_feature_toggles
 from modules.community.fusion.opt_in_view import register_persistent_fusion_views
 from modules.community.shard_tracker.views import register_persistent_shard_views
 from modules.community.reset_reminders.scheduler import register_persistent_reset_views
+from modules.community.live_arena.panel import register_live_arena
 from modules.onboarding import watcher_promo, watcher_welcome
 from modules.onboarding.ui import panels
 
@@ -40,6 +41,12 @@ async def on_ready(bot: commands.Bot) -> None:
             log.exception("CORE_READY FAILURE: register_persistent_shard_views")
             return
 
+        # Live Arena is optional and must never interrupt unrelated ready wiring.
+        try:
+            await register_live_arena(bot)
+        except Exception:
+            log.exception("CORE_READY FAILURE: register_live_arena")
+
         try:
             await register_persistent_reset_views(bot)
         except Exception:
@@ -58,7 +65,10 @@ async def on_ready(bot: commands.Bot) -> None:
                 hook_name,
                 str(cfg.get("ENV_NAME") or "unknown").strip() or "unknown",
                 len(getattr(bot, "guilds", []) or []),
-                [getattr(guild, "id", None) for guild in (getattr(bot, "guilds", []) or [])],
+                [
+                    getattr(guild, "id", None)
+                    for guild in (getattr(bot, "guilds", []) or [])
+                ],
                 reset_feature_enabled,
             )
             return

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -8,7 +8,12 @@ import pytest
 
 from modules.community.live_arena import messages, panel, registration, repository, views
 from modules.community.live_arena.messages import load_messages, load_pr3_config
-from modules.community.live_arena.registration import SignupPreparation, localize_availability
+from modules.community.live_arena.registration import (
+    LocalizedSlot,
+    RegistrationError,
+    SignupPreparation,
+    localize_availability,
+)
 from modules.community.live_arena.service import LiveArenaConfigError, TournamentSnapshot
 from modules.community.live_arena.views import AvailabilityView, JoinTournamentView
 
@@ -270,3 +275,259 @@ def test_timezone_submit_initializes_real_repository_before_preflight(monkeypatc
     sent = interaction.followup.send.await_args.kwargs
     assert isinstance(sent["view"], AvailabilityView)
     assert isinstance(sent["embed"], discord.Embed)
+
+
+@pytest.mark.parametrize(
+    ("key", "change", "match"),
+    [
+        ("signup_open", "remove", "signup_open"),
+        ("signup_confirmed", "remove", "signup_confirmed"),
+        ("signup_open", "inactive", "signup_open"),
+        ("signup_confirmed", "inactive", "signup_confirmed"),
+        ("signup_open", "color", "color_hex"),
+    ],
+)
+def test_required_message_rows_are_strict(monkeypatch, key, change, match):
+    matrix = [row[:] for row in MESSAGE_ROWS]
+    row_index = next(i for i, row in enumerate(matrix) if row[0] == key)
+    if change == "remove":
+        matrix.pop(row_index)
+    elif change == "inactive":
+        matrix[row_index][4] = "FALSE"
+    else:
+        matrix[row_index][3] = "#nothex"
+    monkeypatch.setattr(messages, "afetch_values", AsyncMock(return_value=matrix))
+    with pytest.raises(LiveArenaConfigError, match=match):
+        asyncio.run(load_messages("sheet", "MESSAGES"))
+
+
+def test_signup_confirmed_embed_uses_exact_template_contract(monkeypatch):
+    monkeypatch.setattr(messages, "afetch_values", AsyncMock(return_value=MESSAGE_ROWS))
+    loaded = asyncio.run(load_messages("sheet", "MESSAGES"))
+    embed = loaded["signup_confirmed"].embed(
+        participant="<@7>", tournament_name="Trial Cup", signup_deadline="<t:1:F>"
+    )
+    assert embed.title == "You're aboard"
+    assert embed.description == "<@7>, Trial Cup by <t:1:F>."
+    assert embed.color.value == int("34A853", 16)
+
+
+class _Worksheet:
+    def __init__(self):
+        self.update_cell = AsyncMock()
+
+
+def test_persist_message_id_updates_only_existing_value_cell(monkeypatch):
+    manager, _ = _panel_manager(monkeypatch)
+    worksheet = _Worksheet()
+    matrix = [row[:] for row in CONFIG]
+    original = [row[:] for row in matrix]
+    monkeypatch.setattr(panel, "aget_worksheet", AsyncMock(return_value=worksheet))
+
+    async def call(function, *args):
+        return await function(*args)
+
+    monkeypatch.setattr(panel, "acall_with_backoff", call)
+    asyncio.run(manager.__class__._persist_message_id(manager, matrix, "987"))
+    worksheet.update_cell.assert_awaited_once_with(5, 2, "987")
+    assert matrix == original
+
+
+@pytest.mark.parametrize("matrix", [[*CONFIG[:4]], [*CONFIG, CONFIG[4][:]]])
+def test_persist_message_id_rejects_missing_or_duplicate_key(monkeypatch, matrix):
+    manager, _ = _panel_manager(monkeypatch)
+    monkeypatch.setattr(panel, "aget_worksheet", AsyncMock())
+    with pytest.raises(RuntimeError, match="must occur exactly once"):
+        asyncio.run(manager.__class__._persist_message_id(manager, matrix, "987"))
+    panel.aget_worksheet.assert_not_awaited()
+
+
+def _preparation(slot_count=4):
+    base = datetime(2026, 8, 3, 18, tzinfo=UTC)
+    localized = []
+    rows = []
+    for index in range(slot_count):
+        start = base + timedelta(days=index // 2, hours=2 * (index % 2))
+        slot_id = f"real-{index}"
+        localized.append(LocalizedSlot(slot_id, start, start + timedelta(hours=2)))
+        rows.append(
+            {
+                "slot_id": slot_id,
+                "weekday_utc": start.strftime("%A"),
+                "start_time_utc": start.strftime("%H:%M"),
+                "end_time_utc": (start + timedelta(hours=2)).strftime("%H:%M"),
+                "enabled": "TRUE",
+            }
+        )
+    return SignupPreparation(
+        {"ACTIVE_TOURNAMENT_ID": "LA-1"},
+        {
+            "tournament_name": "Trial Cup",
+            "signup_closes_at_utc": "2026-08-09T20:00:00Z",
+        },
+        tuple(rows),
+        tuple(localized),
+    )
+
+
+def _flow(preparation=None, service=None, manager=None, member=None):
+    manager = manager or SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    service = service or SimpleNamespace(register=AsyncMock())
+    member = member or SimpleNamespace(id=7, display_name="Player", roles=[])
+    return AvailabilityView(manager, service, preparation or _preparation(), "UTC", member)
+
+
+def _edit_interaction():
+    return SimpleNamespace(response=SimpleNamespace(edit_message=AsyncMock(), send_message=AsyncMock()))
+
+
+def test_local_day_above_discord_option_limit_fails_clearly():
+    preparation = _preparation(26)
+    same_day = preparation.localized_slots[0].local_start
+    preparation = SignupPreparation(
+        preparation.config,
+        preparation.tournament,
+        preparation.slots,
+        tuple(
+            LocalizedSlot(slot.slot_id, same_day + timedelta(minutes=i), same_day + timedelta(hours=2, minutes=i))
+            for i, slot in enumerate(preparation.localized_slots)
+        ),
+    )
+    with pytest.raises(RegistrationError, match="25-option"):
+        _flow(preparation)
+
+
+def test_navigation_defaults_and_clear_day_preserve_real_slot_ids():
+    flow = _flow()
+    flow.selected.update({"real-0", "real-2"})
+    interaction = _edit_interaction()
+    asyncio.run(flow.next(interaction))
+    assert flow.index == 1
+    assert {option.value for option in flow.children[0].options if option.default} == {"real-2"}
+    asyncio.run(flow.clear_day(interaction))
+    assert flow.selected == {"real-0"}
+    asyncio.run(flow.previous(interaction))
+    assert {option.value for option in flow.children[0].options if option.default} == {"real-0"}
+
+
+def test_review_gating_and_valid_grouped_content_are_embeds():
+    flow = _flow()
+    interaction = _edit_interaction()
+    flow.selected.update({"real-0", "real-1"})
+    asyncio.run(flow.review(interaction))
+    error = interaction.response.send_message.await_args.kwargs
+    assert error["ephemeral"] is True and isinstance(error["embed"], discord.Embed)
+    interaction.response.send_message.reset_mock()
+    flow.selected.add("real-2")
+    asyncio.run(flow.review(interaction))
+    rendered = interaction.response.edit_message.await_args.kwargs["embed"]
+    assert isinstance(rendered, discord.Embed)
+    for expected in ("Trial Cup", "UTC", "**Windows:** 3", "**Local days:** 2", "Monday", "Tuesday"):
+        assert expected in rendered.description
+
+
+def test_invalid_timezone_preflight_is_embed_only_and_write_free(monkeypatch):
+    service = SimpleNamespace(
+        initialize=AsyncMock(), prepare_signup=AsyncMock(side_effect=RegistrationError("timezone must be a valid IANA timezone")), register=AsyncMock()
+    )
+    manager = SimpleNamespace(sheet_id="sheet", service_factory=lambda _sheet: service)
+    modal = views.TimezoneModal(manager)
+    modal.timezone_input._value = "Mars/Olympus"
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7, roles=[]),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    asyncio.run(modal.on_submit(interaction))
+    result = interaction.followup.send.await_args.kwargs
+    assert result["ephemeral"] is True and isinstance(result["embed"], discord.Embed)
+    service.register.assert_not_awaited()
+
+
+def _submit_interaction(*, roles=(), configured_role=None, add_error=None):
+    member = SimpleNamespace(
+        id=7,
+        display_name="Player",
+        mention="<@7>",
+        roles=list(roles),
+        add_roles=AsyncMock(side_effect=add_error),
+    )
+    guild = SimpleNamespace(get_role=lambda _role_id: configured_role)
+    return SimpleNamespace(
+        user=member,
+        guild=guild,
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def _run_submit(monkeypatch, *, register_error=None, role=None, held=False, add_error=None, sync_error=None):
+    service = SimpleNamespace(register=AsyncMock(side_effect=register_error))
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock(side_effect=sync_error))
+    flow = _flow(service=service, manager=manager)
+    flow.selected.update({"real-0", "real-1", "real-2"})
+    role = role if role is not None else SimpleNamespace(id=99)
+    interaction = _submit_interaction(roles=[role] if held else [], configured_role=role, add_error=add_error)
+    config = {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=(config, CONFIG)))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"signup_confirmed": messages.MessageTemplate("signup_confirmed", "Confirmed", "{participant} joined {tournament_name} by {signup_deadline}.", 0x34A853)}))
+    review = views.ReviewView(flow)
+    asyncio.run(review.children[1].callback(interaction))
+    return flow, service, manager, interaction
+
+
+def test_submit_passes_exact_pr2_contract_and_refreshes_panel(monkeypatch):
+    held_role = SimpleNamespace(id=8)
+    service = SimpleNamespace(register=AsyncMock())
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    flow = _flow(service=service, manager=manager)
+    flow.selected.update({"real-0", "real-1", "real-2"})
+    participant_role = SimpleNamespace(id=99)
+    interaction = _submit_interaction(roles=[held_role], configured_role=participant_role)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}, CONFIG)))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"signup_confirmed": messages.MessageTemplate("signup_confirmed", "Confirmed", "{participant} joined {tournament_name} by {signup_deadline}.", 0x34A853)}))
+    review = views.ReviewView(flow)
+    asyncio.run(review.children[1].callback(interaction))
+    args = service.register.await_args.args
+    assert args[:4] == ("7", "Player", ["8"], "UTC")
+    assert set(args[4]) == {"real-0", "real-1", "real-2"}
+    interaction.user.add_roles.assert_awaited_once_with(participant_role, reason="Live Arena registration confirmed")
+    manager.sync.assert_awaited_once()
+    assert isinstance(interaction.followup.send.await_args.kwargs["embed"], discord.Embed)
+
+
+def test_pr2_rejection_is_embed_and_has_no_role_or_refresh(monkeypatch):
+    flow, _, manager, interaction = _run_submit(monkeypatch, register_error=RegistrationError("closed"))
+    interaction.user.add_roles.assert_not_awaited()
+    manager.sync.assert_not_awaited()
+    result = interaction.followup.send.await_args.kwargs
+    assert result["ephemeral"] is True and isinstance(result["embed"], discord.Embed)
+
+
+@pytest.mark.parametrize(("held", "add_error", "warning"), [(True, None, False), (False, RuntimeError("denied"), True)])
+def test_role_assignment_is_nonredundant_and_failure_is_warning(monkeypatch, held, add_error, warning):
+    _, service, manager, interaction = _run_submit(monkeypatch, held=held, add_error=add_error)
+    service.register.assert_awaited_once()
+    manager.sync.assert_awaited_once()
+    if held:
+        interaction.user.add_roles.assert_not_awaited()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert isinstance(embed, discord.Embed)
+    assert bool(embed.fields) is warning
+
+
+def test_missing_role_and_panel_refresh_failure_keep_success(monkeypatch):
+    _, service, manager, interaction = _run_submit(
+        monkeypatch, role=SimpleNamespace(id=99), sync_error=RuntimeError("refresh failed")
+    )
+    interaction.guild.get_role = lambda _role_id: None
+    # Re-run with the missing role because the helper submits immediately.
+    interaction.followup.send.reset_mock()
+    flow = _flow(service=service, manager=manager)
+    flow.selected.update({"real-0", "real-1", "real-2"})
+    review = views.ReviewView(flow)
+    asyncio.run(review.children[1].callback(interaction))
+    assert service.register.await_count == 2
+    assert manager.sync.await_count == 2
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert isinstance(embed, discord.Embed) and embed.fields

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -1,13 +1,16 @@
 import asyncio
 from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import discord
 import pytest
 
-from modules.community.live_arena import messages
+from modules.community.live_arena import messages, panel, registration, repository, views
 from modules.community.live_arena.messages import load_messages, load_pr3_config
-from modules.community.live_arena.registration import localize_availability
-from modules.community.live_arena.service import LiveArenaConfigError
-from modules.community.live_arena.views import JoinTournamentView
+from modules.community.live_arena.registration import SignupPreparation, localize_availability
+from modules.community.live_arena.service import LiveArenaConfigError, TournamentSnapshot
+from modules.community.live_arena.views import AvailabilityView, JoinTournamentView
 
 
 CONFIG = [
@@ -88,3 +91,182 @@ def test_persistent_join_contract():
     button = view.children[0]
     assert button.custom_id == "live_arena:join"
     assert button.label == "Join Tournament"
+
+
+def _snapshot(status="signup_open"):
+    return TournamentSnapshot(
+        "LA-1", "Trial Cup", status, "selected_clans", 1, 16,
+        "2026-08-01T00:00:00Z", "2026-08-09T20:00:00Z", 1, 3, 99,
+    )
+
+
+class _Template:
+    def embed(self, **values):
+        return discord.Embed(title="Panel", description=str(values))
+
+
+class _PanelRepository:
+    async def initialize(self):
+        return None
+
+    async def participants(self):
+        return []
+
+
+class _Message:
+    def __init__(self, message_id=42):
+        self.id = message_id
+        self.edit = AsyncMock()
+        self.delete = AsyncMock()
+
+
+class _Channel:
+    def __init__(self, fetched=None, fetch_error=None):
+        self.fetched, self.fetch_error = fetched, fetch_error
+        self.sent = []
+
+    async def fetch_message(self, _message_id):
+        if self.fetch_error:
+            raise self.fetch_error
+        return self.fetched
+
+    async def send(self, **_kwargs):
+        message = _Message(100 + len(self.sent))
+        self.sent.append(message)
+        return message
+
+
+def _not_found():
+    return discord.NotFound(SimpleNamespace(status=404, reason="missing"), "missing")
+
+
+def _panel_manager(monkeypatch, *, status="signup_open", panel_id="", channel=None):
+    channel = channel or _Channel()
+    matrix = [row[:] for row in CONFIG]
+    matrix[4][1] = panel_id
+    config = {row[0]: row[1] for row in matrix[1:]}
+    monkeypatch.setattr(panel, "load_pr3_config", AsyncMock(return_value=(config, matrix)))
+    monkeypatch.setattr(panel, "load_messages", AsyncMock(return_value={"signup_open": _Template()}))
+    monkeypatch.setattr(panel, "load_tournament_snapshot", AsyncMock(return_value=_snapshot(status)))
+    monkeypatch.setattr(panel, "LiveArenaRepository", lambda _sheet: _PanelRepository())
+    bot = SimpleNamespace(get_channel=lambda _channel_id: channel)
+    manager = panel.LiveArenaPanelManager(bot, f"sheet-{id(channel)}")
+    manager._persist_message_id = AsyncMock()
+    return manager, channel
+
+
+def test_draft_creates_no_public_panel(monkeypatch):
+    manager, channel = _panel_manager(monkeypatch, status="draft")
+    asyncio.run(manager.sync())
+    assert channel.sent == []
+
+
+def test_blank_panel_creates_once_and_persists_existing_config_cell(monkeypatch):
+    manager, channel = _panel_manager(monkeypatch)
+    asyncio.run(manager.sync())
+    assert len(channel.sent) == 1
+    matrix, message_id = manager._persist_message_id.await_args.args
+    assert matrix[4][0] == "PUBLIC_PANEL_MESSAGE_ID"
+    assert message_id == str(channel.sent[0].id)
+
+
+def test_existing_panel_edits_without_duplicate(monkeypatch):
+    existing = _Message(55)
+    manager, channel = _panel_manager(monkeypatch, panel_id="55", channel=_Channel(existing))
+    asyncio.run(manager.sync())
+    existing.edit.assert_awaited_once()
+    assert channel.sent == []
+
+
+@pytest.mark.parametrize("fetch_error,creates", [(_not_found(), True), (discord.Forbidden(SimpleNamespace(status=403, reason="no"), "no"), False)])
+def test_fetch_failure_only_not_found_can_recreate(monkeypatch, fetch_error, creates):
+    manager, channel = _panel_manager(monkeypatch, panel_id="55", channel=_Channel(fetch_error=fetch_error))
+    asyncio.run(manager.sync())
+    assert bool(channel.sent) is creates
+
+
+def test_failed_panel_id_persistence_deletes_untracked_message(monkeypatch):
+    manager, channel = _panel_manager(monkeypatch)
+    manager._persist_message_id.side_effect = RuntimeError("write failed")
+    with pytest.raises(RuntimeError, match="write failed"):
+        asyncio.run(manager.sync())
+    channel.sent[0].delete.assert_awaited_once()
+
+
+def test_concurrent_managers_for_workbook_create_exactly_one_panel(monkeypatch):
+    manager, channel = _panel_manager(monkeypatch)
+    config = {row[0]: row[1] for row in CONFIG[1:]}
+
+    async def persist(_matrix, message_id):
+        config["PUBLIC_PANEL_MESSAGE_ID"] = message_id
+
+    async def load(_sheet):
+        matrix = [row[:] for row in CONFIG]
+        matrix[4][1] = config["PUBLIC_PANEL_MESSAGE_ID"]
+        return dict(config), matrix
+
+    async def fetch(message_id):
+        return next(message for message in channel.sent if message.id == int(message_id))
+
+    monkeypatch.setattr(panel, "load_pr3_config", load)
+    channel.fetch_message = fetch
+    manager._persist_message_id = persist
+    second = panel.LiveArenaPanelManager(manager.bot, manager.sheet_id)
+    second._persist_message_id = persist
+    async def concurrent_sync():
+        await asyncio.gather(manager.sync(), second.sync())
+
+    asyncio.run(concurrent_sync())
+    assert len(channel.sent) == 1
+
+
+def test_join_opens_timezone_modal_before_sheet_io():
+    interaction = SimpleNamespace(response=SimpleNamespace(send_modal=AsyncMock()))
+    view = JoinTournamentView(object())
+    asyncio.run(view.children[0].callback(interaction))
+    interaction.response.send_modal.assert_awaited_once()
+
+
+def test_timezone_submit_initializes_real_repository_before_preflight(monkeypatch):
+    initialized = False
+
+    async def repo_config(_sheet):
+        nonlocal initialized
+        initialized = True
+        return {"PARTICIPANTS_TAB": "PARTICIPANTS", "PARTICIPANT_AVAILABILITY_TAB": "PARTICIPANT_AVAILABILITY", "AUDIT_LOG_TAB": "AUDIT_LOG"}
+
+    async def repo_fetch(_sheet, tab):
+        headers = {"PARTICIPANTS": repository.PARTICIPANT_HEADERS, "PARTICIPANT_AVAILABILITY": repository.PARTICIPANT_AVAILABILITY_HEADERS, "AUDIT_LOG": repository.AUDIT_LOG_HEADERS}[tab]
+        return [list(headers)]
+
+    slot_rows = [
+        {"slot_id": "mon", "weekday_utc": "Monday", "start_time_utc": "18:00", "end_time_utc": "20:00", "enabled": "TRUE"}
+    ]
+    preparation = SignupPreparation(
+        {"ACTIVE_TOURNAMENT_ID": "LA-1"},
+        {"tournament_name": "Trial", "signup_closes_at_utc": "2026-08-09T20:00:00Z"},
+        tuple(slot_rows),
+        tuple(localize_availability("UTC", slot_rows, "2026-08-09T20:00:00Z")),
+    )
+
+    class RealService(registration.RegistrationService):
+        async def prepare_signup(self, *_args):
+            assert initialized and self.repository.config["PARTICIPANTS_TAB"] == "PARTICIPANTS"
+            return preparation
+
+    monkeypatch.setattr(repository, "load_config", repo_config)
+    monkeypatch.setattr(repository, "afetch_values", repo_fetch)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES"}, CONFIG)))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={}))
+    manager = SimpleNamespace(sheet_id="sheet", service_factory=RealService)
+    modal = views.TimezoneModal(manager)
+    modal.timezone_input._value = "UTC"
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7, roles=[]),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    asyncio.run(modal.on_submit(interaction))
+    sent = interaction.followup.send.await_args.kwargs
+    assert isinstance(sent["view"], AvailabilityView)
+    assert isinstance(sent["embed"], discord.Embed)

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -1,0 +1,90 @@
+import asyncio
+from datetime import date
+
+import pytest
+
+from modules.community.live_arena import messages
+from modules.community.live_arena.messages import load_messages, load_pr3_config
+from modules.community.live_arena.registration import localize_availability
+from modules.community.live_arena.service import LiveArenaConfigError
+from modules.community.live_arena.views import JoinTournamentView
+
+
+CONFIG = [
+    ["Key", "Value", "Notes / clear name"],
+    ["MESSAGES_TAB", "MESSAGES", ""],
+    ["SIGNUP_CHANNEL_ID", "1535020329624146123", ""],
+    ["PARTICIPANT_ROLE_ID", "1535031871191257189", ""],
+    ["PUBLIC_PANEL_MESSAGE_ID", "", ""],
+]
+MESSAGE_ROWS = [
+    ["message_key", "title", "description", "color_hex", "active", "notes"],
+    [
+        "signup_open",
+        "Live Arena signups are open",
+        "{tournament_name} by {signup_deadline}. Confirmed: {confirmed_count}/{max_participants}.",
+        "#1A73E8",
+        "TRUE",
+        "",
+    ],
+    [
+        "signup_confirmed",
+        "You're aboard",
+        "{participant}, {tournament_name} by {signup_deadline}.",
+        "#34A853",
+        "TRUE",
+        "",
+    ],
+]
+
+
+def test_literal_pr3_config_and_messages_render(monkeypatch):
+    async def fetch(_sheet, tab):
+        return CONFIG if tab == "CONFIG" else MESSAGE_ROWS
+
+    monkeypatch.setattr(messages, "afetch_values", fetch)
+    config, _ = asyncio.run(load_pr3_config("sheet"))
+    loaded = asyncio.run(load_messages("sheet", config["MESSAGES_TAB"]))
+    embed = loaded["signup_open"].embed(
+        tournament_name="Trial Cup",
+        signup_deadline="<t:1:F>",
+        confirmed_count=4,
+        max_participants=16,
+    )
+    assert set(loaded) == {"signup_open", "signup_confirmed"}
+    assert "Trial Cup" in embed.description and "4/16" in embed.description
+
+
+def test_unexpected_message_header_fails(monkeypatch):
+    matrix = [MESSAGE_ROWS[0] + ["message"], *(row + [""] for row in MESSAGE_ROWS[1:])]
+
+    async def fetch(*_args):
+        return matrix
+
+    monkeypatch.setattr(messages, "afetch_values", fetch)
+    with pytest.raises(LiveArenaConfigError, match="unexpected header"):
+        asyncio.run(load_messages("sheet", "MESSAGES"))
+
+
+def test_localization_handles_utc_cross_midnight():
+    slots = [
+        dict(
+            slot_id="real-slot",
+            weekday_utc="Monday",
+            start_time_utc="23:00",
+            end_time_utc="01:00",
+            enabled="TRUE",
+        )
+    ]
+    localized = localize_availability("Asia/Kolkata", slots, "2026-08-09T20:00:00Z")
+    assert localized[0].slot_id == "real-slot"
+    assert localized[0].local_start.date() == date(2026, 8, 4)
+    assert localized[0].local_start.hour == 4
+
+
+def test_persistent_join_contract():
+    view = JoinTournamentView(object())
+    assert view.timeout is None
+    button = view.children[0]
+    assert button.custom_id == "live_arena:join"
+    assert button.label == "Join Tournament"


### PR DESCRIPTION
### Motivation
- Implement the user-facing Live Arena signup slice (PR3) that presents a persistent public panel, collects an IANA timezone, lets eligible players pick local availability day-by-day, validates the selection using the merged PR2 registration domain rules, and submits via the existing PR2 `RegistrationService` contract.
- Respect the exact workbook CONFIG / MESSAGES contracts and the explicit non‑scope rules (no sheet schema changes, no PR2 reimplementation, no PR4/PR5 features). 

### Description
- Added strict PR3 config and message loaders in `modules/community/live_arena/messages.py` that validate `CONFIG` keys (`MESSAGES_TAB`, `SIGNUP_CHANNEL_ID`, `PARTICIPANT_ROLE_ID`, `PUBLIC_PANEL_MESSAGE_ID`), require only `signup_open` and `signup_confirmed` active rows, enforce `#RRGGBB` colours, and render Discord-local timestamps via `discord_timestamp`.
- Added a lock-protected `LiveArenaPanelManager` in `modules/community/live_arena/panel.py` to sync/create/edit the persistent public panel, update only the existing `PUBLIC_PANEL_MESSAGE_ID` Value cell, and best-effort delete untracked messages when persistence fails.
- Extended the PR2 registration domain in `modules/community/live_arena/registration.py` with `localize_availability(...)` (signup-close-week anchor projection) and `prepare_signup(...)` (read-only preflight) while preserving all PR2 validation, eligibility, capacity, locking, and audit behavior.
- Implemented Discord UI in `modules/community/live_arena/views.py` including the persistent `Join Tournament` button (`custom_id=live_arena:join`, primary style, `timeout=None`), timezone modal, ephemeral day-by-day availability multi-selects with navigation and `Clear Day`, a gated `Review` embed, and final `Submit Registration` that calls `RegistrationService.register(...)` and then assigns the configured participant role (with success-with-warning handling for role-sync failures).
- Wired the optional Live Arena startup hook into `on_ready` (`modules/coreops/ready.py`) so the panel registration runs after ready without interrupting unrelated startup wiring.
- Added focused tests in `tests/community/test_live_arena_pr3.py` for the literal CONFIG/MESSAGES contract, placeholder rendering, UTC cross-midnight localization, and persistent join-button contract.

### Testing
- Ran `ruff check` on Live Arena modules and the modified `modules/coreops/ready.py` and the checks passed.
- Ran the focused test matrix `pytest -q tests/community/test_live_arena.py tests/community/test_live_arena_registration.py tests/community/test_live_arena_pr3.py` and the three-file run passed (42 tests passed).
- Ran selected startup/guardrail tests `pytest -q tests/coreops/test_ready.py tests/guardrails/test_async_sheets_guardrail.py` and they passed.
- Ran repository guardrails tools `python scripts/ci/check_env_parity.py` and `python -m scripts.ci.guardrails_suite --base-ref main` and both returned success in this environment.
- Observed the full test suite (`python -m pytest -q`) completed but reported 25 unrelated existing failures caused by tests that access `LogRecord.message` after the repository's JSON logging formatter removed that attribute; these failures are independent of the Live Arena changes and do not affect the focused PR3 acceptance tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a760b99c6348323880f1522d68d174f)