### PR TITLE
Live Arena PR4: add player self-service (My Registration, availability updates, withdrawal)

### DIFF
--- a/modules/community/live_arena/messages.py
+++ b/modules/community/live_arena/messages.py
@@ -1,4 +1,4 @@
-"""Literal PR3 message and CONFIG contracts for Live Arena Discord UI."""
+"""Literal player-flow message and CONFIG contracts for Live Arena Discord UI."""
 
 from __future__ import annotations
 
@@ -40,6 +40,8 @@ REQUIRED_MESSAGES = {
         "max_participants",
     },
     "signup_confirmed": {"participant", "tournament_name", "signup_deadline"},
+    "availability_updated": {"participant", "tournament_name"},
+    "withdrawal_confirmed": {"participant", "tournament_name"},
 }
 
 

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -35,12 +35,10 @@ class LiveArenaPanelManager:
     async def sync(self) -> None:
         async with self._lock:
             config, matrix = await load_pr3_config(self.sheet_id)
-            messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"])
             tournament = await load_tournament_snapshot(self.sheet_id)
-            if tournament.status == "draft":
+            if tournament.status != "signup_open":
                 return
-            if tournament.status not in {"signup_open", "signup_closed"}:
-                return
+            messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"])
             repository = LiveArenaRepository(self.sheet_id)
             await repository.initialize()
             participants = await repository.participants()

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -39,7 +39,7 @@ class LiveArenaPanelManager:
             tournament = await load_tournament_snapshot(self.sheet_id)
             if tournament.status == "draft":
                 return
-            if tournament.status != "signup_open":
+            if tournament.status not in {"signup_open", "signup_closed"}:
                 return
             repository = LiveArenaRepository(self.sheet_id)
             await repository.initialize()

--- a/modules/community/live_arena/registration.py
+++ b/modules/community/live_arena/registration.py
@@ -67,6 +67,23 @@ class SignupPreparation:
     localized_slots: tuple[LocalizedSlot, ...]
 
 
+@dataclass(frozen=True)
+class RegistrationSnapshot:
+    """Read-only view of one player's active-tournament registration."""
+
+    config: dict[str, str]
+    tournament: dict[str, object]
+    participant: dict[str, object] | None
+    status: str
+    timezone: str
+    slots: tuple[dict[str, object], ...]
+    selected_slot_ids: tuple[str, ...]
+    localized_slots: tuple[LocalizedSlot, ...]
+    tournament_status: str
+    can_update: bool
+    can_withdraw: bool
+
+
 def localize_availability(
     timezone: str, slots: list[dict[str, object]], close: object
 ) -> list[LocalizedSlot]:
@@ -188,6 +205,56 @@ class RegistrationService:
         if confirmed >= maximum:
             raise RegistrationError("tournament capacity is full")
         return SignupPreparation(config, tournament, tuple(slots), tuple(localized))
+
+    async def get_registration(self, user_id: str) -> RegistrationSnapshot:
+        """Return the active registration without exposing repository reads to UI code."""
+        config, tournament, _, slots = await self._context()
+        tournament_id = config["ACTIVE_TOURNAMENT_ID"]
+        participants, availability = await asyncio.gather(
+            self.repository.participants(), self.repository.availability()
+        )
+        participant = next(
+            (
+                row
+                for row in participants
+                if _text(row["tournament_id"]) == tournament_id
+                and _text(row["discord_user_id"]) == str(user_id)
+            ),
+            None,
+        )
+        status = _text(participant["status"]) if participant else ""
+        timezone = _text(participant["timezone"]) if participant else ""
+        selected = tuple(
+            dict.fromkeys(
+                _text(row["slot_id"])
+                for row in availability
+                if _text(row["tournament_id"]) == tournament_id
+                and _text(row["discord_user_id"]) == str(user_id)
+                and _text(row["slot_id"])
+            )
+        )
+        localized = ()
+        if participant and timezone:
+            enabled = localize_availability(
+                timezone, slots, tournament["signup_closes_at_utc"]
+            )
+            chosen = set(selected)
+            localized = tuple(slot for slot in enabled if slot.slot_id in chosen)
+        tournament_status = _text(tournament["status"])
+        return RegistrationSnapshot(
+            config=config,
+            tournament=tournament,
+            participant=participant,
+            status=status,
+            timezone=timezone,
+            slots=tuple(slots),
+            selected_slot_ids=selected,
+            localized_slots=localized,
+            tournament_status=tournament_status,
+            can_update=status == "confirmed" and tournament_status == "signup_open",
+            can_withdraw=status == "confirmed"
+            and tournament_status in {"signup_open", "signup_closed"},
+        )
 
     async def _context(self):
         config = await load_config(self.sheet_id)

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -132,6 +132,12 @@ class UpdateTimezoneModal(discord.ui.Modal, title="Update Live Arena availabilit
             )
             await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
         except Exception as exc:
+            if not isinstance(exc, (RegistrationError, LiveArenaConfigError)):
+                log.exception(
+                    "❌ Live Arena self-service — availability preparation failed • tournament=%s • user=%s • action=update_timezone",
+                    self.snapshot.config["ACTIVE_TOURNAMENT_ID"],
+                    interaction.user.id,
+                )
             await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
 
 
@@ -238,6 +244,12 @@ class ReviewView(discord.ui.View):
                 await flow.service.register(str(member.id), member.display_name, [str(role.id) for role in getattr(member, "roles", [])], flow.timezone, list(flow.selected))
                 embed = messages["signup_confirmed"].embed(participant=member.mention, tournament_name=flow.preparation.tournament["tournament_name"], signup_deadline=discord_timestamp(flow.preparation.tournament["signup_closes_at_utc"]))
         except Exception as exc:
+            if flow.updating and not isinstance(exc, (RegistrationError, LiveArenaConfigError)):
+                log.exception(
+                    "❌ Live Arena self-service — save failed • tournament=%s • user=%s • action=update_availability",
+                    flow.preparation.config["ACTIVE_TOURNAMENT_ID"],
+                    member.id,
+                )
             await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
             return
         if flow.updating:
@@ -330,14 +342,21 @@ class WithdrawalReasonModal(discord.ui.Modal, title="Confirm Live Arena withdraw
             messages = await load_messages(self.manager.sheet_id, config["MESSAGES_TAB"])
             await self.service.withdraw(str(member.id), str(self.reason).strip())
         except Exception as exc:
+            if not isinstance(exc, (RegistrationError, LiveArenaConfigError)):
+                log.exception(
+                    "❌ Live Arena self-service — withdrawal failed • tournament=%s • user=%s • action=withdraw",
+                    self.snapshot.config["ACTIVE_TOURNAMENT_ID"],
+                    member.id,
+                )
             await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
             return
         embed = messages["withdrawal_confirmed"].embed(participant=member.mention, tournament_name=self.snapshot.tournament["tournament_name"])
         await self._remove_role(interaction, config, embed)
-        try:
-            await self.manager.sync()
-        except Exception:
-            log.exception("⚠️ Live Arena panel — post-withdrawal refresh failed • tournament=%s • user=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id)
+        if self.snapshot.tournament_status == "signup_open":
+            try:
+                await self.manager.sync()
+            except Exception:
+                log.exception("⚠️ Live Arena panel — post-withdrawal refresh failed • tournament=%s • user=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id)
         await interaction.followup.send(embed=embed, ephemeral=True)
 
     async def _remove_role(self, interaction, config, embed):

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -1,4 +1,4 @@
-"""Discord views for the first player-facing Live Arena signup slice."""
+"""Discord views for Live Arena player signup and self-service."""
 
 from __future__ import annotations
 
@@ -9,24 +9,44 @@ import discord
 
 from shared.theme import colors
 
-from modules.community.live_arena.messages import (
-    discord_timestamp,
-    load_messages,
-    load_pr3_config,
-)
+from modules.community.live_arena.messages import discord_timestamp, load_messages, load_pr3_config
 from modules.community.live_arena.registration import (
     RegistrationError,
     RegistrationService,
+    SignupPreparation,
+    localize_availability,
     validate_availability,
 )
+from modules.community.live_arena.service import LiveArenaConfigError
 
 log = logging.getLogger("c1c.community.live_arena.views")
 
 
 def error_embed(message: object) -> discord.Embed:
-    return discord.Embed(
-        title="Live Arena signup", description=str(message), color=colors.c1c_blue
-    )
+    return discord.Embed(title="Live Arena", description=str(message), color=colors.c1c_blue)
+
+
+def _player_error(exc: Exception) -> discord.Embed:
+    if isinstance(exc, (RegistrationError, LiveArenaConfigError)):
+        return error_embed(exc)
+    return error_embed("Something went wrong. Please try again later.")
+
+
+def _grouped_lines(localized_slots, selected_ids) -> tuple[str, int, int]:
+    selected = set(selected_ids)
+    grouped = defaultdict(list)
+    for slot in localized_slots:
+        if slot.slot_id in selected:
+            grouped[slot.local_start.date()].append(slot)
+    lines = [
+        f"**{day:%A, %d %B}**\n"
+        + ", ".join(f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}" for slot in grouped[day])
+        for day in sorted(grouped)
+    ]
+    detail = "\n".join(lines) or "No saved windows."
+    if len(detail) > 3500:
+        detail = detail[:3497] + "…"
+    return detail, len(selected), len(grouped)
 
 
 class JoinTournamentView(discord.ui.View):
@@ -34,22 +54,35 @@ class JoinTournamentView(discord.ui.View):
         super().__init__(timeout=None)
         self.manager = manager
 
-    @discord.ui.button(
-        label="Join Tournament",
-        custom_id="live_arena:join",
-        style=discord.ButtonStyle.primary,
-    )
+    @discord.ui.button(label="Join Tournament", custom_id="live_arena:join", style=discord.ButtonStyle.primary)
     async def join(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        # Opening the modal is deliberately the first and only operation here.
         await interaction.response.send_modal(TimezoneModal(self.manager))
+
+    @discord.ui.button(label="My Registration", custom_id="live_arena:my_registration", style=discord.ButtonStyle.secondary)
+    async def my_registration(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        await interaction.response.defer(ephemeral=True)
+        service = (self.manager.service_factory or RegistrationService)(self.manager.sheet_id)
+        try:
+            await service.initialize()
+            snapshot = await service.get_registration(str(interaction.user.id))
+            if snapshot.participant is None:
+                await interaction.followup.send(
+                    embed=error_embed("You are not currently registered. Use **Join Tournament** to register."),
+                    ephemeral=True,
+                )
+                return
+            await interaction.followup.send(
+                embed=registration_embed(snapshot),
+                view=RegistrationActionsView(self.manager, service, snapshot),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            log.exception("❌ Live Arena self-service — load failed • user=%s", interaction.user.id)
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
 
 
 class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
-    timezone_input = discord.ui.TextInput(
-        label="Timezone",
-        required=True,
-        placeholder="Europe/Vienna, America/New_York, Asia/Kolkata",
-    )
+    timezone_input = discord.ui.TextInput(label="Timezone", required=True, placeholder="Europe/Vienna, America/New_York, Asia/Kolkata")
 
     def __init__(self, manager):
         super().__init__()
@@ -58,173 +91,126 @@ class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
         member = interaction.user
-        roles = [str(role.id) for role in getattr(member, "roles", [])]
-        service = (self.manager.service_factory or RegistrationService)(
-            self.manager.sheet_id
-        )
+        service = (self.manager.service_factory or RegistrationService)(self.manager.sheet_id)
         try:
             await service.initialize()
             preparation = await service.prepare_signup(
-                str(member.id), roles, str(self.timezone_input)
+                str(member.id), [str(role.id) for role in getattr(member, "roles", [])], str(self.timezone_input)
             )
             config, _ = await load_pr3_config(self.manager.sheet_id)
             await load_messages(self.manager.sheet_id, config["MESSAGES_TAB"])
-            view = AvailabilityView(
-                self.manager, service, preparation, str(self.timezone_input), member
-            )
-            await interaction.followup.send(
-                embed=view.embed(), view=view, ephemeral=True
-            )
+            view = AvailabilityView(self.manager, service, preparation, str(self.timezone_input), member)
+            await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
         except Exception as exc:
-            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+            log.exception("❌ Live Arena signup — preflight failed • user=%s", member.id)
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+
+
+class UpdateTimezoneModal(discord.ui.Modal, title="Update Live Arena availability"):
+    def __init__(self, manager, service, snapshot):
+        super().__init__()
+        self.manager, self.service, self.snapshot = manager, service, snapshot
+        self.timezone_input = discord.ui.TextInput(
+            label="Timezone", required=True, default=snapshot.timezone,
+            placeholder="Europe/Vienna, America/New_York, Asia/Kolkata",
+        )
+        self.add_item(self.timezone_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            timezone = str(self.timezone_input)
+            localized = localize_availability(
+                timezone, list(self.snapshot.slots), self.snapshot.tournament["signup_closes_at_utc"]
+            )
+            preparation = SignupPreparation(
+                self.snapshot.config, self.snapshot.tournament, self.snapshot.slots, tuple(localized)
+            )
+            view = AvailabilityView(
+                self.manager, self.service, preparation, timezone, interaction.user,
+                selected=self.snapshot.selected_slot_ids, updating=True,
+            )
+            await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
+        except Exception as exc:
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
 
 
 class AvailabilityView(discord.ui.View):
-    def __init__(self, manager, service, preparation, timezone: str, member):
+    def __init__(self, manager, service, preparation, timezone: str, member, *, selected=(), updating=False):
         super().__init__(timeout=900)
         self.manager, self.service, self.preparation = manager, service, preparation
-        self.timezone, self.member = timezone, member
+        self.timezone, self.member, self.updating = timezone, member, updating
         grouped = defaultdict(list)
         for slot in preparation.localized_slots:
             grouped[slot.local_start.date()].append(slot)
-        self.days = sorted(grouped)
-        self.grouped = dict(grouped)
+        self.days, self.grouped = sorted(grouped), dict(grouped)
+        if not self.days:
+            raise RegistrationError("no enabled availability slots are configured")
         if any(len(values) > 25 for values in grouped.values()):
-            raise RegistrationError(
-                "a local day exceeds Discord's 25-option component limit"
-            )
+            raise RegistrationError("a local day exceeds Discord's 25-option component limit")
         self.index = 0
-        self.selected: set[str] = set()
+        enabled_ids = {slot.slot_id for slot in preparation.localized_slots}
+        self.selected = {str(value) for value in selected if str(value) in enabled_ids}
         self._build()
 
     def _build(self):
         self.clear_items()
         day = self.days[self.index]
-        options = [
-            discord.SelectOption(
-                label=f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}",
-                value=slot.slot_id,
-                default=slot.slot_id in self.selected,
-            )
-            for slot in self.grouped[day]
-        ]
-        select = discord.ui.Select(
-            placeholder="Select available windows",
-            options=options,
-            min_values=0,
-            max_values=len(options),
-            row=0,
-        )
+        options = [discord.SelectOption(label=f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}", value=slot.slot_id, default=slot.slot_id in self.selected) for slot in self.grouped[day]]
+        select = discord.ui.Select(placeholder="Select available windows", options=options, min_values=0, max_values=len(options), row=0)
 
         async def selected(interaction):
-            day_ids = {slot.slot_id for slot in self.grouped[day]}
-            self.selected.difference_update(day_ids)
+            self.selected.difference_update(slot.slot_id for slot in self.grouped[day])
             self.selected.update(select.values)
             self._build()
             await interaction.response.edit_message(embed=self.embed(), view=self)
 
         select.callback = selected
         self.add_item(select)
-        self.add_item(
-            ActionButton(
-                "Previous Day",
-                discord.ButtonStyle.secondary,
-                1,
-                self.previous,
-                disabled=self.index == 0,
-            )
-        )
-        self.add_item(
-            ActionButton(
-                "Next Day",
-                discord.ButtonStyle.secondary,
-                1,
-                self.next,
-                disabled=self.index == len(self.days) - 1,
-            )
-        )
-        self.add_item(
-            ActionButton("Clear Day", discord.ButtonStyle.secondary, 2, self.clear_day)
-        )
-        self.add_item(
-            ActionButton(
-                "Review Registration", discord.ButtonStyle.primary, 2, self.review
-            )
-        )
+        self.add_item(ActionButton("Previous Day", discord.ButtonStyle.secondary, 1, self.previous, disabled=self.index == 0))
+        self.add_item(ActionButton("Next Day", discord.ButtonStyle.secondary, 1, self.next, disabled=self.index == len(self.days) - 1))
+        self.add_item(ActionButton("Clear Day", discord.ButtonStyle.secondary, 2, self.clear_day))
+        self.add_item(ActionButton("Review Changes" if self.updating else "Review Registration", discord.ButtonStyle.primary, 2, self.review))
 
     def counts(self):
-        lookup = {
-            slot.slot_id: slot for values in self.grouped.values() for slot in values
-        }
-        return len(self.selected), len(
-            {lookup[value].local_start.date() for value in self.selected}
-        )
+        lookup = {slot.slot_id: slot for values in self.grouped.values() for slot in values}
+        return len(self.selected), len({lookup[value].local_start.date() for value in self.selected})
 
     def embed(self):
         count, days = self.counts()
-        current = self.days[self.index]
         return discord.Embed(
-            title=f"Availability — {current:%A, %d %B}",
+            title=f"Availability — {self.days[self.index]:%A, %d %B}",
             description=f"Times shown in **{self.timezone}**. Selected: **{count}** windows across **{days}** local days.",
             color=colors.c1c_blue,
         )
 
     async def previous(self, interaction):
-        self.index -= 1
-        self._build()
+        self.index -= 1; self._build()
         await interaction.response.edit_message(embed=self.embed(), view=self)
 
     async def next(self, interaction):
-        self.index += 1
-        self._build()
+        self.index += 1; self._build()
         await interaction.response.edit_message(embed=self.embed(), view=self)
 
     async def clear_day(self, interaction):
-        self.selected.difference_update(
-            slot.slot_id for slot in self.grouped[self.days[self.index]]
-        )
+        self.selected.difference_update(slot.slot_id for slot in self.grouped[self.days[self.index]])
         self._build()
         await interaction.response.edit_message(embed=self.embed(), view=self)
 
     async def review(self, interaction):
         try:
-            validate_availability(
-                self.timezone,
-                list(self.selected),
-                list(self.preparation.slots),
-                self.preparation.tournament["signup_closes_at_utc"],
-            )
+            validate_availability(self.timezone, list(self.selected), list(self.preparation.slots), self.preparation.tournament["signup_closes_at_utc"])
         except Exception as exc:
-            await interaction.response.send_message(
-                embed=error_embed(exc), ephemeral=True
-            )
+            await interaction.response.send_message(embed=_player_error(exc), ephemeral=True)
             return
-        await interaction.response.edit_message(
-            embed=self.review_embed(), view=ReviewView(self)
-        )
+        await interaction.response.edit_message(embed=self.review_embed(), view=ReviewView(self))
 
     def review_embed(self):
-        count, day_count = self.counts()
-        lines = []
-        for day in self.days:
-            chosen = [s for s in self.grouped[day] if s.slot_id in self.selected]
-            if chosen:
-                lines.append(
-                    f"**{day:%A, %d %B}**\n"
-                    + ", ".join(
-                        f"{s.local_start:%H:%M}–{s.local_end:%H:%M}" for s in chosen
-                    )
-                )
-        detail = "\n".join(lines)
-        if len(detail) > 3500:
-            detail = detail[:3497] + "…"
+        detail, count, day_count = _grouped_lines(self.preparation.localized_slots, self.selected)
+        action = "changes" if self.updating else "registration"
         return discord.Embed(
-            title="Review Live Arena registration",
-            color=colors.c1c_blue,
-            description=(
-                f"**Tournament:** {self.preparation.tournament['tournament_name']}\n"
-                f"**Timezone:** {self.timezone}\n**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"
-            ),
+            title=f"Review Live Arena {action}", color=colors.c1c_blue,
+            description=(f"**Tournament:** {self.preparation.tournament['tournament_name']}\n**Timezone:** {self.timezone}\n**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"),
         )
 
 
@@ -232,74 +218,141 @@ class ReviewView(discord.ui.View):
     def __init__(self, availability):
         super().__init__(timeout=900)
         self.availability = availability
+        self.add_item(ActionButton("Back", discord.ButtonStyle.secondary, 0, self.back))
+        self.add_item(ActionButton("Save Changes" if availability.updating else "Submit Registration", discord.ButtonStyle.primary, 0, self.submit))
 
-    @discord.ui.button(label="Back", style=discord.ButtonStyle.secondary)
-    async def back(self, interaction, _button):
+    async def back(self, interaction):
         self.availability._build()
-        await interaction.response.edit_message(
-            embed=self.availability.embed(), view=self.availability
-        )
+        await interaction.response.edit_message(embed=self.availability.embed(), view=self.availability)
 
-    @discord.ui.button(label="Submit Registration", style=discord.ButtonStyle.primary)
-    async def submit(self, interaction, _button):
+    async def submit(self, interaction):
         await interaction.response.defer(ephemeral=True)
         flow, member = self.availability, interaction.user
         try:
             config, _ = await load_pr3_config(flow.manager.sheet_id)
-            messages = await load_messages(
-                flow.manager.sheet_id, config["MESSAGES_TAB"]
-            )
-            await flow.service.register(
-                str(member.id),
-                member.display_name,
-                [str(role.id) for role in getattr(member, "roles", [])],
-                flow.timezone,
-                list(flow.selected),
-            )
+            messages = await load_messages(flow.manager.sheet_id, config["MESSAGES_TAB"])
+            if flow.updating:
+                await flow.service.update_availability(str(member.id), flow.timezone, list(flow.selected))
+                embed = messages["availability_updated"].embed(participant=member.mention, tournament_name=flow.preparation.tournament["tournament_name"])
+            else:
+                await flow.service.register(str(member.id), member.display_name, [str(role.id) for role in getattr(member, "roles", [])], flow.timezone, list(flow.selected))
+                embed = messages["signup_confirmed"].embed(participant=member.mention, tournament_name=flow.preparation.tournament["tournament_name"], signup_deadline=discord_timestamp(flow.preparation.tournament["signup_closes_at_utc"]))
         except Exception as exc:
-            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
             return
-        embed = messages["signup_confirmed"].embed(
-            participant=member.mention,
-            tournament_name=flow.preparation.tournament["tournament_name"],
-            signup_deadline=discord_timestamp(
-                flow.preparation.tournament["signup_closes_at_utc"]
-            ),
-        )
-        role_id = int(config["PARTICIPANT_ROLE_ID"])
-        role = interaction.guild.get_role(role_id) if interaction.guild else None
-        if role is None:
-            embed.add_field(
-                name="Role sync warning",
-                value="Your tournament role could not be synced automatically.",
-                inline=False,
-            )
-            log.error(
-                "❌ Live Arena role — missing • tournament=%s • user=%s • role=%s",
-                flow.preparation.config["ACTIVE_TOURNAMENT_ID"],
-                member.id,
-                role_id,
-            )
-        elif role not in getattr(member, "roles", []):
-            try:
-                await member.add_roles(role, reason="Live Arena registration confirmed")
-            except Exception:
-                embed.add_field(
-                    name="Role sync warning",
-                    value="Your tournament role could not be synced automatically.",
-                    inline=False,
-                )
-                log.exception(
-                    "❌ Live Arena role — assignment failed • tournament=%s • user=%s • role=%s",
-                    flow.preparation.config["ACTIVE_TOURNAMENT_ID"],
-                    member.id,
-                    role_id,
-                )
+        if flow.updating:
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+        await _assign_role(config, flow, interaction, embed)
         await interaction.followup.send(embed=embed, ephemeral=True)
         try:
             await flow.manager.sync()
         except Exception:
             log.exception("⚠️ Live Arena panel — post-registration refresh failed")
+
+
+async def _assign_role(config, flow, interaction, embed):
+    role_id = int(config["PARTICIPANT_ROLE_ID"])
+    member = interaction.user
+    role = interaction.guild.get_role(role_id) if interaction.guild else None
+    if role is None:
+        _role_warning(embed)
+        log.error("❌ Live Arena role — missing • tournament=%s • user=%s • role=%s", flow.preparation.config["ACTIVE_TOURNAMENT_ID"], member.id, role_id)
+    elif role not in getattr(member, "roles", []):
+        try:
+            await member.add_roles(role, reason="Live Arena registration confirmed")
+        except Exception:
+            _role_warning(embed)
+            log.exception("❌ Live Arena role — assignment failed • tournament=%s • user=%s • role=%s", flow.preparation.config["ACTIVE_TOURNAMENT_ID"], member.id, role_id)
+
+
+def _role_warning(embed):
+    embed.add_field(name="Role sync warning", value="Your tournament role could not be synced automatically.", inline=False)
+
+
+def registration_embed(snapshot):
+    detail, count, day_count = _grouped_lines(snapshot.localized_slots, snapshot.selected_slot_ids)
+    description = (
+        f"**Tournament:** {snapshot.tournament['tournament_name']}\n"
+        f"**Status:** {snapshot.status or 'unknown'}\n**Timezone:** {snapshot.timezone or 'Not saved'}\n"
+        f"**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"
+    )
+    if snapshot.status == "withdrawn" and snapshot.tournament_status == "signup_open":
+        description += "\n\nUse **Join Tournament** on the public panel to register again."
+    elif snapshot.status in {"removed", "disqualified"}:
+        description += "\n\nThis status cannot be restored through player self-service."
+    return discord.Embed(title="My Live Arena registration", description=description, color=colors.c1c_blue)
+
+
+class RegistrationActionsView(discord.ui.View):
+    def __init__(self, manager, service, snapshot):
+        super().__init__(timeout=900)
+        self.manager, self.service, self.snapshot = manager, service, snapshot
+        if snapshot.can_update:
+            self.add_item(ActionButton("Update Availability", discord.ButtonStyle.primary, 0, self.update))
+        if snapshot.can_withdraw:
+            self.add_item(ActionButton("Withdraw", discord.ButtonStyle.danger, 0, self.withdraw))
+
+    async def update(self, interaction):
+        await interaction.response.send_modal(UpdateTimezoneModal(self.manager, self.service, self.snapshot))
+
+    async def withdraw(self, interaction):
+        embed = discord.Embed(title="Confirm withdrawal", description=f"Withdraw from **{self.snapshot.tournament['tournament_name']}**? Your saved availability will be retained.", color=colors.c1c_blue)
+        await interaction.response.edit_message(embed=embed, view=WithdrawalConfirmationView(self.manager, self.service, self.snapshot))
+
+
+class WithdrawalConfirmationView(discord.ui.View):
+    def __init__(self, manager, service, snapshot):
+        super().__init__(timeout=900)
+        self.manager, self.service, self.snapshot = manager, service, snapshot
+
+    @discord.ui.button(label="Confirm Withdrawal", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction, _button):
+        await interaction.response.send_modal(WithdrawalReasonModal(self.manager, self.service, self.snapshot))
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction, _button):
+        await interaction.response.edit_message(embed=registration_embed(self.snapshot), view=RegistrationActionsView(self.manager, self.service, self.snapshot))
+
+
+class WithdrawalReasonModal(discord.ui.Modal, title="Confirm Live Arena withdrawal"):
+    reason = discord.ui.TextInput(label="Reason", required=False, max_length=500, style=discord.TextStyle.paragraph)
+
+    def __init__(self, manager, service, snapshot):
+        super().__init__()
+        self.manager, self.service, self.snapshot = manager, service, snapshot
+
+    async def on_submit(self, interaction):
+        await interaction.response.defer(ephemeral=True)
+        member = interaction.user
+        try:
+            config, _ = await load_pr3_config(self.manager.sheet_id)
+            messages = await load_messages(self.manager.sheet_id, config["MESSAGES_TAB"])
+            await self.service.withdraw(str(member.id), str(self.reason).strip())
+        except Exception as exc:
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+            return
+        embed = messages["withdrawal_confirmed"].embed(participant=member.mention, tournament_name=self.snapshot.tournament["tournament_name"])
+        await self._remove_role(interaction, config, embed)
+        try:
+            await self.manager.sync()
+        except Exception:
+            log.exception("⚠️ Live Arena panel — post-withdrawal refresh failed • tournament=%s • user=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id)
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    async def _remove_role(self, interaction, config, embed):
+        role_id = int(config["PARTICIPANT_ROLE_ID"])
+        member = interaction.user
+        role = interaction.guild.get_role(role_id) if interaction.guild else None
+        if role is None:
+            _role_warning(embed)
+            log.error("❌ Live Arena role — removal target missing • tournament=%s • user=%s • role=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id, role_id)
+        elif role in getattr(member, "roles", []):
+            try:
+                await member.remove_roles(role, reason="Live Arena registration withdrawn")
+            except Exception:
+                _role_warning(embed)
+                log.exception("❌ Live Arena role — removal failed • tournament=%s • user=%s • role=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id, role_id)
 
 
 class ActionButton(discord.ui.Button):

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -187,6 +187,18 @@ def test_draft_creates_no_public_panel(monkeypatch):
     assert channel.sent == []
 
 
+def test_signup_closed_does_not_render_edit_or_recreate_public_panel(monkeypatch):
+    existing = _Message(55)
+    manager, channel = _panel_manager(
+        monkeypatch, status="signup_closed", panel_id="55", channel=_Channel(existing)
+    )
+    asyncio.run(manager.sync())
+    panel.load_messages.assert_not_awaited()
+    existing.edit.assert_not_awaited()
+    assert channel.sent == []
+    manager._persist_message_id.assert_not_awaited()
+
+
 def test_blank_panel_creates_once_and_persists_existing_config_cell(monkeypatch):
     manager, channel = _panel_manager(monkeypatch)
     asyncio.run(manager.sync())

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -43,6 +43,22 @@ MESSAGE_ROWS = [
         "TRUE",
         "",
     ],
+    [
+        "availability_updated",
+        "Availability updated",
+        "{participant}, your timezone and availability for {tournament_name} were updated.",
+        "#34A853",
+        "TRUE",
+        "",
+    ],
+    [
+        "withdrawal_confirmed",
+        "Withdrawal recorded",
+        "{participant} has withdrawn from {tournament_name}.",
+        "#34A853",
+        "TRUE",
+        "",
+    ],
 ]
 
 
@@ -59,7 +75,12 @@ def test_literal_pr3_config_and_messages_render(monkeypatch):
         confirmed_count=4,
         max_participants=16,
     )
-    assert set(loaded) == {"signup_open", "signup_confirmed"}
+    assert set(loaded) == {
+        "signup_open",
+        "signup_confirmed",
+        "availability_updated",
+        "withdrawal_confirmed",
+    }
     assert "Trial Cup" in embed.description and "4/16" in embed.description
 
 
@@ -284,6 +305,8 @@ def test_timezone_submit_initializes_real_repository_before_preflight(monkeypatc
         ("signup_confirmed", "remove", "signup_confirmed"),
         ("signup_open", "inactive", "signup_open"),
         ("signup_confirmed", "inactive", "signup_confirmed"),
+        ("availability_updated", "remove", "availability_updated"),
+        ("withdrawal_confirmed", "inactive", "withdrawal_confirmed"),
         ("signup_open", "color", "color_hex"),
     ],
 )

--- a/tests/community/test_live_arena_pr4.py
+++ b/tests/community/test_live_arena_pr4.py
@@ -1,0 +1,183 @@
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from modules.community.live_arena import messages, views
+from modules.community.live_arena.registration import (
+    LocalizedSlot,
+    RegistrationSnapshot,
+    SignupPreparation,
+)
+
+
+def run(value):
+    return asyncio.run(value)
+
+
+def snapshot(*, status="confirmed", tournament_status="signup_open"):
+    base = datetime(2026, 8, 3, 18, tzinfo=UTC)
+    localized = tuple(
+        LocalizedSlot(f"slot-{i}", base + timedelta(days=i // 2, hours=2 * (i % 2)), base + timedelta(days=i // 2, hours=2 * (i % 2) + 2))
+        for i in range(4)
+    )
+    rows = tuple(
+        dict(slot_id=s.slot_id, weekday_utc=s.local_start.strftime("%A"), start_time_utc=s.local_start.strftime("%H:%M"), end_time_utc=s.local_end.strftime("%H:%M"), enabled="TRUE")
+        for s in localized
+    )
+    return RegistrationSnapshot(
+        {"ACTIVE_TOURNAMENT_ID": "LA-1"},
+        {"tournament_name": "Trial Cup", "signup_closes_at_utc": "2026-08-09T20:00:00Z"},
+        {"status": status, "timezone": "UTC"}, status, "UTC", rows,
+        tuple(s.slot_id for s in localized[:3]), localized[:3], tournament_status,
+        status == "confirmed" and tournament_status == "signup_open",
+        status == "confirmed" and tournament_status in {"signup_open", "signup_closed"},
+    )
+
+
+def test_public_panel_has_exact_persistent_player_actions():
+    panel = views.JoinTournamentView(object())
+    assert panel.timeout is None
+    assert [(item.label, item.custom_id, item.style) for item in panel.children] == [
+        ("Join Tournament", "live_arena:join", discord.ButtonStyle.primary),
+        ("My Registration", "live_arena:my_registration", discord.ButtonStyle.secondary),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("status", "tournament_status", "labels"),
+    [
+        ("confirmed", "signup_open", ["Update Availability", "Withdraw"]),
+        ("confirmed", "signup_closed", ["Withdraw"]),
+        ("confirmed", "completed", []),
+        ("withdrawn", "signup_open", []),
+        ("removed", "signup_open", []),
+        ("disqualified", "signup_open", []),
+        ("unexpected", "signup_open", []),
+    ],
+)
+def test_registration_actions_follow_exact_status_rules(status, tournament_status, labels):
+    view = views.RegistrationActionsView(object(), object(), snapshot(status=status, tournament_status=tournament_status))
+    assert [item.label for item in view.children] == labels
+
+
+def test_registration_embed_has_saved_counts_timezone_and_grouped_days():
+    embed = views.registration_embed(snapshot())
+    for expected in ("Trial Cup", "confirmed", "UTC", "**Windows:** 3", "**Local days:** 2", "Monday", "Tuesday"):
+        assert expected in embed.description
+
+
+def test_withdrawn_embed_points_to_join_without_restore():
+    embed = views.registration_embed(snapshot(status="withdrawn"))
+    assert "Join Tournament" in embed.description
+    assert "Restore" not in embed.description
+
+
+def test_update_timezone_prefills_and_preserves_real_slot_ids():
+    current = snapshot()
+    manager = SimpleNamespace()
+    modal = views.UpdateTimezoneModal(manager, object(), current)
+    assert modal.timezone_input.default == "UTC"
+    modal.timezone_input._value = "Asia/Kolkata"
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7), response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    run(modal.on_submit(interaction))
+    view = interaction.followup.send.await_args.kwargs["view"]
+    assert view.timezone == "Asia/Kolkata"
+    assert view.selected == set(current.selected_slot_ids)
+
+
+def test_update_save_calls_pr2_only_and_uses_exact_template(monkeypatch):
+    current = snapshot()
+    preparation = SignupPreparation(current.config, current.tournament, current.slots, current.localized_slots)
+    service = SimpleNamespace(update_availability=AsyncMock())
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    member = SimpleNamespace(id=7, mention="<@7>")
+    flow = views.AvailabilityView(manager, service, preparation, "UTC", member, selected=current.selected_slot_ids, updating=True)
+    config = {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}
+    template = messages.MessageTemplate("availability_updated", "Availability updated", "{participant}, your timezone and availability for {tournament_name} were updated.", 1)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=(config, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"availability_updated": template}))
+    interaction = SimpleNamespace(user=member, response=SimpleNamespace(defer=AsyncMock()), followup=SimpleNamespace(send=AsyncMock()))
+    review = views.ReviewView(flow)
+    run(review.children[1].callback(interaction))
+    args = service.update_availability.await_args.args
+    assert args[:2] == ("7", "UTC") and set(args[2]) == set(current.selected_slot_ids)
+    manager.sync.assert_not_awaited()
+    assert interaction.followup.send.await_args.kwargs["embed"].description == "<@7>, your timezone and availability for Trial Cup were updated."
+
+
+def test_withdraw_cancel_is_embed_only_and_does_not_mutate():
+    current = snapshot()
+    service = SimpleNamespace(withdraw=AsyncMock())
+    interaction = SimpleNamespace(response=SimpleNamespace(edit_message=AsyncMock()))
+    view = views.WithdrawalConfirmationView(object(), service, current)
+    run(view.children[1].callback(interaction))
+    service.withdraw.assert_not_awaited()
+    assert isinstance(interaction.response.edit_message.await_args.kwargs["embed"], discord.Embed)
+
+
+def withdrawal_interaction(role):
+    member = SimpleNamespace(id=7, mention="<@7>", roles=[role] if role else [], remove_roles=AsyncMock())
+    return SimpleNamespace(
+        user=member, guild=SimpleNamespace(get_role=lambda _id: role),
+        response=SimpleNamespace(defer=AsyncMock()), followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def test_withdraw_calls_pr2_once_then_removes_role_and_refreshes(monkeypatch):
+    current = snapshot()
+    service = SimpleNamespace(withdraw=AsyncMock())
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    role = SimpleNamespace(id=99)
+    interaction = withdrawal_interaction(role)
+    config = {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}
+    template = messages.MessageTemplate("withdrawal_confirmed", "Withdrawal recorded", "{participant} has withdrawn from {tournament_name}.", 1)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=(config, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"withdrawal_confirmed": template}))
+    modal = views.WithdrawalReasonModal(manager, service, current)
+    modal.reason._value = "busy"
+    run(modal.on_submit(interaction))
+    service.withdraw.assert_awaited_once_with("7", "busy")
+    interaction.user.remove_roles.assert_awaited_once_with(role, reason="Live Arena registration withdrawn")
+    manager.sync.assert_awaited_once()
+    assert interaction.followup.send.await_args.kwargs["embed"].description == "<@7> has withdrawn from Trial Cup."
+
+
+@pytest.mark.parametrize("role_error,sync_error", [(RuntimeError("denied"), None), (None, RuntimeError("offline"))])
+def test_secondary_withdrawal_failure_keeps_success(monkeypatch, role_error, sync_error):
+    current = snapshot()
+    service = SimpleNamespace(withdraw=AsyncMock())
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock(side_effect=sync_error))
+    role = SimpleNamespace(id=99)
+    interaction = withdrawal_interaction(role)
+    interaction.user.remove_roles.side_effect = role_error
+    config = {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}
+    template = messages.MessageTemplate("withdrawal_confirmed", "Withdrawal recorded", "{participant} has withdrawn from {tournament_name}.", 1)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=(config, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"withdrawal_confirmed": template}))
+    modal = views.WithdrawalReasonModal(manager, service, current)
+    run(modal.on_submit(interaction))
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert service.withdraw.await_count == 1 and isinstance(embed, discord.Embed)
+    assert bool(embed.fields) is bool(role_error)
+
+
+def test_withdrawal_rejection_has_no_role_or_refresh(monkeypatch):
+    current = snapshot()
+    service = SimpleNamespace(withdraw=AsyncMock(side_effect=Exception("write failed")))
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    role = SimpleNamespace(id=99)
+    interaction = withdrawal_interaction(role)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={}))
+    run(views.WithdrawalReasonModal(manager, service, current).on_submit(interaction))
+    interaction.user.remove_roles.assert_not_awaited()
+    manager.sync.assert_not_awaited()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert isinstance(embed, discord.Embed) and "write failed" not in embed.description

--- a/tests/community/test_live_arena_pr4.py
+++ b/tests/community/test_live_arena_pr4.py
@@ -9,6 +9,7 @@ import pytest
 from modules.community.live_arena import messages, views
 from modules.community.live_arena.registration import (
     LocalizedSlot,
+    RegistrationError,
     RegistrationSnapshot,
     SignupPreparation,
 )
@@ -92,6 +93,26 @@ def test_update_timezone_prefills_and_preserves_real_slot_ids():
     assert view.selected == set(current.selected_slot_ids)
 
 
+@pytest.mark.parametrize(
+    ("error", "logged", "visible"),
+    [(RegistrationError("bad timezone"), False, "bad timezone"), (RuntimeError("boom"), True, "Something went wrong")],
+)
+def test_update_timezone_logs_only_unexpected_failures(monkeypatch, caplog, error, logged, visible):
+    current = snapshot()
+    modal = views.UpdateTimezoneModal(SimpleNamespace(), object(), current)
+    modal.timezone_input._value = "UTC"
+    monkeypatch.setattr(views, "localize_availability", lambda *_args: (_ for _ in ()).throw(error))
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7), response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    caplog.set_level("ERROR", logger="c1c.community.live_arena.views")
+    run(modal.on_submit(interaction))
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert visible in embed.description
+    assert ("availability preparation failed" in caplog.text) is logged
+
+
 def test_update_save_calls_pr2_only_and_uses_exact_template(monkeypatch):
     current = snapshot()
     preparation = SignupPreparation(current.config, current.tournament, current.slots, current.localized_slots)
@@ -110,6 +131,23 @@ def test_update_save_calls_pr2_only_and_uses_exact_template(monkeypatch):
     assert args[:2] == ("7", "UTC") and set(args[2]) == set(current.selected_slot_ids)
     manager.sync.assert_not_awaited()
     assert interaction.followup.send.await_args.kwargs["embed"].description == "<@7>, your timezone and availability for Trial Cup were updated."
+
+
+def test_update_save_unexpected_failure_is_logged_and_generic(monkeypatch, caplog):
+    current = snapshot()
+    preparation = SignupPreparation(current.config, current.tournament, current.slots, current.localized_slots)
+    service = SimpleNamespace(update_availability=AsyncMock(side_effect=RuntimeError("database detail")))
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    member = SimpleNamespace(id=7, mention="<@7>")
+    flow = views.AvailabilityView(manager, service, preparation, "UTC", member, selected=current.selected_slot_ids, updating=True)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES"}, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={}))
+    interaction = SimpleNamespace(user=member, response=SimpleNamespace(defer=AsyncMock()), followup=SimpleNamespace(send=AsyncMock()))
+    caplog.set_level("ERROR", logger="c1c.community.live_arena.views")
+    run(views.ReviewView(flow).children[1].callback(interaction))
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert "Something went wrong" in embed.description and "database detail" not in embed.description
+    assert "action=update_availability" in caplog.text
 
 
 def test_withdraw_cancel_is_embed_only_and_does_not_mutate():
@@ -149,6 +187,22 @@ def test_withdraw_calls_pr2_once_then_removes_role_and_refreshes(monkeypatch):
     assert interaction.followup.send.await_args.kwargs["embed"].description == "<@7> has withdrawn from Trial Cup."
 
 
+def test_signup_closed_withdraws_and_removes_role_without_panel_sync(monkeypatch):
+    current = snapshot(tournament_status="signup_closed")
+    service = SimpleNamespace(withdraw=AsyncMock())
+    manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
+    role = SimpleNamespace(id=99)
+    interaction = withdrawal_interaction(role)
+    template = messages.MessageTemplate("withdrawal_confirmed", "Withdrawal recorded", "{participant} has withdrawn from {tournament_name}.", 1)
+    monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}, [])))
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={"withdrawal_confirmed": template}))
+    run(views.WithdrawalReasonModal(manager, service, current).on_submit(interaction))
+    service.withdraw.assert_awaited_once()
+    interaction.user.remove_roles.assert_awaited_once_with(role, reason="Live Arena registration withdrawn")
+    manager.sync.assert_not_awaited()
+    assert isinstance(interaction.followup.send.await_args.kwargs["embed"], discord.Embed)
+
+
 @pytest.mark.parametrize("role_error,sync_error", [(RuntimeError("denied"), None), (None, RuntimeError("offline"))])
 def test_secondary_withdrawal_failure_keeps_success(monkeypatch, role_error, sync_error):
     current = snapshot()
@@ -168,7 +222,7 @@ def test_secondary_withdrawal_failure_keeps_success(monkeypatch, role_error, syn
     assert bool(embed.fields) is bool(role_error)
 
 
-def test_withdrawal_rejection_has_no_role_or_refresh(monkeypatch):
+def test_withdrawal_rejection_has_no_role_or_refresh(monkeypatch, caplog):
     current = snapshot()
     service = SimpleNamespace(withdraw=AsyncMock(side_effect=Exception("write failed")))
     manager = SimpleNamespace(sheet_id="sheet", sync=AsyncMock())
@@ -176,8 +230,10 @@ def test_withdrawal_rejection_has_no_role_or_refresh(monkeypatch):
     interaction = withdrawal_interaction(role)
     monkeypatch.setattr(views, "load_pr3_config", AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}, [])))
     monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={}))
+    caplog.set_level("ERROR", logger="c1c.community.live_arena.views")
     run(views.WithdrawalReasonModal(manager, service, current).on_submit(interaction))
     interaction.user.remove_roles.assert_not_awaited()
     manager.sync.assert_not_awaited()
     embed = interaction.followup.send.await_args.kwargs["embed"]
     assert isinstance(embed, discord.Embed) and "write failed" not in embed.description
+    assert "action=withdraw" in caplog.text

--- a/tests/community/test_live_arena_registration.py
+++ b/tests/community/test_live_arena_registration.py
@@ -144,6 +144,31 @@ def run(awaitable):
     return asyncio.run(awaitable)
 
 
+def test_get_registration_returns_localized_read_only_snapshot():
+    participant = dict(
+        tournament_id=TID,
+        discord_user_id="7",
+        timezone="Asia/Kolkata",
+        status="confirmed",
+    )
+    availability = [
+        dict(tournament_id=TID, discord_user_id="7", slot_id=slot_id)
+        for slot_id in ("mon-a", "tue-a", "wed-a")
+    ]
+    instance = make_service(MemoryRepository([participant], availability))
+    result = run(instance.get_registration("7"))
+    assert result.participant["status"] == "confirmed"
+    assert result.status == "confirmed"
+    assert result.timezone == "Asia/Kolkata"
+    assert result.selected_slot_ids == ("mon-a", "tue-a", "wed-a")
+    assert [slot.slot_id for slot in result.localized_slots] == [
+        "mon-a",
+        "tue-a",
+        "wed-a",
+    ]
+    assert result.can_update is True and result.can_withdraw is True
+
+
 @pytest.mark.parametrize(
     "headers,key",
     [


### PR DESCRIPTION
### Motivation

- Expose player self-service on top of the existing signup flow so players can view `My Registration`, update timezone/availability, and withdraw without organizer actions.
- Keep all persistence, validation, and audit behavior owned by the existing registration domain (PR2/PR3) and avoid any Google Sheets schema changes.

### Description

- Added a read-only `RegistrationSnapshot` DTO and `RegistrationService.get_registration(user_id)` to return an encapsulated registration view (active tournament, participant row, status, saved timezone, real `slot_id`s, localized availability, and allowed actions).
- Extended the public persistent panel to add a secondary `My Registration` button (`custom_id=live_arena:my_registration`) while preserving the existing `Join Tournament` behavior and PR3 reconnect/dedupe logic.
- Reused the PR3 availability wizard for the update flow (timezone modal -> availability view -> review -> `RegistrationService.update_availability()`), ensuring saved real `slot_id`s are preselected, timezone relocalization is display-only, and validation/delegation to PR2 remains unchanged; success uses the exact `MESSAGES.availability_updated` template.
- Implemented the withdraw flow with explicit confirmation and optional reason modal, delegated to `RegistrationService.withdraw()`, then attempted participant-role removal (no rollback on role errors) and refreshed the public confirmed count (non-blocking); success uses the exact `MESSAGES.withdrawal_confirmed` template.

### Testing

- Ran focused Live Arena tests with `pytest tests/community/test_live_arena.py tests/community/test_live_arena_registration.py tests/community/test_live_arena_pr3.py tests/community/test_live_arena_pr4.py` and the Live Arena tests passed (focused coverage for PR1–PR4 scenarios passed).
- Ran repository guardrails with `python -m scripts.ci.guardrails_suite --pr 1069 --status-file /tmp/guardrails-status2 --summary /tmp/guardrails-summary2.md --base-ref aed64f07f66e2230e051133921404f65bd0f05bc` and guardrails passed against the required baseline.
- Attempted a local full test run; `pytest` on the full repo showed unrelated logging-capture failures when executed under the local Python 3.14 environment (25 unrelated failures); these are environment-dependent and CI runs on Python 3.11 where the normal test suite is expected to pass.
- All changes were implemented without modifying any Google Sheets schema or adding new CONFIG keys; templates referenced are the existing message templates enforced in code and tests. Closes #1069.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7620b6c40c8323ac0df394b1542b4a)