### PR TITLE
feat(live-arena): organizer registration controls and registration recovery (PR5)

### DIFF
--- a/modules/community/live_arena/messages.py
+++ b/modules/community/live_arena/messages.py
@@ -24,6 +24,15 @@ PR3_CONFIG_KEYS = (
     "PARTICIPANT_ROLE_ID",
     "PUBLIC_PANEL_MESSAGE_ID",
 )
+PR5_CONFIG_KEYS = (
+    "MESSAGES_TAB",
+    "SIGNUP_CHANNEL_ID",
+    "ORGANIZER_CHANNEL_ID",
+    "ORGANIZER_ROLE_ID",
+    "PARTICIPANT_ROLE_ID",
+    "PUBLIC_PANEL_MESSAGE_ID",
+    "ORGANIZER_PANEL_MESSAGE_ID",
+)
 MESSAGE_HEADERS = (
     "message_key",
     "title",
@@ -43,6 +52,16 @@ REQUIRED_MESSAGES = {
     "availability_updated": {"participant", "tournament_name"},
     "withdrawal_confirmed": {"participant", "tournament_name"},
 }
+PR5_MESSAGES = {
+    "signup_closed": {"tournament_name", "confirmed_count"},
+    "organizer_panel": {
+        "tournament_name",
+        "status",
+        "confirmed_count",
+        "max_participants",
+        "parity_summary",
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -53,7 +72,7 @@ class MessageTemplate:
     color: int
 
     def embed(self, **values: object) -> discord.Embed:
-        expected = REQUIRED_MESSAGES[self.key]
+        expected = (REQUIRED_MESSAGES | PR5_MESSAGES)[self.key]
         fields = {
             name
             for _, name, _, _ in Formatter().parse(self.title + self.description)
@@ -97,10 +116,45 @@ async def load_pr3_config(sheet_id: str) -> tuple[dict[str, str], list[list[obje
     return result, matrix
 
 
-async def load_messages(sheet_id: str, tab: str) -> dict[str, MessageTemplate]:
+async def load_pr5_config(sheet_id: str) -> tuple[dict[str, str], list[list[object]]]:
+    """Load only the exact Discord/config routing contract used by PR5."""
+    matrix = await afetch_values(sheet_id, CONFIG_TAB) or []
+    rows = _rows(matrix, CONFIG_HEADERS, CONFIG_TAB)
+    result = {}
+    for key in PR5_CONFIG_KEYS:
+        matches = [row for row in rows if _text(row["Key"]) == key]
+        if len(matches) != 1:
+            raise LiveArenaConfigError(f"CONFIG: key {key} must occur exactly once")
+        result[key] = _text(matches[0]["Value"])
+    for key in PR5_CONFIG_KEYS:
+        if (
+            key not in {"PUBLIC_PANEL_MESSAGE_ID", "ORGANIZER_PANEL_MESSAGE_ID"}
+            and not result[key]
+        ):
+            raise LiveArenaConfigError(f"CONFIG: missing required key {key}")
+    try:
+        for key in (
+            "SIGNUP_CHANNEL_ID",
+            "ORGANIZER_CHANNEL_ID",
+            "ORGANIZER_ROLE_ID",
+            "PARTICIPANT_ROLE_ID",
+        ):
+            int(result[key])
+        for key in ("PUBLIC_PANEL_MESSAGE_ID", "ORGANIZER_PANEL_MESSAGE_ID"):
+            if result[key]:
+                int(result[key])
+    except ValueError as exc:
+        raise LiveArenaConfigError("CONFIG: PR5 Discord IDs must be numeric") from exc
+    return result, matrix
+
+
+async def load_messages(
+    sheet_id: str, tab: str, keys=None
+) -> dict[str, MessageTemplate]:
     rows = _rows(await afetch_values(sheet_id, tab) or [], MESSAGE_HEADERS, tab)
     templates = {}
-    for key in REQUIRED_MESSAGES:
+    contracts = REQUIRED_MESSAGES | PR5_MESSAGES
+    for key in keys or REQUIRED_MESSAGES:
         matches = [row for row in rows if _text(row["message_key"]) == key]
         if len(matches) != 1 or not _enabled(matches[0]["active"]):
             raise LiveArenaConfigError(
@@ -120,7 +174,7 @@ async def load_messages(sheet_id: str, tab: str) -> dict[str, MessageTemplate]:
             key, _text(row["title"]), _text(row["description"]), parsed
         )
         # Validate placeholders at load time, before any mutation.
-        template.embed(**{name: "x" for name in REQUIRED_MESSAGES[key]})
+        template.embed(**{name: "x" for name in contracts[key]})
         templates[key] = template
     return templates
 

--- a/modules/community/live_arena/organizer.py
+++ b/modules/community/live_arena/organizer.py
@@ -1,0 +1,256 @@
+"""Organizer registration lifecycle domain for Live Arena PR5."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from shared.sheets.async_core import afetch_values
+
+from modules.community.live_arena.registration import (
+    RegistrationError,
+    RegistrationService,
+    _locks,
+    utc_iso,
+    validate_availability,
+)
+from modules.community.live_arena.repository import LiveArenaRepository
+from modules.community.live_arena.service import (
+    AVAILABILITY_SLOT_HEADERS,
+    ELIGIBLE_CLAN_HEADERS,
+    TOURNAMENT_HEADERS,
+    LiveArenaConfigError,
+    _rows,
+    _text,
+    load_config,
+)
+
+log = logging.getLogger("c1c.community.live_arena.organizer")
+KNOWN_STATUSES = ("confirmed", "withdrawn", "removed", "disqualified")
+
+
+class OrganizerService:
+    def __init__(self, sheet_id, repository=None, clock=None):
+        self.sheet_id = sheet_id
+        self.repository = repository or LiveArenaRepository(sheet_id)
+        self.clock = clock or (lambda: datetime.now(UTC))
+
+    async def initialize(self):
+        await self.repository.initialize()
+
+    async def context(self):
+        config = await load_config(self.sheet_id)
+        matrices = await __import__("asyncio").gather(
+            afetch_values(self.sheet_id, config["TOURNAMENTS_TAB"]),
+            afetch_values(self.sheet_id, config["ELIGIBLE_CLANS_TAB"]),
+            afetch_values(self.sheet_id, config["AVAILABILITY_SLOTS_TAB"]),
+        )
+        tournaments = _rows(
+            matrices[0] or [], TOURNAMENT_HEADERS, config["TOURNAMENTS_TAB"]
+        )
+        tournament_id_column = [_text(value) for value in matrices[0][0]].index(
+            "tournament_id"
+        )
+        sheet_rows = [
+            index
+            for index, values in enumerate(matrices[0][1:], 2)
+            if tournament_id_column < len(values)
+            and _text(values[tournament_id_column]) == config["ACTIVE_TOURNAMENT_ID"]
+        ]
+        matches = [
+            row
+            for row in tournaments
+            if _text(row["tournament_id"]) == config["ACTIVE_TOURNAMENT_ID"]
+        ]
+        if len(matches) != 1 or len(sheet_rows) != 1:
+            raise LiveArenaConfigError(
+                "TOURNAMENTS: active tournament must occur exactly once"
+            )
+        return (
+            config,
+            (sheet_rows[0], matches[0]),
+            _rows(
+                matrices[1] or [], ELIGIBLE_CLAN_HEADERS, config["ELIGIBLE_CLANS_TAB"]
+            ),
+            _rows(
+                matrices[2] or [],
+                AVAILABILITY_SLOT_HEADERS,
+                config["AVAILABILITY_SLOTS_TAB"],
+            ),
+        )
+
+    async def transition(self, action, actor_id):
+        expected, new = {
+            "open": ("draft", "signup_open"),
+            "close": ("signup_open", "signup_closed"),
+            "reopen": ("signup_closed", "signup_open"),
+        }[action]
+        config = await load_config(self.sheet_id)
+        tournament_id = config["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tournament_id)]:
+            _, (row_number, tournament), _, _ = await self.context()
+            if _text(tournament["status"]) != expected:
+                raise RegistrationError(
+                    f"registration can only {action} from {expected}"
+                )
+            if action in {"open", "reopen"}:
+                self._future_deadline(tournament["signup_closes_at_utc"])
+            participants = await self.repository.participants()
+            confirmed = sum(
+                _text(r["tournament_id"]) == tournament_id
+                and _text(r["status"]) == "confirmed"
+                for r in participants
+            )
+            values = {"status": new}
+            now = utc_iso(self.clock())
+            if action == "open":
+                values["signup_opens_at_utc"] = now
+            await self.repository.update_tournament_cells(row_number, values)
+            event = {
+                "open": "registration_opened",
+                "close": "registration_closed",
+                "reopen": "registration_reopened",
+            }[action]
+            await self._audit(
+                tournament_id,
+                actor_id,
+                "",
+                event,
+                {
+                    "previous_status": expected,
+                    "new_status": new,
+                    "signup_closes_at_utc": _text(tournament["signup_closes_at_utc"]),
+                    "confirmed_count": confirmed,
+                    "parity": "even" if confirmed % 2 == 0 else "odd",
+                },
+                now,
+            )
+            return confirmed
+
+    def _future_deadline(self, value):
+        try:
+            parsed = datetime.fromisoformat(_text(value).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise RegistrationError(
+                "signup_closes_at_utc must be prepared as a valid future timezone-aware timestamp before opening or reopening"
+            ) from exc
+        if parsed.tzinfo is None or parsed <= self.clock():
+            raise RegistrationError(
+                "signup_closes_at_utc must be prepared as a valid future timezone-aware timestamp before opening or reopening"
+            )
+
+    async def remove(self, actor_id, target_id):
+        return await self._participant_change(actor_id, target_id, restore=False)
+
+    async def restore(self, actor_id, target_id, member):
+        return await self._participant_change(
+            actor_id, target_id, restore=True, member=member
+        )
+
+    async def _participant_change(self, actor_id, target_id, *, restore, member=None):
+        config = await load_config(self.sheet_id)
+        tid = config["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tid)]:
+            _, (_, tournament), clans, slots = await self.context()
+            if _text(tournament["status"]) not in {"signup_open", "signup_closed"}:
+                raise RegistrationError(
+                    "participant changes require open or closed registration"
+                )
+            participants = await self.repository.participants()
+            row = next(
+                (
+                    r
+                    for r in participants
+                    if _text(r["tournament_id"]) == tid
+                    and _text(r["discord_user_id"]) == str(target_id)
+                ),
+                None,
+            )
+            required = "removed" if restore else "confirmed"
+            if row is None or _text(row["status"]) != required:
+                raise RegistrationError(f"participant must currently be {required}")
+            if restore:
+                if member is None:
+                    raise RegistrationError(
+                        "participant Discord member cannot be resolved"
+                    )
+                clan = RegistrationService._eligible(
+                    tournament, clans, [str(r.id) for r in member.roles]
+                )
+                confirmed = sum(
+                    _text(r["tournament_id"]) == tid
+                    and _text(r["status"]) == "confirmed"
+                    for r in participants
+                )
+                if confirmed >= int(_text(tournament["max_participants"])):
+                    raise RegistrationError("tournament capacity is full")
+                availability = await self.repository.availability()
+                saved = [
+                    _text(r["slot_id"])
+                    for r in availability
+                    if _text(r["tournament_id"]) == tid
+                    and _text(r["discord_user_id"]) == str(target_id)
+                ]
+                validate_availability(
+                    _text(row["timezone"]),
+                    saved,
+                    slots,
+                    tournament["signup_closes_at_utc"],
+                )
+            old = [dict(r) for r in participants]
+            now = utc_iso(self.clock())
+            if restore:
+                row.update(
+                    status="confirmed",
+                    confirmed_at_utc=now,
+                    withdrawn_at_utc="",
+                    withdrawal_reason="",
+                    updated_at_utc=now,
+                    display_name_at_signup=member.display_name,
+                    clan_tag_at_signup=_text(clan["clan_tag"]),
+                )
+            else:
+                row.update(status="removed", updated_at_utc=now)
+            await self.repository.persist_participants(
+                participants, previous_participants=old
+            )
+            await self._audit(
+                tid,
+                actor_id,
+                str(target_id),
+                "participant_restored" if restore else "participant_removed",
+                {},
+                now,
+            )
+
+    async def _audit(self, tid, actor, target, event, details, now):
+        try:
+            await self.repository.append_audit(
+                dict(
+                    event_id=str(uuid4()),
+                    tournament_id=tid,
+                    event_type=event,
+                    actor_discord_user_id=str(actor),
+                    target_discord_user_id=target,
+                    details=json.dumps(details, sort_keys=True, separators=(",", ":")),
+                    created_at_utc=now,
+                )
+            )
+        except Exception:
+            log.exception(
+                "❌ Live Arena audit — append failed • tournament=%s • event=%s",
+                tid,
+                event,
+            )
+
+
+def status_counts(participants, tournament_id):
+    return {
+        status: sum(
+            _text(r["tournament_id"]) == tournament_id and _text(r["status"]) == status
+            for r in participants
+        )
+        for status in KNOWN_STATUSES
+    }

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -383,7 +383,12 @@ class ConfirmReconcile(discord.ui.View):
             for r in participants
         )
         already_correct = (
-            0 if role is None else max(0, confirmed - added - len(parity["unresolved"]))
+            0
+            if role is None
+            else max(
+                0,
+                confirmed - len(parity["missing"]) - len(parity["unresolved"]),
+            )
         )
         await interaction.followup.send(
             embed=discord.Embed(

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -1,0 +1,489 @@
+"""Persistent organizer panel and Discord-side recovery controls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import discord
+
+from shared.sheets.async_core import acall_with_backoff, aget_worksheet
+from shared.theme import colors
+
+from modules.community.live_arena.messages import load_messages, load_pr5_config
+from modules.community.live_arena.organizer import OrganizerService, status_counts
+from modules.community.live_arena.service import (
+    LiveArenaConfigError,
+    _text,
+    load_tournament_snapshot,
+)
+from modules.community.live_arena.views import error_embed
+
+log = logging.getLogger("c1c.community.live_arena.organizer_panel")
+_locks: dict[str, asyncio.Lock] = {}
+
+
+class OrganizerPanelManager:
+    def __init__(self, bot, sheet_id, public_manager):
+        self.bot, self.sheet_id, self.public_manager = bot, sheet_id, public_manager
+        self._lock = _locks.setdefault(sheet_id, asyncio.Lock())
+
+    def view(self, status=None):
+        return OrganizerView(self, status)
+
+    async def data(self, guild=None):
+        config, _ = await load_pr5_config(self.sheet_id)
+        tournament = await load_tournament_snapshot(self.sheet_id)
+        service = OrganizerService(self.sheet_id)
+        await service.initialize()
+        participants = await service.repository.participants()
+        counts = status_counts(participants, tournament.tournament_id)
+        parity = await role_parity(
+            guild, config, participants, tournament.tournament_id
+        )
+        return config, tournament, participants, counts, parity
+
+    async def sync(self):
+        async with self._lock:
+            config, _ = await load_pr5_config(self.sheet_id)
+            channel = self.bot.get_channel(int(config["ORGANIZER_CHANNEL_ID"]))
+            if channel is None:
+                channel = await self.bot.fetch_channel(
+                    int(config["ORGANIZER_CHANNEL_ID"])
+                )
+            config, tournament, _, counts, parity = await self.data(
+                getattr(channel, "guild", None)
+            )
+            messages = await load_messages(
+                self.sheet_id, config["MESSAGES_TAB"], {"organizer_panel"}
+            )
+            even = counts["confirmed"] % 2 == 0
+            parity_summary = (
+                "Roster parity: EVEN."
+                if even
+                else "Roster parity: ODD — qualification cannot start until the active roster is even."
+            )
+            embed = messages["organizer_panel"].embed(
+                tournament_name=tournament.tournament_name,
+                status=tournament.status,
+                confirmed_count=counts["confirmed"],
+                max_participants=tournament.max_participants,
+                parity_summary=parity_summary,
+            )
+            embed.add_field(
+                name="Participant statuses",
+                value="\n".join(
+                    f"{key.title()}: **{value}**" for key, value in counts.items()
+                ),
+                inline=False,
+            )
+            embed.add_field(
+                name="Participant role parity",
+                value=f"Missing: **{len(parity['missing'])}** • Extra: **{len(parity['extra'])}** • Unresolved: **{len(parity['unresolved'])}**",
+                inline=False,
+            )
+            message = None
+            if config["ORGANIZER_PANEL_MESSAGE_ID"]:
+                try:
+                    message = await channel.fetch_message(
+                        int(config["ORGANIZER_PANEL_MESSAGE_ID"])
+                    )
+                except discord.NotFound:
+                    pass
+                except Exception:
+                    log.exception("❌ Live Arena organizer panel — fetch failed")
+                    return
+            if message:
+                try:
+                    await message.edit(embed=embed, view=self.view(tournament.status))
+                except Exception:
+                    log.exception("❌ Live Arena organizer panel — edit failed")
+                return
+            created = await channel.send(embed=embed, view=self.view(tournament.status))
+            try:
+                await self._persist(config, str(created.id))
+            except Exception:
+                log.exception(
+                    "❌ Live Arena organizer panel — message ID persistence failed"
+                )
+                try:
+                    await created.delete()
+                except Exception:
+                    log.exception(
+                        "⚠️ Live Arena organizer panel — untracked message cleanup failed"
+                    )
+                raise
+
+    async def _persist(self, config, message_id):
+        from shared.sheets.async_core import afetch_values
+
+        matrix = await afetch_values(self.sheet_id, "CONFIG") or []
+        headers = [_text(v) for v in matrix[0]]
+        key_col, value_col = headers.index("Key"), headers.index("Value")
+        rows = [
+            i
+            for i, row in enumerate(matrix[1:], 2)
+            if key_col < len(row)
+            and _text(row[key_col]) == "ORGANIZER_PANEL_MESSAGE_ID"
+        ]
+        if len(rows) != 1:
+            raise LiveArenaConfigError(
+                "CONFIG: key ORGANIZER_PANEL_MESSAGE_ID must occur exactly once"
+            )
+        worksheet = await aget_worksheet(self.sheet_id, "CONFIG")
+        await acall_with_backoff(
+            worksheet.update_cell, rows[0], value_col + 1, message_id
+        )
+
+    async def secondary_sync(self):
+        warnings = []
+        for label, action in (
+            ("public panel", self.public_manager.sync),
+            ("organizer panel", self.sync),
+        ):
+            try:
+                await action()
+            except Exception:
+                log.exception("⚠️ Live Arena %s — post-mutation refresh failed", label)
+                warnings.append(label)
+        return warnings
+
+
+async def role_parity(guild, config, participants, tournament_id):
+    confirmed = {
+        _text(r["discord_user_id"])
+        for r in participants
+        if _text(r["tournament_id"]) == tournament_id
+        and _text(r["status"]) == "confirmed"
+    }
+    if guild is None:
+        guild = None
+    role = guild.get_role(int(config["PARTICIPANT_ROLE_ID"])) if guild else None
+    members = {_text(m.id): m for m in getattr(role, "members", [])} if role else {}
+    resolved = {uid: guild.get_member(int(uid)) for uid in confirmed} if guild else {}
+    return {
+        "missing": [
+            m for uid, m in resolved.items() if m is not None and uid not in members
+        ],
+        "extra": [m for uid, m in members.items() if uid not in confirmed],
+        "unresolved": [uid for uid in confirmed if not resolved.get(uid)],
+    }
+
+
+class OrganizerView(discord.ui.View):
+    def __init__(self, manager, status=None):
+        super().__init__(timeout=None)
+        self.manager = manager
+        actions = [
+            ("Open Registration", "open", "draft"),
+            ("Close Registration", "close", "signup_open"),
+            ("Reopen Registration", "reopen", "signup_closed"),
+        ]
+        for label, action, applicable in actions:
+            self.add_item(
+                OrganizerButton(
+                    label,
+                    f"live_arena:organizer:{action}",
+                    discord.ButtonStyle.primary,
+                    self.transition,
+                    action,
+                    disabled=status is not None and status != applicable,
+                )
+            )
+        self.add_item(
+            OrganizerButton(
+                "View Roster",
+                "live_arena:organizer:roster",
+                discord.ButtonStyle.secondary,
+                self.roster,
+                "roster",
+            )
+        )
+        self.add_item(
+            OrganizerButton(
+                "Reconcile Roles",
+                "live_arena:organizer:roles",
+                discord.ButtonStyle.secondary,
+                self.reconcile_prompt,
+                "roles",
+            )
+        )
+
+    async def authorized(self, interaction):
+        config, _ = await load_pr5_config(self.manager.sheet_id)
+        allowed = any(
+            str(r.id) == config["ORGANIZER_ROLE_ID"]
+            for r in getattr(interaction.user, "roles", [])
+        )
+        if not allowed:
+            await interaction.response.send_message(
+                embed=error_embed(
+                    "You need the configured organizer role to use this control."
+                ),
+                ephemeral=True,
+            )
+        return allowed
+
+    async def transition(self, interaction, action):
+        if not await self.authorized(interaction):
+            return
+        if action == "close":
+            _, tournament, _, counts, _ = await self.manager.data(interaction.guild)
+            odd = counts["confirmed"] % 2
+            warning = (
+                " The active confirmed roster is odd. Close is still allowed; no player will be auto-demoted, but qualification/pairing must not begin until it is even."
+                if odd
+                else ""
+            )
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    title="Confirm close registration",
+                    description=f"Close registration with **{counts['confirmed']}** confirmed players?{warning}",
+                    color=colors.c1c_blue,
+                ),
+                view=ConfirmTransition(self.manager, "close"),
+                ephemeral=True,
+            )
+            return
+        await interaction.response.defer(ephemeral=True)
+        await execute_transition(interaction, self.manager, action)
+
+    async def roster(self, interaction, _action):
+        if not await self.authorized(interaction):
+            return
+        config, tournament, participants, counts, _ = await self.manager.data(
+            interaction.guild
+        )
+        rows = [
+            r
+            for r in participants
+            if _text(r["tournament_id"]) == tournament.tournament_id
+        ]
+        lines = [
+            f"**{_text(r['display_name_at_signup']) or _text(r['discord_user_id'])}** — {_text(r['clan_tag_at_signup']) or '—'} • {_text(r['status']) or 'unknown'} • {_text(r['timezone']) or '—'}"
+            for r in rows
+        ]
+        description = (
+            f"**{tournament.tournament_name}** • {tournament.status}\nConfirmed: **{counts['confirmed']}/{tournament.max_participants}** • {'EVEN' if counts['confirmed'] % 2 == 0 else 'ODD'}\n\n"
+            + ("\n".join(lines) or "No participants.")
+        )
+        if len(description) > 4000:
+            description = description[:3997] + "…"
+        embed = discord.Embed(
+            title="Live Arena roster", description=description, color=colors.c1c_blue
+        )
+        embed.add_field(
+            name="Status counts",
+            value=" • ".join(f"{k}: {v}" for k, v in counts.items()),
+            inline=False,
+        )
+        await interaction.response.send_message(
+            embed=embed, view=RosterActions(self.manager), ephemeral=True
+        )
+
+    async def reconcile_prompt(self, interaction, _action):
+        if not await self.authorized(interaction):
+            return
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="Confirm role reconciliation",
+                description="Add the Participant role to confirmed members and remove it from members who are not confirmed? No Sheet state will change.",
+                color=colors.c1c_blue,
+            ),
+            view=ConfirmReconcile(self.manager),
+            ephemeral=True,
+        )
+
+
+class OrganizerButton(discord.ui.Button):
+    def __init__(self, label, custom_id, style, handler, action, disabled=False):
+        super().__init__(
+            label=label, custom_id=custom_id, style=style, disabled=disabled
+        )
+        self.handler, self.action = handler, action
+
+    async def callback(self, interaction):
+        await self.handler(interaction, self.action)
+
+
+class ConfirmTransition(discord.ui.View):
+    def __init__(self, manager, action):
+        super().__init__(timeout=300)
+        self.manager, self.action = manager, action
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction, _button):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        await interaction.response.defer(ephemeral=True)
+        await execute_transition(interaction, self.manager, self.action)
+
+
+async def execute_transition(interaction, manager, action):
+    try:
+        service = OrganizerService(manager.sheet_id)
+        await service.initialize()
+        await service.transition(action, str(interaction.user.id))
+        warnings = await manager.secondary_sync()
+        embed = discord.Embed(
+            title="Registration updated",
+            description=f"Registration was successfully {action}ed.",
+            color=colors.c1c_blue,
+        )
+        if warnings:
+            embed.add_field(
+                name="Sync warning",
+                value="Core Sheet state was saved, but "
+                + ", ".join(warnings)
+                + " could not be refreshed.",
+                inline=False,
+            )
+    except Exception as exc:
+        log.exception("❌ Live Arena organizer transition failed")
+        embed = error_embed(exc)
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+class ConfirmReconcile(discord.ui.View):
+    def __init__(self, manager):
+        super().__init__(timeout=300)
+        self.manager = manager
+
+    @discord.ui.button(label="Confirm Reconcile", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction, _button):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        await interaction.response.defer(ephemeral=True)
+        config, tournament, participants, _, parity = await self.manager.data(
+            interaction.guild
+        )
+        role = interaction.guild.get_role(int(config["PARTICIPANT_ROLE_ID"]))
+        added = removed = failures = 0
+        for member, add in [(m, True) for m in parity["missing"]] + [
+            (m, False) for m in parity["extra"]
+        ]:
+            try:
+                if add:
+                    await member.add_roles(
+                        role, reason="Live Arena role reconciliation"
+                    )
+                    added += 1
+                else:
+                    await member.remove_roles(
+                        role, reason="Live Arena role reconciliation"
+                    )
+                    removed += 1
+            except Exception:
+                failures += 1
+                log.exception(
+                    "❌ Live Arena role reconciliation — user=%s • role=%s",
+                    member.id,
+                    role.id,
+                )
+        try:
+            await self.manager.sync()
+        except Exception:
+            log.exception(
+                "⚠️ Live Arena organizer panel — reconciliation refresh failed"
+            )
+        confirmed = sum(
+            _text(r["tournament_id"]) == tournament.tournament_id
+            and _text(r["status"]) == "confirmed"
+            for r in participants
+        )
+        await interaction.followup.send(
+            embed=discord.Embed(
+                title="Role reconciliation complete",
+                description=f"Added: **{added}**\nRemoved: **{removed}**\nAlready correct: **{max(0, confirmed - added - len(parity['unresolved']))}**\nUnresolved: **{len(parity['unresolved'])}**\nFailures: **{failures}**",
+                color=colors.c1c_blue,
+            ),
+            ephemeral=True,
+        )
+
+
+class RosterActions(discord.ui.View):
+    def __init__(self, manager):
+        super().__init__(timeout=900)
+        self.manager = manager
+        self.add_item(TargetSelect(manager, restore=False))
+        self.add_item(TargetSelect(manager, restore=True))
+
+
+class TargetSelect(discord.ui.UserSelect):
+    def __init__(self, manager, restore):
+        super().__init__(
+            placeholder="Restore Participant" if restore else "Remove Participant",
+            min_values=1,
+            max_values=1,
+            row=1 if restore else 0,
+        )
+        self.manager, self.restore = manager, restore
+
+    async def callback(self, interaction):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        target = self.values[0]
+        verb = "restore" if self.restore else "remove"
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title=f"Confirm {verb}",
+                description=f"{verb.title()} {target.mention}?",
+                color=colors.c1c_blue,
+            ),
+            view=ConfirmParticipant(self.manager, target, self.restore),
+            ephemeral=True,
+        )
+
+
+class ConfirmParticipant(discord.ui.View):
+    def __init__(self, manager, target, restore):
+        super().__init__(timeout=300)
+        self.manager, self.target, self.restore = manager, target, restore
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction, _button):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        await interaction.response.defer(ephemeral=True)
+        warnings = []
+        try:
+            service = OrganizerService(self.manager.sheet_id)
+            await service.initialize()
+            if self.restore:
+                await service.restore(
+                    str(interaction.user.id), str(self.target.id), self.target
+                )
+            else:
+                await service.remove(str(interaction.user.id), str(self.target.id))
+            config, _ = await load_pr5_config(self.manager.sheet_id)
+            role = interaction.guild.get_role(int(config["PARTICIPANT_ROLE_ID"]))
+            try:
+                if role is None:
+                    raise RuntimeError("configured Participant role is unavailable")
+                if self.restore and role not in self.target.roles:
+                    await self.target.add_roles(
+                        role, reason="Live Arena participant restored"
+                    )
+                if not self.restore and role in self.target.roles:
+                    await self.target.remove_roles(
+                        role, reason="Live Arena participant removed"
+                    )
+            except Exception:
+                warnings.append("Participant role")
+                log.exception("⚠️ Live Arena participant role sync failed")
+            warnings += await self.manager.secondary_sync()
+            embed = discord.Embed(
+                title="Participant updated",
+                description="The core participant state was saved.",
+                color=colors.c1c_blue,
+            )
+            if warnings:
+                embed.add_field(
+                    name="Sync warning",
+                    value=", ".join(warnings) + " could not be synced.",
+                    inline=False,
+                )
+        except Exception as exc:
+            log.exception("❌ Live Arena participant mutation failed")
+            embed = error_embed(exc)
+        await interaction.followup.send(embed=embed, ephemeral=True)

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -12,6 +12,7 @@ from shared.theme import colors
 
 from modules.community.live_arena.messages import load_messages, load_pr5_config
 from modules.community.live_arena.organizer import OrganizerService, status_counts
+from modules.community.live_arena.panel import PanelSyncResult
 from modules.community.live_arena.service import (
     LiveArenaConfigError,
     _text,
@@ -43,7 +44,7 @@ class OrganizerPanelManager:
         )
         return config, tournament, participants, counts, parity
 
-    async def sync(self):
+    async def sync(self) -> PanelSyncResult:
         async with self._lock:
             config, _ = await load_pr5_config(self.sheet_id)
             channel = self.bot.get_channel(int(config["ORGANIZER_CHANNEL_ID"]))
@@ -92,13 +93,14 @@ class OrganizerPanelManager:
                     pass
                 except Exception:
                     log.exception("❌ Live Arena organizer panel — fetch failed")
-                    return
+                    return PanelSyncResult(False, "fetch")
             if message:
                 try:
                     await message.edit(embed=embed, view=self.view(tournament.status))
                 except Exception:
                     log.exception("❌ Live Arena organizer panel — edit failed")
-                return
+                    return PanelSyncResult(False, "edit")
+                return PanelSyncResult(True)
             created = await channel.send(embed=embed, view=self.view(tournament.status))
             try:
                 await self._persist(config, str(created.id))
@@ -113,6 +115,7 @@ class OrganizerPanelManager:
                         "⚠️ Live Arena organizer panel — untracked message cleanup failed"
                     )
                 raise
+            return PanelSyncResult(True)
 
     async def _persist(self, config, message_id):
         from shared.sheets.async_core import afetch_values
@@ -142,7 +145,9 @@ class OrganizerPanelManager:
             ("organizer panel", self.sync),
         ):
             try:
-                await action()
+                result = await action()
+                if isinstance(result, PanelSyncResult) and not result.ok:
+                    warnings.append(label)
             except Exception:
                 log.exception("⚠️ Live Arena %s — post-mutation refresh failed", label)
                 warnings.append(label)
@@ -251,32 +256,7 @@ class OrganizerView(discord.ui.View):
     async def roster(self, interaction, _action):
         if not await self.authorized(interaction):
             return
-        config, tournament, participants, counts, _ = await self.manager.data(
-            interaction.guild
-        )
-        rows = [
-            r
-            for r in participants
-            if _text(r["tournament_id"]) == tournament.tournament_id
-        ]
-        lines = [
-            f"**{_text(r['display_name_at_signup']) or _text(r['discord_user_id'])}** — {_text(r['clan_tag_at_signup']) or '—'} • {_text(r['status']) or 'unknown'} • {_text(r['timezone']) or '—'}"
-            for r in rows
-        ]
-        description = (
-            f"**{tournament.tournament_name}** • {tournament.status}\nConfirmed: **{counts['confirmed']}/{tournament.max_participants}** • {'EVEN' if counts['confirmed'] % 2 == 0 else 'ODD'}\n\n"
-            + ("\n".join(lines) or "No participants.")
-        )
-        if len(description) > 4000:
-            description = description[:3997] + "…"
-        embed = discord.Embed(
-            title="Live Arena roster", description=description, color=colors.c1c_blue
-        )
-        embed.add_field(
-            name="Status counts",
-            value=" • ".join(f"{k}: {v}" for k, v in counts.items()),
-            inline=False,
-        )
+        embed = await roster_embed(self.manager, interaction.guild)
         await interaction.response.send_message(
             embed=embed, view=RosterActions(self.manager), ephemeral=True
         )
@@ -325,9 +305,10 @@ async def execute_transition(interaction, manager, action):
         await service.initialize()
         await service.transition(action, str(interaction.user.id))
         warnings = await manager.secondary_sync()
+        past_tense = {"open": "opened", "close": "closed", "reopen": "reopened"}
         embed = discord.Embed(
             title="Registration updated",
-            description=f"Registration was successfully {action}ed.",
+            description=f"Registration was successfully {past_tense[action]}.",
             color=colors.c1c_blue,
         )
         if warnings:
@@ -359,9 +340,19 @@ class ConfirmReconcile(discord.ui.View):
         )
         role = interaction.guild.get_role(int(config["PARTICIPANT_ROLE_ID"]))
         added = removed = failures = 0
-        for member, add in [(m, True) for m in parity["missing"]] + [
-            (m, False) for m in parity["extra"]
-        ]:
+        if role is None:
+            failures += 1
+            log.error(
+                "❌ Live Arena role reconciliation — configured role missing • tournament=%s • role=%s",
+                tournament.tournament_id,
+                config["PARTICIPANT_ROLE_ID"],
+            )
+        for member, add in (
+            []
+            if role is None
+            else [(m, True) for m in parity["missing"]]
+            + [(m, False) for m in parity["extra"]]
+        ):
             try:
                 if add:
                     await member.add_roles(
@@ -391,10 +382,13 @@ class ConfirmReconcile(discord.ui.View):
             and _text(r["status"]) == "confirmed"
             for r in participants
         )
+        already_correct = (
+            0 if role is None else max(0, confirmed - added - len(parity["unresolved"]))
+        )
         await interaction.followup.send(
             embed=discord.Embed(
                 title="Role reconciliation complete",
-                description=f"Added: **{added}**\nRemoved: **{removed}**\nAlready correct: **{max(0, confirmed - added - len(parity['unresolved']))}**\nUnresolved: **{len(parity['unresolved'])}**\nFailures: **{failures}**",
+                description=f"Added: **{added}**\nRemoved: **{removed}**\nAlready correct: **{already_correct}**\nUnresolved: **{len(parity['unresolved'])}**\nFailures: **{failures}**",
                 color=colors.c1c_blue,
             ),
             ephemeral=True,
@@ -407,6 +401,58 @@ class RosterActions(discord.ui.View):
         self.manager = manager
         self.add_item(TargetSelect(manager, restore=False))
         self.add_item(TargetSelect(manager, restore=True))
+        self.add_item(RefreshRoster(manager))
+
+
+class RefreshRoster(discord.ui.Button):
+    def __init__(self, manager):
+        super().__init__(
+            label="Refresh",
+            custom_id="live_arena:organizer:roster:refresh",
+            style=discord.ButtonStyle.secondary,
+            row=2,
+        )
+        self.manager = manager
+
+    async def callback(self, interaction):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        embed = await roster_embed(self.manager, interaction.guild)
+        await interaction.response.edit_message(
+            embed=embed, view=RosterActions(self.manager)
+        )
+
+
+async def roster_embed(manager, guild):
+    """Re-read and render the current roster without mutating workbook state."""
+    _, tournament, participants, counts, parity = await manager.data(guild)
+    rows = [
+        row
+        for row in participants
+        if _text(row["tournament_id"]) == tournament.tournament_id
+    ]
+    lines = [
+        f"**{_text(row['display_name_at_signup']) or _text(row['discord_user_id'])}** — {_text(row['clan_tag_at_signup']) or '—'} • {_text(row['status']) or 'unknown'} • {_text(row['timezone']) or '—'}"
+        for row in rows
+    ]
+    description = (
+        f"**{tournament.tournament_name}** • {tournament.status}\n"
+        f"Confirmed: **{counts['confirmed']}/{tournament.max_participants}** • "
+        f"{'EVEN' if counts['confirmed'] % 2 == 0 else 'ODD'}\n"
+        f"Role parity: **{len(parity['missing'])} missing / {len(parity['extra'])} extra / {len(parity['unresolved'])} unresolved**\n\n"
+        + ("\n".join(lines) or "No participants.")
+    )
+    if len(description) > 4000:
+        description = description[:3997] + "…"
+    embed = discord.Embed(
+        title="Live Arena roster", description=description, color=colors.c1c_blue
+    )
+    embed.add_field(
+        name="Status counts",
+        value=" • ".join(f"{key}: {value}" for key, value in counts.items()),
+        inline=False,
+    )
+    return embed
 
 
 class TargetSelect(discord.ui.UserSelect):

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -36,9 +36,14 @@ class LiveArenaPanelManager:
         async with self._lock:
             config, matrix = await load_pr3_config(self.sheet_id)
             tournament = await load_tournament_snapshot(self.sheet_id)
-            if tournament.status != "signup_open":
+            if tournament.status == "draft":
                 return
-            messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"])
+            key = (
+                "signup_open" if tournament.status == "signup_open" else "signup_closed"
+            )
+            if tournament.status not in {"signup_open", "signup_closed"}:
+                return
+            messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"], {key})
             repository = LiveArenaRepository(self.sheet_id)
             await repository.initialize()
             participants = await repository.participants()
@@ -47,12 +52,15 @@ class LiveArenaPanelManager:
                 and str(row["status"]).strip() == "confirmed"
                 for row in participants
             )
-            embed = messages["signup_open"].embed(
-                tournament_name=tournament.tournament_name,
-                signup_deadline=discord_timestamp(tournament.signup_closes_at_utc),
-                confirmed_count=count,
-                max_participants=tournament.max_participants,
+            values = dict(
+                tournament_name=tournament.tournament_name, confirmed_count=count
             )
+            if key == "signup_open":
+                values.update(
+                    signup_deadline=discord_timestamp(tournament.signup_closes_at_utc),
+                    max_participants=tournament.max_participants,
+                )
+            embed = messages[key].embed(**values)
             channel = self.bot.get_channel(int(config["SIGNUP_CHANNEL_ID"]))
             if channel is None:
                 channel = await self.bot.fetch_channel(int(config["SIGNUP_CHANNEL_ID"]))
@@ -67,9 +75,16 @@ class LiveArenaPanelManager:
                 except Exception:
                     log.exception("❌ Live Arena panel — fetch failed")
                     return
-            from modules.community.live_arena.views import JoinTournamentView
+            from modules.community.live_arena.views import (
+                ClosedTournamentView,
+                JoinTournamentView,
+            )
 
-            view = JoinTournamentView(self)
+            view = (
+                JoinTournamentView(self)
+                if key == "signup_open"
+                else ClosedTournamentView(self)
+            )
             if message is not None:
                 try:
                     await message.edit(embed=embed, view=view)
@@ -115,8 +130,17 @@ async def register_live_arena(bot):
     manager = _managers.setdefault(
         (id(bot), sheet_id), LiveArenaPanelManager(bot, sheet_id)
     )
-    from modules.community.live_arena.views import JoinTournamentView
+    from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+    from modules.community.live_arena.views import (
+        ClosedTournamentView,
+        JoinTournamentView,
+    )
 
     bot.add_view(JoinTournamentView(manager))
+    bot.add_view(ClosedTournamentView(manager))
+    organizer = OrganizerPanelManager(bot, sheet_id, manager)
+    bot.add_view(organizer.view())
     await manager.sync()
+    await organizer.sync()
+    manager.organizer_manager = organizer
     return manager

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 
 import discord
 
@@ -23,6 +24,14 @@ _sync_locks: dict[str, asyncio.Lock] = {}
 _managers: dict[tuple[int, str], "LiveArenaPanelManager"] = {}
 
 
+@dataclass(frozen=True)
+class PanelSyncResult:
+    """Outcome of a panel sync, including failures deliberately handled here."""
+
+    ok: bool
+    operation: str = ""
+
+
 class LiveArenaPanelManager:
     def __init__(self, bot, sheet_id: str, service_factory=None):
         self.bot = bot
@@ -32,17 +41,17 @@ class LiveArenaPanelManager:
         # on_ready dispatches).  The workbook, not a transient manager, owns sync.
         self._lock = _sync_locks.setdefault(sheet_id, asyncio.Lock())
 
-    async def sync(self) -> None:
+    async def sync(self) -> PanelSyncResult:
         async with self._lock:
             config, matrix = await load_pr3_config(self.sheet_id)
             tournament = await load_tournament_snapshot(self.sheet_id)
             if tournament.status == "draft":
-                return
+                return PanelSyncResult(True)
             key = (
                 "signup_open" if tournament.status == "signup_open" else "signup_closed"
             )
             if tournament.status not in {"signup_open", "signup_closed"}:
-                return
+                return PanelSyncResult(True)
             messages = await load_messages(self.sheet_id, config["MESSAGES_TAB"], {key})
             repository = LiveArenaRepository(self.sheet_id)
             await repository.initialize()
@@ -74,7 +83,7 @@ class LiveArenaPanelManager:
                     message = None
                 except Exception:
                     log.exception("❌ Live Arena panel — fetch failed")
-                    return
+                    return PanelSyncResult(False, "fetch")
             from modules.community.live_arena.views import (
                 ClosedTournamentView,
                 JoinTournamentView,
@@ -90,7 +99,8 @@ class LiveArenaPanelManager:
                     await message.edit(embed=embed, view=view)
                 except Exception:
                     log.exception("❌ Live Arena panel — edit failed")
-                return
+                    return PanelSyncResult(False, "edit")
+                return PanelSyncResult(True)
             created = await channel.send(embed=embed, view=view)
             try:
                 await self._persist_message_id(matrix, str(created.id))
@@ -103,6 +113,7 @@ class LiveArenaPanelManager:
                         "⚠️ Live Arena panel — untracked message cleanup failed"
                     )
                 raise
+            return PanelSyncResult(True)
 
     async def _persist_message_id(self, matrix, message_id: str) -> None:
         headers = [str(value).strip() for value in matrix[0]]

--- a/modules/community/live_arena/repository.py
+++ b/modules/community/live_arena/repository.py
@@ -11,6 +11,7 @@ from modules.community.live_arena.service import (
     LiveArenaConfigError,
     _rows,
     load_config,
+    TOURNAMENT_HEADERS,
 )
 
 PARTICIPANT_HEADERS = (
@@ -160,6 +161,17 @@ class LiveArenaRepository:
             [str(row.get(header, "") or "") for header in AUDIT_LOG_HEADERS],
             value_input_option="RAW",
         )
+
+    async def update_tournament_cells(
+        self, row_number: int, values: dict[str, object]
+    ) -> None:
+        """Update only named cells in the frozen TOURNAMENTS row."""
+        worksheet = await aget_worksheet(self.sheet_id, self.config["TOURNAMENTS_TAB"])
+        for header, value in values.items():
+            column = TOURNAMENT_HEADERS.index(header) + 1
+            await acall_with_backoff(
+                worksheet.update_cell, row_number, column, str(value)
+            )
 
 
 def _column(number: int) -> str:

--- a/modules/community/live_arena/repository.py
+++ b/modules/community/live_arena/repository.py
@@ -165,13 +165,18 @@ class LiveArenaRepository:
     async def update_tournament_cells(
         self, row_number: int, values: dict[str, object]
     ) -> None:
-        """Update only named cells in the frozen TOURNAMENTS row."""
+        """Atomically batch-update only named cells in the frozen TOURNAMENTS row."""
         worksheet = await aget_worksheet(self.sheet_id, self.config["TOURNAMENTS_TAB"])
+        tab = self.config["TOURNAMENTS_TAB"].replace("'", "''")
+        data = []
         for header, value in values.items():
             column = TOURNAMENT_HEADERS.index(header) + 1
-            await acall_with_backoff(
-                worksheet.update_cell, row_number, column, str(value)
-            )
+            cell = f"{_column(column)}{row_number}"
+            data.append({"range": f"'{tab}'!{cell}", "values": [[str(value)]]})
+        await acall_with_backoff(
+            worksheet.spreadsheet.values_batch_update,
+            body={"valueInputOption": "RAW", "data": data},
+        )
 
 
 def _column(number: int) -> str:

--- a/modules/community/live_arena/service.py
+++ b/modules/community/live_arena/service.py
@@ -124,6 +124,9 @@ async def load_config(sheet_id: str) -> dict[str, str]:
     rows = _rows(matrix or [], CONFIG_HEADERS, CONFIG_TAB)
     values = {_text(row["Key"]): _text(row["Value"]) for row in rows}
     for key in CONFIG_KEYS:
+        matches = [row for row in rows if _text(row["Key"]) == key]
+        if len(matches) != 1:
+            raise LiveArenaConfigError(f"CONFIG: key {key} must occur exactly once")
         if not values.get(key):
             raise LiveArenaConfigError(f"CONFIG: missing required key {key}")
     return {key: values[key] for key in CONFIG_KEYS}

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -81,6 +81,14 @@ class JoinTournamentView(discord.ui.View):
             await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
 
 
+class ClosedTournamentView(JoinTournamentView):
+    """Persistent closed-state panel containing self-service only."""
+
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.remove_item(self.join)
+
+
 class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
     timezone_input = discord.ui.TextInput(label="Timezone", required=True, placeholder="Europe/Vienna, America/New_York, Asia/Kolkata")
 
@@ -261,6 +269,12 @@ class ReviewView(discord.ui.View):
             await flow.manager.sync()
         except Exception:
             log.exception("⚠️ Live Arena panel — post-registration refresh failed")
+        organizer = getattr(flow.manager, "organizer_manager", None)
+        if organizer:
+            try:
+                await organizer.sync()
+            except Exception:
+                log.exception("⚠️ Live Arena organizer panel — post-registration refresh failed")
 
 
 async def _assign_role(config, flow, interaction, embed):
@@ -357,6 +371,12 @@ class WithdrawalReasonModal(discord.ui.Modal, title="Confirm Live Arena withdraw
                 await self.manager.sync()
             except Exception:
                 log.exception("⚠️ Live Arena panel — post-withdrawal refresh failed • tournament=%s • user=%s", self.snapshot.config["ACTIVE_TOURNAMENT_ID"], member.id)
+        organizer = getattr(self.manager, "organizer_manager", None)
+        if organizer:
+            try:
+                await organizer.sync()
+            except Exception:
+                log.exception("⚠️ Live Arena organizer panel — post-withdrawal refresh failed")
         await interaction.followup.send(embed=embed, ephemeral=True)
 
     async def _remove_role(self, interaction, config, embed):

--- a/tests/community/test_live_arena_pr3.py
+++ b/tests/community/test_live_arena_pr3.py
@@ -172,7 +172,7 @@ def _panel_manager(monkeypatch, *, status="signup_open", panel_id="", channel=No
     matrix[4][1] = panel_id
     config = {row[0]: row[1] for row in matrix[1:]}
     monkeypatch.setattr(panel, "load_pr3_config", AsyncMock(return_value=(config, matrix)))
-    monkeypatch.setattr(panel, "load_messages", AsyncMock(return_value={"signup_open": _Template()}))
+    monkeypatch.setattr(panel, "load_messages", AsyncMock(return_value={"signup_open": _Template(), "signup_closed": _Template()}))
     monkeypatch.setattr(panel, "load_tournament_snapshot", AsyncMock(return_value=_snapshot(status)))
     monkeypatch.setattr(panel, "LiveArenaRepository", lambda _sheet: _PanelRepository())
     bot = SimpleNamespace(get_channel=lambda _channel_id: channel)
@@ -187,14 +187,15 @@ def test_draft_creates_no_public_panel(monkeypatch):
     assert channel.sent == []
 
 
-def test_signup_closed_does_not_render_edit_or_recreate_public_panel(monkeypatch):
+def test_signup_closed_edits_existing_public_panel_without_recreating(monkeypatch):
     existing = _Message(55)
     manager, channel = _panel_manager(
         monkeypatch, status="signup_closed", panel_id="55", channel=_Channel(existing)
     )
     asyncio.run(manager.sync())
-    panel.load_messages.assert_not_awaited()
-    existing.edit.assert_not_awaited()
+    panel.load_messages.assert_awaited_once()
+    existing.edit.assert_awaited_once()
+    assert len(existing.edit.await_args.kwargs["view"].children) == 1
     assert channel.sent == []
     manager._persist_message_id.assert_not_awaited()
 

--- a/tests/community/test_live_arena_pr5.py
+++ b/tests/community/test_live_arena_pr5.py
@@ -3,18 +3,39 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import discord
+import pytest
+
+from modules.community.live_arena.messages import (
+    MESSAGE_HEADERS,
+    PR5_CONFIG_KEYS,
+    PR5_MESSAGES,
+    REQUIRED_MESSAGES,
+    load_messages,
+)
+from modules.community.live_arena.organizer import OrganizerService
 from modules.community.live_arena.organizer_panel import (
     ConfirmReconcile,
     OrganizerPanelManager,
     OrganizerView,
     RosterActions,
+    role_parity,
+    roster_embed,
 )
 from modules.community.live_arena.panel import PanelSyncResult
-from modules.community.live_arena.repository import LiveArenaRepository
-from modules.community.live_arena.service import TOURNAMENT_HEADERS
+from modules.community.live_arena.repository import (
+    AUDIT_LOG_HEADERS,
+    PARTICIPANT_AVAILABILITY_HEADERS,
+    PARTICIPANT_HEADERS,
+    LiveArenaRepository,
+)
+from modules.community.live_arena.service import (
+    TOURNAMENT_HEADERS,
+)
 
 
 def run(awaitable):
@@ -127,3 +148,272 @@ def test_reconcile_missing_participant_role_reports_failure_without_crashing():
     assert "Added: **0**" in embed.description
     assert "Failures: **1**" in embed.description
     manager.sync.assert_awaited_once()
+
+
+def test_reconcile_failed_add_does_not_inflate_already_correct():
+    role = SimpleNamespace(id=999)
+    already = SimpleNamespace(id=10)
+    missing = SimpleNamespace(
+        id=11, add_roles=AsyncMock(side_effect=RuntimeError("no"))
+    )
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        data=AsyncMock(
+            return_value=(
+                {"PARTICIPANT_ROLE_ID": "999"},
+                SimpleNamespace(tournament_id="cup"),
+                [
+                    {
+                        "tournament_id": "cup",
+                        "discord_user_id": str(member.id),
+                        "status": "confirmed",
+                    }
+                    for member in (already, missing)
+                ],
+                {},
+                {"missing": [missing], "extra": [], "unresolved": []},
+            )
+        ),
+        sync=AsyncMock(return_value=PanelSyncResult(True)),
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, roles=[]),
+        guild=SimpleNamespace(get_role=lambda _role_id: role),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    with patch.object(OrganizerView, "authorized", AsyncMock(return_value=True)):
+        run(ConfirmReconcile(manager).children[0].callback(interaction))
+
+    description = interaction.followup.send.await_args.kwargs["embed"].description
+    assert "Added: **0**" in description
+    assert "Already correct: **1**" in description
+    assert "Failures: **1**" in description
+
+
+def test_pr5_exact_contracts_are_additive_and_schema_is_frozen():
+    assert PR5_CONFIG_KEYS == (
+        "MESSAGES_TAB",
+        "SIGNUP_CHANNEL_ID",
+        "ORGANIZER_CHANNEL_ID",
+        "ORGANIZER_ROLE_ID",
+        "PARTICIPANT_ROLE_ID",
+        "PUBLIC_PANEL_MESSAGE_ID",
+        "ORGANIZER_PANEL_MESSAGE_ID",
+    )
+    assert PR5_MESSAGES == {
+        "signup_closed": {"tournament_name", "confirmed_count"},
+        "organizer_panel": {
+            "tournament_name",
+            "status",
+            "confirmed_count",
+            "max_participants",
+            "parity_summary",
+        },
+    }
+    assert "signup_closed" not in REQUIRED_MESSAGES
+    assert "organizer_panel" not in REQUIRED_MESSAGES
+    assert PARTICIPANT_HEADERS[-4:] == (
+        "withdrawn_at_utc",
+        "withdrawal_reason",
+        "updated_at_utc",
+        "notes",
+    )
+    assert PARTICIPANT_AVAILABILITY_HEADERS == (
+        "tournament_id",
+        "discord_user_id",
+        "slot_id",
+        "created_at_utc",
+        "updated_at_utc",
+        "notes",
+    )
+    assert AUDIT_LOG_HEADERS == (
+        "event_id",
+        "tournament_id",
+        "event_type",
+        "actor_discord_user_id",
+        "target_discord_user_id",
+        "details",
+        "created_at_utc",
+    )
+
+
+def test_organizer_message_loading_isolated_from_player_rows():
+    matrix = [
+        list(MESSAGE_HEADERS),
+        [
+            "organizer_panel",
+            "Panel {tournament_name}",
+            "{status} {confirmed_count}/{max_participants} {parity_summary}",
+            "#123456",
+            "TRUE",
+            "",
+        ],
+    ]
+    with patch(
+        "modules.community.live_arena.messages.afetch_values",
+        AsyncMock(return_value=matrix),
+    ):
+        templates = run(load_messages("sheet", "MESSAGES", {"organizer_panel"}))
+    assert set(templates) == {"organizer_panel"}
+    assert isinstance(
+        templates["organizer_panel"].embed(
+            tournament_name="Cup",
+            status="draft",
+            confirmed_count=0,
+            max_participants=32,
+            parity_summary="EVEN",
+        ),
+        discord.Embed,
+    )
+
+
+@pytest.mark.parametrize(
+    "status,enabled",
+    [
+        ("draft", [True, False, False]),
+        ("signup_open", [False, True, False]),
+        ("signup_closed", [False, False, True]),
+    ],
+)
+def test_transition_button_state_contract(status, enabled):
+    buttons = OrganizerView(SimpleNamespace(), status).children[:3]
+    assert [not item.disabled for item in buttons] == enabled
+
+
+def test_authorization_denial_is_embed_and_does_not_invoke_handler():
+    manager = SimpleNamespace(sheet_id="sheet")
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(roles=[SimpleNamespace(id=4)]),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    with patch(
+        "modules.community.live_arena.organizer_panel.load_pr5_config",
+        AsyncMock(return_value=({"ORGANIZER_ROLE_ID": "5"}, [])),
+    ):
+        assert run(OrganizerView(manager).authorized(interaction)) is False
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs["embed"], discord.Embed)
+    assert kwargs["ephemeral"] is True
+
+
+def test_role_parity_reports_missing_extra_and_unresolved_exactly():
+    role = SimpleNamespace(members=[SimpleNamespace(id=1), SimpleNamespace(id=9)])
+    members = {1: role.members[0], 2: SimpleNamespace(id=2)}
+    guild = SimpleNamespace(
+        get_role=lambda _id: role,
+        get_member=lambda member_id: members.get(member_id),
+    )
+    participants = [
+        {"tournament_id": "cup", "discord_user_id": uid, "status": "confirmed"}
+        for uid in ("1", "2", "3")
+    ]
+    parity = run(role_parity(guild, {"PARTICIPANT_ROLE_ID": "8"}, participants, "cup"))
+    assert [m.id for m in parity["missing"]] == [2]
+    assert [m.id for m in parity["extra"]] == [9]
+    assert parity["unresolved"] == ["3"]
+
+
+def test_roster_is_embed_with_counts_status_parity_and_user_select_controls():
+    manager = SimpleNamespace(
+        data=AsyncMock(
+            return_value=(
+                {},
+                SimpleNamespace(
+                    tournament_id="cup",
+                    tournament_name="Cup",
+                    status="signup_open",
+                    max_participants=16,
+                ),
+                [
+                    {
+                        "tournament_id": "cup",
+                        "display_name_at_signup": "Ada",
+                        "discord_user_id": "1",
+                        "clan_tag_at_signup": "C1C",
+                        "status": "confirmed",
+                        "timezone": "Europe/London",
+                    }
+                ],
+                {"confirmed": 1, "withdrawn": 0, "removed": 0, "disqualified": 0},
+                {"missing": [object()], "extra": [], "unresolved": []},
+            )
+        )
+    )
+    embed = run(roster_embed(manager, object()))
+    assert isinstance(embed, discord.Embed)
+    assert "signup_open" in embed.description and "1/16" in embed.description
+    assert "1 missing / 0 extra / 0 unresolved" in embed.description
+    assert (
+        sum(
+            isinstance(item, discord.ui.UserSelect)
+            for item in RosterActions(manager).children
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize("deadline", ["", "not-a-date", "2026-08-06T00:00:00Z"])
+def test_open_rejects_blank_invalid_or_nonfuture_deadline_without_mutation(deadline):
+    repo = SimpleNamespace(
+        initialize=AsyncMock(),
+        participants=AsyncMock(return_value=[]),
+        update_tournament_cells=AsyncMock(),
+        append_audit=AsyncMock(),
+    )
+    service = OrganizerService(
+        "sheet", repository=repo, clock=lambda: datetime(2026, 8, 7, tzinfo=UTC)
+    )
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": "cup"},
+            (2, {"status": "draft", "signup_closes_at_utc": deadline}),
+            [],
+            [],
+        )
+    )
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(Exception, match="valid future"):
+            run(service.transition("open", "7"))
+    repo.update_tournament_cells.assert_not_awaited()
+    repo.append_audit.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "action,old,new,event",
+    [
+        ("open", "draft", "signup_open", "registration_opened"),
+        ("close", "signup_open", "signup_closed", "registration_closed"),
+        ("reopen", "signup_closed", "signup_open", "registration_reopened"),
+    ],
+)
+def test_transitions_use_exact_targeted_mutations_and_audits(action, old, new, event):
+    repo = SimpleNamespace(
+        participants=AsyncMock(return_value=[]),
+        update_tournament_cells=AsyncMock(),
+        append_audit=AsyncMock(),
+    )
+    now = datetime(2026, 8, 7, tzinfo=UTC)
+    service = OrganizerService("sheet", repository=repo, clock=lambda: now)
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": "cup"},
+            (9, {"status": old, "signup_closes_at_utc": "2026-08-08T00:00:00Z"}),
+            [],
+            [],
+        )
+    )
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        run(service.transition(action, "7"))
+    expected = {"status": new}
+    if action == "open":
+        expected["signup_opens_at_utc"] = "2026-08-07T00:00:00Z"
+    repo.update_tournament_cells.assert_awaited_once_with(9, expected)
+    assert repo.append_audit.await_args.args[0]["event_type"] == event

--- a/tests/community/test_live_arena_pr5.py
+++ b/tests/community/test_live_arena_pr5.py
@@ -1,0 +1,129 @@
+"""Focused PR5 regression tests for organizer production repair behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from modules.community.live_arena.organizer_panel import (
+    ConfirmReconcile,
+    OrganizerPanelManager,
+    OrganizerView,
+    RosterActions,
+)
+from modules.community.live_arena.panel import PanelSyncResult
+from modules.community.live_arena.repository import LiveArenaRepository
+from modules.community.live_arena.service import TOURNAMENT_HEADERS
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+def test_secondary_sync_reports_handled_panel_failures():
+    public = SimpleNamespace(
+        sync=AsyncMock(return_value=PanelSyncResult(False, "edit"))
+    )
+    manager = object.__new__(OrganizerPanelManager)
+    manager.public_manager = public
+    manager.sync = AsyncMock(return_value=PanelSyncResult(False, "fetch"))
+
+    assert run(manager.secondary_sync()) == ["public panel", "organizer panel"]
+
+
+def test_secondary_sync_preserves_success_and_exception_reporting():
+    public = SimpleNamespace(sync=AsyncMock(return_value=PanelSyncResult(True)))
+    manager = object.__new__(OrganizerPanelManager)
+    manager.public_manager = public
+    manager.sync = AsyncMock(side_effect=RuntimeError("persist failed"))
+
+    assert run(manager.secondary_sync()) == ["organizer panel"]
+
+
+def test_open_cells_use_one_targeted_values_batch():
+    spreadsheet = SimpleNamespace(values_batch_update=AsyncMock())
+    worksheet = SimpleNamespace(spreadsheet=spreadsheet)
+    repository = LiveArenaRepository("sheet")
+    repository.config = {"TOURNAMENTS_TAB": "TOURNAMENTS"}
+    row = 7
+
+    with (
+        patch(
+            "modules.community.live_arena.repository.aget_worksheet",
+            AsyncMock(return_value=worksheet),
+        ),
+        patch(
+            "modules.community.live_arena.repository.acall_with_backoff",
+            AsyncMock(),
+        ) as call,
+    ):
+        run(
+            repository.update_tournament_cells(
+                row,
+                {
+                    "status": "signup_open",
+                    "signup_opens_at_utc": "2026-08-07T12:00:00Z",
+                },
+            )
+        )
+
+    assert call.await_count == 1
+    body = call.await_args.kwargs["body"]
+    status_col = chr(65 + TOURNAMENT_HEADERS.index("status"))
+    opens_col = chr(65 + TOURNAMENT_HEADERS.index("signup_opens_at_utc"))
+    assert body == {
+        "valueInputOption": "RAW",
+        "data": [
+            {"range": f"'TOURNAMENTS'!{status_col}{row}", "values": [["signup_open"]]},
+            {
+                "range": f"'TOURNAMENTS'!{opens_col}{row}",
+                "values": [["2026-08-07T12:00:00Z"]],
+            },
+        ],
+    }
+
+
+def test_roster_actions_include_remove_restore_and_refresh():
+    labels = [
+        getattr(item, "label", None) or getattr(item, "placeholder", None)
+        for item in RosterActions(object()).children
+    ]
+    assert labels == ["Remove Participant", "Restore Participant", "Refresh"]
+
+
+def test_reconcile_missing_participant_role_reports_failure_without_crashing():
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        data=AsyncMock(
+            return_value=(
+                {"PARTICIPANT_ROLE_ID": "999"},
+                SimpleNamespace(tournament_id="cup"),
+                [
+                    {
+                        "tournament_id": "cup",
+                        "discord_user_id": "10",
+                        "status": "confirmed",
+                    }
+                ],
+                {},
+                {"missing": [SimpleNamespace(id=10)], "extra": [], "unresolved": []},
+            )
+        ),
+        sync=AsyncMock(return_value=PanelSyncResult(True)),
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, roles=[]),
+        guild=SimpleNamespace(get_role=lambda _role_id: None),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    view = ConfirmReconcile(manager)
+
+    with patch.object(OrganizerView, "authorized", AsyncMock(return_value=True)):
+        run(view.children[0].callback(interaction))
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert "Added: **0**" in embed.description
+    assert "Failures: **1**" in embed.description
+    manager.sync.assert_awaited_once()

--- a/tests/community/test_live_arena_pr5_completion.py
+++ b/tests/community/test_live_arena_pr5_completion.py
@@ -1,0 +1,953 @@
+"""Remaining PR5 lifecycle regressions from Issue #1071's frozen contract."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+from modules.community.live_arena import organizer as organizer_module
+from modules.community.live_arena import organizer_panel as organizer_panel_module
+from modules.community.live_arena import panel as panel_module
+from modules.community.live_arena import views
+from modules.community.live_arena.messages import MessageTemplate
+from modules.community.live_arena.organizer import OrganizerService
+from modules.community.live_arena.organizer_panel import (
+    ConfirmParticipant,
+    ConfirmReconcile,
+    ConfirmTransition,
+    OrganizerPanelManager,
+    OrganizerView,
+)
+from modules.community.live_arena.panel import LiveArenaPanelManager, PanelSyncResult
+from modules.community.live_arena.registration import RegistrationError
+from modules.community.live_arena.service import TournamentSnapshot
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+class _Template:
+    def __init__(self, title="Panel"):
+        self.title = title
+
+    def embed(self, **values):
+        return discord.Embed(title=self.title, description=str(values))
+
+
+class _Message:
+    def __init__(self, message_id=55):
+        self.id = message_id
+        self.edit = AsyncMock()
+        self.delete = AsyncMock()
+
+
+class _Channel:
+    def __init__(self, fetched=None, fetch_error=None, guild=None):
+        self.fetched = fetched
+        self.fetch_error = fetch_error
+        self.guild = guild
+        self.sent = []
+
+    async def fetch_message(self, _message_id):
+        if self.fetch_error:
+            raise self.fetch_error
+        return self.fetched
+
+    async def send(self, **_kwargs):
+        message = _Message(100 + len(self.sent))
+        self.sent.append(message)
+        return message
+
+
+def _not_found():
+    return discord.NotFound(
+        SimpleNamespace(status=404, reason="missing"), "missing"
+    )
+
+
+def _organizer_sync_manager(
+    monkeypatch,
+    *,
+    panel_id="",
+    status="draft",
+    channel=None,
+    sheet_id="sheet-organizer-sync",
+):
+    channel = channel or _Channel(guild=SimpleNamespace())
+    config = {
+        "ORGANIZER_CHANNEL_ID": "10",
+        "ORGANIZER_PANEL_MESSAGE_ID": panel_id,
+        "PARTICIPANT_ROLE_ID": "99",
+        "MESSAGES_TAB": "MESSAGES",
+    }
+    tournament = SimpleNamespace(
+        tournament_id="cup",
+        tournament_name="Trial Cup",
+        status=status,
+        max_participants=16,
+    )
+    counts = {"confirmed": 0, "withdrawn": 0, "removed": 0, "disqualified": 0}
+    parity = {"missing": [], "extra": [], "unresolved": []}
+    monkeypatch.setattr(
+        organizer_panel_module,
+        "load_pr5_config",
+        AsyncMock(return_value=(dict(config), [])),
+    )
+    monkeypatch.setattr(
+        organizer_panel_module,
+        "load_messages",
+        AsyncMock(return_value={"organizer_panel": _Template("Organizer")}),
+    )
+    bot = SimpleNamespace(
+        get_channel=lambda _channel_id: channel,
+        fetch_channel=AsyncMock(return_value=channel),
+    )
+    manager = OrganizerPanelManager(bot, sheet_id, SimpleNamespace(sync=AsyncMock()))
+    manager.data = AsyncMock(
+        return_value=(dict(config), tournament, [], counts, parity)
+    )
+    manager._persist = AsyncMock()
+    return manager, channel
+
+
+def test_organizer_panel_exists_in_draft_and_persists_created_id(monkeypatch):
+    manager, channel = _organizer_sync_manager(
+        monkeypatch, status="draft", sheet_id="sheet-organizer-draft"
+    )
+
+    result = run(manager.sync())
+
+    assert result == PanelSyncResult(True)
+    assert len(channel.sent) == 1
+    manager._persist.assert_awaited_once_with(
+        manager.data.await_args_list[0].args and manager.data.return_value[0]
+        or manager.data.return_value[0],
+        str(channel.sent[0].id),
+    )
+
+
+def test_organizer_existing_panel_edits_without_duplicate(monkeypatch):
+    existing = _Message(77)
+    manager, channel = _organizer_sync_manager(
+        monkeypatch,
+        panel_id="77",
+        status="signup_open",
+        channel=_Channel(fetched=existing, guild=SimpleNamespace()),
+        sheet_id="sheet-organizer-edit",
+    )
+
+    result = run(manager.sync())
+
+    assert result == PanelSyncResult(True)
+    existing.edit.assert_awaited_once()
+    assert channel.sent == []
+    manager._persist.assert_not_awaited()
+
+
+def test_organizer_notfound_recreates_once_and_transient_fetch_does_not(monkeypatch):
+    recreate, recreate_channel = _organizer_sync_manager(
+        monkeypatch,
+        panel_id="77",
+        channel=_Channel(fetch_error=_not_found(), guild=SimpleNamespace()),
+        sheet_id="sheet-organizer-notfound",
+    )
+    result = run(recreate.sync())
+    assert result == PanelSyncResult(True)
+    assert len(recreate_channel.sent) == 1
+    recreate._persist.assert_awaited_once()
+
+    transient, transient_channel = _organizer_sync_manager(
+        monkeypatch,
+        panel_id="77",
+        channel=_Channel(
+            fetch_error=RuntimeError("temporary Discord failure"), guild=SimpleNamespace()
+        ),
+        sheet_id="sheet-organizer-transient",
+    )
+    result = run(transient.sync())
+    assert result == PanelSyncResult(False, "fetch")
+    assert transient_channel.sent == []
+    transient._persist.assert_not_awaited()
+
+
+def test_organizer_edit_failure_reports_failure_without_duplicate(monkeypatch):
+    existing = _Message(77)
+    existing.edit.side_effect = RuntimeError("edit denied")
+    manager, channel = _organizer_sync_manager(
+        monkeypatch,
+        panel_id="77",
+        channel=_Channel(fetched=existing, guild=SimpleNamespace()),
+        sheet_id="sheet-organizer-edit-failure",
+    )
+
+    result = run(manager.sync())
+
+    assert result == PanelSyncResult(False, "edit")
+    assert channel.sent == []
+
+
+def test_organizer_failed_id_persistence_deletes_untracked_message(monkeypatch):
+    manager, channel = _organizer_sync_manager(
+        monkeypatch, sheet_id="sheet-organizer-persist-failure"
+    )
+    manager._persist.side_effect = RuntimeError("write failed")
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        run(manager.sync())
+
+    channel.sent[0].delete.assert_awaited_once()
+
+
+def test_organizer_persist_updates_only_existing_value_cell(monkeypatch):
+    matrix = [
+        ["Key", "Value", "Notes / clear name"],
+        ["ORGANIZER_CHANNEL_ID", "10", "channel"],
+        ["ORGANIZER_PANEL_MESSAGE_ID", "", "bot managed"],
+        ["PARTICIPANT_ROLE_ID", "99", "role"],
+    ]
+    worksheet = SimpleNamespace(update_cell=AsyncMock())
+    manager = OrganizerPanelManager(
+        SimpleNamespace(), "sheet-persist-cell", SimpleNamespace()
+    )
+
+    with (
+        patch(
+            "shared.sheets.async_core.afetch_values",
+            AsyncMock(return_value=matrix),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.aget_worksheet",
+            AsyncMock(return_value=worksheet),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.acall_with_backoff",
+            AsyncMock(),
+        ) as call,
+    ):
+        run(manager._persist({}, "777"))
+
+    assert call.await_count == 1
+    assert call.await_args.args == (worksheet.update_cell, 3, 2, "777")
+
+
+def test_concurrent_organizer_sync_creates_exactly_one_panel(monkeypatch):
+    state = {
+        "ORGANIZER_CHANNEL_ID": "10",
+        "ORGANIZER_PANEL_MESSAGE_ID": "",
+        "PARTICIPANT_ROLE_ID": "99",
+        "MESSAGES_TAB": "MESSAGES",
+    }
+    channel = _Channel(guild=SimpleNamespace())
+
+    async def fetch_message(message_id):
+        return next(message for message in channel.sent if message.id == int(message_id))
+
+    channel.fetch_message = fetch_message
+
+    async def load_config(_sheet_id):
+        return dict(state), []
+
+    async def data(_guild=None):
+        return (
+            dict(state),
+            SimpleNamespace(
+                tournament_id="cup",
+                tournament_name="Trial Cup",
+                status="draft",
+                max_participants=16,
+            ),
+            [],
+            {"confirmed": 0, "withdrawn": 0, "removed": 0, "disqualified": 0},
+            {"missing": [], "extra": [], "unresolved": []},
+        )
+
+    async def persist(_config, message_id):
+        state["ORGANIZER_PANEL_MESSAGE_ID"] = message_id
+
+    monkeypatch.setattr(organizer_panel_module, "load_pr5_config", load_config)
+    monkeypatch.setattr(
+        organizer_panel_module,
+        "load_messages",
+        AsyncMock(return_value={"organizer_panel": _Template("Organizer")}),
+    )
+    bot = SimpleNamespace(get_channel=lambda _id: channel)
+    first = OrganizerPanelManager(
+        bot, "sheet-organizer-concurrent", SimpleNamespace(sync=AsyncMock())
+    )
+    second = OrganizerPanelManager(
+        bot, "sheet-organizer-concurrent", SimpleNamespace(sync=AsyncMock())
+    )
+    first.data = data
+    second.data = data
+    first._persist = persist
+    second._persist = persist
+
+    async def concurrent():
+        await asyncio.gather(first.sync(), second.sync())
+
+    run(concurrent())
+    assert len(channel.sent) == 1
+    channel.sent[0].edit.assert_awaited_once()
+
+
+def _public_snapshot(status):
+    return TournamentSnapshot(
+        "cup",
+        "Trial Cup",
+        status,
+        "selected_clans",
+        8,
+        16,
+        "2026-08-01T00:00:00Z",
+        "2026-08-09T20:00:00Z",
+        1,
+        84,
+        50,
+    )
+
+
+def test_public_panel_open_closed_reopen_reuses_same_message(monkeypatch):
+    existing = _Message(55)
+    channel = _Channel(fetched=existing)
+    config = {
+        "MESSAGES_TAB": "MESSAGES",
+        "SIGNUP_CHANNEL_ID": "10",
+        "PUBLIC_PANEL_MESSAGE_ID": "55",
+    }
+    matrix = [
+        ["Key", "Value", "Notes / clear name"],
+        ["PUBLIC_PANEL_MESSAGE_ID", "55", "bot managed"],
+    ]
+
+    class Repo:
+        async def initialize(self):
+            return None
+
+        async def participants(self):
+            return []
+
+    async def load_messages(_sheet_id, _tab, keys):
+        key = next(iter(keys))
+        return {key: _Template(key)}
+
+    monkeypatch.setattr(
+        panel_module, "load_pr3_config", AsyncMock(return_value=(config, matrix))
+    )
+    monkeypatch.setattr(
+        panel_module,
+        "load_tournament_snapshot",
+        AsyncMock(
+            side_effect=[
+                _public_snapshot("signup_open"),
+                _public_snapshot("signup_closed"),
+                _public_snapshot("signup_open"),
+            ]
+        ),
+    )
+    monkeypatch.setattr(panel_module, "load_messages", load_messages)
+    monkeypatch.setattr(panel_module, "LiveArenaRepository", lambda _sheet: Repo())
+    manager = LiveArenaPanelManager(
+        SimpleNamespace(get_channel=lambda _id: channel),
+        "sheet-public-lifecycle",
+    )
+
+    run(manager.sync())
+    run(manager.sync())
+    run(manager.sync())
+
+    assert existing.edit.await_count == 3
+    assert [
+        len(call.kwargs["view"].children) for call in existing.edit.await_args_list
+    ] == [2, 1, 2]
+    assert channel.sent == []
+
+
+def test_close_odd_roster_confirmation_warns_without_mutating(monkeypatch):
+    manager = SimpleNamespace(
+        data=AsyncMock(
+            return_value=(
+                {},
+                SimpleNamespace(tournament_name="Trial Cup"),
+                [],
+                {"confirmed": 5},
+                {},
+            )
+        )
+    )
+    interaction = SimpleNamespace(
+        guild=SimpleNamespace(),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    view = OrganizerView(manager, "signup_open")
+
+    monkeypatch.setattr(
+        OrganizerView, "authorized", AsyncMock(return_value=True)
+    )
+    run(view.transition(interaction, "close"))
+
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs["embed"], discord.Embed)
+    assert "odd" in kwargs["embed"].description.lower()
+    assert "no player will be auto-demoted" in kwargs["embed"].description
+    assert isinstance(kwargs["view"], ConfirmTransition)
+    assert kwargs["ephemeral"] is True
+
+
+def _participant_row(status="confirmed", *, timezone="UTC"):
+    return {
+        "tournament_id": "cup",
+        "discord_user_id": "7",
+        "display_name_at_signup": "Old Name",
+        "clan_tag_at_signup": "OLD",
+        "timezone": timezone,
+        "status": status,
+        "signed_up_at_utc": "2026-08-01T00:00:00Z",
+        "confirmed_at_utc": "2026-08-01T00:00:00Z",
+        "withdrawn_at_utc": "",
+        "withdrawal_reason": "",
+        "updated_at_utc": "2026-08-01T00:00:00Z",
+        "notes": "keep",
+    }
+
+
+def _tournament(status="signup_open", *, maximum=16):
+    return {
+        "tournament_id": "cup",
+        "tournament_name": "Trial Cup",
+        "status": status,
+        "eligibility_scope": "selected_clans",
+        "min_participants": "8",
+        "max_participants": str(maximum),
+        "signup_opens_at_utc": "2026-08-01T00:00:00Z",
+        "signup_closes_at_utc": "2026-08-09T20:00:00Z",
+        "notes": "",
+    }
+
+
+def _slots(*, disable_first=False):
+    return [
+        {
+            "slot_id": "MON_0000_0200",
+            "weekday_utc": "Monday",
+            "start_time_utc": "00:00",
+            "end_time_utc": "02:00",
+            "enabled": "FALSE" if disable_first else "TRUE",
+            "sort_order": "1",
+            "display_label": "Monday 00:00–02:00 UTC",
+        },
+        {
+            "slot_id": "MON_0200_0400",
+            "weekday_utc": "Monday",
+            "start_time_utc": "02:00",
+            "end_time_utc": "04:00",
+            "enabled": "TRUE",
+            "sort_order": "2",
+            "display_label": "Monday 02:00–04:00 UTC",
+        },
+        {
+            "slot_id": "TUE_0000_0200",
+            "weekday_utc": "Tuesday",
+            "start_time_utc": "00:00",
+            "end_time_utc": "02:00",
+            "enabled": "TRUE",
+            "sort_order": "13",
+            "display_label": "Tuesday 00:00–02:00 UTC",
+        },
+    ]
+
+
+def _availability():
+    return [
+        {
+            "tournament_id": "cup",
+            "discord_user_id": "7",
+            "slot_id": slot_id,
+            "created_at_utc": "2026-08-01T00:00:00Z",
+            "updated_at_utc": "2026-08-01T00:00:00Z",
+            "notes": "",
+        }
+        for slot_id in ("MON_0000_0200", "MON_0200_0400", "TUE_0000_0200")
+    ]
+
+
+def _service_with_context(participants, tournament, clans=None, slots=None, availability=None):
+    repo = SimpleNamespace(
+        participants=AsyncMock(return_value=participants),
+        availability=AsyncMock(return_value=availability or []),
+        persist_participants=AsyncMock(),
+        append_audit=AsyncMock(),
+    )
+    service = OrganizerService(
+        "sheet",
+        repository=repo,
+        clock=lambda: datetime(2026, 8, 7, 12, tzinfo=UTC),
+    )
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": "cup"},
+            (2, tournament),
+            clans or [],
+            slots or [],
+        )
+    )
+    return service, repo
+
+
+@pytest.mark.parametrize("tournament_status", ["signup_open", "signup_closed"])
+def test_remove_preserves_historical_fields_and_availability(tournament_status):
+    row = _participant_row()
+    original = dict(row)
+    service, repo = _service_with_context([row], _tournament(tournament_status))
+
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        run(service.remove("100", "7"))
+
+    assert row["status"] == "removed"
+    assert row["signed_up_at_utc"] == original["signed_up_at_utc"]
+    assert row["confirmed_at_utc"] == original["confirmed_at_utc"]
+    assert row["timezone"] == original["timezone"]
+    assert row["notes"] == "keep"
+    repo.availability.assert_not_awaited()
+    previous = repo.persist_participants.await_args.kwargs["previous_participants"]
+    assert previous[0]["status"] == "confirmed"
+    audit = repo.append_audit.await_args.args[0]
+    assert audit["event_type"] == "participant_removed"
+    assert audit["actor_discord_user_id"] == "100"
+    assert audit["target_discord_user_id"] == "7"
+
+
+@pytest.mark.parametrize(
+    ("participant_status", "tournament_status"),
+    [("withdrawn", "signup_open"), ("confirmed", "draft")],
+)
+def test_remove_rejects_wrong_participant_or_tournament_status(
+    participant_status, tournament_status
+):
+    row = _participant_row(participant_status)
+    service, repo = _service_with_context([row], _tournament(tournament_status))
+
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError):
+            run(service.remove("100", "7"))
+
+    repo.persist_participants.assert_not_awaited()
+    repo.append_audit.assert_not_awaited()
+
+
+def _restore_fixture(
+    *,
+    member_role_id=123,
+    maximum=16,
+    timezone="UTC",
+    disable_first=False,
+    extra_confirmed=False,
+):
+    row = _participant_row("removed", timezone=timezone)
+    row["withdrawn_at_utc"] = "2026-08-05T00:00:00Z"
+    row["withdrawal_reason"] = "old reason"
+    participants = [row]
+    if extra_confirmed:
+        participants.append(
+            {
+                **_participant_row("confirmed"),
+                "discord_user_id": "8",
+                "display_name_at_signup": "Other",
+            }
+        )
+    clans = [
+        {
+            "tournament_id": "cup",
+            "clan_tag": "C1CM",
+            "clan_name": "Martyrs",
+            "discord_role_id": "123",
+            "active": "TRUE",
+            "notes": "",
+        }
+    ]
+    service, repo = _service_with_context(
+        participants,
+        _tournament("signup_open", maximum=maximum),
+        clans,
+        _slots(disable_first=disable_first),
+        _availability(),
+    )
+    member = SimpleNamespace(
+        id=7,
+        display_name="Current Name",
+        roles=[SimpleNamespace(id=member_role_id)],
+    )
+    return service, repo, row, member
+
+
+def test_restore_revalidates_and_restores_same_row_without_replacing_availability():
+    service, repo, row, member = _restore_fixture()
+    signed_up = row["signed_up_at_utc"]
+
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        run(service.restore("100", "7", member))
+
+    assert row["status"] == "confirmed"
+    assert row["signed_up_at_utc"] == signed_up
+    assert row["display_name_at_signup"] == "Current Name"
+    assert row["clan_tag_at_signup"] == "C1CM"
+    assert row["withdrawn_at_utc"] == ""
+    assert row["withdrawal_reason"] == ""
+    repo.availability.assert_awaited_once()
+    assert not hasattr(repo, "persist_availability")
+    audit = repo.append_audit.await_args.args[0]
+    assert audit["event_type"] == "participant_restored"
+    assert audit["actor_discord_user_id"] == "100"
+    assert audit["target_discord_user_id"] == "7"
+
+
+def test_restore_rejects_unresolved_or_ineligible_member_without_mutation():
+    service, repo, _row, member = _restore_fixture()
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError, match="cannot be resolved"):
+            run(service.restore("100", "7", None))
+    repo.persist_participants.assert_not_awaited()
+
+    service, repo, _row, member = _restore_fixture(member_role_id=999)
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError, match="eligible clan role"):
+            run(service.restore("100", "7", member))
+    repo.persist_participants.assert_not_awaited()
+
+
+def test_restore_rejects_capacity_timezone_and_disabled_saved_slots():
+    service, repo, _row, member = _restore_fixture(maximum=1, extra_confirmed=True)
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError, match="capacity"):
+            run(service.restore("100", "7", member))
+    repo.persist_participants.assert_not_awaited()
+
+    service, repo, _row, member = _restore_fixture(timezone="Mars/Nope")
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError, match="IANA"):
+            run(service.restore("100", "7", member))
+    repo.persist_participants.assert_not_awaited()
+
+    service, repo, _row, member = _restore_fixture(disable_first=True)
+    with patch(
+        "modules.community.live_arena.organizer.load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    ):
+        with pytest.raises(RegistrationError, match="disabled"):
+            run(service.restore("100", "7", member))
+    repo.persist_participants.assert_not_awaited()
+
+
+@pytest.mark.parametrize("restore", [False, True])
+def test_participant_role_failure_and_panel_failure_do_not_rollback_core(
+    monkeypatch, restore
+):
+    role = SimpleNamespace(id=99)
+    target = SimpleNamespace(
+        id=7,
+        roles=[] if restore else [role],
+        add_roles=AsyncMock(side_effect=RuntimeError("role denied")),
+        remove_roles=AsyncMock(side_effect=RuntimeError("role denied")),
+    )
+    service = SimpleNamespace(
+        initialize=AsyncMock(), remove=AsyncMock(), restore=AsyncMock()
+    )
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        secondary_sync=AsyncMock(return_value=["public panel", "organizer panel"]),
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=100),
+        guild=SimpleNamespace(get_role=lambda _id: role),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    monkeypatch.setattr(
+        organizer_panel_module, "OrganizerService", lambda _sheet_id: service
+    )
+    monkeypatch.setattr(
+        organizer_panel_module,
+        "load_pr5_config",
+        AsyncMock(return_value=({"PARTICIPANT_ROLE_ID": "99"}, [])),
+    )
+    monkeypatch.setattr(
+        OrganizerView, "authorized", AsyncMock(return_value=True)
+    )
+
+    run(ConfirmParticipant(manager, target, restore).children[0].callback(interaction))
+
+    if restore:
+        service.restore.assert_awaited_once_with("100", "7", target)
+        target.add_roles.assert_awaited_once()
+    else:
+        service.remove.assert_awaited_once_with("100", "7")
+        target.remove_roles.assert_awaited_once()
+    manager.secondary_sync.assert_awaited_once()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert isinstance(embed, discord.Embed)
+    assert embed.fields
+    warning = embed.fields[0].value
+    assert "Participant role" in warning
+    assert "public panel" in warning
+    assert "organizer panel" in warning
+
+
+def test_participant_core_failure_skips_role_and_panel_sync(monkeypatch):
+    role = SimpleNamespace(id=99)
+    target = SimpleNamespace(
+        id=7,
+        roles=[role],
+        remove_roles=AsyncMock(),
+    )
+    service = SimpleNamespace(
+        initialize=AsyncMock(),
+        remove=AsyncMock(side_effect=RegistrationError("participant must currently be confirmed")),
+    )
+    manager = SimpleNamespace(
+        sheet_id="sheet", secondary_sync=AsyncMock()
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=100),
+        guild=SimpleNamespace(get_role=lambda _id: role),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    monkeypatch.setattr(
+        organizer_panel_module, "OrganizerService", lambda _sheet_id: service
+    )
+    monkeypatch.setattr(
+        OrganizerView, "authorized", AsyncMock(return_value=True)
+    )
+
+    run(ConfirmParticipant(manager, target, False).children[0].callback(interaction))
+
+    target.remove_roles.assert_not_awaited()
+    manager.secondary_sync.assert_not_awaited()
+    assert isinstance(
+        interaction.followup.send.await_args.kwargs["embed"], discord.Embed
+    )
+
+
+def test_reconcile_adds_removes_continues_after_failures_and_refreshes(monkeypatch):
+    role = SimpleNamespace(id=99)
+    missing_ok = SimpleNamespace(id=1, add_roles=AsyncMock())
+    missing_fail = SimpleNamespace(
+        id=2, add_roles=AsyncMock(side_effect=RuntimeError("add denied"))
+    )
+    extra_ok = SimpleNamespace(id=8, remove_roles=AsyncMock())
+    extra_fail = SimpleNamespace(
+        id=9, remove_roles=AsyncMock(side_effect=RuntimeError("remove denied"))
+    )
+    participants = [
+        {"tournament_id": "cup", "discord_user_id": uid, "status": "confirmed"}
+        for uid in ("1", "2", "3", "4")
+    ]
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        data=AsyncMock(
+            return_value=(
+                {"PARTICIPANT_ROLE_ID": "99"},
+                SimpleNamespace(tournament_id="cup"),
+                participants,
+                {},
+                {
+                    "missing": [missing_ok, missing_fail],
+                    "extra": [extra_ok, extra_fail],
+                    "unresolved": ["4"],
+                },
+            )
+        ),
+        sync=AsyncMock(return_value=PanelSyncResult(True)),
+    )
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=100),
+        guild=SimpleNamespace(get_role=lambda _id: role),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    monkeypatch.setattr(
+        OrganizerView, "authorized", AsyncMock(return_value=True)
+    )
+
+    run(ConfirmReconcile(manager).children[0].callback(interaction))
+
+    missing_ok.add_roles.assert_awaited_once()
+    missing_fail.add_roles.assert_awaited_once()
+    extra_ok.remove_roles.assert_awaited_once()
+    extra_fail.remove_roles.assert_awaited_once()
+    manager.sync.assert_awaited_once()
+    description = interaction.followup.send.await_args.kwargs["embed"].description
+    assert "Added: **1**" in description
+    assert "Removed: **1**" in description
+    assert "Already correct: **1**" in description
+    assert "Unresolved: **1**" in description
+    assert "Failures: **2**" in description
+
+
+def _review_flow(*, updating, manager, service):
+    return SimpleNamespace(
+        updating=updating,
+        manager=manager,
+        service=service,
+        timezone="UTC",
+        selected={"a", "b", "c"},
+        preparation=SimpleNamespace(
+            config={"ACTIVE_TOURNAMENT_ID": "cup"},
+            tournament={
+                "tournament_name": "Trial Cup",
+                "signup_closes_at_utc": "2026-08-09T20:00:00Z",
+            },
+        ),
+    )
+
+
+def test_player_signup_refreshes_organizer_but_availability_update_does_not(monkeypatch):
+    organizer = SimpleNamespace(sync=AsyncMock())
+    manager = SimpleNamespace(
+        sheet_id="sheet", sync=AsyncMock(), organizer_manager=organizer
+    )
+    member = SimpleNamespace(
+        id=7,
+        display_name="Player",
+        mention="<@7>",
+        roles=[],
+    )
+    interaction = SimpleNamespace(
+        user=member,
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    config = {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"}
+    signup_template = MessageTemplate(
+        "signup_confirmed",
+        "You're aboard",
+        "{participant} {tournament_name} {signup_deadline}",
+        1,
+    )
+    update_template = MessageTemplate(
+        "availability_updated",
+        "Availability updated",
+        "{participant} {tournament_name}",
+        1,
+    )
+    monkeypatch.setattr(
+        views, "load_pr3_config", AsyncMock(return_value=(config, []))
+    )
+    monkeypatch.setattr(
+        views,
+        "load_messages",
+        AsyncMock(
+            return_value={
+                "signup_confirmed": signup_template,
+                "availability_updated": update_template,
+            }
+        ),
+    )
+    monkeypatch.setattr(views, "_assign_role", AsyncMock())
+
+    signup_service = SimpleNamespace(register=AsyncMock())
+    run(
+        views.ReviewView(
+            _review_flow(updating=False, manager=manager, service=signup_service)
+        ).children[1].callback(interaction)
+    )
+    signup_service.register.assert_awaited_once()
+    manager.sync.assert_awaited_once()
+    organizer.sync.assert_awaited_once()
+
+    manager.sync.reset_mock()
+    organizer.sync.reset_mock()
+    interaction.followup.send.reset_mock()
+    update_service = SimpleNamespace(update_availability=AsyncMock())
+    run(
+        views.ReviewView(
+            _review_flow(updating=True, manager=manager, service=update_service)
+        ).children[1].callback(interaction)
+    )
+    update_service.update_availability.assert_awaited_once()
+    manager.sync.assert_not_awaited()
+    organizer.sync.assert_not_awaited()
+
+
+def test_closed_player_withdrawal_refreshes_organizer_without_reopening_public(monkeypatch):
+    organizer = SimpleNamespace(sync=AsyncMock())
+    manager = SimpleNamespace(
+        sheet_id="sheet", sync=AsyncMock(), organizer_manager=organizer
+    )
+    service = SimpleNamespace(withdraw=AsyncMock())
+    role = SimpleNamespace(id=99)
+    member = SimpleNamespace(
+        id=7,
+        mention="<@7>",
+        roles=[],
+        remove_roles=AsyncMock(),
+    )
+    interaction = SimpleNamespace(
+        user=member,
+        guild=SimpleNamespace(get_role=lambda _id: role),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    snapshot = SimpleNamespace(
+        config={"ACTIVE_TOURNAMENT_ID": "cup"},
+        tournament={"tournament_name": "Trial Cup"},
+        tournament_status="signup_closed",
+    )
+    template = MessageTemplate(
+        "withdrawal_confirmed",
+        "Withdrawal recorded",
+        "{participant} has withdrawn from {tournament_name}.",
+        1,
+    )
+    monkeypatch.setattr(
+        views,
+        "load_pr3_config",
+        AsyncMock(
+            return_value=(
+                {"MESSAGES_TAB": "MESSAGES", "PARTICIPANT_ROLE_ID": "99"},
+                [],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        views,
+        "load_messages",
+        AsyncMock(return_value={"withdrawal_confirmed": template}),
+    )
+
+    modal = views.WithdrawalReasonModal(manager, service, snapshot)
+    modal.reason._value = "busy"
+    run(modal.on_submit(interaction))
+
+    service.withdraw.assert_awaited_once_with("7", "busy")
+    manager.sync.assert_not_awaited()
+    organizer.sync.assert_awaited_once()
+    assert isinstance(
+        interaction.followup.send.await_args.kwargs["embed"], discord.Embed
+    )


### PR DESCRIPTION
### Motivation

- Complete PR5 of Live Arena registration lifecycle to provide organizers with a persistent panel and exact Open/Close/Reopen controls plus Remove/Restore recovery without introducing rounds/matchmaking logic.
- Ensure core Sheet-state mutations follow the frozen contract (TOURNAMENTS/PARTICIPANTS/AUDIT_LOG) while Discord role/panel sync remains best-effort and never rolls back core state.

### Description

- Implemented `OrganizerService` which performs locked tournament transitions (`open`, `close`, `reopen`) with `signup_closes_at_utc` validation, targeted TOURNAMENTS-cell updates, and audit appends for registration lifecycle events.
- Added `organizer_panel.py` providing a persistent organizer panel view with exact-role authorization, Open/Close/Reopen button controls (disabled/visible rules), View Roster, Remove/Restore flows (selection + confirmation + validations), participant-role parity reporting, and Reconcile Roles with best-effort role changes and per-user failure reporting.
- Extended message/config handling to support PR5 contract items (`signup_closed`, `organizer_panel`) and added a PR5 config loader plus flow-scoped message validation so each flow validates only the templates it requires.
- Extended repository persistence with `update_tournament_cells` to atomically update only named TOURNAMENTS cells, wired organizer panel startup/sync behavior, and added best-effort organizer-panel refreshes after player signup/withdrawal while preserving existing PR1–PR4 domain rules.

### Testing

- Ran static checks and formatting with `ruff` on modified files and `python -m compileall` for the live_arena module, both succeeded for the changed code.
- Executed focused Live Arena test suite (`pytest -q tests/community/test_live_arena*.py`) covering PR1–PR4 and the PR5-focused tests, and those Live Arena tests passed in this environment.
- Ran broader `pytest -q` which showed the Live Arena tests passed but uncovered 25 unrelated, pre-existing logging-test failures (tests expecting `LogRecord.message`) and other repository-wide guardrail items reported by `scripts.ci.guardrails_suite`; these failures are outside PR5 scope and require a separate remediation.
- Note: I could not open the GitHub pull request from this environment because the `make_pr` / GitHub creation tooling and authenticated remote are not available here; the branch/commit is prepared for PR submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76326d53e48323a19d95af9a0562f9)