### PR TITLE
test(fusion): make announcement boundary scheduling deterministic

### DIFF
--- a/tests/community/test_fusion_scheduler.py
+++ b/tests/community/test_fusion_scheduler.py
@@ -169,6 +169,7 @@ def test_announcement_refresh_uses_event_boundaries(monkeypatch) -> None:
     parent = _fusion(now, start_delta=-24, end_delta=24)
     event_start = now + dt.timedelta(hours=2)
     event_end = now + dt.timedelta(hours=3)
+    daily_due = event_end + dt.timedelta(hours=1)
     event = SimpleNamespace()
     runtime = _runtime()
     _patch_fusion_data(monkeypatch, published=(parent,), events=(event,))
@@ -177,6 +178,7 @@ def test_announcement_refresh_uses_event_boundaries(monkeypatch) -> None:
         "get_valid_event_timing",
         lambda _event, **_kwargs: (event_start, event_end),
     )
+    monkeypatch.setattr(fusion_scheduler, "_next_daily", lambda _now: daily_due)
 
     asyncio.run(fusion_scheduler.reconcile_fusion_jobs(runtime))
     job = next(


### PR DESCRIPTION
### Why
`test_announcement_refresh_uses_event_boundaries` depended on the real UTC clock. During roughly 22:15–00:15 UTC, the scheduler correctly chose the earlier daily 00:15 refresh instead of the test's `now + 2h` event boundary, making the test fail despite correct production behavior.

### Change
- Test-only change in `tests/community/test_fusion_scheduler.py`.
- Explicitly patch `_next_daily` in the event-boundary test so the mocked daily refresh occurs after the mocked event boundary.
- Keep the existing adjacent test covering the opposite case where the daily refresh is earlier.

### Scope
- No Fusion production code changes.
- No scheduler behavior changes.
- No Google Sheets changes.
- No unrelated changes.