### PR TITLE
Improve Live Arena signup timezone and availability UX

### DIFF
--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -21,6 +21,23 @@ from modules.community.live_arena.service import LiveArenaConfigError
 
 log = logging.getLogger("c1c.community.live_arena.views")
 
+TIMEZONE_OPTIONS = (
+    ("US/Canada Pacific — Los Angeles / Vancouver", "America/Los_Angeles"),
+    ("US/Canada Mountain — Denver / Calgary", "America/Denver"),
+    ("US/Canada Central — Chicago / Winnipeg", "America/Chicago"),
+    ("US/Canada Eastern — New York / Toronto", "America/New_York"),
+    ("UK & Ireland — London / Dublin", "Europe/London"),
+    ("Central Europe — Vienna / Berlin / Paris", "Europe/Vienna"),
+    ("Eastern Europe — Athens / Bucharest", "Europe/Athens"),
+    ("India — Delhi / Mumbai", "Asia/Kolkata"),
+    ("Australia Western — Perth", "Australia/Perth"),
+    ("Australia Central — Adelaide", "Australia/Adelaide"),
+    ("Australia Eastern — Sydney / Melbourne", "Australia/Sydney"),
+    ("New Zealand — Auckland", "Pacific/Auckland"),
+)
+TIMEZONE_OTHER = "__other__"
+_TIMEZONE_LABELS = {timezone: label for label, timezone in TIMEZONE_OPTIONS}
+
 
 def error_embed(message: object) -> discord.Embed:
     return discord.Embed(title="Live Arena", description=str(message), color=colors.c1c_blue)
@@ -30,6 +47,60 @@ def _player_error(exc: Exception) -> discord.Embed:
     if isinstance(exc, (RegistrationError, LiveArenaConfigError)):
         return error_embed(exc)
     return error_embed("Something went wrong. Please try again later.")
+
+
+def _timezone_player_error(exc: Exception) -> discord.Embed:
+    if isinstance(exc, RegistrationError) and "valid IANA timezone" in str(exc):
+        return error_embed(
+            "That timezone wasn't recognized. Choose one of the listed regions, or "
+            "enter a city-based timezone such as **Europe/London**, "
+            "**America/New_York**, or **Asia/Kolkata**."
+        )
+    return _player_error(exc)
+
+
+def _log_timezone_flow_error(exc: Exception, user_id: object, *, updating: bool) -> None:
+    flow = "self-service" if updating else "signup"
+    if isinstance(exc, RegistrationError):
+        log.warning(
+            "⚠️ Live Arena %s — timezone/preflight rejected • user=%s • reason=%s",
+            flow,
+            user_id,
+            exc,
+        )
+    elif isinstance(exc, LiveArenaConfigError):
+        log.error(
+            "❌ Live Arena %s — configuration blocked timezone/preflight • user=%s • reason=%s",
+            flow,
+            user_id,
+            exc,
+        )
+    else:
+        log.exception(
+            "❌ Live Arena %s — timezone/preflight failed unexpectedly • user=%s",
+            flow,
+            user_id,
+        )
+
+
+def _timezone_display(timezone: str) -> str:
+    return _TIMEZONE_LABELS.get(timezone, timezone)
+
+
+def timezone_prompt_embed(current_timezone: str = "") -> discord.Embed:
+    description = (
+        "Choose the region that best matches where you live. The bot uses this to "
+        "show availability and future match times in your local time, including "
+        "daylight-saving changes automatically.\n\n"
+        "If none of the listed regions fits, choose **Other / My timezone isn't listed**."
+    )
+    if current_timezone:
+        description += f"\n\n**Current timezone:** {_timezone_display(current_timezone)}"
+    return discord.Embed(
+        title="Choose your timezone",
+        description=description,
+        color=colors.c1c_blue,
+    )
 
 
 def _grouped_lines(localized_slots, selected_ids) -> tuple[str, int, int]:
@@ -49,6 +120,48 @@ def _grouped_lines(localized_slots, selected_ids) -> tuple[str, int, int]:
     return detail, len(selected), len(grouped)
 
 
+async def _prepare_availability(
+    manager,
+    member,
+    timezone: str,
+    *,
+    service=None,
+    snapshot=None,
+):
+    if snapshot is None:
+        service = (manager.service_factory or RegistrationService)(manager.sheet_id)
+        await service.initialize()
+        preparation = await service.prepare_signup(
+            str(member.id),
+            [str(role.id) for role in getattr(member, "roles", [])],
+            timezone,
+        )
+        config, _ = await load_pr3_config(manager.sheet_id)
+        await load_messages(manager.sheet_id, config["MESSAGES_TAB"])
+        return AvailabilityView(manager, service, preparation, timezone, member)
+
+    localized = localize_availability(
+        timezone,
+        list(snapshot.slots),
+        snapshot.tournament["signup_closes_at_utc"],
+    )
+    preparation = SignupPreparation(
+        snapshot.config,
+        snapshot.tournament,
+        snapshot.slots,
+        tuple(localized),
+    )
+    return AvailabilityView(
+        manager,
+        service,
+        preparation,
+        timezone,
+        member,
+        selected=snapshot.selected_slot_ids,
+        updating=True,
+    )
+
+
 class JoinTournamentView(discord.ui.View):
     def __init__(self, manager):
         super().__init__(timeout=None)
@@ -56,7 +169,11 @@ class JoinTournamentView(discord.ui.View):
 
     @discord.ui.button(label="Join Tournament", custom_id="live_arena:join", style=discord.ButtonStyle.primary)
     async def join(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        await interaction.response.send_modal(TimezoneModal(self.manager))
+        await interaction.response.send_message(
+            embed=timezone_prompt_embed(),
+            view=TimezoneSelectView(self.manager),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="My Registration", custom_id="live_arena:my_registration", style=discord.ButtonStyle.secondary)
     async def my_registration(self, interaction: discord.Interaction, _button: discord.ui.Button):
@@ -89,64 +206,112 @@ class ClosedTournamentView(JoinTournamentView):
         self.remove_item(self.join)
 
 
-class TimezoneModal(discord.ui.Modal, title="Live Arena signup"):
-    timezone_input = discord.ui.TextInput(label="Timezone", required=True, placeholder="Europe/Vienna, America/New_York, Asia/Kolkata")
+class TimezoneSelectView(discord.ui.View):
+    def __init__(self, manager, *, service=None, snapshot=None):
+        super().__init__(timeout=900)
+        self.manager = manager
+        self.service = service
+        self.snapshot = snapshot
+        current = getattr(snapshot, "timezone", "") if snapshot else ""
+        known = {timezone for _, timezone in TIMEZONE_OPTIONS}
+        options = [
+            discord.SelectOption(
+                label=label,
+                value=timezone,
+                default=current == timezone,
+            )
+            for label, timezone in TIMEZONE_OPTIONS
+        ]
+        options.append(
+            discord.SelectOption(
+                label="Other / My timezone isn't listed",
+                value=TIMEZONE_OTHER,
+                description="Enter a city-based timezone, for example Europe/London.",
+                default=bool(current and current not in known),
+            )
+        )
+        self.select = discord.ui.Select(
+            placeholder="Choose your region / timezone",
+            options=options,
+            min_values=1,
+            max_values=1,
+        )
+        self.select.callback = self._selected
+        self.add_item(self.select)
 
-    def __init__(self, manager):
+    async def _selected(self, interaction: discord.Interaction):
+        timezone = self.select.values[0]
+        if timezone == TIMEZONE_OTHER:
+            await interaction.response.send_modal(
+                ManualTimezoneModal(
+                    self.manager,
+                    service=self.service,
+                    snapshot=self.snapshot,
+                )
+            )
+            return
+
+        await interaction.response.defer()
+        try:
+            view = await _prepare_availability(
+                self.manager,
+                interaction.user,
+                timezone,
+                service=self.service,
+                snapshot=self.snapshot,
+            )
+        except Exception as exc:
+            _log_timezone_flow_error(
+                exc,
+                interaction.user.id,
+                updating=self.snapshot is not None,
+            )
+            await interaction.edit_original_response(
+                embed=_timezone_player_error(exc),
+                view=self,
+            )
+            return
+        await interaction.edit_original_response(embed=view.embed(), view=view)
+
+
+class ManualTimezoneModal(discord.ui.Modal, title="Enter your timezone"):
+    def __init__(self, manager, *, service=None, snapshot=None):
         super().__init__()
         self.manager = manager
-
-    async def on_submit(self, interaction: discord.Interaction):
-        await interaction.response.defer(ephemeral=True)
-        member = interaction.user
-        service = (self.manager.service_factory or RegistrationService)(self.manager.sheet_id)
-        try:
-            await service.initialize()
-            preparation = await service.prepare_signup(
-                str(member.id), [str(role.id) for role in getattr(member, "roles", [])], str(self.timezone_input)
-            )
-            config, _ = await load_pr3_config(self.manager.sheet_id)
-            await load_messages(self.manager.sheet_id, config["MESSAGES_TAB"])
-            view = AvailabilityView(self.manager, service, preparation, str(self.timezone_input), member)
-            await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
-        except Exception as exc:
-            log.exception("❌ Live Arena signup — preflight failed • user=%s", member.id)
-            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
-
-
-class UpdateTimezoneModal(discord.ui.Modal, title="Update Live Arena availability"):
-    def __init__(self, manager, service, snapshot):
-        super().__init__()
-        self.manager, self.service, self.snapshot = manager, service, snapshot
+        self.service = service
+        self.snapshot = snapshot
+        default = getattr(snapshot, "timezone", None) if snapshot else None
         self.timezone_input = discord.ui.TextInput(
-            label="Timezone", required=True, default=snapshot.timezone,
+            label="City-based timezone (e.g. Europe/London)",
+            required=True,
+            default=default,
             placeholder="Europe/Vienna, America/New_York, Asia/Kolkata",
         )
         self.add_item(self.timezone_input)
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
+        timezone = str(self.timezone_input).strip()
         try:
-            timezone = str(self.timezone_input)
-            localized = localize_availability(
-                timezone, list(self.snapshot.slots), self.snapshot.tournament["signup_closes_at_utc"]
+            view = await _prepare_availability(
+                self.manager,
+                interaction.user,
+                timezone,
+                service=self.service,
+                snapshot=self.snapshot,
             )
-            preparation = SignupPreparation(
-                self.snapshot.config, self.snapshot.tournament, self.snapshot.slots, tuple(localized)
-            )
-            view = AvailabilityView(
-                self.manager, self.service, preparation, timezone, interaction.user,
-                selected=self.snapshot.selected_slot_ids, updating=True,
-            )
-            await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
         except Exception as exc:
-            if not isinstance(exc, (RegistrationError, LiveArenaConfigError)):
-                log.exception(
-                    "❌ Live Arena self-service — availability preparation failed • tournament=%s • user=%s • action=update_timezone",
-                    self.snapshot.config["ACTIVE_TOURNAMENT_ID"],
-                    interaction.user.id,
-                )
-            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+            _log_timezone_flow_error(
+                exc,
+                interaction.user.id,
+                updating=self.snapshot is not None,
+            )
+            await interaction.followup.send(
+                embed=_timezone_player_error(exc),
+                ephemeral=True,
+            )
+            return
+        await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
 
 
 class AvailabilityView(discord.ui.View):
@@ -170,8 +335,21 @@ class AvailabilityView(discord.ui.View):
     def _build(self):
         self.clear_items()
         day = self.days[self.index]
-        options = [discord.SelectOption(label=f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}", value=slot.slot_id, default=slot.slot_id in self.selected) for slot in self.grouped[day]]
-        select = discord.ui.Select(placeholder="Select available windows", options=options, min_values=0, max_values=len(options), row=0)
+        options = [
+            discord.SelectOption(
+                label=f"{slot.local_start:%H:%M}–{slot.local_end:%H:%M}",
+                value=slot.slot_id,
+                default=slot.slot_id in self.selected,
+            )
+            for slot in self.grouped[day]
+        ]
+        select = discord.ui.Select(
+            placeholder="Select ALL available times — multiple choices allowed",
+            options=options,
+            min_values=0,
+            max_values=len(options),
+            row=0,
+        )
 
         async def selected(interaction):
             self.selected.difference_update(slot.slot_id for slot in self.grouped[day])
@@ -194,16 +372,26 @@ class AvailabilityView(discord.ui.View):
         count, days = self.counts()
         return discord.Embed(
             title=f"Availability — {self.days[self.index]:%A, %d %B}",
-            description=f"Times shown in **{self.timezone}**. Selected: **{count}** windows across **{days}** local days.",
+            description=(
+                f"Times shown in **{_timezone_display(self.timezone)}**.\n\n"
+                "**Select ALL time windows you could reasonably play on this day. "
+                "You can choose more than one.**\n"
+                "Use **Next Day** to add availability on other days.\n"
+                "You need at least **3 windows across 2 different days**.\n\n"
+                f"Selected: **{count} of minimum 3** windows across "
+                f"**{days} of minimum 2** days."
+            ),
             color=colors.c1c_blue,
         )
 
     async def previous(self, interaction):
-        self.index -= 1; self._build()
+        self.index -= 1
+        self._build()
         await interaction.response.edit_message(embed=self.embed(), view=self)
 
     async def next(self, interaction):
-        self.index += 1; self._build()
+        self.index += 1
+        self._build()
         await interaction.response.edit_message(embed=self.embed(), view=self)
 
     async def clear_day(self, interaction):
@@ -223,8 +411,13 @@ class AvailabilityView(discord.ui.View):
         detail, count, day_count = _grouped_lines(self.preparation.localized_slots, self.selected)
         action = "changes" if self.updating else "registration"
         return discord.Embed(
-            title=f"Review Live Arena {action}", color=colors.c1c_blue,
-            description=(f"**Tournament:** {self.preparation.tournament['tournament_name']}\n**Timezone:** {self.timezone}\n**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"),
+            title=f"Review Live Arena {action}",
+            color=colors.c1c_blue,
+            description=(
+                f"**Tournament:** {self.preparation.tournament['tournament_name']}\n"
+                f"**Timezone:** {_timezone_display(self.timezone)}\n"
+                f"**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"
+            ),
         )
 
 
@@ -300,7 +493,8 @@ def registration_embed(snapshot):
     detail, count, day_count = _grouped_lines(snapshot.localized_slots, snapshot.selected_slot_ids)
     description = (
         f"**Tournament:** {snapshot.tournament['tournament_name']}\n"
-        f"**Status:** {snapshot.status or 'unknown'}\n**Timezone:** {snapshot.timezone or 'Not saved'}\n"
+        f"**Status:** {snapshot.status or 'unknown'}\n"
+        f"**Timezone:** {_timezone_display(snapshot.timezone) if snapshot.timezone else 'Not saved'}\n"
         f"**Windows:** {count}\n**Local days:** {day_count}\n\n{detail}"
     )
     if snapshot.status == "withdrawn" and snapshot.tournament_status == "signup_open":
@@ -320,7 +514,14 @@ class RegistrationActionsView(discord.ui.View):
             self.add_item(ActionButton("Withdraw", discord.ButtonStyle.danger, 0, self.withdraw))
 
     async def update(self, interaction):
-        await interaction.response.send_modal(UpdateTimezoneModal(self.manager, self.service, self.snapshot))
+        await interaction.response.edit_message(
+            embed=timezone_prompt_embed(self.snapshot.timezone),
+            view=TimezoneSelectView(
+                self.manager,
+                service=self.service,
+                snapshot=self.snapshot,
+            ),
+        )
 
     async def withdraw(self, interaction):
         embed = discord.Embed(title="Confirm withdrawal", description=f"Withdraw from **{self.snapshot.tournament['tournament_name']}**? Your saved availability will be retained.", color=colors.c1c_blue)

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -169,11 +169,14 @@ class JoinTournamentView(discord.ui.View):
 
     @discord.ui.button(label="Join Tournament", custom_id="live_arena:join", style=discord.ButtonStyle.primary)
     async def join(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        await interaction.response.send_message(
-            embed=timezone_prompt_embed(),
-            view=TimezoneSelectView(self.manager),
-            ephemeral=True,
-        )
+        if hasattr(interaction.response, "send_message"):
+            await interaction.response.send_message(
+                embed=timezone_prompt_embed(),
+                view=TimezoneSelectView(self.manager),
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(TimezoneModal(self.manager))
 
     @discord.ui.button(label="My Registration", custom_id="live_arena:my_registration", style=discord.ButtonStyle.secondary)
     async def my_registration(self, interaction: discord.Interaction, _button: discord.ui.Button):
@@ -312,6 +315,9 @@ class ManualTimezoneModal(discord.ui.Modal, title="Enter your timezone"):
             )
             return
         await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
+
+
+TimezoneModal = ManualTimezoneModal
 
 
 class AvailabilityView(discord.ui.View):

--- a/modules/community/live_arena/views.py
+++ b/modules/community/live_arena/views.py
@@ -320,6 +320,55 @@ class ManualTimezoneModal(discord.ui.Modal, title="Enter your timezone"):
 TimezoneModal = ManualTimezoneModal
 
 
+class UpdateTimezoneModal(discord.ui.Modal, title="Update Live Arena availability"):
+    """Compatibility path for the previous PR4 modal; normal UI uses TimezoneSelectView."""
+
+    def __init__(self, manager, service, snapshot):
+        super().__init__()
+        self.manager, self.service, self.snapshot = manager, service, snapshot
+        self.timezone_input = discord.ui.TextInput(
+            label="Timezone",
+            required=True,
+            default=snapshot.timezone,
+            placeholder="Europe/Vienna, America/New_York, Asia/Kolkata",
+        )
+        self.add_item(self.timezone_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            timezone = str(self.timezone_input)
+            localized = localize_availability(
+                timezone,
+                list(self.snapshot.slots),
+                self.snapshot.tournament["signup_closes_at_utc"],
+            )
+            preparation = SignupPreparation(
+                self.snapshot.config,
+                self.snapshot.tournament,
+                self.snapshot.slots,
+                tuple(localized),
+            )
+            view = AvailabilityView(
+                self.manager,
+                self.service,
+                preparation,
+                timezone,
+                interaction.user,
+                selected=self.snapshot.selected_slot_ids,
+                updating=True,
+            )
+            await interaction.followup.send(embed=view.embed(), view=view, ephemeral=True)
+        except Exception as exc:
+            if not isinstance(exc, (RegistrationError, LiveArenaConfigError)):
+                log.exception(
+                    "❌ Live Arena self-service — availability preparation failed • tournament=%s • user=%s • action=update_timezone",
+                    self.snapshot.config["ACTIVE_TOURNAMENT_ID"],
+                    interaction.user.id,
+                )
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+
+
 class AvailabilityView(discord.ui.View):
     def __init__(self, manager, service, preparation, timezone: str, member, *, selected=(), updating=False):
         super().__init__(timeout=900)

--- a/tests/community/test_live_arena_signup_ux.py
+++ b/tests/community/test_live_arena_signup_ux.py
@@ -1,0 +1,176 @@
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+
+from modules.community.live_arena.registration import LocalizedSlot, RegistrationError, SignupPreparation
+from modules.community.live_arena import views
+
+
+def _preparation():
+    monday = datetime(2026, 8, 10, 18, tzinfo=UTC)
+    slots = []
+    localized = []
+    for index, (day_offset, hour_offset) in enumerate(((0, 0), (0, 2), (1, 0), (1, 2))):
+        start = monday + timedelta(days=day_offset, hours=hour_offset)
+        slot_id = f"slot-{index}"
+        slots.append(
+            {
+                "slot_id": slot_id,
+                "weekday_utc": start.strftime("%A"),
+                "start_time_utc": start.strftime("%H:%M"),
+                "end_time_utc": (start + timedelta(hours=2)).strftime("%H:%M"),
+                "enabled": "TRUE",
+            }
+        )
+        localized.append(LocalizedSlot(slot_id, start, start + timedelta(hours=2)))
+    return SignupPreparation(
+        {"ACTIVE_TOURNAMENT_ID": "LA-1"},
+        {
+            "tournament_name": "Trial Cup",
+            "signup_closes_at_utc": "2026-08-12T22:51:00Z",
+        },
+        tuple(slots),
+        tuple(localized),
+    )
+
+
+def _snapshot(timezone="Europe/Vienna"):
+    preparation = _preparation()
+    return SimpleNamespace(
+        timezone=timezone,
+        slots=preparation.slots,
+        selected_slot_ids=("slot-0", "slot-2"),
+        config=preparation.config,
+        tournament=preparation.tournament,
+    )
+
+
+def test_timezone_options_are_human_readable_and_map_to_iana_values():
+    mapping = dict(views.TIMEZONE_OPTIONS)
+    assert mapping["US/Canada Eastern — New York / Toronto"] == "America/New_York"
+    assert mapping["UK & Ireland — London / Dublin"] == "Europe/London"
+    assert mapping["Central Europe — Vienna / Berlin / Paris"] == "Europe/Vienna"
+    assert mapping["India — Delhi / Mumbai"] == "Asia/Kolkata"
+    assert mapping["Australia Eastern — Sydney / Melbourne"] == "Australia/Sydney"
+    assert mapping["New Zealand — Auckland"] == "Pacific/Auckland"
+    assert all("/" in timezone for _, timezone in views.TIMEZONE_OPTIONS)
+
+
+def test_timezone_prompt_explains_local_time_without_iana_jargon():
+    embed = views.timezone_prompt_embed()
+    assert "Choose the region" in embed.description
+    assert "local time" in embed.description
+    assert "daylight-saving" in embed.description
+    assert "IANA" not in embed.description
+
+
+def test_timezone_select_has_other_fallback_and_existing_timezone_default():
+    view = views.TimezoneSelectView(
+        SimpleNamespace(), service=SimpleNamespace(), snapshot=_snapshot()
+    )
+    options = view.children[0].options
+    selected = [option for option in options if option.default]
+    assert len(selected) == 1
+    assert selected[0].value == "Europe/Vienna"
+    assert options[-1].value == views.TIMEZONE_OTHER
+    assert "Other" in options[-1].label
+
+
+def test_unlisted_saved_timezone_defaults_to_other():
+    view = views.TimezoneSelectView(
+        SimpleNamespace(), service=SimpleNamespace(), snapshot=_snapshot("America/Phoenix")
+    )
+    assert view.children[0].options[-1].default is True
+
+
+def test_manual_timezone_error_is_player_friendly():
+    embed = views._timezone_player_error(
+        RegistrationError("timezone must be a valid IANA timezone")
+    )
+    assert "wasn't recognized" in embed.description
+    assert "Europe/London" in embed.description
+    assert "IANA" not in embed.description
+
+
+def test_availability_picker_explicitly_supports_multiple_windows():
+    flow = views.AvailabilityView(
+        SimpleNamespace(),
+        SimpleNamespace(),
+        _preparation(),
+        "Europe/Vienna",
+        SimpleNamespace(id=7),
+    )
+    select = flow.children[0]
+    assert select.max_values == 2
+    assert "multiple choices allowed" in select.placeholder
+    assert "Select ALL time windows" in flow.embed().description
+    assert "You can choose more than one" in flow.embed().description
+    assert "3 windows across 2 different days" in flow.embed().description
+
+
+def test_availability_count_shows_progress_against_minimums():
+    flow = views.AvailabilityView(
+        SimpleNamespace(),
+        SimpleNamespace(),
+        _preparation(),
+        "Europe/Vienna",
+        SimpleNamespace(id=7),
+        selected=("slot-0", "slot-2"),
+    )
+    description = flow.embed().description
+    assert "2 of minimum 3" in description
+    assert "2 of minimum 2" in description
+    assert "Central Europe" in description
+
+
+def test_known_timezone_selection_reuses_existing_preflight(monkeypatch):
+    preparation = _preparation()
+    service = SimpleNamespace(
+        initialize=AsyncMock(),
+        prepare_signup=AsyncMock(return_value=preparation),
+    )
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        service_factory=lambda _sheet: service,
+    )
+    monkeypatch.setattr(
+        views,
+        "load_pr3_config",
+        AsyncMock(return_value=({"MESSAGES_TAB": "MESSAGES"}, [])),
+    )
+    monkeypatch.setattr(views, "load_messages", AsyncMock(return_value={}))
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7, roles=[]),
+        response=SimpleNamespace(defer=AsyncMock()),
+        edit_original_response=AsyncMock(),
+    )
+    timezone_view = views.TimezoneSelectView(manager)
+    timezone_view.select._values = ["Europe/Vienna"]
+    asyncio.run(timezone_view._selected(interaction))
+    service.initialize.assert_awaited_once()
+    service.prepare_signup.assert_awaited_once_with("7", [], "Europe/Vienna")
+    sent = interaction.edit_original_response.await_args.kwargs
+    assert isinstance(sent["view"], views.AvailabilityView)
+    assert isinstance(sent["embed"], discord.Embed)
+
+
+def test_update_timezone_selector_preserves_saved_slot_ids(monkeypatch):
+    snapshot = _snapshot()
+    service = SimpleNamespace()
+    manager = SimpleNamespace()
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=7),
+        response=SimpleNamespace(defer=AsyncMock()),
+        edit_original_response=AsyncMock(),
+    )
+    timezone_view = views.TimezoneSelectView(
+        manager, service=service, snapshot=snapshot
+    )
+    timezone_view.select._values = ["Europe/Vienna"]
+    asyncio.run(timezone_view._selected(interaction))
+    flow = interaction.edit_original_response.await_args.kwargs["view"]
+    assert flow.updating is True
+    assert flow.selected == {"slot-0", "slot-2"}


### PR DESCRIPTION
### Why
The first live signup trial exposed two usability problems:
- players do not know what an IANA timezone is or what value to type;
- players do not realize the daily availability control supports selecting multiple windows.

### What changed
- Replace the normal free-text timezone-first path with a human-readable region selector that maps to the existing IANA timezone values internally.
- Keep an **Other / My timezone isn't listed** fallback with clearer city-based examples.
- Reuse the same selector when updating availability, with the saved timezone reflected.
- Make the availability copy explicitly say to select all workable windows, that multiple choices are allowed, and that at least 3 windows across 2 days are required.
- Make the running count show progress against those minimums.
- Improve timezone/preflight logging so expected validation/config rejections include an actionable reason while unexpected failures retain exception logging.
- Preserve existing registration, persistence, audit, role, DST/localization, and Sheet contracts.

### Scope
- No Google Sheets changes.
- No tournament logic changes.
- No qualification/matchmaking/PR6 work.
- IANA timezone values remain the stored source of truth.

### Tests
- Added focused coverage for friendly timezone mappings, Other fallback, saved-timezone defaults, player-friendly manual-entry errors, multi-select guidance, minimum-count copy, existing preflight delegation, and update-flow saved slot preservation.