### PR TITLE
Fix Live Arena organizer interaction timeouts

### DIFF
--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -175,6 +175,27 @@ async def role_parity(guild, config, participants, tournament_id):
     }
 
 
+def _response_is_done(interaction) -> bool:
+    is_done = getattr(interaction.response, "is_done", None)
+    return bool(is_done()) if callable(is_done) else False
+
+
+async def _defer_ephemeral(interaction) -> None:
+    defer = getattr(interaction.response, "defer", None)
+    if callable(defer):
+        await defer(ephemeral=True)
+
+
+async def _send_ephemeral(interaction, *, embed, view=None) -> None:
+    kwargs = {"embed": embed, "ephemeral": True}
+    if view is not None:
+        kwargs["view"] = view
+    if _response_is_done(interaction):
+        await interaction.followup.send(**kwargs)
+    else:
+        await interaction.response.send_message(**kwargs)
+
+
 class OrganizerView(discord.ui.View):
     def __init__(self, manager, status=None):
         super().__init__(timeout=None)
@@ -221,44 +242,67 @@ class OrganizerView(discord.ui.View):
             for r in getattr(interaction.user, "roles", [])
         )
         if not allowed:
-            await interaction.response.send_message(
+            await _send_ephemeral(
+                interaction,
                 embed=error_embed(
                     "You need the configured organizer role to use this control."
                 ),
-                ephemeral=True,
             )
         return allowed
 
     async def transition(self, interaction, action):
-        if not await self.authorized(interaction):
-            return
         if action == "close":
-            _, tournament, _, counts, _ = await self.manager.data(interaction.guild)
-            odd = counts["confirmed"] % 2
-            warning = (
-                " The active confirmed roster is odd. Close is still allowed; no player will be auto-demoted, but qualification/pairing must not begin until it is even."
-                if odd
-                else ""
-            )
-            await interaction.response.send_message(
-                embed=discord.Embed(
+            await _defer_ephemeral(interaction)
+            if not await self.authorized(interaction):
+                return
+            try:
+                _, tournament, _, counts, _ = await self.manager.data(interaction.guild)
+                odd = counts["confirmed"] % 2
+                warning = (
+                    " The active confirmed roster is odd. Close is still allowed; no player will be auto-demoted, but qualification/pairing must not begin until it is even."
+                    if odd
+                    else ""
+                )
+                embed = discord.Embed(
                     title="Confirm close registration",
                     description=f"Close registration with **{counts['confirmed']}** confirmed players?{warning}",
                     color=colors.c1c_blue,
-                ),
+                )
+            except Exception as exc:
+                log.exception(
+                    "❌ Live Arena organizer close preflight failed • user=%s",
+                    interaction.user.id,
+                )
+                await _send_ephemeral(interaction, embed=error_embed(exc))
+                return
+            await _send_ephemeral(
+                interaction,
+                embed=embed,
                 view=ConfirmTransition(self.manager, "close"),
-                ephemeral=True,
             )
+            return
+        if not await self.authorized(interaction):
             return
         await interaction.response.defer(ephemeral=True)
         await execute_transition(interaction, self.manager, action)
 
     async def roster(self, interaction, _action):
+        await _defer_ephemeral(interaction)
         if not await self.authorized(interaction):
             return
-        embed = await roster_embed(self.manager, interaction.guild)
-        await interaction.response.send_message(
-            embed=embed, view=RosterActions(self.manager), ephemeral=True
+        try:
+            embed = await roster_embed(self.manager, interaction.guild)
+        except Exception as exc:
+            log.exception(
+                "❌ Live Arena organizer roster load failed • user=%s",
+                interaction.user.id,
+            )
+            await _send_ephemeral(interaction, embed=error_embed(exc))
+            return
+        await _send_ephemeral(
+            interaction,
+            embed=embed,
+            view=RosterActions(self.manager),
         )
 
     async def reconcile_prompt(self, interaction, _action):

--- a/tests/community/test_live_arena_organizer_interactions.py
+++ b/tests/community/test_live_arena_organizer_interactions.py
@@ -1,0 +1,148 @@
+"""Regression coverage for Live Arena organizer interaction acknowledgement."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import discord
+
+from modules.community.live_arena import organizer_panel
+from modules.community.live_arena.organizer_panel import (
+    ConfirmTransition,
+    OrganizerView,
+    RosterActions,
+)
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+class _Response:
+    def __init__(self, events):
+        self.events = events
+        self._done = False
+        self.send_message = AsyncMock()
+
+    async def defer(self, *, ephemeral=False):
+        self.events.append("defer")
+        self._done = True
+        assert ephemeral is True
+
+    def is_done(self):
+        return self._done
+
+
+def _interaction(events, *, roles=()):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=7, roles=list(roles)),
+        guild=SimpleNamespace(),
+        response=_Response(events),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def test_view_roster_defers_before_loading_and_uses_followup():
+    events = []
+    manager = SimpleNamespace(sheet_id="sheet")
+    interaction = _interaction(events)
+    embed = discord.Embed(title="Roster")
+
+    async def render(_manager, _guild):
+        assert events == ["defer"]
+        events.append("roster")
+        return embed
+
+    with (
+        patch.object(OrganizerView, "authorized", AsyncMock(return_value=True)),
+        patch.object(organizer_panel, "roster_embed", AsyncMock(side_effect=render)),
+    ):
+        run(OrganizerView(manager).roster(interaction, "roster"))
+
+    assert events == ["defer", "roster"]
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert kwargs["embed"] is embed
+    assert isinstance(kwargs["view"], RosterActions)
+    assert kwargs["ephemeral"] is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+def test_close_registration_defers_before_roster_preflight_and_uses_followup():
+    events = []
+
+    async def data(_guild):
+        assert events == ["defer"]
+        events.append("data")
+        return (
+            {},
+            SimpleNamespace(tournament_name="Trial Cup"),
+            [],
+            {"confirmed": 5},
+            {},
+        )
+
+    manager = SimpleNamespace(sheet_id="sheet", data=AsyncMock(side_effect=data))
+    interaction = _interaction(events)
+
+    with patch.object(OrganizerView, "authorized", AsyncMock(return_value=True)):
+        run(OrganizerView(manager, "signup_open").transition(interaction, "close"))
+
+    assert events == ["defer", "data"]
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert isinstance(kwargs["embed"], discord.Embed)
+    assert "odd" in kwargs["embed"].description.lower()
+    assert isinstance(kwargs["view"], ConfirmTransition)
+    assert kwargs["ephemeral"] is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+def test_deferred_authorization_denial_uses_followup_without_loading_roster():
+    events = []
+    manager = SimpleNamespace(sheet_id="sheet")
+    interaction = _interaction(events, roles=[SimpleNamespace(id=4)])
+
+    with (
+        patch.object(
+            organizer_panel,
+            "load_pr5_config",
+            AsyncMock(return_value=({"ORGANIZER_ROLE_ID": "5"}, [])),
+        ),
+        patch.object(organizer_panel, "roster_embed", AsyncMock()) as render,
+    ):
+        run(OrganizerView(manager).roster(interaction, "roster"))
+
+    assert events == ["defer"]
+    render.assert_not_awaited()
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert "organizer role" in kwargs["embed"].description.lower()
+    assert kwargs["ephemeral"] is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+def test_roster_load_failure_after_defer_is_logged_and_reported(caplog):
+    events = []
+    manager = SimpleNamespace(sheet_id="sheet")
+    interaction = _interaction(events)
+
+    with (
+        patch.object(OrganizerView, "authorized", AsyncMock(return_value=True)),
+        patch.object(
+            organizer_panel,
+            "roster_embed",
+            AsyncMock(side_effect=RuntimeError("sheet timeout")),
+        ),
+        caplog.at_level(
+            logging.ERROR,
+            logger="c1c.community.live_arena.organizer_panel",
+        ),
+    ):
+        run(OrganizerView(manager).roster(interaction, "roster"))
+
+    assert events == ["defer"]
+    assert "organizer roster load failed" in caplog.text
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert "sheet timeout" in kwargs["embed"].description
+    assert kwargs["ephemeral"] is True


### PR DESCRIPTION
### Why
The live tournament trial exposed a Discord interaction timeout in **View Roster**. The callback performed authorization plus multiple Sheet/repository reads before acknowledging the button interaction, so Discord could expire the interaction and show `C1C Woadkeeper didn't respond in time`. **Close Registration** had the same structural risk because it also loaded roster data before responding.

### What changed
- Acknowledge **View Roster** immediately with an ephemeral defer before authorization and roster loading.
- Acknowledge **Close Registration** immediately before authorization and close-preflight roster reads.
- After a defer, send authorization denials, roster results, close confirmation, and preflight errors through the interaction follow-up path.
- Preserve the existing direct-response path for controls that have not already been acknowledged.
- Catch and log roster-load and close-preflight failures with the organizer/user context instead of allowing them to bubble to discord.py's generic `Ignoring exception in view` handler.

### Scope
- No Google Sheets changes.
- No tournament state/rules changes.
- No matchmaking/qualification/PR6 work.
- No changes to Remove/Restore/Reconcile behavior.

### Tests
Added focused regression coverage proving:
- View Roster defers before roster I/O and then uses a follow-up.
- Close Registration defers before roster preflight and then uses a follow-up.
- Authorization denial still works after the interaction has been deferred.
- Roster load failures are logged and returned to the organizer instead of escaping the view callback.