### PR TITLE
fix(live-arena): polish repeat signup and organizer panel refresh

### DIFF
--- a/modules/community/live_arena/entry_views.py
+++ b/modules/community/live_arena/entry_views.py
@@ -1,0 +1,147 @@
+"""Persistent player entry controls for Live Arena registration."""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from shared.theme import colors
+
+from modules.community.live_arena.registration import RegistrationService
+from modules.community.live_arena.views import (
+    RegistrationActionsView,
+    TimezoneSelectView,
+    _player_error,
+    error_embed,
+    registration_embed,
+    timezone_prompt_embed,
+)
+
+log = logging.getLogger("c1c.community.live_arena.entry_views")
+
+
+async def _send_my_registration(manager, interaction: discord.Interaction) -> None:
+    service = (manager.service_factory or RegistrationService)(manager.sheet_id)
+    try:
+        await service.initialize()
+        snapshot = await service.get_registration(str(interaction.user.id))
+        if snapshot.participant is None:
+            await interaction.followup.send(
+                embed=error_embed(
+                    "You are not currently registered. Use **Join Tournament** to register."
+                ),
+                ephemeral=True,
+            )
+            return
+        await interaction.followup.send(
+            embed=registration_embed(snapshot),
+            view=RegistrationActionsView(manager, service, snapshot),
+            ephemeral=True,
+        )
+    except Exception as exc:
+        log.exception(
+            "❌ Live Arena self-service — load failed • user=%s",
+            interaction.user.id,
+        )
+        await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+
+
+class MyRegistrationShortcutView(discord.ui.View):
+    """Transient shortcut shown when a confirmed player presses Join again."""
+
+    def __init__(self, manager):
+        super().__init__(timeout=900)
+        self.manager = manager
+
+    @discord.ui.button(label="My Registration", style=discord.ButtonStyle.secondary)
+    async def my_registration(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await _send_my_registration(self.manager, interaction)
+
+
+class RegistrationEntryView(discord.ui.View):
+    """Persistent public registration controls with status-aware Join routing."""
+
+    def __init__(self, manager):
+        super().__init__(timeout=None)
+        self.manager = manager
+
+    @discord.ui.button(
+        label="Join Tournament",
+        custom_id="live_arena:join",
+        style=discord.ButtonStyle.primary,
+    )
+    async def join(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        service = (self.manager.service_factory or RegistrationService)(
+            self.manager.sheet_id
+        )
+        try:
+            await service.initialize()
+            snapshot = await service.get_registration(str(interaction.user.id))
+        except Exception as exc:
+            log.exception(
+                "❌ Live Arena signup — registration preflight failed • user=%s",
+                interaction.user.id,
+            )
+            await interaction.followup.send(embed=_player_error(exc), ephemeral=True)
+            return
+
+        if snapshot.status == "confirmed":
+            tournament_name = snapshot.tournament["tournament_name"]
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="Already registered",
+                    description=(
+                        f"You're already registered for **{tournament_name}**. "
+                        "Use **My Registration** to view or update your availability."
+                    ),
+                    color=colors.c1c_blue,
+                ),
+                view=MyRegistrationShortcutView(self.manager),
+                ephemeral=True,
+            )
+            return
+
+        if snapshot.status in {"removed", "disqualified"}:
+            await interaction.followup.send(
+                embed=error_embed(
+                    f"Your registration is currently **{snapshot.status}** and cannot "
+                    "be restored through player self-service. Please contact a "
+                    "tournament organizer."
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if snapshot.status and snapshot.status != "withdrawn":
+            await interaction.followup.send(
+                embed=error_embed(
+                    f"Your registration has unsupported status **{snapshot.status}**. "
+                    "Please contact a tournament organizer."
+                ),
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            embed=timezone_prompt_embed(),
+            view=TimezoneSelectView(self.manager),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="My Registration",
+        custom_id="live_arena:my_registration",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def my_registration(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await _send_my_registration(self.manager, interaction)

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -84,13 +84,11 @@ class LiveArenaPanelManager:
                 except Exception:
                     log.exception("❌ Live Arena panel — fetch failed")
                     return PanelSyncResult(False, "fetch")
-            from modules.community.live_arena.views import (
-                ClosedTournamentView,
-                JoinTournamentView,
-            )
+            from modules.community.live_arena.entry_views import RegistrationEntryView
+            from modules.community.live_arena.views import ClosedTournamentView
 
             view = (
-                JoinTournamentView(self)
+                RegistrationEntryView(self)
                 if key == "signup_open"
                 else ClosedTournamentView(self)
             )
@@ -141,17 +139,18 @@ async def register_live_arena(bot):
     manager = _managers.setdefault(
         (id(bot), sheet_id), LiveArenaPanelManager(bot, sheet_id)
     )
+    from modules.community.live_arena.entry_views import RegistrationEntryView
     from modules.community.live_arena.organizer_panel import OrganizerPanelManager
-    from modules.community.live_arena.views import (
-        ClosedTournamentView,
-        JoinTournamentView,
-    )
+    from modules.community.live_arena.views import ClosedTournamentView
 
-    bot.add_view(JoinTournamentView(manager))
-    bot.add_view(ClosedTournamentView(manager))
     organizer = OrganizerPanelManager(bot, sheet_id, manager)
+    # Wire player-side mutation hooks before any startup sync. If an initial
+    # organizer-panel sync fails, later signups/withdrawals must still be able
+    # to refresh the organizer panel using this manager.
+    manager.organizer_manager = organizer
+    bot.add_view(RegistrationEntryView(manager))
+    bot.add_view(ClosedTournamentView(manager))
     bot.add_view(organizer.view())
     await manager.sync()
     await organizer.sync()
-    manager.organizer_manager = organizer
     return manager

--- a/tests/community/test_live_arena_registration_polish.py
+++ b/tests/community/test_live_arena_registration_polish.py
@@ -1,0 +1,169 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from modules.community.live_arena import organizer_panel, panel
+from modules.community.live_arena.entry_views import (
+    MyRegistrationShortcutView,
+    RegistrationEntryView,
+)
+from modules.community.live_arena.views import TimezoneSelectView
+
+
+def _snapshot(status="", *, participant=None):
+    return SimpleNamespace(
+        participant=participant,
+        status=status,
+        tournament={"tournament_name": "C1C Live Arena Trial Cup"},
+        timezone="Europe/Vienna",
+        localized_slots=(),
+        selected_slot_ids=(),
+        tournament_status="signup_open",
+        can_update=status == "confirmed",
+        can_withdraw=status == "confirmed",
+    )
+
+
+def _manager(snapshot):
+    service = SimpleNamespace(
+        initialize=AsyncMock(),
+        get_registration=AsyncMock(return_value=snapshot),
+    )
+    manager = SimpleNamespace(
+        sheet_id="sheet",
+        service_factory=lambda _sheet: service,
+    )
+    return manager, service
+
+
+def _interaction():
+    return SimpleNamespace(
+        user=SimpleNamespace(id=77),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def _button(view, custom_id):
+    return next(child for child in view.children if child.custom_id == custom_id)
+
+
+def test_registration_entry_keeps_persistent_public_custom_ids():
+    manager, _ = _manager(_snapshot())
+    view = RegistrationEntryView(manager)
+    assert view.timeout is None
+    assert [child.custom_id for child in view.children] == [
+        "live_arena:join",
+        "live_arena:my_registration",
+    ]
+
+
+def test_confirmed_join_exits_before_timezone_and_routes_to_my_registration():
+    manager, service = _manager(_snapshot("confirmed", participant={"status": "confirmed"}))
+    interaction = _interaction()
+    view = RegistrationEntryView(manager)
+
+    asyncio.run(_button(view, "live_arena:join").callback(interaction))
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    service.initialize.assert_awaited_once()
+    service.get_registration.assert_awaited_once_with("77")
+    sent = interaction.followup.send.await_args.kwargs
+    assert sent["embed"].title == "Already registered"
+    assert "My Registration" in sent["embed"].description
+    assert isinstance(sent["view"], MyRegistrationShortcutView)
+    assert not isinstance(sent["view"], TimezoneSelectView)
+
+
+@pytest.mark.parametrize(
+    ("status", "participant"),
+    [
+        ("", None),
+        ("withdrawn", {"status": "withdrawn"}),
+    ],
+)
+def test_join_still_allows_new_or_withdrawn_player_to_choose_timezone(
+    status, participant
+):
+    manager, _ = _manager(_snapshot(status, participant=participant))
+    interaction = _interaction()
+    view = RegistrationEntryView(manager)
+
+    asyncio.run(_button(view, "live_arena:join").callback(interaction))
+
+    sent = interaction.followup.send.await_args.kwargs
+    assert isinstance(sent["view"], TimezoneSelectView)
+    assert sent["embed"].title == "Choose your timezone"
+
+
+@pytest.mark.parametrize("status", ["removed", "disqualified"])
+def test_join_blocks_removed_or_disqualified_without_timezone_flow(status):
+    manager, _ = _manager(_snapshot(status, participant={"status": status}))
+    interaction = _interaction()
+    view = RegistrationEntryView(manager)
+
+    asyncio.run(_button(view, "live_arena:join").callback(interaction))
+
+    sent = interaction.followup.send.await_args.kwargs
+    assert status in sent["embed"].description
+    assert "view" not in sent
+
+
+def test_already_registered_shortcut_opens_saved_registration():
+    manager, service = _manager(_snapshot("confirmed", participant={"status": "confirmed"}))
+    interaction = _interaction()
+    view = MyRegistrationShortcutView(manager)
+
+    asyncio.run(view.children[0].callback(interaction))
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    service.get_registration.assert_awaited_once_with("77")
+    sent = interaction.followup.send.await_args.kwargs
+    assert sent["embed"].title == "My Live Arena registration"
+    assert sent["ephemeral"] is True
+
+
+def test_register_live_arena_wires_organizer_before_startup_sync_failure(monkeypatch):
+    monkeypatch.setattr(panel, "_managers", {})
+    monkeypatch.setattr(
+        panel,
+        "cfg",
+        SimpleNamespace(get=lambda _key, _default=None: "sheet"),
+    )
+
+    class PublicManager:
+        def __init__(self, bot, sheet_id):
+            self.bot = bot
+            self.sheet_id = sheet_id
+            self.service_factory = None
+            self.sync = AsyncMock(return_value=panel.PanelSyncResult(True))
+
+    created = []
+
+    class OrganizerManager:
+        def __init__(self, bot, sheet_id, public_manager):
+            self.bot = bot
+            self.sheet_id = sheet_id
+            self.public_manager = public_manager
+            self.sync = AsyncMock(side_effect=RuntimeError("startup organizer sync failed"))
+            created.append(self)
+
+        def view(self):
+            return SimpleNamespace()
+
+    monkeypatch.setattr(panel, "LiveArenaPanelManager", PublicManager)
+    monkeypatch.setattr(organizer_panel, "OrganizerPanelManager", OrganizerManager)
+
+    registered_views = []
+    bot = SimpleNamespace(add_view=registered_views.append)
+
+    with pytest.raises(RuntimeError, match="startup organizer sync failed"):
+        asyncio.run(panel.register_live_arena(bot))
+
+    public_manager = next(iter(panel._managers.values()))
+    assert public_manager.organizer_manager is created[0]
+    public_manager.sync.assert_awaited_once()
+    created[0].sync.assert_awaited_once()
+    assert len(registered_views) == 3


### PR DESCRIPTION
### Why
Two registration polish issues showed up in live testing after PR5:

1. A player who is already confirmed can press **Join Tournament**, gets an `already registered` rejection only after entering the timezone flow, and is then left at a dead-end selector instead of being routed to their saved registration.
2. The Captains Table organizer panel can remain stale while **View Roster** shows current Sheet data. The public manager's organizer refresh hook was wired only after startup panel syncs completed, so a startup organizer-sync exception could leave the persistent organizer controls alive but player signup/withdrawal refresh hooks disconnected.

### Changes
- Add a status-aware persistent registration entry view using the existing `live_arena:join` and `live_arena:my_registration` custom IDs.
- Confirmed players pressing Join now receive an **Already registered** embed with a direct **My Registration** shortcut. No timezone/availability wizard is started.
- New players and withdrawn players still enter the normal timezone/signup flow.
- Removed/disqualified players remain blocked from self-restoring.
- Wire `manager.organizer_manager` before startup panel synchronization so later signup/re-registration/withdrawal hooks retain the organizer refresh manager even if initial organizer-panel sync fails.
- Add focused regressions for repeat Join routing, withdrawn/new routing, removed/disqualified blocking, shortcut behavior, persistent custom IDs, and organizer-manager startup wiring.

### Scope
- No Google Sheets changes.
- No CONFIG or MESSAGES changes.
- No qualification/round/matchmaking work.
- Existing registration domain rules remain unchanged.