### PR TITLE
test(fusion): keep traditional progress denominator fixture deterministic

### DIFF
--- a/tests/community/conftest.py
+++ b/tests/community/conftest.py
@@ -1,0 +1,36 @@
+import datetime as dt
+
+import pytest
+
+from modules.community.fusion import progress_share
+
+
+class _FrozenTraditionalProgressDateTime(dt.datetime):
+    """Stable clock for the one historical traditional-fusion denominator fixture."""
+
+    @classmethod
+    def now(cls, tz=None):
+        fixed = cls(2026, 8, 8, 12, 0, tzinfo=dt.timezone.utc)
+        if tz is None:
+            return fixed.replace(tzinfo=None)
+        return fixed.astimezone(tz)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_traditional_denominator_test_clock(request, monkeypatch):
+    """Keep fixed 8-9 Aug event fixtures from aging into `missed` status.
+
+    This applies only to the denominator/source-count regression. Other Fusion tests
+    continue to use their normal real or explicitly supplied clocks.
+    """
+    if (
+        request.node.name
+        != "test_traditional_my_progress_uses_required_rare_denominator_not_source_count"
+    ):
+        return
+
+    monkeypatch.setattr(
+        progress_share.dt,
+        "datetime",
+        _FrozenTraditionalProgressDateTime,
+    )


### PR DESCRIPTION
### Why
`test_traditional_my_progress_uses_required_rare_denominator_not_source_count` uses fixed 8–9 August 2026 event fixtures while the progress renderer evaluates missed/not-started state against the real current UTC clock. Once those fixture dates passed, the test began reporting the 12 untouched rare events as `Missed` even though the denominator/source-count behavior under test is unchanged.

### Change
- Test-only change.
- Add a narrowly scoped autouse fixture that freezes the `progress_share` clock only for this exact historical denominator regression.
- The fixture clock sits inside the event window, so untouched events remain `Not Started` and the test continues measuring `16 required rares` vs `17 rare sources available` rather than calendar passage.
- All other Fusion tests keep their existing real or explicitly supplied clocks.

### Scope
- No Fusion production code changes.
- No scheduler/runtime behavior changes.
- No Google Sheets changes.
- No Live Arena changes.