### PR TITLE
feat(live-arena): add qualification round 1 draw and publication

### DIFF
--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -141,6 +141,9 @@ async def register_live_arena(bot):
     )
     from modules.community.live_arena.entry_views import RegistrationEntryView
     from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+    from modules.community.live_arena.qualification_lock import (
+        install_qualification_roster_lock,
+    )
     from modules.community.live_arena.qualification_panel import (
         install_qualification,
         reconcile_qualification_publication,
@@ -151,6 +154,7 @@ async def register_live_arena(bot):
     organizer = OrganizerPanelManager(bot, sheet_id, manager)
     qualification_installed = install_qualification(organizer)
     if qualification_installed:
+        install_qualification_roster_lock(organizer)
         try:
             await refresh_qualification_state(organizer)
         except Exception:

--- a/modules/community/live_arena/panel.py
+++ b/modules/community/live_arena/panel.py
@@ -141,9 +141,23 @@ async def register_live_arena(bot):
     )
     from modules.community.live_arena.entry_views import RegistrationEntryView
     from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+    from modules.community.live_arena.qualification_panel import (
+        install_qualification,
+        reconcile_qualification_publication,
+        refresh_qualification_state,
+    )
     from modules.community.live_arena.views import ClosedTournamentView
 
     organizer = OrganizerPanelManager(bot, sheet_id, manager)
+    qualification_installed = install_qualification(organizer)
+    if qualification_installed:
+        try:
+            await refresh_qualification_state(organizer)
+        except Exception:
+            # Registration remains independently usable if qualification routing is
+            # temporarily unavailable. The organizer action itself will surface the
+            # exact workbook/config error when used.
+            log.exception("⚠️ Live Arena Q1 startup state refresh failed")
     # Wire player-side mutation hooks before any startup sync. If an initial
     # organizer-panel sync fails, later signups/withdrawals must still be able
     # to refresh the organizer panel using this manager.
@@ -153,4 +167,14 @@ async def register_live_arena(bot):
     bot.add_view(organizer.view())
     await manager.sync()
     await organizer.sync()
+    if qualification_installed:
+        try:
+            warnings = await reconcile_qualification_publication(organizer)
+            if warnings:
+                log.warning(
+                    "⚠️ Live Arena Q1 startup publication retry incomplete • %s",
+                    ", ".join(warnings),
+                )
+        except Exception:
+            log.exception("⚠️ Live Arena Q1 startup publication retry failed")
     return manager

--- a/modules/community/live_arena/qualification.py
+++ b/modules/community/live_arena/qualification.py
@@ -1,0 +1,795 @@
+"""Qualification-round draw, persistence, and publication state for Live Arena."""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from functools import lru_cache
+from uuid import uuid4
+
+from shared.sheets.async_core import acall_with_backoff, afetch_values, aget_worksheet
+
+from modules.community.live_arena.organizer import OrganizerService
+from modules.community.live_arena.registration import RegistrationError, _locks, utc_iso
+from modules.community.live_arena.repository import LiveArenaRepository
+from modules.community.live_arena.service import (
+    CONFIG_HEADERS,
+    CONFIG_TAB,
+    LiveArenaConfigError,
+    _enabled,
+    _rows,
+    _text,
+    load_config,
+)
+
+log = logging.getLogger("c1c.community.live_arena.qualification")
+
+QUALIFICATION_CONFIG_KEYS = (
+    "ROUNDS_TAB",
+    "MATCHES_TAB",
+    "MATCH_FORUM_CHANNEL_ID",
+    "ROUND_OVERVIEW_CHANNEL_ID",
+)
+ROUND_HEADERS = (
+    "tournament_id",
+    "round_id",
+    "round_name",
+    "round_stage",
+    "round_number",
+    "status",
+    "opens_at_utc",
+    "deadline_at_utc",
+    "published_at_utc",
+    "overview_message_id",
+    "completed_at_utc",
+    "generated_at_utc",
+    "generated_by_discord_user_id",
+    "approved_at_utc",
+    "approved_by_discord_user_id",
+    "notes",
+)
+MATCH_HEADERS = (
+    "tournament_id",
+    "round_id",
+    "match_id",
+    "match_number",
+    "player_a_discord_user_id",
+    "player_a_display_name",
+    "player_b_discord_user_id",
+    "player_b_display_name",
+    "status",
+    "shared_slot_ids_csv",
+    "has_scheduling_conflict",
+    "scheduling_conflict_notes",
+    "published_at_utc",
+    "deadline_at_utc",
+    "thread_id",
+    "reported_by_discord_user_id",
+    "reported_score_a",
+    "reported_score_b",
+    "reported_at_utc",
+    "confirm_due_at_utc",
+    "confirmed_by_discord_user_id",
+    "confirmed_at_utc",
+    "disputed_by_discord_user_id",
+    "disputed_at_utc",
+    "scheduling_problem_reported_by_discord_user_id",
+    "scheduling_problem_reported_at_utc",
+    "extension_count",
+    "final_result_type",
+    "final_score_a",
+    "final_score_b",
+    "final_winner_discord_user_id",
+    "finalized_by_discord_user_id",
+    "finalized_at_utc",
+    "notes",
+)
+
+
+@dataclass(frozen=True)
+class QualificationSnapshot:
+    round_row: dict[str, object] | None
+    matches: tuple[dict[str, object], ...]
+
+    @property
+    def status(self) -> str:
+        return _text(self.round_row.get("status")) if self.round_row else ""
+
+
+async def load_qualification_config(sheet_id: str) -> dict[str, str]:
+    """Load only the frozen qualification routing contract from CONFIG."""
+    matrix = await afetch_values(sheet_id, CONFIG_TAB) or []
+    rows = _rows(matrix, CONFIG_HEADERS, CONFIG_TAB)
+    result: dict[str, str] = {}
+    for key in QUALIFICATION_CONFIG_KEYS:
+        matches = [row for row in rows if _text(row["Key"]) == key]
+        if len(matches) != 1:
+            raise LiveArenaConfigError(f"CONFIG: key {key} must occur exactly once")
+        result[key] = _text(matches[0]["Value"])
+        if not result[key]:
+            raise LiveArenaConfigError(f"CONFIG: missing required key {key}")
+    try:
+        int(result["MATCH_FORUM_CHANNEL_ID"])
+        int(result["ROUND_OVERVIEW_CHANNEL_ID"])
+    except ValueError as exc:
+        raise LiveArenaConfigError(
+            "CONFIG: qualification Discord channel IDs must be numeric"
+        ) from exc
+    return result
+
+
+class QualificationRepository:
+    """Exact-schema workbook adapter for ROUNDS and MATCHES."""
+
+    def __init__(self, sheet_id: str) -> None:
+        self.sheet_id = sheet_id
+        self.config: dict[str, str] = {}
+
+    async def initialize(self) -> None:
+        self.config = await load_qualification_config(self.sheet_id)
+        await self.rounds()
+        await self.matches()
+
+    async def _read(self, key: str, headers: tuple[str, ...]):
+        tab = self.config[key]
+        return _rows(await afetch_values(self.sheet_id, tab) or [], headers, tab)
+
+    async def rounds(self) -> list[dict[str, object]]:
+        return await self._read("ROUNDS_TAB", ROUND_HEADERS)
+
+    async def matches(self) -> list[dict[str, object]]:
+        return await self._read("MATCHES_TAB", MATCH_HEADERS)
+
+    async def persist_state(
+        self,
+        rounds,
+        matches,
+        *,
+        previous_rounds,
+        previous_matches,
+    ) -> None:
+        await self._persist_tables(
+            (
+                ("ROUNDS_TAB", ROUND_HEADERS, rounds, previous_rounds),
+                ("MATCHES_TAB", MATCH_HEADERS, matches, previous_matches),
+            )
+        )
+
+    async def persist_rounds(self, rounds, *, previous_rounds) -> None:
+        await self._persist_tables(
+            (("ROUNDS_TAB", ROUND_HEADERS, rounds, previous_rounds),)
+        )
+
+    async def persist_matches(self, matches, *, previous_matches) -> None:
+        await self._persist_tables(
+            (("MATCHES_TAB", MATCH_HEADERS, matches, previous_matches),)
+        )
+
+    async def _persist_tables(self, tables) -> None:
+        first_key = tables[0][0]
+        worksheet = await aget_worksheet(self.sheet_id, self.config[first_key])
+        spreadsheet = worksheet.spreadsheet
+        update = self._batch_body(tables, use_previous=False)
+        rollback = self._batch_body(tables, use_previous=True)
+        try:
+            await acall_with_backoff(spreadsheet.values_batch_update, body=update)
+        except Exception as write_error:
+            try:
+                await acall_with_backoff(spreadsheet.values_batch_update, body=rollback)
+            except Exception as rollback_error:
+                raise QualificationPersistenceError(
+                    write_error=write_error, rollback_error=rollback_error
+                ) from rollback_error
+            raise
+
+    def _batch_body(self, tables, *, use_previous: bool):
+        data = []
+        for key, headers, current, previous in tables:
+            rows = previous if use_previous else current
+            row_count = max(len(current), len(previous), 1)
+            values = [
+                [str(row.get(header, "") or "") for header in headers] for row in rows
+            ]
+            values.extend([[""] * len(headers) for _ in range(row_count - len(values))])
+            tab = self.config[key].replace("'", "''")
+            data.append(
+                {
+                    "range": f"'{tab}'!A2:{_column(len(headers))}{row_count + 1}",
+                    "values": values,
+                }
+            )
+        return {"valueInputOption": "RAW", "data": data}
+
+
+def _column(number: int) -> str:
+    if number <= 0:
+        raise LiveArenaConfigError("Live Arena table width must be positive")
+    result = ""
+    while number:
+        number, remainder = divmod(number - 1, 26)
+        result = chr(65 + remainder) + result
+    return result
+
+
+@dataclass
+class QualificationPersistenceError(RuntimeError):
+    write_error: Exception
+    rollback_error: Exception
+
+    def __str__(self) -> str:
+        return (
+            "Live Arena qualification persistence and compensation both failed: "
+            f"write={self.write_error!r}; rollback={self.rollback_error!r}"
+        )
+
+
+class QualificationService:
+    def __init__(
+        self,
+        sheet_id: str,
+        registration_repository=None,
+        qualification_repository=None,
+        clock=None,
+        rng=None,
+    ) -> None:
+        self.sheet_id = sheet_id
+        self.registration_repository = registration_repository or LiveArenaRepository(sheet_id)
+        self.repository = qualification_repository or QualificationRepository(sheet_id)
+        self.clock = clock or (lambda: datetime.now(UTC))
+        self.rng = rng or random.SystemRandom()
+
+    async def initialize(self) -> None:
+        await self.registration_repository.initialize()
+        await self.repository.initialize()
+
+    async def context(self):
+        service = OrganizerService(
+            self.sheet_id,
+            repository=self.registration_repository,
+            clock=self.clock,
+        )
+        return await service.context()
+
+    async def snapshot(self) -> QualificationSnapshot:
+        config = await load_config(self.sheet_id)
+        tid = config["ACTIVE_TOURNAMENT_ID"]
+        rounds = await self.repository.rounds()
+        matches = await self.repository.matches()
+        round_row = _single_q1_round(rounds, tid)
+        round_id = f"{tid}-Q1"
+        qmatches = tuple(
+            dict(row)
+            for row in matches
+            if _text(row["tournament_id"]) == tid
+            and _text(row["round_id"]) == round_id
+        )
+        qmatches = tuple(sorted(qmatches, key=_match_sort_key))
+        return QualificationSnapshot(dict(round_row) if round_row else None, qmatches)
+
+    async def generate_draw(self, actor_id: str) -> QualificationSnapshot:
+        return await self._generate(actor_id, regenerate=False)
+
+    async def regenerate_draw(self, actor_id: str) -> QualificationSnapshot:
+        return await self._generate(actor_id, regenerate=True)
+
+    async def _generate(self, actor_id: str, *, regenerate: bool) -> QualificationSnapshot:
+        base = await load_config(self.sheet_id)
+        tid = base["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tid)]:
+            _, (_, tournament), _, slots = await self.context()
+            participants = await self.registration_repository.participants()
+            roster = _confirmed_roster(participants, tid)
+            _validate_draw_roster(tournament, roster)
+
+            old_rounds = await self.repository.rounds()
+            old_matches = await self.repository.matches()
+            existing = _single_q1_round(old_rounds, tid)
+            if regenerate:
+                if existing is None or _text(existing["status"]) != "proposed":
+                    raise RegistrationError(
+                        "Q1 can only be regenerated while its draw is proposed"
+                    )
+            elif existing is not None:
+                if _text(existing["status"]) in {"active", "completed"}:
+                    raise RegistrationError("Q1 has already started")
+                raise RegistrationError(
+                    "Q1 draw already exists; use Regenerate Draw instead"
+                )
+
+            availability = await self.registration_repository.availability()
+            pairings = self._optimal_pairings(roster, availability, slots, tid)
+            now = utc_iso(self.clock())
+            round_id = f"{tid}-Q1"
+            round_row = _blank(ROUND_HEADERS)
+            if existing is not None:
+                round_row.update(dict(existing))
+            round_row.update(
+                tournament_id=tid,
+                round_id=round_id,
+                round_name="Qualification Round 1",
+                round_stage="qualification",
+                round_number="1",
+                status="proposed",
+                opens_at_utc="",
+                deadline_at_utc="",
+                published_at_utc="",
+                overview_message_id="",
+                completed_at_utc="",
+                generated_at_utc=now,
+                generated_by_discord_user_id=str(actor_id),
+                approved_at_utc="",
+                approved_by_discord_user_id="",
+            )
+            new_rounds = [
+                dict(row)
+                for row in old_rounds
+                if not (
+                    _text(row["tournament_id"]) == tid
+                    and _text(row["round_id"]) == round_id
+                )
+            ]
+            new_rounds.append(round_row)
+            generated_matches = [
+                _match_row(tid, round_id, index, player_a, player_b, shared)
+                for index, (player_a, player_b, shared) in enumerate(pairings, 1)
+            ]
+            new_matches = [
+                dict(row)
+                for row in old_matches
+                if not (
+                    _text(row["tournament_id"]) == tid
+                    and _text(row["round_id"]) == round_id
+                )
+            ] + generated_matches
+            await self.repository.persist_state(
+                new_rounds,
+                new_matches,
+                previous_rounds=old_rounds,
+                previous_matches=old_matches,
+            )
+            await self._audit(
+                tid,
+                actor_id,
+                "q1_draw_regenerated" if regenerate else "q1_draw_generated",
+                {
+                    "match_count": len(generated_matches),
+                    "scheduling_conflicts": sum(
+                        _text(row["has_scheduling_conflict"]).lower() == "true"
+                        for row in generated_matches
+                    ),
+                },
+                now,
+            )
+            return QualificationSnapshot(round_row, tuple(generated_matches))
+
+    def _optimal_pairings(self, roster, availability, slots, tid):
+        enabled = {
+            _text(row["slot_id"])
+            for row in slots
+            if _enabled(row["enabled"])
+        }
+        rank = {
+            _text(row["slot_id"]): (
+                _safe_int(row.get("sort_order")),
+                _text(row["slot_id"]),
+            )
+            for row in slots
+            if _text(row["slot_id"]) in enabled
+        }
+        selected: dict[str, set[str]] = {
+            _text(player["discord_user_id"]): set() for player in roster
+        }
+        for row in availability:
+            if _text(row["tournament_id"]) != tid:
+                continue
+            uid = _text(row["discord_user_id"])
+            slot_id = _text(row["slot_id"])
+            if uid in selected and slot_id in enabled:
+                selected[uid].add(slot_id)
+
+        shared: dict[tuple[int, int], tuple[str, ...]] = {}
+        for i in range(len(roster)):
+            for j in range(i + 1, len(roster)):
+                ids = selected[_text(roster[i]["discord_user_id"])] & selected[
+                    _text(roster[j]["discord_user_id"])
+                ]
+                shared[(i, j)] = tuple(sorted(ids, key=lambda slot: rank[slot]))
+
+        @lru_cache(maxsize=None)
+        def best(mask: int) -> int:
+            if not mask:
+                return 0
+            low = mask & -mask
+            i = low.bit_length() - 1
+            remaining = mask ^ (1 << i)
+            score = len(roster) + 1
+            bits = remaining
+            while bits:
+                low_j = bits & -bits
+                j = low_j.bit_length() - 1
+                pair = (i, j) if i < j else (j, i)
+                conflict = 0 if shared[pair] else 1
+                score = min(score, conflict + best(remaining ^ (1 << j)))
+                bits ^= low_j
+            return score
+
+        def choose(mask: int):
+            if not mask:
+                return []
+            low = mask & -mask
+            i = low.bit_length() - 1
+            remaining = mask ^ (1 << i)
+            target = best(mask)
+            candidates = []
+            bits = remaining
+            while bits:
+                low_j = bits & -bits
+                j = low_j.bit_length() - 1
+                pair = (i, j) if i < j else (j, i)
+                conflict = 0 if shared[pair] else 1
+                if conflict + best(remaining ^ (1 << j)) == target:
+                    candidates.append(j)
+                bits ^= low_j
+            j = self.rng.choice(candidates)
+            pair = (i, j) if i < j else (j, i)
+            return [(roster[i], roster[j], shared[pair])] + choose(
+                remaining ^ (1 << j)
+            )
+
+        return choose((1 << len(roster)) - 1)
+
+    async def swap_players(
+        self, actor_id: str, first_user_id: str, second_user_id: str
+    ) -> QualificationSnapshot:
+        if str(first_user_id) == str(second_user_id):
+            raise RegistrationError("Choose two different players to swap")
+        base = await load_config(self.sheet_id)
+        tid = base["ACTIVE_TOURNAMENT_ID"]
+        round_id = f"{tid}-Q1"
+        async with _locks[(self.sheet_id, tid)]:
+            _, (_, tournament), _, slots = await self.context()
+            if _text(tournament["status"]) != "signup_closed":
+                raise RegistrationError("Q1 draw changes require closed registration")
+            rounds = await self.repository.rounds()
+            round_row = _single_q1_round(rounds, tid)
+            if round_row is None or _text(round_row["status"]) != "proposed":
+                raise RegistrationError("Players can only be swapped in a proposed Q1 draw")
+            old_matches = await self.repository.matches()
+            matches = [dict(row) for row in old_matches]
+            q_indices = [
+                index
+                for index, row in enumerate(matches)
+                if _text(row["tournament_id"]) == tid
+                and _text(row["round_id"]) == round_id
+            ]
+            first = _find_player_location(matches, q_indices, str(first_user_id))
+            second = _find_player_location(matches, q_indices, str(second_user_id))
+            if first is None or second is None:
+                raise RegistrationError(
+                    "Both selected players must belong to the proposed Q1 draw"
+                )
+            if first[0] == second[0]:
+                raise RegistrationError("Choose players from two different matches")
+            _swap_match_player(
+                matches[first[0]], first[1], matches[second[0]], second[1]
+            )
+
+            availability = await self.registration_repository.availability()
+            selected = _enabled_availability(availability, slots, tid)
+            rank = _slot_rank(slots)
+            for index in {first[0], second[0]}:
+                _refresh_match_availability(matches[index], selected, rank)
+
+            await self.repository.persist_matches(
+                matches, previous_matches=old_matches
+            )
+            now = utc_iso(self.clock())
+            await self._audit(
+                tid,
+                actor_id,
+                "q1_players_swapped",
+                {"player_1": str(first_user_id), "player_2": str(second_user_id)},
+                now,
+            )
+            qmatches = tuple(
+                sorted((matches[index] for index in q_indices), key=_match_sort_key)
+            )
+            return QualificationSnapshot(dict(round_row), qmatches)
+
+    async def approve_draw(self, actor_id: str) -> QualificationSnapshot:
+        base = await load_config(self.sheet_id)
+        tid = base["ACTIVE_TOURNAMENT_ID"]
+        round_id = f"{tid}-Q1"
+        async with _locks[(self.sheet_id, tid)]:
+            _, (_, tournament), _, _ = await self.context()
+            participants = await self.registration_repository.participants()
+            roster = _confirmed_roster(participants, tid)
+            _validate_draw_roster(tournament, roster)
+
+            old_rounds = await self.repository.rounds()
+            old_matches = await self.repository.matches()
+            round_row = _single_q1_round(old_rounds, tid)
+            if round_row is None or _text(round_row["status"]) != "proposed":
+                raise RegistrationError("Only a proposed Q1 draw can be approved")
+            qmatches = [
+                dict(row)
+                for row in old_matches
+                if _text(row["tournament_id"]) == tid
+                and _text(row["round_id"]) == round_id
+            ]
+            proposed_ids = [
+                _text(row[key])
+                for row in qmatches
+                for key in (
+                    "player_a_discord_user_id",
+                    "player_b_discord_user_id",
+                )
+            ]
+            roster_ids = {_text(row["discord_user_id"]) for row in roster}
+            if (
+                len(proposed_ids) != len(roster_ids)
+                or len(set(proposed_ids)) != len(proposed_ids)
+                or set(proposed_ids) != roster_ids
+            ):
+                raise RegistrationError(
+                    "The confirmed roster changed after this draw was generated. "
+                    "Regenerate Q1 before approving it."
+                )
+
+            now_dt = self.clock().astimezone(UTC)
+            now = utc_iso(now_dt)
+            deadline = utc_iso(now_dt + timedelta(days=6))
+            new_rounds = [dict(row) for row in old_rounds]
+            target = next(
+                row
+                for row in new_rounds
+                if _text(row["tournament_id"]) == tid
+                and _text(row["round_id"]) == round_id
+            )
+            target.update(
+                status="active",
+                opens_at_utc=now,
+                deadline_at_utc=deadline,
+                published_at_utc=now,
+                approved_at_utc=now,
+                approved_by_discord_user_id=str(actor_id),
+            )
+            new_matches = [dict(row) for row in old_matches]
+            for row in new_matches:
+                if (
+                    _text(row["tournament_id"]) == tid
+                    and _text(row["round_id"]) == round_id
+                ):
+                    row.update(
+                        status="published",
+                        published_at_utc=now,
+                        deadline_at_utc=deadline,
+                    )
+            await self.repository.persist_state(
+                new_rounds,
+                new_matches,
+                previous_rounds=old_rounds,
+                previous_matches=old_matches,
+            )
+            await self._audit(
+                tid,
+                actor_id,
+                "q1_draw_approved",
+                {"match_count": len(qmatches), "deadline_at_utc": deadline},
+                now,
+            )
+            published = tuple(
+                sorted(
+                    (
+                        row
+                        for row in new_matches
+                        if _text(row["tournament_id"]) == tid
+                        and _text(row["round_id"]) == round_id
+                    ),
+                    key=_match_sort_key,
+                )
+            )
+            return QualificationSnapshot(target, published)
+
+    async def record_thread_id(
+        self, match_id: str, thread_id: str
+    ) -> dict[str, object]:
+        base = await load_config(self.sheet_id)
+        tid = base["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tid)]:
+            old_matches = await self.repository.matches()
+            matches = [dict(row) for row in old_matches]
+            targets = [
+                row
+                for row in matches
+                if _text(row["tournament_id"]) == tid
+                and _text(row["match_id"]) == str(match_id)
+            ]
+            if len(targets) != 1:
+                raise RegistrationError("Published match could not be resolved")
+            targets[0]["thread_id"] = str(thread_id)
+            await self.repository.persist_matches(
+                matches, previous_matches=old_matches
+            )
+            return targets[0]
+
+    async def record_overview_message_id(
+        self, round_id: str, message_id: str
+    ) -> dict[str, object]:
+        base = await load_config(self.sheet_id)
+        tid = base["ACTIVE_TOURNAMENT_ID"]
+        async with _locks[(self.sheet_id, tid)]:
+            old_rounds = await self.repository.rounds()
+            rounds = [dict(row) for row in old_rounds]
+            targets = [
+                row
+                for row in rounds
+                if _text(row["tournament_id"]) == tid
+                and _text(row["round_id"]) == str(round_id)
+            ]
+            if len(targets) != 1:
+                raise RegistrationError("Published round could not be resolved")
+            targets[0]["overview_message_id"] = str(message_id)
+            await self.repository.persist_rounds(rounds, previous_rounds=old_rounds)
+            return targets[0]
+
+    async def _audit(self, tid, actor, event, details, now):
+        try:
+            await self.registration_repository.append_audit(
+                dict(
+                    event_id=str(uuid4()),
+                    tournament_id=tid,
+                    event_type=event,
+                    actor_discord_user_id=str(actor),
+                    target_discord_user_id="",
+                    details=json.dumps(details, sort_keys=True, separators=(",", ":")),
+                    created_at_utc=now,
+                )
+            )
+        except Exception:
+            log.exception(
+                "❌ Live Arena qualification audit append failed • tournament=%s • event=%s",
+                tid,
+                event,
+            )
+
+
+def _blank(headers):
+    return {header: "" for header in headers}
+
+
+def _single_q1_round(rounds, tid):
+    round_id = f"{tid}-Q1"
+    matches = [
+        row
+        for row in rounds
+        if _text(row["tournament_id"]) == tid
+        and _text(row["round_id"]) == round_id
+    ]
+    if len(matches) > 1:
+        raise LiveArenaConfigError(f"ROUNDS: duplicate round_id {round_id}")
+    return matches[0] if matches else None
+
+
+def _confirmed_roster(participants, tid):
+    return [
+        dict(row)
+        for row in participants
+        if _text(row["tournament_id"]) == tid and _text(row["status"]) == "confirmed"
+    ]
+
+
+def _validate_draw_roster(tournament, roster):
+    if _text(tournament["status"]) != "signup_closed":
+        raise RegistrationError("Q1 can only be generated after registration is closed")
+    minimum = int(_text(tournament["min_participants"]))
+    if len(roster) < minimum:
+        raise RegistrationError(
+            f"Q1 requires at least {minimum} confirmed participants; currently {len(roster)}"
+        )
+    if len(roster) % 2:
+        raise RegistrationError(
+            "Q1 requires an even confirmed roster. No bye or automatic removal will be created."
+        )
+
+
+def _safe_int(value) -> int:
+    try:
+        return int(_text(value))
+    except ValueError:
+        return 1_000_000
+
+
+def _slot_rank(slots):
+    return {
+        _text(row["slot_id"]): (
+            _safe_int(row.get("sort_order")),
+            _text(row["slot_id"]),
+        )
+        for row in slots
+        if _enabled(row["enabled"])
+    }
+
+
+def _enabled_availability(availability, slots, tid):
+    enabled = set(_slot_rank(slots))
+    selected: dict[str, set[str]] = {}
+    for row in availability:
+        if _text(row["tournament_id"]) != tid:
+            continue
+        slot_id = _text(row["slot_id"])
+        if slot_id in enabled:
+            selected.setdefault(_text(row["discord_user_id"]), set()).add(slot_id)
+    return selected
+
+
+def _shared_slots(player_a, player_b, selected, rank):
+    shared = selected.get(str(player_a), set()) & selected.get(str(player_b), set())
+    return tuple(sorted(shared, key=lambda slot: rank[slot]))
+
+
+def _match_row(tid, round_id, number, player_a, player_b, shared):
+    row = _blank(MATCH_HEADERS)
+    row.update(
+        tournament_id=tid,
+        round_id=round_id,
+        match_id=f"{round_id}-M{number:02d}",
+        match_number=str(number),
+        player_a_discord_user_id=_text(player_a["discord_user_id"]),
+        player_a_display_name=_text(player_a["display_name_at_signup"]),
+        player_b_discord_user_id=_text(player_b["discord_user_id"]),
+        player_b_display_name=_text(player_b["display_name_at_signup"]),
+        status="proposed",
+        shared_slot_ids_csv=",".join(shared),
+        has_scheduling_conflict="FALSE" if shared else "TRUE",
+        scheduling_conflict_notes=""
+        if shared
+        else "No shared enabled availability slot",
+        extension_count="0",
+    )
+    return row
+
+
+def _match_sort_key(row):
+    return (_safe_int(row.get("match_number")), _text(row.get("match_id")))
+
+
+def _find_player_location(matches, q_indices, user_id):
+    found = []
+    for index in q_indices:
+        row = matches[index]
+        if _text(row["player_a_discord_user_id"]) == user_id:
+            found.append((index, "a"))
+        if _text(row["player_b_discord_user_id"]) == user_id:
+            found.append((index, "b"))
+    if len(found) > 1:
+        raise LiveArenaConfigError(
+            f"MATCHES: player occurs more than once in Q1: {user_id}"
+        )
+    return found[0] if found else None
+
+
+def _swap_match_player(first, first_side, second, second_side):
+    first_id = f"player_{first_side}_discord_user_id"
+    first_name = f"player_{first_side}_display_name"
+    second_id = f"player_{second_side}_discord_user_id"
+    second_name = f"player_{second_side}_display_name"
+    first[first_id], second[second_id] = second[second_id], first[first_id]
+    first[first_name], second[second_name] = second[second_name], first[first_name]
+
+
+def _refresh_match_availability(match, selected, rank):
+    shared = _shared_slots(
+        _text(match["player_a_discord_user_id"]),
+        _text(match["player_b_discord_user_id"]),
+        selected,
+        rank,
+    )
+    match["shared_slot_ids_csv"] = ",".join(shared)
+    match["has_scheduling_conflict"] = "FALSE" if shared else "TRUE"
+    match["scheduling_conflict_notes"] = (
+        "" if shared else "No shared enabled availability slot"
+    )

--- a/modules/community/live_arena/qualification_lock.py
+++ b/modules/community/live_arena/qualification_lock.py
@@ -1,0 +1,118 @@
+"""Roster freeze guards once Live Arena Qualification Round 1 has started."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import discord
+
+from modules.community.live_arena import organizer_panel as organizer_panel_module
+from modules.community.live_arena.organizer import OrganizerService
+from modules.community.live_arena.qualification import (
+    QualificationRepository,
+    _single_q1_round,
+    load_qualification_config,
+)
+from modules.community.live_arena.registration import RegistrationError, RegistrationService
+from modules.community.live_arena.service import _text, load_config
+
+_LOCKED_Q1_STATUSES = {"active", "completed"}
+_LOCK_MESSAGE = "Qualification Round 1 has started; the tournament roster is locked."
+_ORIGINAL_ROSTER_ACTIONS = organizer_panel_module.RosterActions
+
+
+async def qualification_roster_locked(sheet_id: str) -> bool:
+    """Return whether the active tournament's Q1 has started and freezes its roster."""
+    base = await load_config(sheet_id)
+    repository = QualificationRepository(sheet_id)
+    repository.config = await load_qualification_config(sheet_id)
+    round_row = _single_q1_round(
+        await repository.rounds(), base["ACTIVE_TOURNAMENT_ID"]
+    )
+    return bool(
+        round_row and _text(round_row.get("status")) in _LOCKED_Q1_STATUSES
+    )
+
+
+class LockedRegistrationService(RegistrationService):
+    """Player registration service that respects the active qualification roster."""
+
+    async def get_registration(self, user_id: str):
+        snapshot = await super().get_registration(user_id)
+        if (
+            snapshot.can_withdraw
+            and snapshot.tournament_status == "signup_closed"
+            and await qualification_roster_locked(self.sheet_id)
+        ):
+            return replace(snapshot, can_withdraw=False)
+        return snapshot
+
+    async def withdraw(self, user_id: str, reason: str = "") -> None:
+        if await qualification_roster_locked(self.sheet_id):
+            raise RegistrationError(_LOCK_MESSAGE)
+        await super().withdraw(user_id, reason)
+
+
+class LockedOrganizerService(OrganizerService):
+    """Organizer mutations that cannot change a roster after Q1 publication."""
+
+    async def transition(self, action, actor_id):
+        if action == "reopen" and await qualification_roster_locked(self.sheet_id):
+            raise RegistrationError(_LOCK_MESSAGE)
+        return await super().transition(action, actor_id)
+
+    async def _participant_change(self, actor_id, target_id, *, restore, member=None):
+        if await qualification_roster_locked(self.sheet_id):
+            raise RegistrationError(_LOCK_MESSAGE)
+        return await super()._participant_change(
+            actor_id, target_id, restore=restore, member=member
+        )
+
+
+class LockedRosterActions(_ORIGINAL_ROSTER_ACTIONS):
+    """Keep roster inspection available while disabling remove/restore controls."""
+
+    def __init__(self, manager):
+        super().__init__(manager)
+        if _cached_roster_locked(manager):
+            for child in self.children:
+                if isinstance(child, discord.ui.UserSelect):
+                    child.disabled = True
+
+
+def install_qualification_roster_lock(manager) -> bool:
+    """Install UI and service guards without changing the established PR5 workflow."""
+    if getattr(manager, "_qualification_roster_lock_installed", False):
+        return True
+    if not getattr(manager, "_qualification_installed", False):
+        return False
+
+    base_view = manager.view
+
+    def view(status=None):
+        result = base_view(status)
+        if _cached_roster_locked(manager):
+            for child in result.children:
+                if getattr(child, "custom_id", None) == "live_arena:organizer:reopen":
+                    child.disabled = True
+        return result
+
+    manager.view = view
+    manager._qualification_roster_lock_installed = True
+
+    # Organizer callbacks resolve these symbols from organizer_panel at runtime.
+    # Replacing them here keeps the already-stable PR5 module untouched while
+    # ensuring stale buttons/confirmation views still hit a live Sheet guard.
+    organizer_panel_module.OrganizerService = LockedOrganizerService
+    organizer_panel_module.RosterActions = LockedRosterActions
+
+    # Player entry/self-service already supports a manager-scoped service factory.
+    # Production uses the default service, so route it through the locked subclass.
+    public_manager = getattr(manager, "public_manager", None)
+    if public_manager is not None and getattr(public_manager, "service_factory", None) is None:
+        public_manager.service_factory = LockedRegistrationService
+    return True
+
+
+def _cached_roster_locked(manager) -> bool:
+    return _text(getattr(manager, "_qualification_q1_status", "")) in _LOCKED_Q1_STATUSES

--- a/modules/community/live_arena/qualification_panel.py
+++ b/modules/community/live_arena/qualification_panel.py
@@ -1,0 +1,589 @@
+"""Organizer controls and Discord publication for Live Arena qualification round 1."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time, timedelta
+
+import discord
+
+from shared.theme import colors
+
+from modules.community.live_arena.organizer_panel import OrganizerView, _send_ephemeral
+from modules.community.live_arena.qualification import (
+    QualificationService,
+    QualificationSnapshot,
+)
+from modules.community.live_arena.registration import RegistrationError
+from modules.community.live_arena.service import _enabled, _text
+from modules.community.live_arena.views import error_embed
+
+log = logging.getLogger("c1c.community.live_arena.qualification_panel")
+
+
+def install_qualification(manager) -> bool:
+    """Add persistent Q1 controls to the real organizer manager without changing PR5."""
+    if getattr(manager, "_qualification_installed", False):
+        return True
+    if manager.__class__.__module__ != "modules.community.live_arena.organizer_panel":
+        return False
+    if manager.__class__.__name__ != "OrganizerPanelManager":
+        return False
+
+    base_view = manager.view
+    manager._qualification_q1_status = ""
+    manager._qualification_installed = True
+
+    def view(status=None):
+        result = base_view(status)
+        qstatus = getattr(manager, "_qualification_q1_status", "")
+        result.add_item(
+            QualificationButton(
+                manager,
+                "Generate Q1 Draw",
+                "generate",
+                discord.ButtonStyle.success,
+                disabled=status is not None
+                and not (status == "signup_closed" and not qstatus),
+            )
+        )
+        result.add_item(
+            QualificationButton(
+                manager,
+                "Approve Draw",
+                "approve",
+                discord.ButtonStyle.success,
+                disabled=status is not None
+                and not (status == "signup_closed" and qstatus == "proposed"),
+            )
+        )
+        result.add_item(
+            QualificationButton(
+                manager,
+                "Regenerate Draw",
+                "regenerate",
+                discord.ButtonStyle.secondary,
+                disabled=status is not None
+                and not (status == "signup_closed" and qstatus == "proposed"),
+            )
+        )
+        result.add_item(
+            QualificationButton(
+                manager,
+                "Swap Players",
+                "swap",
+                discord.ButtonStyle.secondary,
+                disabled=status is not None
+                and not (status == "signup_closed" and qstatus == "proposed"),
+            )
+        )
+        return result
+
+    manager.view = view
+    return True
+
+
+async def refresh_qualification_state(manager) -> QualificationSnapshot | None:
+    """Refresh the cached Q1 state used to disable organizer controls."""
+    if not getattr(manager, "_qualification_installed", False):
+        return None
+    service = _service(manager)
+    await service.initialize()
+    snapshot = await service.snapshot()
+    manager._qualification_q1_status = snapshot.status
+    return snapshot
+
+
+async def reconcile_qualification_publication(manager) -> list[str]:
+    """Best-effort startup retry for an already-approved Q1."""
+    snapshot = await refresh_qualification_state(manager)
+    if snapshot is None or snapshot.status != "active":
+        return []
+    service = _service(manager)
+    await service.initialize()
+    return await QualificationPublisher(manager.bot, service).reconcile()
+
+
+def _service(manager):
+    factory = getattr(manager, "qualification_service_factory", None)
+    if factory is not None:
+        return factory(manager.sheet_id)
+    return QualificationService(manager.sheet_id)
+
+
+class QualificationButton(discord.ui.Button):
+    def __init__(self, manager, label, action, style, *, disabled=False):
+        super().__init__(
+            label=label,
+            custom_id=f"live_arena:organizer:q1:{action}",
+            style=style,
+            disabled=disabled,
+        )
+        self.manager = manager
+        self.action = action
+
+    async def callback(self, interaction):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        if self.action == "approve":
+            await self._approve_prompt(interaction)
+            return
+        if self.action == "swap":
+            await self._swap_prompt(interaction)
+            return
+        await interaction.response.defer(ephemeral=True)
+        try:
+            service = _service(self.manager)
+            await service.initialize()
+            if self.action == "generate":
+                snapshot = await service.generate_draw(str(interaction.user.id))
+            else:
+                snapshot = await service.regenerate_draw(str(interaction.user.id))
+            self.manager._qualification_q1_status = snapshot.status
+            await _refresh_organizer_panel(self.manager)
+            await interaction.followup.send(
+                embed=proposal_embed(snapshot), ephemeral=True
+            )
+        except Exception as exc:
+            log.exception("❌ Live Arena Q1 %s failed", self.action)
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+
+    async def _approve_prompt(self, interaction):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            service = _service(self.manager)
+            await service.initialize()
+            snapshot = await service.snapshot()
+            if snapshot.status != "proposed":
+                raise RegistrationError("Only a proposed Q1 draw can be approved")
+            embed = proposal_embed(snapshot)
+            embed.title = "Approve Qualification Round 1?"
+            embed.description = (
+                (embed.description or "")
+                + "\n\nApproval publishes every matchup and starts the six-day round window."
+            )
+            await interaction.followup.send(
+                embed=embed,
+                view=ConfirmApproveDraw(self.manager),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            log.exception("❌ Live Arena Q1 approval preflight failed")
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+
+    async def _swap_prompt(self, interaction):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            service = _service(self.manager)
+            await service.initialize()
+            snapshot = await service.snapshot()
+            if snapshot.status != "proposed":
+                raise RegistrationError("Players can only be swapped in a proposed Q1 draw")
+            await interaction.followup.send(
+                embed=proposal_embed(snapshot),
+                view=SwapPlayersView(self.manager, snapshot),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            log.exception("❌ Live Arena Q1 swap preflight failed")
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+
+
+class ConfirmApproveDraw(discord.ui.View):
+    def __init__(self, manager):
+        super().__init__(timeout=300)
+        self.manager = manager
+
+    @discord.ui.button(label="Approve & Publish", style=discord.ButtonStyle.success)
+    async def confirm(self, interaction, _button):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        await interaction.response.defer(ephemeral=True)
+        try:
+            service = _service(self.manager)
+            await service.initialize()
+            snapshot = await service.approve_draw(str(interaction.user.id))
+            self.manager._qualification_q1_status = snapshot.status
+            warnings = await QualificationPublisher(
+                self.manager.bot, service
+            ).reconcile()
+            panel_warning = await _refresh_organizer_panel(self.manager)
+            if panel_warning:
+                warnings.append(panel_warning)
+            embed = discord.Embed(
+                title="Qualification Round 1 published",
+                description=(
+                    f"**{len(snapshot.matches)}** matchups are active. "
+                    "Players have six days maximum to complete the round."
+                ),
+                color=colors.c1c_blue,
+            )
+            if warnings:
+                embed.add_field(
+                    name="Publication warning",
+                    value=(
+                        "The Sheet state is saved, but these Discord items need a retry:\n"
+                        + "\n".join(f"• {item}" for item in warnings)
+                    )[:1024],
+                    inline=False,
+                )
+        except Exception as exc:
+            log.exception("❌ Live Arena Q1 approval failed")
+            embed = error_embed(exc)
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+class SwapPlayersView(discord.ui.View):
+    def __init__(self, manager, snapshot):
+        super().__init__(timeout=600)
+        self.manager = manager
+        seen = set()
+        options = []
+        for match in snapshot.matches:
+            for side in ("a", "b"):
+                user_id = _text(match[f"player_{side}_discord_user_id"])
+                if user_id in seen:
+                    continue
+                seen.add(user_id)
+                label = _text(match[f"player_{side}_display_name"]) or user_id
+                options.append(
+                    discord.SelectOption(label=label[:100], value=user_id)
+                )
+        self.add_item(SwapPlayersSelect(manager, options))
+
+
+class SwapPlayersSelect(discord.ui.Select):
+    def __init__(self, manager, options):
+        super().__init__(
+            placeholder="Choose two players from different matches",
+            min_values=2,
+            max_values=2,
+            options=options,
+        )
+        self.manager = manager
+
+    async def callback(self, interaction):
+        if not await OrganizerView(self.manager).authorized(interaction):
+            return
+        await interaction.response.defer(ephemeral=True)
+        try:
+            service = _service(self.manager)
+            await service.initialize()
+            snapshot = await service.swap_players(
+                str(interaction.user.id), self.values[0], self.values[1]
+            )
+            self.manager._qualification_q1_status = snapshot.status
+            await _refresh_organizer_panel(self.manager)
+            await interaction.followup.send(
+                embed=proposal_embed(snapshot), ephemeral=True
+            )
+        except Exception as exc:
+            log.exception("❌ Live Arena Q1 player swap failed")
+            await interaction.followup.send(embed=error_embed(exc), ephemeral=True)
+
+
+async def _refresh_organizer_panel(manager) -> str:
+    try:
+        result = await manager.sync()
+        if getattr(result, "ok", True) is False:
+            return "organizer panel"
+    except Exception:
+        log.exception("⚠️ Live Arena Q1 organizer panel refresh failed")
+        return "organizer panel"
+    return ""
+
+
+def proposal_embed(snapshot: QualificationSnapshot) -> discord.Embed:
+    if snapshot.round_row is None:
+        return discord.Embed(
+            title="Qualification Round 1",
+            description="No Q1 draw has been generated.",
+            color=colors.c1c_blue,
+        )
+    conflicts = sum(
+        _text(match["has_scheduling_conflict"]).lower() == "true"
+        for match in snapshot.matches
+    )
+    embed = discord.Embed(
+        title="Qualification Round 1 · Proposed Draw",
+        description=(
+            f"**{len(snapshot.matches)}** matches • "
+            f"**{conflicts}** scheduling conflict{'s' if conflicts != 1 else ''}."
+        ),
+        color=colors.c1c_blue,
+    )
+    for match in snapshot.matches:
+        shared = [
+            value for value in _text(match["shared_slot_ids_csv"]).split(",") if value
+        ]
+        conflict = _text(match["has_scheduling_conflict"]).lower() == "true"
+        availability = (
+            "⚠️ No shared availability"
+            if conflict
+            else f"Shared availability: **{len(shared)}** window{'s' if len(shared) != 1 else ''}"
+        )
+        embed.add_field(
+            name=f"Match {_text(match['match_number'])}",
+            value=(
+                f"**{_text(match['player_a_display_name'])}** vs "
+                f"**{_text(match['player_b_display_name'])}**\n{availability}"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+class QualificationPublisher:
+    def __init__(self, bot, service: QualificationService):
+        self.bot = bot
+        self.service = service
+
+    async def reconcile(self) -> list[str]:
+        """Create only missing Q1 Discord artifacts and refresh the existing overview."""
+        snapshot = await self.service.snapshot()
+        if snapshot.round_row is None or snapshot.status != "active":
+            return []
+        config = self.service.repository.config
+        _, (_, tournament), _, slots = await self.service.context()
+        warnings: list[str] = []
+        matches = [dict(row) for row in snapshot.matches]
+
+        try:
+            forum = await _resolve_channel(
+                self.bot, int(config["MATCH_FORUM_CHANNEL_ID"])
+            )
+        except Exception:
+            log.exception("❌ Live Arena Q1 forum channel resolution failed")
+            forum = None
+            warnings.append("duelling-decks forum")
+
+        if forum is not None:
+            for match in matches:
+                label = f"Match {_text(match['match_number'])} forum post"
+                try:
+                    existing = await _resolve_existing_thread(
+                        self.bot, _text(match["thread_id"])
+                    )
+                    if existing is not None:
+                        continue
+                    created = await forum.create_thread(
+                        name=_thread_name(match),
+                        content=(
+                            f"<@{_text(match['player_a_discord_user_id'])}> "
+                            f"<@{_text(match['player_b_discord_user_id'])}>"
+                        ),
+                        embed=match_embed(tournament, snapshot.round_row, match, slots),
+                        allowed_mentions=discord.AllowedMentions(
+                            users=True, roles=False, everyone=False
+                        ),
+                    )
+                    thread = getattr(created, "thread", None)
+                    if thread is None and isinstance(created, tuple):
+                        thread = created[0]
+                    if thread is None:
+                        thread = created
+                    try:
+                        await self.service.record_thread_id(
+                            _text(match["match_id"]), str(thread.id)
+                        )
+                    except Exception:
+                        try:
+                            await thread.delete(
+                                reason="Live Arena thread ID persistence failed"
+                            )
+                        except Exception:
+                            log.exception(
+                                "⚠️ Live Arena Q1 untracked forum post cleanup failed"
+                            )
+                        raise
+                    match["thread_id"] = str(thread.id)
+                except Exception:
+                    log.exception(
+                        "❌ Live Arena Q1 forum publication failed • match=%s",
+                        _text(match["match_id"]),
+                    )
+                    warnings.append(label)
+
+        try:
+            overview_channel = await _resolve_channel(
+                self.bot, int(config["ROUND_OVERVIEW_CHANNEL_ID"])
+            )
+            embed = overview_embed(tournament, snapshot.round_row, matches)
+            overview_id = _text(snapshot.round_row["overview_message_id"])
+            message = None
+            if overview_id:
+                try:
+                    message = await overview_channel.fetch_message(int(overview_id))
+                except discord.NotFound:
+                    message = None
+                except Exception:
+                    log.exception("❌ Live Arena Q1 overview fetch failed")
+                    warnings.append("Victory Ledger overview")
+                    return _dedupe(warnings)
+            if message is not None:
+                await message.edit(embed=embed)
+            else:
+                created = await overview_channel.send(embed=embed)
+                try:
+                    await self.service.record_overview_message_id(
+                        _text(snapshot.round_row["round_id"]), str(created.id)
+                    )
+                except Exception:
+                    try:
+                        await created.delete()
+                    except Exception:
+                        log.exception(
+                            "⚠️ Live Arena Q1 untracked overview cleanup failed"
+                        )
+                    raise
+        except Exception:
+            log.exception("❌ Live Arena Q1 overview publication failed")
+            warnings.append("Victory Ledger overview")
+        return _dedupe(warnings)
+
+
+async def _resolve_channel(bot, channel_id):
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        channel = await bot.fetch_channel(channel_id)
+    return channel
+
+
+async def _resolve_existing_thread(bot, thread_id):
+    if not thread_id:
+        return None
+    thread = bot.get_channel(int(thread_id))
+    if thread is not None:
+        return thread
+    try:
+        return await bot.fetch_channel(int(thread_id))
+    except discord.NotFound:
+        return None
+
+
+def _thread_name(match):
+    raw = (
+        f"Q1 • M{int(_text(match['match_number'])):02d} • "
+        f"{_text(match['player_a_display_name'])} vs {_text(match['player_b_display_name'])}"
+    )
+    return raw[:100]
+
+
+def match_embed(tournament, round_row, match, slots):
+    deadline = _format_timestamp(_text(round_row["deadline_at_utc"]), "F")
+    shared_ids = [
+        value for value in _text(match["shared_slot_ids_csv"]).split(",") if value
+    ]
+    by_id = {
+        _text(row["slot_id"]): row for row in slots if _enabled(row["enabled"])
+    }
+    windows = [
+        _render_slot(by_id[slot_id], round_row)
+        for slot_id in shared_ids
+        if slot_id in by_id
+    ]
+    if not windows:
+        availability = (
+            "⚠️ **No shared availability window was found.** "
+            "Please coordinate directly in this thread and contact an organiser "
+            "if scheduling becomes a problem."
+        )
+    else:
+        availability = "\n".join(f"• {window}" for window in windows)
+    description = (
+        f"<@{_text(match['player_a_discord_user_id'])}> vs "
+        f"<@{_text(match['player_b_discord_user_id'])}>\n\n"
+        "**Format:** Best of 3\n"
+        f"**Round deadline:** {deadline}\n\n"
+        "**Shared availability**\n"
+        f"{availability}\n\n"
+        "Arrange the exact fight time between yourselves. After the BO3, "
+        "**post at least one screenshot of the match result in this thread**. "
+        "Result reporting controls will use this thread as the match record."
+    )
+    return discord.Embed(
+        title=(
+            f"{_text(round_row['round_name'])} · Match {_text(match['match_number'])}"
+        ),
+        description=description,
+        color=colors.c1c_blue,
+    )
+
+
+def overview_embed(tournament, round_row, matches):
+    deadline = _format_timestamp(_text(round_row["deadline_at_utc"]), "F")
+    embed = discord.Embed(
+        title=_text(round_row["round_name"]),
+        description=(
+            f"**{_text(tournament['tournament_name'])}**\n"
+            f"Round deadline: {deadline}\n"
+            f"Completed: **0 / {len(matches)}**"
+        ),
+        color=colors.c1c_blue,
+    )
+    for match in sorted(matches, key=lambda row: int(_text(row["match_number"]))):
+        thread_id = _text(match["thread_id"])
+        # Discord channel mentions are <#ID>; keep a plain fallback while a retry is pending.
+        location = f"<#{thread_id}>" if thread_id else "Forum post pending"
+        embed.add_field(
+            name=f"Match {_text(match['match_number'])}",
+            value=(
+                f"<@{_text(match['player_a_discord_user_id'])}> vs "
+                f"<@{_text(match['player_b_discord_user_id'])}>\n{location}"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+def _format_timestamp(value, style):
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    return f"<t:{int(parsed.timestamp())}:{style}>"
+
+
+def _render_slot(slot, round_row):
+    """Use a local Discord timestamp for the next in-round occurrence when possible."""
+    label = _text(slot["display_label"]) or _text(slot["slot_id"])
+    try:
+        opened = datetime.fromisoformat(
+            _text(round_row["opens_at_utc"]).replace("Z", "+00:00")
+        ).astimezone(UTC)
+        deadline = datetime.fromisoformat(
+            _text(round_row["deadline_at_utc"]).replace("Z", "+00:00")
+        ).astimezone(UTC)
+        weekdays = {
+            name: index
+            for index, name in enumerate(
+                (
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday",
+                    "Sunday",
+                )
+            )
+        }
+        target = weekdays[_text(slot["weekday_utc"])]
+        start_clock = time.fromisoformat(_text(slot["start_time_utc"]))
+        end_clock = time.fromisoformat(_text(slot["end_time_utc"]))
+        days = (target - opened.weekday()) % 7
+        start = datetime.combine(opened.date() + timedelta(days=days), start_clock, UTC)
+        if start < opened:
+            start += timedelta(days=7)
+        end = datetime.combine(start.date(), end_clock, UTC)
+        if end <= start:
+            end += timedelta(days=1)
+        if start <= deadline:
+            return (
+                f"{_format_timestamp(start.isoformat(), 'F')} – "
+                f"{_format_timestamp(end.isoformat(), 't')}"
+            )
+    except (KeyError, ValueError):
+        pass
+    return label
+
+
+def _dedupe(values):
+    return list(dict.fromkeys(values))

--- a/tests/community/test_live_arena_qualification.py
+++ b/tests/community/test_live_arena_qualification.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from modules.community.live_arena import qualification
+from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+from modules.community.live_arena.qualification import (
+    MATCH_HEADERS,
+    ROUND_HEADERS,
+    QualificationRepository,
+    QualificationService,
+)
+from modules.community.live_arena.qualification_panel import (
+    QualificationPublisher,
+    install_qualification,
+)
+from modules.community.live_arena.registration import RegistrationError
+
+TID = "LA-2026-TRIAL-01"
+NOW = datetime(2026, 8, 13, 12, 0, tzinfo=UTC)
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+def tournament(status="signup_closed", minimum="4"):
+    return {
+        "tournament_id": TID,
+        "tournament_name": "C1C Live Arena Trial Cup",
+        "status": status,
+        "eligibility_scope": "selected_clans",
+        "min_participants": minimum,
+        "max_participants": "16",
+        "signup_opens_at_utc": "2026-08-01T00:00:00Z",
+        "signup_closes_at_utc": "2026-08-12T22:51:00Z",
+        "notes": "",
+    }
+
+
+def slots():
+    return [
+        {
+            "slot_id": "MON_A",
+            "weekday_utc": "Monday",
+            "start_time_utc": "18:00",
+            "end_time_utc": "20:00",
+            "enabled": "TRUE",
+            "sort_order": "1",
+            "display_label": "Monday 18:00–20:00 UTC",
+        },
+        {
+            "slot_id": "TUE_A",
+            "weekday_utc": "Tuesday",
+            "start_time_utc": "18:00",
+            "end_time_utc": "20:00",
+            "enabled": "TRUE",
+            "sort_order": "2",
+            "display_label": "Tuesday 18:00–20:00 UTC",
+        },
+        {
+            "slot_id": "OFF",
+            "weekday_utc": "Wednesday",
+            "start_time_utc": "18:00",
+            "end_time_utc": "20:00",
+            "enabled": "FALSE",
+            "sort_order": "3",
+            "display_label": "disabled",
+        },
+    ]
+
+
+def participant(uid, name):
+    return {
+        "tournament_id": TID,
+        "discord_user_id": str(uid),
+        "display_name_at_signup": name,
+        "clan_tag_at_signup": "C1CM",
+        "timezone": "Europe/Vienna",
+        "status": "confirmed",
+        "signed_up_at_utc": "2026-08-01T00:00:00Z",
+        "confirmed_at_utc": "2026-08-01T00:00:00Z",
+        "withdrawn_at_utc": "",
+        "withdrawal_reason": "",
+        "updated_at_utc": "2026-08-01T00:00:00Z",
+        "notes": "",
+    }
+
+
+def availability(mapping):
+    return [
+        {
+            "tournament_id": TID,
+            "discord_user_id": str(uid),
+            "slot_id": slot_id,
+            "created_at_utc": "2026-08-01T00:00:00Z",
+            "updated_at_utc": "2026-08-01T00:00:00Z",
+            "notes": "",
+        }
+        for uid, slot_ids in mapping.items()
+        for slot_id in slot_ids
+    ]
+
+
+class MemoryRegistrationRepository:
+    def __init__(self, participants, availability_rows):
+        self.p = deepcopy(participants)
+        self.a = deepcopy(availability_rows)
+        self.audit = []
+
+    async def initialize(self):
+        pass
+
+    async def participants(self):
+        return deepcopy(self.p)
+
+    async def availability(self):
+        return deepcopy(self.a)
+
+    async def append_audit(self, row):
+        self.audit.append(deepcopy(row))
+
+
+class MemoryQualificationRepository:
+    def __init__(self):
+        self.r = []
+        self.m = []
+        self.config = {
+            "ROUNDS_TAB": "ROUNDS",
+            "MATCHES_TAB": "MATCHES",
+            "MATCH_FORUM_CHANNEL_ID": "10",
+            "ROUND_OVERVIEW_CHANNEL_ID": "20",
+        }
+
+    async def initialize(self):
+        pass
+
+    async def rounds(self):
+        return deepcopy(self.r)
+
+    async def matches(self):
+        return deepcopy(self.m)
+
+    async def persist_state(
+        self,
+        rounds,
+        matches,
+        *,
+        previous_rounds,
+        previous_matches,
+    ):
+        self.r = deepcopy(rounds)
+        self.m = deepcopy(matches)
+
+    async def persist_rounds(self, rounds, *, previous_rounds):
+        self.r = deepcopy(rounds)
+
+    async def persist_matches(self, matches, *, previous_matches):
+        self.m = deepcopy(matches)
+
+
+def make_service(monkeypatch, *, mapping=None, roster=None):
+    roster = roster or [
+        participant(1, "One"),
+        participant(2, "Two"),
+        participant(3, "Three"),
+        participant(4, "Four"),
+    ]
+    mapping = mapping or {
+        1: ["MON_A"],
+        2: ["MON_A"],
+        3: ["TUE_A"],
+        4: ["TUE_A"],
+    }
+    registration_repo = MemoryRegistrationRepository(roster, availability(mapping))
+    qrepo = MemoryQualificationRepository()
+    service = QualificationService(
+        "sheet",
+        registration_repository=registration_repo,
+        qualification_repository=qrepo,
+        clock=lambda: NOW,
+        rng=SimpleNamespace(choice=lambda values: values[0]),
+    )
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": TID},
+            (2, tournament()),
+            [],
+            slots(),
+        )
+    )
+    monkeypatch.setattr(
+        qualification,
+        "load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": TID}),
+    )
+    return service, registration_repo, qrepo
+
+
+def test_q1_generation_chooses_zero_conflict_complete_draw_and_exact_rows(monkeypatch):
+    service, registration_repo, qrepo = make_service(monkeypatch)
+    run(service.initialize())
+
+    snapshot = run(service.generate_draw("999"))
+
+    assert snapshot.status == "proposed"
+    assert snapshot.round_row == qrepo.r[0]
+    assert snapshot.round_row["round_id"] == f"{TID}-Q1"
+    assert snapshot.round_row["generated_by_discord_user_id"] == "999"
+    assert snapshot.round_row["deadline_at_utc"] == ""
+    assert len(snapshot.matches) == 2
+    pairs = {
+        frozenset(
+            (row["player_a_discord_user_id"], row["player_b_discord_user_id"])
+        )
+        for row in snapshot.matches
+    }
+    assert pairs == {frozenset(("1", "2")), frozenset(("3", "4"))}
+    assert all(
+        row["has_scheduling_conflict"] == "FALSE" for row in snapshot.matches
+    )
+    assert all(set(row) == set(MATCH_HEADERS) for row in snapshot.matches)
+    assert set(snapshot.round_row) == set(ROUND_HEADERS)
+    assert registration_repo.audit[-1]["event_type"] == "q1_draw_generated"
+
+
+def test_q1_generation_minimizes_unavoidable_conflicts(monkeypatch):
+    mapping = {1: ["MON_A"], 2: ["MON_A"], 3: ["TUE_A"], 4: []}
+    service, _, _ = make_service(monkeypatch, mapping=mapping)
+    run(service.initialize())
+
+    snapshot = run(service.generate_draw("999"))
+
+    assert (
+        sum(
+            row["has_scheduling_conflict"] == "TRUE" for row in snapshot.matches
+        )
+        == 1
+    )
+    assert any(
+        {row["player_a_discord_user_id"], row["player_b_discord_user_id"]}
+        == {"1", "2"}
+        for row in snapshot.matches
+    )
+
+
+def test_q1_generation_blocks_odd_roster_without_bye(monkeypatch):
+    service, _, qrepo = make_service(
+        monkeypatch,
+        roster=[
+            participant(1, "One"),
+            participant(2, "Two"),
+            participant(3, "Three"),
+        ],
+    )
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": TID},
+            (2, tournament(minimum="3")),
+            [],
+            slots(),
+        )
+    )
+    run(service.initialize())
+
+    with pytest.raises(RegistrationError, match="even confirmed roster"):
+        run(service.generate_draw("999"))
+    assert qrepo.r == [] and qrepo.m == []
+
+
+def test_swap_players_recalculates_only_affected_pair_availability(monkeypatch):
+    service, _, _ = make_service(monkeypatch)
+    run(service.initialize())
+    first = run(service.generate_draw("999"))
+    one = next(
+        row
+        for row in first.matches
+        if "1" in {row["player_a_discord_user_id"], row["player_b_discord_user_id"]}
+    )
+    three = next(
+        row
+        for row in first.matches
+        if "3" in {row["player_a_discord_user_id"], row["player_b_discord_user_id"]}
+    )
+    first_partner = (
+        one["player_b_discord_user_id"]
+        if one["player_a_discord_user_id"] == "1"
+        else one["player_a_discord_user_id"]
+    )
+    second_partner = (
+        three["player_b_discord_user_id"]
+        if three["player_a_discord_user_id"] == "3"
+        else three["player_a_discord_user_id"]
+    )
+
+    swapped = run(service.swap_players("999", first_partner, second_partner))
+
+    assert all(row["has_scheduling_conflict"] == "TRUE" for row in swapped.matches)
+
+
+def test_approve_publishes_sheet_state_with_six_day_deadline(monkeypatch):
+    service, registration_repo, qrepo = make_service(monkeypatch)
+    run(service.initialize())
+    run(service.generate_draw("999"))
+
+    snapshot = run(service.approve_draw("999"))
+
+    assert snapshot.status == "active"
+    assert snapshot.round_row["opens_at_utc"] == "2026-08-13T12:00:00Z"
+    assert snapshot.round_row["deadline_at_utc"] == "2026-08-19T12:00:00Z"
+    assert snapshot.round_row["approved_by_discord_user_id"] == "999"
+    assert all(row["status"] == "published" for row in snapshot.matches)
+    assert all(
+        row["deadline_at_utc"] == "2026-08-19T12:00:00Z"
+        for row in snapshot.matches
+    )
+    assert registration_repo.audit[-1]["event_type"] == "q1_draw_approved"
+    assert qrepo.r[0]["overview_message_id"] == ""
+
+
+def test_approve_rejects_roster_change_and_requires_regenerate(monkeypatch):
+    service, registration_repo, _ = make_service(monkeypatch)
+    run(service.initialize())
+    run(service.generate_draw("999"))
+    registration_repo.p[-1]["status"] = "removed"
+    service.context = AsyncMock(
+        return_value=(
+            {"ACTIVE_TOURNAMENT_ID": TID},
+            (2, tournament(minimum="3")),
+            [],
+            slots(),
+        )
+    )
+
+    with pytest.raises(RegistrationError, match="even confirmed roster"):
+        run(service.approve_draw("999"))
+
+
+def test_qualification_repository_supports_frozen_match_width_through_AH():
+    repo = QualificationRepository("sheet")
+    repo.config = {"ROUNDS_TAB": "ROUNDS", "MATCHES_TAB": "MATCHES"}
+    body = repo._batch_body(
+        (("MATCHES_TAB", MATCH_HEADERS, [], []),), use_previous=False
+    )
+    assert body["data"][0]["range"] == "'MATCHES'!A2:AH2"
+
+
+def test_install_qualification_adds_persistent_q1_controls_with_state_gating():
+    manager = OrganizerPanelManager(SimpleNamespace(), "sheet", SimpleNamespace())
+    assert install_qualification(manager) is True
+
+    initial = manager.view("signup_closed")
+    buttons = {child.custom_id: child for child in initial.children}
+    assert buttons["live_arena:organizer:q1:generate"].disabled is False
+    assert buttons["live_arena:organizer:q1:approve"].disabled is True
+
+    manager._qualification_q1_status = "proposed"
+    proposed = manager.view("signup_closed")
+    buttons = {child.custom_id: child for child in proposed.children}
+    assert buttons["live_arena:organizer:q1:generate"].disabled is True
+    assert buttons["live_arena:organizer:q1:approve"].disabled is False
+    assert buttons["live_arena:organizer:q1:regenerate"].disabled is False
+    assert buttons["live_arena:organizer:q1:swap"].disabled is False
+
+
+class FakeMessage:
+    def __init__(self, message_id):
+        self.id = message_id
+        self.edit = AsyncMock()
+        self.delete = AsyncMock()
+
+
+class FakeThread:
+    def __init__(self, thread_id):
+        self.id = thread_id
+        self.delete = AsyncMock()
+
+
+class FakeForum:
+    def __init__(self, bot):
+        self.bot = bot
+        self.calls = []
+
+    async def create_thread(self, **kwargs):
+        self.calls.append(kwargs)
+        thread = FakeThread(1000 + len(self.calls))
+        self.bot.channels[thread.id] = thread
+        return SimpleNamespace(thread=thread, message=FakeMessage(thread.id))
+
+
+class FakeOverviewChannel:
+    def __init__(self):
+        self.sent = []
+        self.messages = {}
+
+    async def send(self, **kwargs):
+        message = FakeMessage(2000 + len(self.sent))
+        self.sent.append((message, kwargs))
+        self.messages[message.id] = message
+        return message
+
+    async def fetch_message(self, message_id):
+        return self.messages[message_id]
+
+
+class FakeBot:
+    def __init__(self):
+        self.channels = {}
+
+    def get_channel(self, channel_id):
+        return self.channels.get(channel_id)
+
+    async def fetch_channel(self, channel_id):
+        return self.channels[channel_id]
+
+
+class PublisherService:
+    def __init__(self):
+        self.repository = SimpleNamespace(
+            config={
+                "MATCH_FORUM_CHANNEL_ID": "10",
+                "ROUND_OVERVIEW_CHANNEL_ID": "20",
+            }
+        )
+        self.round = {header: "" for header in ROUND_HEADERS}
+        self.round.update(
+            tournament_id=TID,
+            round_id=f"{TID}-Q1",
+            round_name="Qualification Round 1",
+            status="active",
+            opens_at_utc="2026-08-13T12:00:00Z",
+            deadline_at_utc="2026-08-19T12:00:00Z",
+        )
+        self.matches = []
+        for number, (a, b) in enumerate((("1", "2"), ("3", "4")), 1):
+            row = {header: "" for header in MATCH_HEADERS}
+            row.update(
+                tournament_id=TID,
+                round_id=f"{TID}-Q1",
+                match_id=f"{TID}-Q1-M{number:02d}",
+                match_number=str(number),
+                player_a_discord_user_id=a,
+                player_a_display_name=f"Player {a}",
+                player_b_discord_user_id=b,
+                player_b_display_name=f"Player {b}",
+                status="published",
+                shared_slot_ids_csv="MON_A",
+                has_scheduling_conflict="FALSE",
+            )
+            self.matches.append(row)
+
+    async def snapshot(self):
+        return qualification.QualificationSnapshot(
+            deepcopy(self.round), tuple(deepcopy(self.matches))
+        )
+
+    async def context(self):
+        return (
+            {"ACTIVE_TOURNAMENT_ID": TID},
+            (2, tournament()),
+            [],
+            slots(),
+        )
+
+    async def record_thread_id(self, match_id, thread_id):
+        row = next(row for row in self.matches if row["match_id"] == match_id)
+        row["thread_id"] = str(thread_id)
+        return row
+
+    async def record_overview_message_id(self, round_id, message_id):
+        assert round_id == self.round["round_id"]
+        self.round["overview_message_id"] = str(message_id)
+        return self.round
+
+
+def test_publisher_creates_one_forum_post_per_match_requires_screenshot_and_is_idempotent():
+    bot = FakeBot()
+    forum = FakeForum(bot)
+    overview = FakeOverviewChannel()
+    bot.channels[10] = forum
+    bot.channels[20] = overview
+    service = PublisherService()
+    publisher = QualificationPublisher(bot, service)
+
+    warnings = run(publisher.reconcile())
+
+    assert warnings == []
+    assert len(forum.calls) == 2
+    assert len(overview.sent) == 1
+    assert all(row["thread_id"] for row in service.matches)
+    assert service.round["overview_message_id"] == "2000"
+    first_embed = forum.calls[0]["embed"]
+    assert "post at least one screenshot" in first_embed.description
+    assert "Best of 3" in first_embed.description
+
+    warnings = run(publisher.reconcile())
+
+    assert warnings == []
+    assert len(forum.calls) == 2
+    assert len(overview.sent) == 1
+    overview.messages[2000].edit.assert_awaited_once()

--- a/tests/community/test_live_arena_qualification_roster_lock.py
+++ b/tests/community/test_live_arena_qualification_roster_lock.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from modules.community.live_arena import organizer_panel
+from modules.community.live_arena import qualification_lock as lock_module
+from modules.community.live_arena.organizer import OrganizerService
+from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+from modules.community.live_arena.registration import (
+    RegistrationError,
+    RegistrationService,
+    RegistrationSnapshot,
+)
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+def _registration_snapshot(*, can_withdraw=True):
+    return RegistrationSnapshot(
+        config={},
+        tournament={"tournament_name": "Trial Cup"},
+        participant={"status": "confirmed"},
+        status="confirmed",
+        timezone="Europe/Vienna",
+        slots=(),
+        selected_slot_ids=(),
+        localized_slots=(),
+        tournament_status="signup_closed",
+        can_update=False,
+        can_withdraw=can_withdraw,
+    )
+
+
+@pytest.mark.parametrize(("status", "expected"), [("active", True), ("completed", True), ("proposed", False)])
+def test_qualification_roster_locked_uses_live_q1_status(monkeypatch, status, expected):
+    class Repo:
+        def __init__(self, _sheet_id):
+            self.config = {}
+
+        async def rounds(self):
+            return [
+                {
+                    "tournament_id": "cup",
+                    "round_id": "cup-Q1",
+                    "status": status,
+                }
+            ]
+
+    monkeypatch.setattr(
+        lock_module,
+        "load_config",
+        AsyncMock(return_value={"ACTIVE_TOURNAMENT_ID": "cup"}),
+    )
+    monkeypatch.setattr(
+        lock_module,
+        "load_qualification_config",
+        AsyncMock(return_value={"ROUNDS_TAB": "ROUNDS"}),
+    )
+    monkeypatch.setattr(lock_module, "QualificationRepository", Repo)
+
+    assert run(lock_module.qualification_roster_locked("sheet")) is expected
+
+
+def test_locked_registration_hides_and_blocks_withdrawal(monkeypatch):
+    original_get = AsyncMock(return_value=_registration_snapshot())
+    original_withdraw = AsyncMock()
+    monkeypatch.setattr(RegistrationService, "get_registration", original_get)
+    monkeypatch.setattr(RegistrationService, "withdraw", original_withdraw)
+    monkeypatch.setattr(
+        lock_module,
+        "qualification_roster_locked",
+        AsyncMock(return_value=True),
+    )
+    service = lock_module.LockedRegistrationService("sheet")
+
+    snapshot = run(service.get_registration("7"))
+    assert snapshot.can_withdraw is False
+
+    with pytest.raises(RegistrationError, match="roster is locked"):
+        run(service.withdraw("7", "changed mind"))
+    original_withdraw.assert_not_awaited()
+
+
+def test_locked_organizer_blocks_reopen_remove_and_restore(monkeypatch):
+    original_transition = AsyncMock(return_value=123)
+    original_change = AsyncMock()
+    monkeypatch.setattr(OrganizerService, "transition", original_transition)
+    monkeypatch.setattr(OrganizerService, "_participant_change", original_change)
+    monkeypatch.setattr(
+        lock_module,
+        "qualification_roster_locked",
+        AsyncMock(return_value=True),
+    )
+    service = lock_module.LockedOrganizerService("sheet", repository=SimpleNamespace())
+
+    with pytest.raises(RegistrationError, match="roster is locked"):
+        run(service.transition("reopen", "99"))
+    with pytest.raises(RegistrationError, match="roster is locked"):
+        run(service._participant_change("99", "7", restore=False))
+    with pytest.raises(RegistrationError, match="roster is locked"):
+        run(service._participant_change("99", "7", restore=True, member=SimpleNamespace()))
+
+    original_transition.assert_not_awaited()
+    original_change.assert_not_awaited()
+
+
+def test_install_lock_disables_reopen_and_roster_mutation_controls():
+    public_manager = SimpleNamespace(service_factory=None)
+    manager = OrganizerPanelManager(SimpleNamespace(), "sheet", public_manager)
+    manager._qualification_installed = True
+    manager._qualification_q1_status = "active"
+
+    original_service = organizer_panel.OrganizerService
+    original_actions = organizer_panel.RosterActions
+    try:
+        assert lock_module.install_qualification_roster_lock(manager) is True
+
+        view = manager.view("signup_closed")
+        reopen = next(
+            child
+            for child in view.children
+            if getattr(child, "custom_id", None) == "live_arena:organizer:reopen"
+        )
+        assert reopen.disabled is True
+        assert public_manager.service_factory is lock_module.LockedRegistrationService
+        assert organizer_panel.OrganizerService is lock_module.LockedOrganizerService
+        assert organizer_panel.RosterActions is lock_module.LockedRosterActions
+
+        roster_actions = lock_module.LockedRosterActions(manager)
+        selectors = [
+            child for child in roster_actions.children if isinstance(child, discord.ui.UserSelect)
+        ]
+        assert selectors
+        assert all(child.disabled for child in selectors)
+    finally:
+        organizer_panel.OrganizerService = original_service
+        organizer_panel.RosterActions = original_actions
+
+
+def test_proposed_q1_does_not_freeze_reopen_button():
+    public_manager = SimpleNamespace(service_factory=None)
+    manager = OrganizerPanelManager(SimpleNamespace(), "sheet", public_manager)
+    manager._qualification_installed = True
+    manager._qualification_q1_status = "proposed"
+
+    original_service = organizer_panel.OrganizerService
+    original_actions = organizer_panel.RosterActions
+    try:
+        lock_module.install_qualification_roster_lock(manager)
+        view = manager.view("signup_closed")
+        reopen = next(
+            child
+            for child in view.children
+            if getattr(child, "custom_id", None) == "live_arena:organizer:reopen"
+        )
+        assert reopen.disabled is False
+    finally:
+        organizer_panel.OrganizerService = original_service
+        organizer_panel.RosterActions = original_actions


### PR DESCRIPTION
## What this adds

Implements the agreed PR6A Live Arena qualification workflow from closed registration through an approved/published Q1 draw.

- exact-schema `ROUNDS` / `MATCHES` persistence using the already-prepared workbook contract
- Q1 draw generation from confirmed participants only
- pairing optimization that minimizes zero-overlap scheduling conflicts while still allowing unavoidable conflict matches
- organizer **Generate Q1 Draw**, **Approve Draw**, **Regenerate Draw**, and **Swap Players** controls
- roster/minimum/evenness guards and approval-time stale-roster validation
- 6-day maximum round deadline beginning at approval/publication
- one `#duelling-decks` forum post per approved matchup, with shared availability and explicit result-screenshot instructions
- one persistent `#victory-ledger` round overview
- idempotent/restart-safe Discord publication using persisted `thread_id` / `overview_message_id`
- audit events for generate/regenerate/swap/approve

## Frozen Sheet contract

This PR does **not** modify Google Sheets. It consumes only the live contract already prepared in the tournament workbook:

- `ROUNDS_TAB = ROUNDS`
- `MATCHES_TAB = MATCHES`
- `MATCH_FORUM_CHANNEL_ID = 1535020967372259479`
- `ROUND_OVERVIEW_CHANNEL_ID = 1535020764779253900`

No new Sheet columns, aliases, fallbacks, or hard-coded tab/channel routing are introduced.

## Explicitly out of scope

- result reporting / screenshot enforcement
- Confirm / Dispute
- confirmation-overdue timer
- scheduling-problem resolution and extensions
- standings / ranking
- Q2/Q3 Swiss-like pairing
- advancement / Cup bracket

## Tests

Adds `tests/community/test_live_arena_qualification.py` covering pairing quality, unavoidable conflicts, odd-roster rejection, player swaps, approval/deadline state, frozen `AH` MATCHES width, organizer control gating, forum publication, screenshot copy, overview creation, and idempotent retry behavior.