### PR TITLE
Fix Live Arena organizer panel refresh and wording

### DIFF
--- a/modules/community/live_arena/messages.py
+++ b/modules/community/live_arena/messages.py
@@ -78,11 +78,20 @@ class MessageTemplate:
             for _, name, _, _ in Formatter().parse(self.title + self.description)
             if name
         }
-        if fields != expected:
-            raise LiveArenaConfigError(
-                f"MESSAGES.{self.key}: placeholders must be exactly {', '.join(sorted(expected))}"
+        allowed = {frozenset(expected)}
+        if self.key == "organizer_panel":
+            # Roster readiness is rendered directly by the organizer panel now.
+            # Keep the legacy placeholder optional so existing Sheet templates
+            # continue to work without forcing it into user-facing copy.
+            allowed.add(frozenset(expected - {"parity_summary"}))
+        if frozenset(fields) not in allowed:
+            choices = " or ".join(
+                ", ".join(sorted(option)) for option in sorted(allowed, key=len)
             )
-        missing = expected - values.keys()
+            raise LiveArenaConfigError(
+                f"MESSAGES.{self.key}: placeholders must be exactly {choices}"
+            )
+        missing = fields - values.keys()
         if missing:
             raise LiveArenaConfigError(
                 f"MESSAGES.{self.key}: missing render value {', '.join(sorted(missing))}"

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -52,25 +52,29 @@ class OrganizerPanelManager:
                 channel = await self.bot.fetch_channel(
                     int(config["ORGANIZER_CHANNEL_ID"])
                 )
-            config, tournament, _, counts, parity = await self.data(
+            config, tournament, participants, counts, parity = await self.data(
                 getattr(channel, "guild", None)
             )
             messages = await load_messages(
                 self.sheet_id, config["MESSAGES_TAB"], {"organizer_panel"}
             )
-            even = counts["confirmed"] % 2 == 0
-            parity_summary = (
-                "Roster parity: EVEN."
-                if even
-                else "Roster parity: ODD — qualification cannot start until the active roster is even."
-            )
-            embed = messages["organizer_panel"].embed(
+            template = messages["organizer_panel"]
+            readiness = _roster_readiness(self, tournament, counts)
+            embed = template.embed(
                 tournament_name=tournament.tournament_name,
-                status=tournament.status,
+                status=_status_label(tournament.status),
                 confirmed_count=counts["confirmed"],
                 max_participants=tournament.max_participants,
-                parity_summary=parity_summary,
+                # Backward compatibility for an older Sheet template. The live
+                # template no longer needs or displays this placeholder.
+                parity_summary=readiness,
             )
+            if "{parity_summary}" not in template.title + template.description:
+                embed.add_field(
+                    name="Roster readiness",
+                    value=readiness,
+                    inline=False,
+                )
             embed.add_field(
                 name="Participant statuses",
                 value="\n".join(
@@ -79,8 +83,8 @@ class OrganizerPanelManager:
                 inline=False,
             )
             embed.add_field(
-                name="Participant role parity",
-                value=f"Missing: **{len(parity['missing'])}** • Extra: **{len(parity['extra'])}** • Unresolved: **{len(parity['unresolved'])}**",
+                name="Tournament roles",
+                value=_tournament_roles_text(parity, participants),
                 inline=False,
             )
             message = None
@@ -161,8 +165,6 @@ async def role_parity(guild, config, participants, tournament_id):
         if _text(r["tournament_id"]) == tournament_id
         and _text(r["status"]) == "confirmed"
     }
-    if guild is None:
-        guild = None
     role = guild.get_role(int(config["PARTICIPANT_ROLE_ID"])) if guild else None
     members = {_text(m.id): m for m in getattr(role, "members", [])} if role else {}
     resolved = {uid: guild.get_member(int(uid)) for uid in confirmed} if guild else {}
@@ -172,7 +174,110 @@ async def role_parity(guild, config, participants, tournament_id):
         ],
         "extra": [m for uid, m in members.items() if uid not in confirmed],
         "unresolved": [uid for uid in confirmed if not resolved.get(uid)],
+        "role_missing": role is None,
     }
+
+
+def _status_label(status: str) -> str:
+    return {
+        "draft": "Draft",
+        "signup_open": "Registration open",
+        "signup_closed": "Registration closed",
+    }.get(_text(status), _text(status).replace("_", " ").title() or "Unknown")
+
+
+def _roster_readiness(manager, tournament, counts) -> str:
+    confirmed = int(counts.get("confirmed", 0) or 0)
+    player_word = "player" if confirmed == 1 else "players"
+    qualification_status = _text(
+        getattr(manager, "_qualification_q1_status", "")
+    ).lower()
+
+    if qualification_status == "active":
+        return "Qualification Round 1 is active. The tournament roster is locked."
+    if qualification_status == "completed":
+        return "Qualification Round 1 is complete. The tournament roster remains locked."
+    if tournament.status == "draft":
+        return "Registration has not opened yet."
+    if tournament.status == "signup_open":
+        return (
+            "Registration is open. Pairing starts after registration closes. "
+            f"Currently: **{confirmed} confirmed {player_word}**. At least "
+            f"**{tournament.min_participants} players** and an even final roster are required."
+        )
+    if tournament.status == "signup_closed":
+        if confirmed < tournament.min_participants:
+            return (
+                "Not ready for pairing: at least "
+                f"**{tournament.min_participants} confirmed players** are required. "
+                f"Currently: **{confirmed} {player_word}**."
+            )
+        if confirmed % 2:
+            return (
+                "Not ready for pairing: an even number of confirmed players is needed "
+                "before the first qualification round can be created. "
+                f"Currently: **{confirmed} {player_word}**."
+            )
+        return (
+            f"Ready for pairing: **{confirmed} confirmed players** can be paired "
+            "for the first qualification round."
+        )
+    return f"Current confirmed roster: **{confirmed} {player_word}**."
+
+
+def _member_label(member) -> str:
+    return (
+        _text(getattr(member, "display_name", ""))
+        or _text(getattr(member, "name", ""))
+        or _text(getattr(member, "id", ""))
+        or "Unknown member"
+    )
+
+
+def _tournament_roles_text(parity, participants) -> str:
+    if parity.get("role_missing"):
+        return (
+            "The configured Tournament Participant role could not be found in Discord. "
+            "**Reconcile Roles** cannot fix this until the role configuration is corrected."
+        )
+
+    missing = [_member_label(member) for member in parity.get("missing", [])]
+    extra = [_member_label(member) for member in parity.get("extra", [])]
+    unresolved_ids = {_text(value) for value in parity.get("unresolved", [])}
+    participant_names = {
+        _text(row.get("discord_user_id")): (
+            _text(row.get("display_name_at_signup"))
+            or _text(row.get("discord_user_id"))
+        )
+        for row in participants
+    }
+    unresolved = [
+        participant_names.get(user_id, user_id) for user_id in sorted(unresolved_ids)
+    ]
+
+    if not missing and not extra and not unresolved:
+        return "All confirmed players have the correct Tournament Participant role."
+
+    lines = []
+    if missing:
+        lines.append(
+            "Missing Tournament Participant role: **" + ", ".join(missing) + "**"
+        )
+    if extra:
+        lines.append(
+            "Has Tournament Participant role but is not confirmed: **"
+            + ", ".join(extra)
+            + "**"
+        )
+    if missing or extra:
+        lines.append("Use **Reconcile Roles** below to fix these Discord roles.")
+    if unresolved:
+        lines.append("Could not find in server: **" + ", ".join(unresolved) + "**")
+        lines.append(
+            "**Reconcile Roles** cannot fix unresolved participants automatically. "
+            "Check them manually."
+        )
+    return "\n".join(lines)
 
 
 def _response_is_done(interaction) -> bool:
@@ -257,12 +362,13 @@ class OrganizerView(discord.ui.View):
                 return
             try:
                 _, tournament, _, counts, _ = await self.manager.data(interaction.guild)
-                odd = counts["confirmed"] % 2
-                warning = (
-                    " The active confirmed roster is odd. Close is still allowed; no player will be auto-demoted, but qualification/pairing must not begin until it is even."
-                    if odd
-                    else ""
-                )
+                warning = ""
+                if counts["confirmed"] % 2:
+                    warning = (
+                        f" There are currently {counts['confirmed']} confirmed players. "
+                        "Closing registration is still allowed, but an even number is "
+                        "required before the first qualification round can be paired."
+                    )
                 embed = discord.Embed(
                     title="Confirm close registration",
                     description=f"Close registration with **{counts['confirmed']}** confirmed players?{warning}",

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -69,7 +69,11 @@ class OrganizerPanelManager:
                 # template no longer needs or displays this placeholder.
                 parity_summary=readiness,
             )
-            if "{parity_summary}" not in template.title + template.description:
+            template_text = (
+                _text(getattr(template, "title", ""))
+                + _text(getattr(template, "description", ""))
+            )
+            if "{parity_summary}" not in template_text:
                 embed.add_field(
                     name="Roster readiness",
                     value=readiness,
@@ -189,6 +193,7 @@ def _status_label(status: str) -> str:
 def _roster_readiness(manager, tournament, counts) -> str:
     confirmed = int(counts.get("confirmed", 0) or 0)
     player_word = "player" if confirmed == 1 else "players"
+    minimum = int(getattr(tournament, "min_participants", 2) or 2)
     qualification_status = _text(
         getattr(manager, "_qualification_q1_status", "")
     ).lower()
@@ -203,13 +208,13 @@ def _roster_readiness(manager, tournament, counts) -> str:
         return (
             "Registration is open. Pairing starts after registration closes. "
             f"Currently: **{confirmed} confirmed {player_word}**. At least "
-            f"**{tournament.min_participants} players** and an even final roster are required."
+            f"**{minimum} players** and an even final roster are required."
         )
     if tournament.status == "signup_closed":
-        if confirmed < tournament.min_participants:
+        if confirmed < minimum:
             return (
                 "Not ready for pairing: at least "
-                f"**{tournament.min_participants} confirmed players** are required. "
+                f"**{minimum} confirmed players** are required. "
                 f"Currently: **{confirmed} {player_word}**."
             )
         if confirmed % 2:
@@ -365,9 +370,10 @@ class OrganizerView(discord.ui.View):
                 warning = ""
                 if counts["confirmed"] % 2:
                     warning = (
-                        f" There are currently {counts['confirmed']} confirmed players. "
-                        "Closing registration is still allowed, but an even number is "
-                        "required before the first qualification round can be paired."
+                        " The confirmed roster currently has an odd number of players "
+                        f"(**{counts['confirmed']}**). Closing registration is still "
+                        "allowed, but an even number is required before the first "
+                        "qualification round can be paired."
                     )
                 embed = discord.Embed(
                     title="Confirm close registration",

--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -372,8 +372,8 @@ class OrganizerView(discord.ui.View):
                     warning = (
                         " The confirmed roster currently has an odd number of players "
                         f"(**{counts['confirmed']}**). Closing registration is still "
-                        "allowed, but an even number is required before the first "
-                        "qualification round can be paired."
+                        "allowed and no player will be auto-demoted, but an even number "
+                        "is required before the first qualification round can be paired."
                     )
                 embed = discord.Embed(
                     title="Confirm close registration",

--- a/tests/community/test_live_arena_organizer_panel_refresh.py
+++ b/tests/community/test_live_arena_organizer_panel_refresh.py
@@ -1,0 +1,171 @@
+"""Regression coverage for the Live Arena Captains Table refresh."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from modules.community.live_arena.messages import (
+    MESSAGE_HEADERS,
+    MessageTemplate,
+    load_messages,
+)
+from modules.community.live_arena.organizer_panel import (
+    OrganizerPanelManager,
+    _roster_readiness,
+    _tournament_roles_text,
+)
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+def test_organizer_message_no_longer_requires_readiness_placeholder():
+    matrix = [
+        list(MESSAGE_HEADERS),
+        [
+            "organizer_panel",
+            "Tournament registration controls",
+            (
+                "Manage registration for {tournament_name}.\n\n"
+                "Status: {status}.\nConfirmed: {confirmed_count}/{max_participants}."
+            ),
+            "#5F6368",
+            "TRUE",
+            "Private organizer registration panel.",
+        ],
+    ]
+    with patch(
+        "modules.community.live_arena.messages.afetch_values",
+        AsyncMock(return_value=matrix),
+    ):
+        template = run(load_messages("sheet", "MESSAGES", {"organizer_panel"}))[
+            "organizer_panel"
+        ]
+
+    embed = template.embed(
+        tournament_name="Cup",
+        status="Registration open",
+        confirmed_count=5,
+        max_participants=16,
+        parity_summary="legacy value is optional",
+    )
+    assert "Confirmed: 5/16" in embed.description
+
+
+def test_roster_readiness_uses_plain_tournament_language():
+    manager = SimpleNamespace(_qualification_q1_status="")
+    tournament = SimpleNamespace(
+        status="signup_closed",
+        min_participants=4,
+    )
+
+    text = _roster_readiness(manager, tournament, {"confirmed": 5})
+
+    assert "even number of confirmed players" in text
+    assert "first qualification round" in text
+    assert "Q1" not in text
+    assert "parity" not in text.lower()
+
+
+def test_tournament_role_issue_names_every_affected_participant():
+    text = _tournament_roles_text(
+        {
+            "missing": [SimpleNamespace(display_name="Alice", id=1)],
+            "extra": [SimpleNamespace(display_name="Bob", id=2)],
+            "unresolved": ["3"],
+            "role_missing": False,
+        },
+        [
+            {
+                "discord_user_id": "3",
+                "display_name_at_signup": "Cara",
+                "status": "confirmed",
+            }
+        ],
+    )
+
+    assert "Alice" in text
+    assert "Bob" in text
+    assert "Cara" in text
+    assert "Reconcile Roles" in text
+    assert "cannot fix unresolved participants automatically" in text
+
+
+def test_organizer_sync_edits_existing_panel_with_current_confirmed_count():
+    config = {
+        "ORGANIZER_CHANNEL_ID": "123",
+        "MESSAGES_TAB": "MESSAGES",
+        "ORGANIZER_PANEL_MESSAGE_ID": "456",
+    }
+    tournament = SimpleNamespace(
+        tournament_id="cup",
+        tournament_name="Friendly Live Arena",
+        status="signup_open",
+        min_participants=4,
+        max_participants=16,
+    )
+    participants = [
+        {
+            "tournament_id": "cup",
+            "discord_user_id": str(user_id),
+            "display_name_at_signup": f"Player {user_id}",
+            "status": "confirmed",
+        }
+        for user_id in range(1, 6)
+    ]
+    counts = {"confirmed": 5, "withdrawn": 0, "removed": 1, "disqualified": 0}
+    roles = {"missing": [], "extra": [], "unresolved": [], "role_missing": False}
+
+    message = SimpleNamespace(edit=AsyncMock())
+    channel = SimpleNamespace(
+        guild=SimpleNamespace(),
+        fetch_message=AsyncMock(return_value=message),
+    )
+    bot = SimpleNamespace(
+        get_channel=lambda _channel_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    manager = OrganizerPanelManager(bot, "sheet-refresh-regression", SimpleNamespace())
+    manager.data = AsyncMock(
+        return_value=(config, tournament, participants, counts, roles)
+    )
+    template = MessageTemplate(
+        "organizer_panel",
+        "Tournament registration controls",
+        (
+            "Manage registration for {tournament_name}.\n\n"
+            "Status: {status}.\nConfirmed: {confirmed_count}/{max_participants}."
+        ),
+        0x5F6368,
+    )
+
+    with (
+        patch(
+            "modules.community.live_arena.organizer_panel.load_pr5_config",
+            AsyncMock(return_value=(config, [])),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.load_messages",
+            AsyncMock(return_value={"organizer_panel": template}),
+        ),
+    ):
+        result = run(manager.sync())
+
+    assert result.ok is True
+    message.edit.assert_awaited_once()
+    embed = message.edit.await_args.kwargs["embed"]
+    assert "Status: Registration open" in embed.description
+    assert "Confirmed: 5/16" in embed.description
+
+    fields = {field.name: field.value for field in embed.fields}
+    assert "Roster readiness" in fields
+    assert "Tournament roles" in fields
+    assert "Q1" not in fields["Roster readiness"]
+    assert "parity" not in fields["Roster readiness"].lower()
+    assert (
+        fields["Tournament roles"]
+        == "All confirmed players have the correct Tournament Participant role."
+    )


### PR DESCRIPTION
## What this fixes
- Captains Table organizer panel can refresh again when the Sheet template does not contain the old `{parity_summary}` placeholder.
- The organizer panel uses plain user-facing tournament language instead of parity/Q1 shorthand.
- Current confirmed count is re-read and rendered on every organizer sync.
- Roster readiness is shown as a clear action/readiness message.
- Tournament role issues name the affected participants and explicitly direct organizers to **Reconcile Roles** when it can fix them.
- Unresolved Discord members are named from their signup display name where possible and clearly marked as manual checks.
- Raw tournament status values such as `signup_open` are rendered as human-facing labels.

## Sheet change already made outside this PR
The live `MESSAGES` row for `organizer_panel` was cleaned so its notes cell now contains only `Private organizer registration panel.`. No new columns or config keys were added.

## Tests
Adds focused regression coverage for:
- organizer templates without `{parity_summary}`
- plain-language roster readiness
- participant names in role problems
- existing organizer message refresh using the current confirmed count

No qualification/result behavior is changed.