### PR TITLE
Fix Live Arena organizer panel direct refresh

### DIFF
--- a/modules/community/live_arena/organizer_panel.py
+++ b/modules/community/live_arena/organizer_panel.py
@@ -91,24 +91,67 @@ class OrganizerPanelManager:
                 value=_tournament_roles_text(parity, participants),
                 inline=False,
             )
+
+            message_id = _text(config["ORGANIZER_PANEL_MESSAGE_ID"])
             message = None
-            if config["ORGANIZER_PANEL_MESSAGE_ID"]:
-                try:
-                    message = await channel.fetch_message(
-                        int(config["ORGANIZER_PANEL_MESSAGE_ID"])
-                    )
-                except discord.NotFound:
-                    pass
-                except Exception:
-                    log.exception("❌ Live Arena organizer panel — fetch failed")
-                    return PanelSyncResult(False, "fetch")
+            if message_id:
+                # We already own and persist the organizer message ID. Prefer a
+                # PartialMessage so refreshing does not depend on Read Message
+                # History or a separate GET succeeding before the edit.
+                get_partial_message = getattr(channel, "get_partial_message", None)
+                if callable(get_partial_message):
+                    try:
+                        message = get_partial_message(int(message_id))
+                    except Exception as exc:
+                        log.exception(
+                            "❌ Live Arena organizer panel — direct edit target failed • message_id=%s • error=%s: %s",
+                            message_id,
+                            type(exc).__name__,
+                            exc,
+                        )
+                        return PanelSyncResult(False, "edit")
+                else:
+                    # Compatibility fallback for messageable channel-like objects
+                    # without discord.py's get_partial_message helper.
+                    try:
+                        message = await channel.fetch_message(int(message_id))
+                    except discord.NotFound:
+                        message = None
+                    except Exception as exc:
+                        log.exception(
+                            "❌ Live Arena organizer panel — fallback fetch failed • message_id=%s • error=%s: %s",
+                            message_id,
+                            type(exc).__name__,
+                            exc,
+                        )
+                        return PanelSyncResult(False, "fetch")
+
             if message:
                 try:
                     await message.edit(embed=embed, view=self.view(tournament.status))
-                except Exception:
-                    log.exception("❌ Live Arena organizer panel — edit failed")
+                except discord.NotFound:
+                    # Only a confirmed 404 should cause recreation. Permission or
+                    # transient edit failures must never create a duplicate panel.
+                    log.warning(
+                        "⚠️ Live Arena organizer panel — saved message missing; recreating • message_id=%s",
+                        message_id,
+                    )
+                except Exception as exc:
+                    log.exception(
+                        "❌ Live Arena organizer panel — edit failed • message_id=%s • error=%s: %s",
+                        message_id,
+                        type(exc).__name__,
+                        exc,
+                    )
                     return PanelSyncResult(False, "edit")
-                return PanelSyncResult(True)
+                else:
+                    log.info(
+                        "✅ Live Arena organizer panel refreshed • message_id=%s • confirmed=%s",
+                        message_id,
+                        counts["confirmed"],
+                    )
+                    return PanelSyncResult(True)
+
             created = await channel.send(embed=embed, view=self.view(tournament.status))
             try:
                 await self._persist(config, str(created.id))

--- a/tests/community/test_live_arena_organizer_direct_edit.py
+++ b/tests/community/test_live_arena_organizer_direct_edit.py
@@ -1,0 +1,157 @@
+"""Regression coverage for direct refresh of the saved Live Arena organizer panel."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import discord
+
+from modules.community.live_arena.organizer_panel import OrganizerPanelManager
+from modules.community.live_arena.panel import PanelSyncResult
+
+
+def run(awaitable):
+    return asyncio.run(awaitable)
+
+
+class _Template:
+    title = "Tournament registration controls"
+    description = (
+        "Manage registration for {tournament_name}.\n\n"
+        "Status: {status}.\n"
+        "Confirmed: {confirmed_count}/{max_participants}."
+    )
+
+    def embed(self, **values):
+        return discord.Embed(
+            title=self.title,
+            description=self.description.format(**values),
+        )
+
+
+def _not_found():
+    return discord.NotFound(
+        SimpleNamespace(status=404, reason="missing"), "missing"
+    )
+
+
+def _manager(*, partial_edit_error=None):
+    partial = SimpleNamespace(edit=AsyncMock())
+    if partial_edit_error is not None:
+        partial.edit.side_effect = partial_edit_error
+
+    created = SimpleNamespace(id=999, delete=AsyncMock())
+    channel = SimpleNamespace(
+        guild=SimpleNamespace(),
+        get_partial_message=Mock(return_value=partial),
+        fetch_message=AsyncMock(side_effect=RuntimeError("history fetch must not run")),
+        send=AsyncMock(return_value=created),
+    )
+    bot = SimpleNamespace(
+        get_channel=lambda _channel_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    manager = OrganizerPanelManager(bot, "sheet-direct-organizer", SimpleNamespace())
+    manager.data = AsyncMock(
+        return_value=(
+            {
+                "ORGANIZER_CHANNEL_ID": "10",
+                "ORGANIZER_PANEL_MESSAGE_ID": "77",
+                "MESSAGES_TAB": "MESSAGES",
+            },
+            SimpleNamespace(
+                tournament_id="cup",
+                tournament_name="Trial Cup",
+                status="signup_open",
+                min_participants=4,
+                max_participants=16,
+            ),
+            [],
+            {"confirmed": 5, "withdrawn": 0, "removed": 1, "disqualified": 0},
+            {"missing": [], "extra": [], "unresolved": [], "role_missing": False},
+        )
+    )
+    manager._persist = AsyncMock()
+    return manager, channel, partial
+
+
+def _config():
+    return {
+        "ORGANIZER_CHANNEL_ID": "10",
+        "ORGANIZER_PANEL_MESSAGE_ID": "77",
+        "MESSAGES_TAB": "MESSAGES",
+    }
+
+
+def test_saved_organizer_panel_edits_by_id_without_fetching_message_history():
+    manager, channel, partial = _manager()
+
+    with (
+        patch(
+            "modules.community.live_arena.organizer_panel.load_pr5_config",
+            AsyncMock(return_value=(_config(), [])),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.load_messages",
+            AsyncMock(return_value={"organizer_panel": _Template()}),
+        ),
+    ):
+        result = run(manager.sync())
+
+    assert result == PanelSyncResult(True)
+    channel.get_partial_message.assert_called_once_with(77)
+    channel.fetch_message.assert_not_awaited()
+    channel.send.assert_not_awaited()
+    manager._persist.assert_not_awaited()
+    partial.edit.assert_awaited_once()
+    embed = partial.edit.await_args.kwargs["embed"]
+    assert "Confirmed: 5/16" in embed.description
+    assert "Registration open" in embed.description
+
+
+def test_direct_edit_not_found_recreates_and_persists_one_replacement():
+    manager, channel, partial = _manager(partial_edit_error=_not_found())
+
+    with (
+        patch(
+            "modules.community.live_arena.organizer_panel.load_pr5_config",
+            AsyncMock(return_value=(_config(), [])),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.load_messages",
+            AsyncMock(return_value={"organizer_panel": _Template()}),
+        ),
+    ):
+        result = run(manager.sync())
+
+    assert result == PanelSyncResult(True)
+    partial.edit.assert_awaited_once()
+    channel.fetch_message.assert_not_awaited()
+    channel.send.assert_awaited_once()
+    manager._persist.assert_awaited_once_with(_config(), "999")
+
+
+def test_direct_edit_transient_failure_never_creates_duplicate_panel():
+    manager, channel, partial = _manager(
+        partial_edit_error=RuntimeError("temporary Discord edit failure")
+    )
+
+    with (
+        patch(
+            "modules.community.live_arena.organizer_panel.load_pr5_config",
+            AsyncMock(return_value=(_config(), [])),
+        ),
+        patch(
+            "modules.community.live_arena.organizer_panel.load_messages",
+            AsyncMock(return_value={"organizer_panel": _Template()}),
+        ),
+    ):
+        result = run(manager.sync())
+
+    assert result == PanelSyncResult(False, "edit")
+    partial.edit.assert_awaited_once()
+    channel.fetch_message.assert_not_awaited()
+    channel.send.assert_not_awaited()
+    manager._persist.assert_not_awaited()


### PR DESCRIPTION
## What this fixes
The Captains Table panel can remain stale even when its exact Discord message ID is already persisted, because organizer sync first requires `fetch_message()` to succeed before it attempts an edit.

This changes the saved organizer-panel refresh path to edit the bot-owned message directly by ID using Discord's partial-message API. That removes the unnecessary message-history fetch dependency.

## Safety behavior
- Existing saved organizer message: edit directly by ID.
- Confirmed `NotFound` while editing: recreate once and persist the replacement ID.
- Permission/transient edit failure: do **not** create a duplicate; log the exact message ID and exception and return a sync failure.
- Channel-like test doubles without partial-message support keep the existing fetch fallback.
- Successful refresh logs the message ID and current confirmed count for production verification.

## Tests
Adds focused regressions proving:
- saved organizer panel refresh does not call `fetch_message()` when direct edit is available;
- the refreshed embed uses the current confirmed count;
- `NotFound` recreates exactly once;
- transient edit failure never creates a duplicate.

No Sheet changes. No registration, qualification, pairing, or result behavior changes.